### PR TITLE
fix(meetings): include password param in new-tab detail href

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -138,7 +138,7 @@
             size="small"
             styleClass="w-full"
             label="See Meeting Details"
-            [href]="meetingDetailUrl()"
+            [href]="meetingDetailHref()"
             target="_blank"
             type="button"
             [outlined]="true"

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -64,6 +64,7 @@ export class DashboardMeetingCardComponent {
   public readonly isRecurring: Signal<boolean> = this.initIsRecurring();
   public readonly meetingDetailUrl: Signal<string> = this.initMeetingDetailUrl();
   public readonly meetingDetailQueryParams: Signal<Record<string, string>> = this.initMeetingDetailQueryParams();
+  public readonly meetingDetailHref: Signal<string> = this.initMeetingDetailHref();
   public readonly recordingShareUrl: Signal<string | null> = this.initRecordingShareUrl();
 
   public constructor() {
@@ -274,6 +275,15 @@ export class DashboardMeetingCardComponent {
     return computed((): Record<string, string> => {
       const meeting = this.meeting();
       return meeting.password ? { password: meeting.password } : {};
+    });
+  }
+
+  private initMeetingDetailHref(): Signal<string> {
+    return computed(() => {
+      const url = this.meetingDetailUrl();
+      const params = this.meetingDetailQueryParams();
+      const queryString = new URLSearchParams(params).toString();
+      return queryString ? `${url}?${queryString}` : url;
     });
   }
 


### PR DESCRIPTION
## Summary
- The dashboard meeting card's "See Meeting Details" button opens in a new tab by default using `[href]`, which did not include the meeting password query parameter
- Added a `meetingDetailHref` computed signal that combines the detail URL with query params (including password) into a full URL string for the href branch
- The `[routerLink]` branch (same-tab navigation) was already correct via `[queryParams]`

Generated with [Claude Code](https://claude.ai/code)