### PR TITLE
ci: added github owners and reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @asithade
+* @jordane

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -1,0 +1,18 @@
+---
+name: Assign Reviewers
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  add-reviewers:
+    if: github.event.pull_request.draft == false
+    name: Add Reviewers
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto Assign Action
+        uses: kentaro-m/auto-assign-action@v1.2.4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: ".github/workflows/config/reviewers.yml"

--- a/.github/workflows/config/reviewers.yml
+++ b/.github/workflows/config/reviewers.yml
@@ -7,6 +7,9 @@ addAssignees: author
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
   - audigregorie
+  - asithade
+  - andrest50
+  - mauriciozanettisalomao
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)

--- a/.github/workflows/config/reviewers.yml
+++ b/.github/workflows/config/reviewers.yml
@@ -1,0 +1,18 @@
+# https://github.com/marketplace/actions/auto-assign-action
+
+addReviewers: true
+
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - audigregorie
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - WIP
+  - DNM


### PR DESCRIPTION
This pull request introduces changes to streamline the code review process by adding a workflow for automatically assigning reviewers to pull requests and updating the code ownership file. The most important changes include the addition of a GitHub Actions workflow for assigning reviewers, the configuration for the workflow, and updates to the `CODEOWNERS` file.

### Workflow automation for assigning reviewers:
* [`.github/workflows/assign-reviewers.yml`](diffhunk://#diff-691434e916199e67b6adc3ca20a6a905f32dc64d4956ca730a193e9b23fd3e12R1-R18): Added a GitHub Actions workflow to automatically assign reviewers to pull requests when they are opened, marked ready for review, or reopened. The workflow uses the `auto-assign-action` to handle the reviewer assignment.
* [`.github/workflows/config/reviewers.yml`](diffhunk://#diff-9809ce36e626fe5a7d3de7b1a92e61c77d46a58bec528bab7ebbb65baf890579R1-R18): Added configuration for the `auto-assign-action`, specifying reviewers, the number of reviewers to assign, and keywords to skip the assignment process (e.g., "WIP" or "DNM").

### Updates to code ownership:
* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1-R2): Added `@asithade` and `@jordane` as code owners for the repository.