### PR TITLE
LFXV2-872: Tie chart releases to app releases

### DIFF
--- a/.github/workflows/docker-build-tag.yml
+++ b/.github/workflows/docker-build-tag.yml
@@ -37,7 +37,7 @@ jobs:
           set -euo pipefail
           APP_VERSION=$(echo ${{ github.ref_name }} | sed 's/v//g')
           CHART_NAME="$(yq '.name' charts/*/Chart.yaml)"
-          CHART_VERSION="$(yq '.version' charts/*/Chart.yaml)"
+          CHART_VERSION=$(echo ${{ github.ref_name }} | sed 's/v//g')
           {
             echo "app_version=$APP_VERSION"
             echo "chart_name=$CHART_NAME"
@@ -102,7 +102,7 @@ jobs:
 
       - name: Publish Chart to GHCR
         id: publish-ghcr
-        uses: linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher@c465d6571fa0b8be9d551d902955164ea04a00af # main
+        uses: linuxfoundation/lfx-public-workflows/.github/actions/helm-chart-oci-publisher@17e4144d7ba68f7c3e8c16eece5aed15fd7c2dc8 # main
         with:
           name: ${{ needs.build-and-push.outputs.chart_name }}
           repository: ${{ github.repository }}/chart

--- a/charts/lfx-v2-ui/Chart.yaml
+++ b/charts/lfx-v2-ui/Chart.yaml
@@ -5,7 +5,9 @@ apiVersion: v2
 name: lfx-v2-ui
 description: A Helm chart for LFX v2 UI - Angular SSR application with Express backend
 type: application
-version: 0.3.3
+# This version should not be incremented, as it is dynamically replaced with the release version during the chart build
+# job.
+version: 0.0.1
 appVersion: "latest"
 keywords:
   - lfx


### PR DESCRIPTION
This PR implements the standardized changes for LFXV2-872 to tie chart releases to app releases.

## Changes Made

### Chart.yaml Updates
- Reset version from `0.3.3` to `0.0.1` 
- Added explanatory comment about dynamic version replacement during chart build

### GitHub Workflow Updates  
- Updated `CHART_VERSION` calculation to use `github.ref_name` instead of reading from Chart.yaml
- Updated `helm-chart-oci-publisher` to newer version `@17e4144d7ba68f7c3e8c16eece5aed15fd7c2dc8`

## Related
- **Jira**: LFXV2-872 - Tie chart releases to app releases  
- **Pattern**: Standardized changes applied across all LFX v2 repositories

## Testing
The changes ensure that:
- Chart version is dynamically set to match the release tag during builds
- Chart builds use the updated publisher with latest features
- Version consistency between application and chart releases