### PR TITLE
feat(permissions): implement email-first workflow with email-to-sub l…

### DIFF
--- a/apps/lfx-one/src/app/modules/project/settings/components/user-form/user-form.component.html
+++ b/apps/lfx-one/src/app/modules/project/settings/components/user-form/user-form.component.html
@@ -4,21 +4,76 @@
 <form [formGroup]="form()" (ngSubmit)="onSubmit()" class="space-y-6">
   <!-- User Information Section -->
   <div class="flex flex-col gap-3">
-    <!-- Username or Email -->
+    <!-- Email - Always shown first -->
     <div>
-      <label for="username" class="block text-sm font-medium text-gray-700 mb-1"> Username or Email <span class="text-red-500">*</span> </label>
+      <label for="email" class="block text-sm font-medium text-gray-700 mb-1"> Email <span class="text-red-500">*</span> </label>
       <lfx-input-text
         size="small"
         [form]="form()"
-        control="username"
-        id="username"
-        placeholder="Enter username or email address"
+        control="email"
+        id="email"
+        type="email"
+        placeholder="Enter email address"
         styleClass="w-full"
-        data-testid="settings-user-form-username"></lfx-input-text>
-      @if (form().get('username')?.errors?.['required'] && form().get('username')?.touched) {
-        <p class="mt-1 text-xs text-red-600">Username or email is required</p>
+        data-testid="settings-user-form-email"></lfx-input-text>
+      @if (form().get('email')?.errors?.['required'] && form().get('email')?.touched) {
+        <p class="mt-1 text-xs text-red-600">Email is required</p>
+      }
+      @if (form().get('email')?.errors?.['email'] && form().get('email')?.touched) {
+        <p class="mt-1 text-xs text-red-600">Please enter a valid email address</p>
+      }
+      @if (!isEditing() && !showManualFields()) {
+        <p class="mt-1 text-xs text-gray-500">Enter the user's email address to look them up in the directory</p>
       }
     </div>
+
+    <!-- Manual entry fields - Only shown after user not found confirmation -->
+    @if (showManualFields()) {
+      <!-- Name -->
+      <div>
+        <label for="name" class="block text-sm font-medium text-gray-700 mb-1"> Full Name <span class="text-red-500">*</span> </label>
+        <lfx-input-text
+          size="small"
+          [form]="form()"
+          control="name"
+          id="name"
+          placeholder="Enter full name"
+          styleClass="w-full"
+          data-testid="settings-user-form-name"></lfx-input-text>
+        @if (form().get('name')?.errors?.['required'] && form().get('name')?.touched) {
+          <p class="mt-1 text-xs text-red-600">Full name is required</p>
+        }
+      </div>
+
+      <!-- Username -->
+      <div>
+        <label for="username" class="block text-sm font-medium text-gray-700 mb-1"> Username <span class="text-red-500">*</span> </label>
+        <lfx-input-text
+          size="small"
+          [form]="form()"
+          control="username"
+          id="username"
+          placeholder="Enter username"
+          styleClass="w-full"
+          data-testid="settings-user-form-username"></lfx-input-text>
+        @if (form().get('username')?.errors?.['required'] && form().get('username')?.touched) {
+          <p class="mt-1 text-xs text-red-600">Username is required</p>
+        }
+      </div>
+
+      <!-- Avatar URL -->
+      <div>
+        <label for="avatar" class="block text-sm font-medium text-gray-700 mb-1"> Avatar URL </label>
+        <lfx-input-text
+          size="small"
+          [form]="form()"
+          control="avatar"
+          id="avatar"
+          placeholder="Enter avatar image URL (optional)"
+          styleClass="w-full"
+          data-testid="settings-user-form-avatar"></lfx-input-text>
+      </div>
+    }
   </div>
 
   <!-- Permission Settings Section -->
@@ -83,3 +138,6 @@
     <div><strong>Manage:</strong> Full access to create, edit, delete, and manage all project content</div>
   </div>
 </ng-template>
+
+<!-- Confirmation Dialog -->
+<p-confirmDialog></p-confirmDialog>

--- a/apps/lfx-one/src/app/modules/project/settings/components/user-permissions-table/user-permissions-table.component.html
+++ b/apps/lfx-one/src/app/modules/project/settings/components/user-permissions-table/user-permissions-table.component.html
@@ -23,7 +23,10 @@
         currentPageReportTemplate="Showing {first} to {last} of {totalRecords} users">
         <ng-template #header>
           <tr>
+            <th class="w-16"><span class="text-sm font-sans text-gray-500">Avatar</span></th>
+            <th><span class="text-sm font-sans text-gray-500">Name</span></th>
             <th><span class="text-sm font-sans text-gray-500">Username</span></th>
+            <th><span class="text-sm font-sans text-gray-500">Email</span></th>
             <th><span class="text-sm font-sans text-gray-500">Role</span></th>
             <th class="text-center">
               <div class="flex justify-center">
@@ -35,9 +38,32 @@
 
         <ng-template #body let-user>
           <tr>
+            <!-- Avatar Column -->
+            <td>
+              <div class="flex items-center justify-center">
+                @if (user.avatar) {
+                  <img [src]="user.avatar" [alt]="user.name" class="w-8 h-8 rounded-full object-cover" />
+                } @else {
+                  <div class="w-8 h-8 rounded-full bg-blue-600 flex items-center justify-center text-white text-xs font-medium">
+                    {{ getUserInitials(user.name) }}
+                  </div>
+                }
+              </div>
+            </td>
+
+            <!-- Name Column -->
+            <td>
+              <div class="text-sm font-sans text-gray-900 font-medium">{{ user.name }}</div>
+            </td>
+
             <!-- Username Column -->
             <td>
-              <div class="text-sm font-sans text-gray-900 font-medium">{{ user.username }}</div>
+              <div class="text-sm font-sans text-gray-700">{{ user.username }}</div>
+            </td>
+
+            <!-- Email Column -->
+            <td>
+              <div class="text-sm font-sans text-gray-600">{{ user.email }}</div>
             </td>
 
             <!-- Role Column -->
@@ -66,7 +92,7 @@
 
         <ng-template #emptymessage>
           <tr>
-            <td colspan="3" class="text-center py-8">
+            <td colspan="6" class="text-center py-8">
               <div class="text-center py-8 text-gray-500">
                 <i class="fa-light fa-users text-4xl text-gray-400 mb-4"></i>
                 <h3 class="text-lg font-medium text-gray-900 mb-2">No User Permissions</h3>

--- a/apps/lfx-one/src/app/modules/project/settings/components/user-permissions-table/user-permissions-table.component.ts
+++ b/apps/lfx-one/src/app/modules/project/settings/components/user-permissions-table/user-permissions-table.component.ts
@@ -91,6 +91,17 @@ export class UserPermissionsTableComponent {
     });
   }
 
