### PR TITLE
feat(api): add meeting update functionality

### DIFF
--- a/apps/lfx-pcc/src/app/modules/project/meetings/components/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-pcc/src/app/modules/project/meetings/components/meeting-manage/meeting-manage.component.ts
@@ -401,6 +401,11 @@ export class MeetingManageComponent {
     // Map recurrence object back to form value
     const recurrenceValue = mapRecurrenceToFormValue(meeting.recurrence);
 
+    // If recording_enabled is true, enable controls for transcript_enabled and youtube_upload_enabled
+    this.form().get('transcript_enabled')?.enable();
+    this.form().get('youtube_upload_enabled')?.enable();
+    this.form().get('zoom_ai_enabled')?.enable();
+
     this.form().patchValue({
       title: meeting.title,
       description: meeting.description,

--- a/apps/lfx-pcc/src/server/routes/meetings.ts
+++ b/apps/lfx-pcc/src/server/routes/meetings.ts
@@ -168,46 +168,8 @@ router.get('/:id', (req, res) => meetingController.getMeetingById(req, res));
 // POST /meetings - using new controller pattern
 router.post('/', (req, res) => meetingController.createMeeting(req, res));
 
-router.put('/:id', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const meetingId = req.params['id'];
-    const meetingData = req.body;
-    const { editType } = req.query;
-
-    if (!meetingId) {
-      return res.status(400).json({
-        error: 'Meeting ID is required',
-        code: 'MISSING_MEETING_ID',
-      });
-    }
-
-    // Validate editType for recurring meetings
-    if (editType && !['single', 'future'].includes(editType as string)) {
-      return res.status(400).json({
-        error: 'Edit type must be "single" or "future"',
-        code: 'INVALID_EDIT_TYPE',
-      });
-    }
-
-    // Remove fields that shouldn't be updated directly
-    delete meetingData.id;
-    delete meetingData.created_at;
-
-    const meeting = await supabaseService.updateMeeting(meetingId, meetingData, editType as 'single' | 'future');
-
-    return res.json(meeting);
-  } catch (error) {
-    req.log.error(
-      {
-        error: error instanceof Error ? error.message : error,
-        meeting_id: req.params['id'],
-        edit_type: req.query['editType'],
-      },
-      'Failed to update meeting'
-    );
-    return next(error);
-  }
-});
+// PUT /meetings/:id - using new controller pattern
+router.put('/:id', (req, res) => meetingController.updateMeeting(req, res));
 
 router.delete('/:id', (req, res) => meetingController.deleteMeeting(req, res));
 

--- a/apps/lfx-pcc/src/server/services/etag.service.ts
+++ b/apps/lfx-pcc/src/server/services/etag.service.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ETagError, ETagResult, extractErrorDetails } from '@lfx-pcc/shared/interfaces';
 import { HTTP_HEADERS } from '@lfx-pcc/shared/constants';
+import { ETagError, ETagResult, extractErrorDetails } from '@lfx-pcc/shared/interfaces';
 import { Request } from 'express';
 
 import { MicroserviceProxyService } from './microservice-proxy.service';


### PR DESCRIPTION
## Summary
Implements the ability to update meetings in the LFX PCC v3 application with proper ETag-based concurrency control to prevent lost updates.

## Changes
- **MeetingService**: Added `updateMeeting` method with ETag support for safe concurrent updates
- **MeetingController**: Added comprehensive HTTP handler with validation for required fields
- **Routes**: Updated PUT endpoint to use controller pattern instead of direct database calls
- **Frontend**: Enhanced meeting management component to support updates

## Key Features
- ✅ ETag concurrency control prevents lost updates when multiple users edit the same meeting
- ✅ Support for recurring meeting updates with `editType` parameter ('single' or 'future')
- ✅ Automatic organizer management maintains current user as organizer
- ✅ Comprehensive validation matching create meeting operation
- ✅ Proper error handling and logging following established patterns

## Technical Implementation
- Uses microservice proxy pattern for consistency with other CRUD operations
- Validates required fields: title, start_time, duration, timezone, project_uid
- Validates duration range (0-600 minutes)
- Validates editType parameter for recurring meetings

## Files Changed
- `apps/lfx-pcc/src/server/controllers/meeting.controller.ts` - Added updateMeeting method
- `apps/lfx-pcc/src/server/routes/meetings.ts` - Updated to use controller pattern
- `apps/lfx-pcc/src/server/services/meeting.service.ts` - Added updateMeeting with ETag support
- `apps/lfx-pcc/src/server/services/etag.service.ts` - Fixed header usage for updates
- `apps/lfx-pcc/src/app/modules/project/meetings/components/meeting-manage/meeting-manage.component.ts` - Frontend update support

## Testing
- ✅ Lint checks passed
- ✅ Build successful  
- ✅ TypeScript compilation successful
- Manual testing through existing meeting management UI recommended

## Related JIRA Ticket
[LFXV2-378](https://linuxfoundation.atlassian.net/browse/LFXV2-378)

Generated with [Claude Code](https://claude.ai/code)