### PR TITLE
feat(profile): add forgot password link to change password page

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/password/profile-password.component.html
+++ b/apps/lfx-one/src/app/modules/profile/password/profile-password.component.html
@@ -197,7 +197,7 @@
     <lfx-card>
       <div class="flex flex-col gap-6">
         <div>
-          <h3 class="text-base font-medium text-gray-900" data-testid="password-recovery-heading">Account Recovery</h3>
+          <h3 class="text-base font-medium text-gray-900" data-testid="password-recovery-heading" #accountRecovery>Account Recovery</h3>
           <p class="text-sm text-gray-500 mt-1">Send a password reset link to your email address if you've forgotten your password</p>
         </div>
 

--- a/apps/lfx-one/src/app/modules/profile/password/profile-password.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/password/profile-password.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, OnInit, Signal, signal } from '@angular/core';
+import { Component, computed, ElementRef, inject, OnInit, Signal, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { markFormControlsAsTouched } from '@lfx-one/shared';
@@ -25,6 +25,7 @@ import { BehaviorSubject, catchError, finalize, of, switchMap } from 'rxjs';
   templateUrl: './profile-password.component.html',
 })
 export class ProfilePasswordComponent implements OnInit {
+  private readonly accountRecovery = viewChild<ElementRef>('accountRecovery');
   private readonly fb = inject(FormBuilder);
   private readonly userService = inject(UserService);
   private readonly messageService = inject(MessageService);
@@ -174,7 +175,7 @@ export class ProfilePasswordComponent implements OnInit {
   }
 
   public scrollToAccountRecovery(): void {
-    const accountRecoveryElement = document.querySelector('[data-testid="password-recovery-heading"]');
+    const accountRecoveryElement = this.accountRecovery()?.nativeElement;
     if (accountRecoveryElement) {
       accountRecoveryElement.scrollIntoView({
         behavior: 'smooth',


### PR DESCRIPTION
Add subtle forgot password link under current password field that smoothly scrolls to Account Recovery section. Link uses minimal styling to avoid form disruption while maintaining accessibility.

References: LFXV2-573

🤖 Generated with [Claude Code](https://claude.ai/code)