### PR TITLE
fix(server): m2m token generation endpoint

### DIFF
--- a/apps/lfx-pcc/src/server/utils/m2m-token.util.ts
+++ b/apps/lfx-pcc/src/server/utils/m2m-token.util.ts
@@ -29,7 +29,7 @@ export async function generateM2MToken(req: Request): Promise<string> {
 
     // Select the appropriate request configuration
     const config = isAuthelia ? AUTHELIA_TOKEN_REQUEST : AUTH0_TOKEN_REQUEST;
-    const tokenEndpoint = issuerBaseUrl + config.endpoint;
+    const tokenEndpoint = new URL(config.endpoint, issuerBaseUrl).toString();
 
     // Prepare request options based on auth provider
     const requestOptions = {


### PR DESCRIPTION
This pull request makes a small update to the `generateM2MToken` utility function. The change simplifies how the `tokenEndpoint` URL is constructed by removing an unnecessary slash, which helps prevent double slashes in the final URL.