+  protected getUserInitials(name: string): string {
+    if (!name) return '?';
+
+    const parts = name.trim().split(' ');
+    if (parts.length === 1) {
+      return parts[0].charAt(0).toUpperCase();
+    }
+
+    return (parts[0].charAt(0) + parts[parts.length - 1].charAt(0)).toUpperCase();
+  }
+
   private removeUser(user: ProjectPermissionUser): void {
     if (!this.project()) return;
 

--- a/apps/lfx-one/src/app/shared/services/permissions.service.ts
+++ b/apps/lfx-one/src/app/shared/services/permissions.service.ts
@@ -36,8 +36,11 @@ export class PermissionsService {
         // Add auditors (view permissions)
         if (settings.auditors) {
           users.push(
-            ...settings.auditors.map((username) => ({
-              username,
+            ...settings.auditors.map((userInfo) => ({
+              name: userInfo.name,
+              email: userInfo.email,
+              username: userInfo.username,
+              avatar: userInfo.avatar,
               role: 'view' as const,
             }))
           );
@@ -46,8 +49,11 @@ export class PermissionsService {
         // Add writers (manage permissions)
         if (settings.writers) {
           users.push(
-            ...settings.writers.map((username) => ({
-              username,
+            ...settings.writers.map((userInfo) => ({
+              name: userInfo.name,
+              email: userInfo.email,
+              username: userInfo.username,
+              avatar: userInfo.avatar,
               role: 'manage' as const,
             }))
           );

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -285,7 +285,21 @@ export class ProjectController {
         );
       }
 
-      const result = await this.projectService.updateProjectPermissions(req, uid, 'add', username, userData.role);
+      // Check if manual user data is provided (for users not found in directory)
+      let manualUserInfo: { name: string; email: string; username: string; avatar?: string } | undefined;
+      if (userData.name || userData.email || userData.avatar) {
+        manualUserInfo = {
+          name: userData.name || '',
+          email: userData.email || '',
+          username,
+        };
+        // Only include avatar if it's not empty
+        if (userData.avatar) {
+          manualUserInfo.avatar = userData.avatar;
+        }
+      }
+
+      const result = await this.projectService.updateProjectPermissions(req, uid, 'add', username, userData.role, manualUserInfo);
 
       Logger.success(req, 'add_user_project_permissions', startTime, {
         uid,

--- a/packages/shared/src/enums/nats.enum.ts
+++ b/packages/shared/src/enums/nats.enum.ts
@@ -8,4 +8,6 @@ export enum NatsSubjects {
   PROJECT_SLUG_TO_UID = 'lfx.projects-api.slug_to_uid',
   USER_METADATA_UPDATE = 'lfx.auth-service.user_metadata.update',
   EMAIL_TO_USERNAME = 'lfx.auth-service.email_to_username',
+  EMAIL_TO_SUB = 'lfx.auth-service.email_to_sub',
+  USERNAME_TO_USER_INFO = 'lfx.auth-service.username_to_user_info',
 }

--- a/packages/shared/src/interfaces/permissions.interface.ts
+++ b/packages/shared/src/interfaces/permissions.interface.ts
@@ -143,8 +143,14 @@ export interface UpdateUserPermissionRequest {
  * @description Simplified representation of user permissions for table display
  */
 export interface ProjectPermissionUser {
+  /** User's full name */
+  name: string;
+  /** User's email address */
+  email: string;
   /** Username identifier */
   username: string;
+  /** URL to user's avatar image (optional) */
+  avatar?: string;
   /** Permission role - 'view' for auditors, 'manage' for writers */
   role: 'view' | 'manage';
 }
@@ -152,12 +158,19 @@ export interface ProjectPermissionUser {
 /**
  * Request payload for adding user to project
  * @description Data required to add a user to project writers or auditors
+ * Can include optional manual entry fields when user is not found in directory
  */
 export interface AddUserToProjectRequest {
   /** Username to add */
   username: string;
   /** Role to assign - 'view' for auditors, 'manage' for writers */
   role: 'view' | 'manage';
+  /** User's full name (optional, for manual entry when user not found) */
+  name?: string;
+  /** User's email address (optional, for manual entry when user not found) */
+  email?: string;
+  /** User's avatar URL (optional, for manual entry when user not found) */
+  avatar?: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -118,6 +118,21 @@ export interface ProjectCard extends Partial<Project> {
 export type ProjectQueryResponse = Project[];
 
 /**
+ * User information for project permissions
+ * @description Complete user profile data for project writers and auditors
+ */
+export interface UserInfo {
+  /** User's full name */
+  name: string;
+  /** User's email address */
+  email: string;
+  /** User's username/LFID */
+  username: string;
+  /** URL to user's avatar image (optional) */
+  avatar?: string;
+}
+
+/**
  * Project settings
  * @description Project settings for the LFX platform
  */
@@ -126,10 +141,10 @@ export interface ProjectSettings {
   uid: string;
   /** Project announcement date */
   announcement_date: string;
-  /** Project writers */
-  writers: string[];
-  /** Project auditors */
-  auditors: string[];
+  /** Project writers with full user information */
+  writers: UserInfo[];
+  /** Project auditors with full user information */
+  auditors: UserInfo[];
   /** Project created at */
   created_at: string;
   /** Project updated at */


### PR DESCRIPTION
…ookup

Update project permissions user form to use email-first workflow:
- Ask for email first, then show confirmation if user not found
- Support manual entry with full user details (name, username, avatar)
- Replace EMAIL_TO_USERNAME with EMAIL_TO_SUB NATS subject
- Convert writers/auditors from string arrays to UserInfo objects
- Clean empty avatar fields before API submission to fix validation
- Add user initials fallback when avatar not available
- Display full user info (name, email, username, avatar) in table

Changes include:
- Add EMAIL_TO_SUB to NatsSubjects enum
- Update resolveEmailToUsername to use email_to_sub endpoint
- Add getUserInfo method for fetching complete user profile
- Modify updateProjectPermissions to handle UserInfo objects
- Update user form with conditional field display logic
- Add confirmation dialog for user not found scenario
- Enhance permissions table with avatar, name, and email columns
- Clean up empty avatar strings to prevent API validation errors

🤖 Generated with [Claude Code](https://claude.ai/code)