### PR TITLE
fix(ui): query service tag filtering

### DIFF
--- a/apps/lfx-pcc/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-pcc/src/app/shared/services/meeting.service.ts
@@ -39,8 +39,7 @@ export class MeetingService {
   }
 
   public getMeetingsByProject(projectId: string, limit?: number, orderBy?: string): Observable<Meeting[]> {
-    // TODO: Replace tags with parent when API supports it
-    let params = new HttpParams().set('tags', `${projectId}`);
+    let params = new HttpParams().set('tags', `project_uid:${projectId}`);
 
     if (limit) {
       params = params.set('limit', limit.toString());
@@ -58,10 +57,9 @@ export class MeetingService {
   }
 
   public getUpcomingMeetingsByProject(projectId: string, limit: number = 3): Observable<Meeting[]> {
-    // TODO: Replace tags with parent when API supports it
-    // TODO: Replace start_time_gte with start_time_gte when API supports it
-    let params = new HttpParams().set('tags', `${projectId}`);
+    let params = new HttpParams().set('tags', `project_uid:${projectId}`);
 
+    // TODO: Add filter for upcoming meetings
     if (limit) {
       params = params.set('limit', limit.toString());
     }
@@ -70,10 +68,9 @@ export class MeetingService {
   }
 
   public getPastMeetingsByProject(projectId: string, limit: number = 3): Observable<Meeting[]> {
-    // TODO: Create new past meetings endpoint when new indexer is added
-    // TODO: Replace tags with parent when API supports it
-    let params = new HttpParams().set('tags', `${projectId}`);
+    let params = new HttpParams().set('tags', `project_uid:${projectId}`);
 
+    // TODO: Add filter for past meetings
     if (limit) {
       params = params.set('limit', limit.toString());
     }

--- a/apps/lfx-pcc/src/server/services/meeting.service.ts
+++ b/apps/lfx-pcc/src/server/services/meeting.service.ts
@@ -56,7 +56,7 @@ export class MeetingService {
   public async getMeetingById(req: Request, meetingUid: string): Promise<Meeting> {
     const params = {
       type: 'meeting',
-      tags: meetingUid,
+      tags: `meeting_uid:${meetingUid}`,
     };
 
     const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Meeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', params);


### PR DESCRIPTION
This pull request updates how meetings are queried by changing the format of the `tags` parameter to use explicit UID-based keys, improving clarity and future-proofing the API calls. The changes affect both client and server meeting service methods for fetching meetings by project or by meeting ID.

**Meeting query parameter updates:**

* Updated the `tags` parameter in `getMeetingsByProject`, `getUpcomingMeetingsByProject`, and `getPastMeetingsByProject` methods in `meeting.service.ts` to use the format `project_uid:<projectId>` instead of just the project ID. [[1]](diffhunk://#diff-44cdff0df6a1a6ce22588c6c6d2182f63bca2850e9c58edeb639a873e115f8e4L42-R42) [[2]](diffhunk://#diff-44cdff0df6a1a6ce22588c6c6d2182f63bca2850e9c58edeb639a873e115f8e4L61-R62) [[3]](diffhunk://#diff-44cdff0df6a1a6ce22588c6c6d2182f63bca2850e9c58edeb639a873e115f8e4L73-R73)
* Updated the `tags` parameter in the server-side `getMeetingById` method to use the format `meeting_uid:<meetingUid>` instead of just the meeting UID.