### PR TITLE
Docker Builds for PRs

### DIFF
--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -1,0 +1,150 @@
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+---
+name: Deploy Branch to Development
+
+on:
+  pull_request:
+    types: [closed, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  check-label:
+    runs-on: ubuntu-latest
+    outputs:
+      should-deploy: ${{ steps.check.outputs.should-deploy }}
+    steps:
+      - name: Check for deployment label
+        id: check
+        run: |
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'branch-preview') }}" == "true" ]]; then
+            echo "should-deploy=true" >> $GITHUB_OUTPUT
+            echo "✅ Deploy label found - will proceed with deployment"
+          else
+            echo "should-deploy=false" >> $GITHUB_OUTPUT
+            echo "⏭️ No deploy label found - skipping deployment"
+          fi
+
+  build-and-push:
+    needs: check-label
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: read
+    if: needs.check-label.outputs.should-deploy == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr,prefix=pcc-
+          labels: |
+            org.opencontainers.image.title=LFX PCC UI
+            org.opencontainers.image.description=Linux Foundation LFX Project Control Center UI application
+            org.opencontainers.image.vendor=The Linux Foundation
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}/blob/main/README.md
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            com.github.actions.run_id=${{ github.run_id }}
+            com.github.actions.run_number=${{ github.run_number }}
+            com.github.actions.workflow=${{ github.workflow }}
+
+      - name: Build and push Docker image
+        id: docker-build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILD_ENV=production
+
+      - name: Comment deployment URL on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deploymentUrl = `https://pcc-pr-${{ github.event.pull_request.number }}.dev.v2.cluster.linuxfound.info`;
+            const comment = `## 🚀 Deployment Status
+            
+            Your branch has been deployed to: ${deploymentUrl}
+            
+            **Deployment Details:**
+            - Environment: Development
+            - Namespace: pcc-pr-${{ github.event.pull_request.number }}
+            - ArgoCD App: pcc-pr-${{ github.event.pull_request.number }}
+            
+            The deployment will be automatically removed when this PR is closed.`;
+            
+            // Check if we already commented
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            
+            const botComment = comments.data.find(comment => 
+              comment.user.type === 'Bot' && 
+              comment.body.includes('## 🚀 Deployment Status')
+            );
+            
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                comment_id: botComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+            }
+
+  cleanup-on-close:
+    if: github.event.action == 'closed' || (github.event.action == 'unlabeled' && github.event.label.name == 'branch-preview')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment removal on PR
+        if: github.event.action == 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comment = `## 🧹 Deployment Removed
+
+            The deployment for PR #${{ github.event.pull_request.number }} has been removed.`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: comment
+            });


### PR DESCRIPTION
Adds a Github Workflow for building docker images for the PR when the
'deploy-preview' label is added.

ArgoCD is watching the repository and will automatically deploy a branch
preview of PCC UI when the label is applied.

Generated with [Claude Code](https://claude.ai/code)
Signed-off-by: Trevor Bramwell <tbramwell@linuxfoundation.org>
