### PR TITLE
fix(docker): use direct server startup to avoid Turbo cache misses

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ RUN yarn build
 # Expose port 4200
 EXPOSE 4200
 
-# Start the SSR server
-CMD ["yarn", "start:server"]
+# Start the SSR server directly from built artifacts
+CMD ["yarn", "workspace", "lfx-pcc", "start:server"]


### PR DESCRIPTION
Change CMD to use workspace-specific start:server command instead of Turbo's start:server task. This prevents unnecessary rebuilds on container startup by using pre-built artifacts directly.

🤖 Generated with [Claude Code](https://claude.ai/code)