### PR TITLE
fix: disable token middleware

### DIFF
--- a/apps/lfx-pcc/src/server/server.ts
+++ b/apps/lfx-pcc/src/server/server.ts
@@ -14,7 +14,6 @@ import pinoHttp from 'pino-http';
 
 import { extractBearerToken } from './middleware/auth-token.middleware';
 import { apiErrorHandler } from './middleware/error-handler.middleware';
-import { tokenRefreshMiddleware } from './middleware/token-refresh.middleware';
 import committeesRouter from './routes/committees';
 import meetingsRouter from './routes/meetings';
 import permissionsRouter from './routes/permissions';
@@ -80,7 +79,7 @@ const authConfig: ConfigParams = {
 
 app.use(auth(authConfig));
 
-app.use(tokenRefreshMiddleware);
+// app.use(tokenRefreshMiddleware);
 
 // Apply bearer token middleware to all API routes
 app.use('/api', extractBearerToken);


### PR DESCRIPTION
This pull request makes a small change to the server middleware configuration by commenting out the `tokenRefreshMiddleware`. This affects authentication token refresh handling in the application. No other significant changes are included.