### PR TITLE
feat(sidebar): use persona projects for project selector

### DIFF
--- a/apps/lfx-one/src/app/layouts/dev-toolbar/dev-toolbar.component.html
+++ b/apps/lfx-one/src/app/layouts/dev-toolbar/dev-toolbar.component.html
@@ -19,26 +19,28 @@
           data-testid="dev-tools-bar-persona-selector" />
       </div>
 
-      <!-- Project/Foundation Selector -->
-      <div class="flex items-center gap-2" data-testid="dev-tools-bar-project-override">
-        <label for="project-override-select" class="text-xs text-gray-400">{{ selectorLabel() }}</label>
-        <lfx-select
-          [form]="form"
-          control="selectedProjectUid"
-          [options]="projectContextService.availableProjects"
-          optionLabel="name"
-          optionValue="uid"
-          [filter]="true"
-          filterPlaceholder="Search..."
-          placeholder="Select..."
-          [showClear]="false"
-          styleClass="min-w-52 dev-tools-select"
-          inputId="project-override-select"
-          data-testid="dev-tools-bar-project-override-select" />
-      </div>
+      <!-- Project/Foundation Selector (hidden on Me lens) -->
+      @if (showProjectSelector()) {
+        <div class="flex items-center gap-2" data-testid="dev-tools-bar-project-override">
+          <label for="project-override-select" class="text-xs text-gray-400">{{ selectorLabel() }}</label>
+          <lfx-select
+            [form]="form"
+            control="selectedProjectUid"
+            [options]="projectContextService.availableProjects"
+            optionLabel="name"
+            optionValue="uid"
+            [filter]="true"
+            filterPlaceholder="Search..."
+            placeholder="Select..."
+            [showClear]="false"
+            styleClass="min-w-52 dev-tools-select"
+            inputId="project-override-select"
+            data-testid="dev-tools-bar-project-override-select" />
+        </div>
+      }
 
-      <!-- Organization Selector (only visible on board dashboard) -->
-      @if (showOrganizationSelector() && isOnBoardDashboard()) {
+      <!-- Organization Selector (visible on foundation lens) -->
+      @if (isFoundationLens() && showOrganizationSelector()) {
         <div class="flex items-center gap-2" data-testid="dev-tools-bar-organization">
           <label for="organization-select" class="text-xs text-gray-400">Organization:</label>
           <lfx-select

--- a/apps/lfx-one/src/app/layouts/dev-toolbar/dev-toolbar.component.ts
+++ b/apps/lfx-one/src/app/layouts/dev-toolbar/dev-toolbar.component.ts
@@ -1,10 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, signal, Signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { NavigationEnd, Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { SelectComponent } from '@components/select/select.component';
 import { ACCOUNTS, DEV_PERSONA_PRESETS } from '@lfx-one/shared/constants';
@@ -12,9 +11,10 @@ import { Account, DevPersonaPreset, isBoardScopedPersona } from '@lfx-one/shared
 import { AccountContextService } from '@services/account-context.service';
 import { CookieRegistryService } from '@services/cookie-registry.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
+import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { filter, map, skip, startWith } from 'rxjs';
+import { skip } from 'rxjs';
 
 @Component({
   selector: 'lfx-dev-toolbar',
@@ -27,8 +27,8 @@ export class DevToolbarComponent {
   protected readonly projectContextService = inject(ProjectContextService);
   private readonly accountContextService = inject(AccountContextService);
   private readonly cookieRegistry = inject(CookieRegistryService);
+  private readonly lensService = inject(LensService);
   private readonly featureFlagService = inject(FeatureFlagService);
-  private readonly router = inject(Router);
 
   // Feature flags
   protected readonly showDevToolbar = this.featureFlagService.getBooleanFlag('dev-toolbar', true);
@@ -46,8 +46,14 @@ export class DevToolbarComponent {
   /** Label for the project/foundation selector */
   protected readonly selectorLabel = computed(() => (isBoardScopedPersona(this.activePreset().primary) ? 'Foundation:' : 'Project:'));
 
-  // Check if we're on the board dashboard page
-  protected readonly isOnBoardDashboard: Signal<boolean> = this.initIsOnBoardDashboard();
+  /** Hide project and organization selectors on the "Me" lens */
+  protected readonly showProjectSelector = computed(() => {
+    const lens = this.lensService.activeLens();
+    return lens === 'project' || lens === 'foundation';
+  });
+
+  /** Organization selector is only relevant on the foundation lens */
+  protected readonly isFoundationLens = computed(() => this.lensService.activeLens() === 'foundation');
 
   // Form for persona selector and organization selector
   public form: FormGroup;
@@ -162,18 +168,6 @@ export class DevToolbarComponent {
       ) ??
       DEV_PERSONA_PRESETS.find((p) => p.primary === persona) ??
       DEV_PERSONA_PRESETS[1]
-    );
-  }
-
-  private initIsOnBoardDashboard(): Signal<boolean> {
-    return toSignal(
-      this.router.events.pipe(
-        filter((event): event is NavigationEnd => event instanceof NavigationEnd),
-        map((event) => event.urlAfterRedirects),
-        startWith(this.router.url),
-        map((url) => url === '/' || url.startsWith('/?'))
-      ),
-      { initialValue: this.router.url === '/' }
     );
   }
 }

--- a/apps/lfx-one/src/app/layouts/dev-toolbar/dev-toolbar.component.ts
+++ b/apps/lfx-one/src/app/layouts/dev-toolbar/dev-toolbar.component.ts
@@ -46,11 +46,8 @@ export class DevToolbarComponent {
   /** Label for the project/foundation selector */
   protected readonly selectorLabel = computed(() => (isBoardScopedPersona(this.activePreset().primary) ? 'Foundation:' : 'Project:'));
 
-  /** Hide project and organization selectors on the "Me" lens */
-  protected readonly showProjectSelector = computed(() => {
-    const lens = this.lensService.activeLens();
-    return lens === 'project' || lens === 'foundation';
-  });
+  /** Hide project selector on the "Me" lens */
+  protected readonly showProjectSelector = computed(() => this.lensService.activeLens() !== 'me');
 
   /** Organization selector is only relevant on the foundation lens */
   protected readonly isFoundationLens = computed(() => this.lensService.activeLens() === 'foundation');

--- a/apps/lfx-one/src/app/modules/dashboards/components/recent-progress/recent-progress.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/recent-progress/recent-progress.component.ts
@@ -20,7 +20,7 @@ import { AnalyticsService } from '@services/analytics.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ScrollShadowDirective } from '@shared/directives/scroll-shadow.directive';
-import { catchError, of, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, of, switchMap, tap } from 'rxjs';
 
 import type {
   ActiveWeeksStreakResponse,
@@ -749,8 +749,12 @@ export class RecentProgressComponent {
 
   private initializeProjectIssuesResolutionData() {
     return toSignal(
-      toObservable(this.projectSlug).pipe(
-        switchMap((projectSlug) => {
+      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
+        switchMap(([projectSlug, persona]) => {
+          if (persona !== 'maintainer') {
+            this.loadingState.update((state) => ({ ...state, projectIssuesResolution: false }));
+            return [{ data: [], totalOpenedIssues: 0, totalClosedIssues: 0, resolutionRatePct: 0, medianDaysToClose: 0, totalDays: 0 }];
+          }
           if (!projectSlug) {
             this.loadingState.update((state) => ({ ...state, projectIssuesResolution: false }));
             return [{ data: [], totalOpenedIssues: 0, totalClosedIssues: 0, resolutionRatePct: 0, medianDaysToClose: 0, totalDays: 0 }];
@@ -781,8 +785,12 @@ export class RecentProgressComponent {
 
   private initializeProjectPullRequestsWeeklyData() {
     return toSignal(
-      toObservable(this.projectSlug).pipe(
-        switchMap((projectSlug) => {
+      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
+        switchMap(([projectSlug, persona]) => {
+          if (persona !== 'maintainer') {
+            this.loadingState.update((state) => ({ ...state, projectPullRequestsWeekly: false }));
+            return [{ data: [], totalMergedPRs: 0, avgMergeTime: 0, totalWeeks: 0 }];
+          }
           if (!projectSlug) {
             this.loadingState.update((state) => ({ ...state, projectPullRequestsWeekly: false }));
             return [{ data: [], totalMergedPRs: 0, avgMergeTime: 0, totalWeeks: 0 }];
@@ -811,8 +819,12 @@ export class RecentProgressComponent {
 
   private initializeContributorsMentoredData() {
     return toSignal(
-      toObservable(this.projectSlug).pipe(
-        switchMap((projectSlug) => {
+      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
+        switchMap(([projectSlug, persona]) => {
+          if (persona !== 'maintainer') {
+            this.loadingState.update((state) => ({ ...state, contributorsMentored: false }));
+            return [{ data: [], totalMentored: 0, avgWeeklyNew: 0, totalWeeks: 0 }];
+          }
           if (!projectSlug) {
             this.loadingState.update((state) => ({ ...state, contributorsMentored: false }));
             return [{ data: [], totalMentored: 0, avgWeeklyNew: 0, totalWeeks: 0 }];
@@ -840,8 +852,12 @@ export class RecentProgressComponent {
 
   private initializeUniqueContributorsWeeklyData() {
     return toSignal(
-      toObservable(this.projectSlug).pipe(
-        switchMap((projectSlug) => {
+      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
+        switchMap(([projectSlug, persona]) => {
+          if (persona !== 'maintainer') {
+            this.loadingState.update((state) => ({ ...state, uniqueContributorsWeekly: false }));
+            return [{ data: [], totalUniqueContributors: 0, avgUniqueContributors: 0, totalWeeks: 0 }];
+          }
           if (!projectSlug) {
             this.loadingState.update((state) => ({ ...state, uniqueContributorsWeekly: false }));
             return [{ data: [], totalUniqueContributors: 0, avgUniqueContributors: 0, totalWeeks: 0 }];
@@ -870,8 +886,12 @@ export class RecentProgressComponent {
 
   private initializeHealthMetricsDailyData() {
     return toSignal(
-      toObservable(this.projectSlug).pipe(
-        switchMap((projectSlug) => {
+      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
+        switchMap(([projectSlug, persona]) => {
+          if (persona !== 'maintainer') {
+            this.loadingState.update((state) => ({ ...state, healthMetricsDaily: false }));
+            return [{ data: [], currentAvgHealthScore: 0, totalDays: 0 }];
+          }
           if (!projectSlug) {
             this.loadingState.update((state) => ({ ...state, healthMetricsDaily: false }));
             return [{ data: [], currentAvgHealthScore: 0, totalDays: 0 }];
@@ -899,8 +919,12 @@ export class RecentProgressComponent {
 
   private initializeCodeCommitsDailyData() {
     return toSignal(
-      toObservable(this.projectSlug).pipe(
-        switchMap((projectSlug) => {
+      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
+        switchMap(([projectSlug, persona]) => {
+          if (persona !== 'maintainer') {
+            this.loadingState.update((state) => ({ ...state, codeCommitsDaily: false }));
+            return [{ data: [], totalCommits: 0, totalDays: 0 }];
+          }
           if (!projectSlug) {
             this.loadingState.update((state) => ({ ...state, codeCommitsDaily: false }));
             return [{ data: [], totalCommits: 0, totalDays: 0 }];

--- a/apps/lfx-one/src/app/modules/dashboards/components/recent-progress/recent-progress.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/recent-progress/recent-progress.component.ts
@@ -20,7 +20,7 @@ import { AnalyticsService } from '@services/analytics.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ScrollShadowDirective } from '@shared/directives/scroll-shadow.directive';
-import { catchError, combineLatest, of, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, Observable, of, switchMap, tap } from 'rxjs';
 
 import type {
   ActiveWeeksStreakResponse,
@@ -65,6 +65,7 @@ export class RecentProgressComponent {
   });
   public readonly projectSlug = computed(() => this.projectContextService.selectedFoundation()?.slug || this.projectContextService.selectedProject()?.slug);
   private readonly entityType = computed<'foundation' | 'project'>(() => (this.projectContextService.selectedFoundation() ? 'foundation' : 'project'));
+  private readonly isMaintainer = computed(() => this.personaService.currentPersona() === 'maintainer');
   private readonly activeWeeksStreakData = this.initializeActiveWeeksStreakData();
   private readonly pullRequestsMergedData = this.initializePullRequestsMergedData();
   private readonly codeCommitsData = this.initializeCodeCommitsData();
@@ -748,205 +749,82 @@ export class RecentProgressComponent {
   }
 
   private initializeProjectIssuesResolutionData() {
-    return toSignal(
-      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
-        switchMap(([projectSlug, persona]) => {
-          if (persona !== 'maintainer') {
-            this.loadingState.update((state) => ({ ...state, projectIssuesResolution: false }));
-            return [{ data: [], totalOpenedIssues: 0, totalClosedIssues: 0, resolutionRatePct: 0, medianDaysToClose: 0, totalDays: 0 }];
-          }
-          if (!projectSlug) {
-            this.loadingState.update((state) => ({ ...state, projectIssuesResolution: false }));
-            return [{ data: [], totalOpenedIssues: 0, totalClosedIssues: 0, resolutionRatePct: 0, medianDaysToClose: 0, totalDays: 0 }];
-          }
-          this.loadingState.update((state) => ({ ...state, projectIssuesResolution: true }));
-          const entityType = this.entityType();
-          return this.analyticsService.getProjectIssuesResolution(projectSlug, entityType).pipe(
-            tap(() => this.loadingState.update((state) => ({ ...state, projectIssuesResolution: false }))),
-            catchError(() => {
-              this.loadingState.update((state) => ({ ...state, projectIssuesResolution: false }));
-              return of({ data: [], totalOpenedIssues: 0, totalClosedIssues: 0, resolutionRatePct: 0, medianDaysToClose: 0, totalDays: 0 });
-            })
-          );
-        })
-      ),
-      {
-        initialValue: {
-          data: [],
-          totalOpenedIssues: 0,
-          totalClosedIssues: 0,
-          resolutionRatePct: 0,
-          medianDaysToClose: 0,
-          totalDays: 0,
-        },
-      }
-    );
+    const defaultValue: ProjectIssuesResolutionResponse = {
+      data: [],
+      totalOpenedIssues: 0,
+      totalClosedIssues: 0,
+      resolutionRatePct: 0,
+      medianDaysToClose: 0,
+      totalDays: 0,
+    };
+
+    return this.maintainerGuardedFetch('projectIssuesResolution', defaultValue, (slug) => {
+      const entityType = this.entityType();
+      return this.analyticsService.getProjectIssuesResolution(slug, entityType);
+    });
   }
 
   private initializeProjectPullRequestsWeeklyData() {
-    return toSignal(
-      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
-        switchMap(([projectSlug, persona]) => {
-          if (persona !== 'maintainer') {
-            this.loadingState.update((state) => ({ ...state, projectPullRequestsWeekly: false }));
-            return [{ data: [], totalMergedPRs: 0, avgMergeTime: 0, totalWeeks: 0 }];
-          }
-          if (!projectSlug) {
-            this.loadingState.update((state) => ({ ...state, projectPullRequestsWeekly: false }));
-            return [{ data: [], totalMergedPRs: 0, avgMergeTime: 0, totalWeeks: 0 }];
-          }
-          this.loadingState.update((state) => ({ ...state, projectPullRequestsWeekly: true }));
-          const entityType = this.entityType();
-          return this.analyticsService.getProjectPullRequestsWeekly(projectSlug, entityType).pipe(
-            tap(() => this.loadingState.update((state) => ({ ...state, projectPullRequestsWeekly: false }))),
-            catchError(() => {
-              this.loadingState.update((state) => ({ ...state, projectPullRequestsWeekly: false }));
-              return of({ data: [], totalMergedPRs: 0, avgMergeTime: 0, totalWeeks: 0 });
-            })
-          );
-        })
-      ),
-      {
-        initialValue: {
-          data: [],
-          totalMergedPRs: 0,
-          avgMergeTime: 0,
-          totalWeeks: 0,
-        },
-      }
-    );
+    const defaultValue: ProjectPullRequestsWeeklyResponse = { data: [], totalMergedPRs: 0, avgMergeTime: 0, totalWeeks: 0 };
+
+    return this.maintainerGuardedFetch('projectPullRequestsWeekly', defaultValue, (slug) => {
+      const entityType = this.entityType();
+      return this.analyticsService.getProjectPullRequestsWeekly(slug, entityType);
+    });
   }
 
   private initializeContributorsMentoredData() {
-    return toSignal(
-      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
-        switchMap(([projectSlug, persona]) => {
-          if (persona !== 'maintainer') {
-            this.loadingState.update((state) => ({ ...state, contributorsMentored: false }));
-            return [{ data: [], totalMentored: 0, avgWeeklyNew: 0, totalWeeks: 0 }];
-          }
-          if (!projectSlug) {
-            this.loadingState.update((state) => ({ ...state, contributorsMentored: false }));
-            return [{ data: [], totalMentored: 0, avgWeeklyNew: 0, totalWeeks: 0 }];
-          }
-          this.loadingState.update((state) => ({ ...state, contributorsMentored: true }));
-          return this.analyticsService.getContributorsMentored(projectSlug).pipe(
-            tap(() => this.loadingState.update((state) => ({ ...state, contributorsMentored: false }))),
-            catchError(() => {
-              this.loadingState.update((state) => ({ ...state, contributorsMentored: false }));
-              return of({ data: [], totalMentored: 0, avgWeeklyNew: 0, totalWeeks: 0 });
-            })
-          );
-        })
-      ),
-      {
-        initialValue: {
-          data: [],
-          totalMentored: 0,
-          avgWeeklyNew: 0,
-          totalWeeks: 0,
-        },
-      }
-    );
+    const defaultValue: FoundationContributorsMentoredResponse = { data: [], totalMentored: 0, avgWeeklyNew: 0, totalWeeks: 0 };
+
+    return this.maintainerGuardedFetch('contributorsMentored', defaultValue, (slug) => this.analyticsService.getContributorsMentored(slug));
   }
 
   private initializeUniqueContributorsWeeklyData() {
-    return toSignal(
-      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
-        switchMap(([projectSlug, persona]) => {
-          if (persona !== 'maintainer') {
-            this.loadingState.update((state) => ({ ...state, uniqueContributorsWeekly: false }));
-            return [{ data: [], totalUniqueContributors: 0, avgUniqueContributors: 0, totalWeeks: 0 }];
-          }
-          if (!projectSlug) {
-            this.loadingState.update((state) => ({ ...state, uniqueContributorsWeekly: false }));
-            return [{ data: [], totalUniqueContributors: 0, avgUniqueContributors: 0, totalWeeks: 0 }];
-          }
-          this.loadingState.update((state) => ({ ...state, uniqueContributorsWeekly: true }));
-          const entityType = this.entityType();
-          return this.analyticsService.getUniqueContributorsWeekly(projectSlug, entityType).pipe(
-            tap(() => this.loadingState.update((state) => ({ ...state, uniqueContributorsWeekly: false }))),
-            catchError(() => {
-              this.loadingState.update((state) => ({ ...state, uniqueContributorsWeekly: false }));
-              return of({ data: [], totalUniqueContributors: 0, avgUniqueContributors: 0, totalWeeks: 0 });
-            })
-          );
-        })
-      ),
-      {
-        initialValue: {
-          data: [],
-          totalUniqueContributors: 0,
-          avgUniqueContributors: 0,
-          totalWeeks: 0,
-        },
-      }
-    );
+    const defaultValue: UniqueContributorsWeeklyResponse = { data: [], totalUniqueContributors: 0, avgUniqueContributors: 0, totalWeeks: 0 };
+
+    return this.maintainerGuardedFetch('uniqueContributorsWeekly', defaultValue, (slug) => {
+      const entityType = this.entityType();
+      return this.analyticsService.getUniqueContributorsWeekly(slug, entityType);
+    });
   }
 
   private initializeHealthMetricsDailyData() {
-    return toSignal(
-      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
-        switchMap(([projectSlug, persona]) => {
-          if (persona !== 'maintainer') {
-            this.loadingState.update((state) => ({ ...state, healthMetricsDaily: false }));
-            return [{ data: [], currentAvgHealthScore: 0, totalDays: 0 }];
-          }
-          if (!projectSlug) {
-            this.loadingState.update((state) => ({ ...state, healthMetricsDaily: false }));
-            return [{ data: [], currentAvgHealthScore: 0, totalDays: 0 }];
-          }
-          this.loadingState.update((state) => ({ ...state, healthMetricsDaily: true }));
-          const entityType = this.entityType();
-          return this.analyticsService.getHealthMetricsDaily(projectSlug, entityType).pipe(
-            tap(() => this.loadingState.update((state) => ({ ...state, healthMetricsDaily: false }))),
-            catchError(() => {
-              this.loadingState.update((state) => ({ ...state, healthMetricsDaily: false }));
-              return of({ data: [], currentAvgHealthScore: 0, totalDays: 0 });
-            })
-          );
-        })
-      ),
-      {
-        initialValue: {
-          data: [],
-          currentAvgHealthScore: 0,
-          totalDays: 0,
-        },
-      }
-    );
+    const defaultValue: HealthMetricsDailyResponse = { data: [], currentAvgHealthScore: 0, totalDays: 0 };
+
+    return this.maintainerGuardedFetch('healthMetricsDaily', defaultValue, (slug) => {
+      const entityType = this.entityType();
+      return this.analyticsService.getHealthMetricsDaily(slug, entityType);
+    });
   }
 
   private initializeCodeCommitsDailyData() {
+    const defaultValue: CodeCommitsDailyResponse = { data: [], totalCommits: 0, totalDays: 0 };
+
+    return this.maintainerGuardedFetch('codeCommitsDaily', defaultValue, (slug) => {
+      const entityType = this.entityType();
+      return this.analyticsService.getCodeCommitsDaily(slug, entityType);
+    });
+  }
+
+  private maintainerGuardedFetch<T>(loadingKey: string, defaultValue: T, fetchFn: (slug: string) => Observable<T>) {
     return toSignal(
-      combineLatest([toObservable(this.projectSlug), toObservable(this.personaService.currentPersona)]).pipe(
-        switchMap(([projectSlug, persona]) => {
-          if (persona !== 'maintainer') {
-            this.loadingState.update((state) => ({ ...state, codeCommitsDaily: false }));
-            return [{ data: [], totalCommits: 0, totalDays: 0 }];
+      combineLatest([toObservable(this.projectSlug), toObservable(this.isMaintainer)]).pipe(
+        switchMap(([projectSlug, isMaintainer]) => {
+          if (!isMaintainer || !projectSlug) {
+            this.loadingState.update((state) => ({ ...state, [loadingKey]: false }));
+            return [defaultValue];
           }
-          if (!projectSlug) {
-            this.loadingState.update((state) => ({ ...state, codeCommitsDaily: false }));
-            return [{ data: [], totalCommits: 0, totalDays: 0 }];
-          }
-          this.loadingState.update((state) => ({ ...state, codeCommitsDaily: true }));
-          const entityType = this.entityType();
-          return this.analyticsService.getCodeCommitsDaily(projectSlug, entityType).pipe(
-            tap(() => this.loadingState.update((state) => ({ ...state, codeCommitsDaily: false }))),
+          this.loadingState.update((state) => ({ ...state, [loadingKey]: true }));
+          return fetchFn(projectSlug).pipe(
+            tap(() => this.loadingState.update((state) => ({ ...state, [loadingKey]: false }))),
             catchError(() => {
-              this.loadingState.update((state) => ({ ...state, codeCommitsDaily: false }));
-              return of({ data: [], totalCommits: 0, totalDays: 0 });
+              this.loadingState.update((state) => ({ ...state, [loadingKey]: false }));
+              return of(defaultValue);
             })
           );
         })
       ),
-      {
-        initialValue: {
-          data: [],
-          totalCommits: 0,
-          totalDays: 0,
-        },
-      }
+      { initialValue: defaultValue }
     );
   }
 

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.html
@@ -46,18 +46,18 @@
 
       <!-- Projects List -->
       <div class="max-h-[400px] overflow-y-auto">
-        @for (foundation of foundations(); track foundation.uid) {
+        @for (foundation of foundations(); track foundation.projectUid) {
           <div>
             <!-- Foundation -->
             <div
               class="flex items-center gap-3 p-2 cursor-pointer hover:bg-gray-100 rounded-lg transition-colors"
               (click)="selectProject(foundation, popover)"
-              [attr.data-testid]="'foundation-' + foundation.slug">
+              [attr.data-testid]="'foundation-' + foundation.projectSlug">
               <!-- Foundation Logo (32px) -->
               <div class="bg-gray-100 overflow-clip rounded-full shrink-0 size-[32px]">
                 <div class="flex items-center justify-center size-full p-[8px]">
-                  @if (foundation.logo_url) {
-                    <img [alt]="foundation.name" class="w-full h-full object-contain" [src]="foundation.logo_url" />
+                  @if (foundation.logoUrl) {
+                    <img [alt]="foundation.projectName" class="w-full h-full object-contain" [src]="foundation.logoUrl" />
                   }
                 </div>
               </div>
@@ -65,26 +65,28 @@
               <!-- Foundation Info -->
               <div class="flex-1 min-w-0">
                 <div class="flex items-center gap-2">
-                  <p class="font-medium text-sm text-gray-900 mb-0">{{ foundation.name }}</p>
+                  <p class="font-medium text-sm text-gray-900 mb-0">{{ foundation.projectName }}</p>
                   <lfx-tag value="Foundation" severity="info"></lfx-tag>
                 </div>
-                <p class="text-xs text-gray-500 line-clamp-1">{{ foundation.description }}</p>
+                @if (foundation.description) {
+                  <p class="text-xs text-gray-500 line-clamp-1">{{ foundation.description }}</p>
+                }
               </div>
             </div>
 
             <!-- Child Projects -->
-            @if (childProjectsMap().has(foundation.uid)) {
+            @if (childProjectsMap().has(foundation.projectUid)) {
               <div class="ml-4 border-l-2 border-gray-200 pl-2 my-1">
-                @for (project of childProjectsMap().get(foundation.uid); track project.uid) {
+                @for (project of childProjectsMap().get(foundation.projectUid); track project.projectUid) {
                   <div
                     class="flex items-center gap-3 p-2 cursor-pointer hover:bg-gray-100 rounded-lg transition-colors"
                     (click)="selectProject(project, popover)"
-                    [attr.data-testid]="'project-' + project.slug">
+                    [attr.data-testid]="'project-' + project.projectSlug">
                     <!-- Project Logo (28px) -->
                     <div class="bg-gray-100 overflow-clip rounded-full shrink-0 size-[28px]">
                       <div class="flex items-center justify-center size-full p-[6px]">
-                        @if (project.logo_url) {
-                          <img [alt]="project.name" class="w-full h-full object-contain" [src]="project.logo_url" />
+                        @if (project.logoUrl) {
+                          <img [alt]="project.projectName" class="w-full h-full object-contain" [src]="project.logoUrl" />
                         } @else {
                           <svg width="14" height="14" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
                             <path d="M3.96369 15.9789V7.98987H0V19.9504H11.9372V15.9789H3.96369Z" fill="#0094FF" />
@@ -96,8 +98,10 @@
 
                     <!-- Project Info -->
                     <div class="flex-1 min-w-0">
-                      <p class="font-medium text-sm text-gray-900">{{ project.name }}</p>
-                      <p class="text-xs text-gray-500 line-clamp-1">{{ project.description }}</p>
+                      <p class="font-medium text-sm text-gray-900">{{ project.projectName }}</p>
+                      @if (project.description) {
+                        <p class="text-xs text-gray-500 line-clamp-1">{{ project.description }}</p>
+                      }
                     </div>
                   </div>
                 }

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
@@ -4,7 +4,8 @@
 import { Component, computed, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
-import { Project } from '@lfx-one/shared/interfaces';
+import { EnrichedPersonaProject } from '@lfx-one/shared/interfaces';
+import { isFoundationProject } from '@lfx-one/shared/utils';
 import { AutoFocus } from 'primeng/autofocus';
 import { InputTextModule } from 'primeng/inputtext';
 import { Popover, PopoverModule } from 'primeng/popover';
@@ -18,22 +19,23 @@ import { TagComponent } from '../tag/tag.component';
   styleUrl: './project-selector.component.scss',
 })
 export class ProjectSelectorComponent {
-  public readonly projects = input.required<Project[]>();
-  public readonly selectedProject = input<Project | null>(null);
+  public readonly projects = input.required<EnrichedPersonaProject[]>();
+  public readonly selectedProject = input<EnrichedPersonaProject | null>(null);
 
-  public readonly projectChange = output<Project>();
+  public readonly projectChange = output<EnrichedPersonaProject>();
 
   protected readonly searchQuery = signal<string>('');
 
+  private readonly validProjectIds = computed(() => new Set(this.projects().map((p) => p.projectUid)));
   protected readonly displayName = this.initializeDisplayName();
   protected readonly displayLogo = this.initializeDisplayLogo();
   protected readonly foundations = this.initializeFoundations();
   protected readonly childProjectsMap = this.initializeChildProjectsMap();
   protected readonly hasResults = this.initializeHasResults();
 
-  protected selectProject(project: Project, popover: Popover): void {
+  protected selectProject(project: EnrichedPersonaProject, popover: Popover): void {
     this.projectChange.emit(project);
-    this.searchQuery.set(''); // Reset search on selection
+    this.searchQuery.set('');
     popover.hide();
   }
 
@@ -42,21 +44,20 @@ export class ProjectSelectorComponent {
   }
 
   protected onPopoverHide(): void {
-    // Reset search when popover closes
     this.searchQuery.set('');
   }
 
   private initializeDisplayName() {
     return computed(() => {
       const project = this.selectedProject();
-      return project?.name?.trim() ?? 'Select Project';
+      return project?.projectName?.trim() ?? 'Select Project';
     });
   }
 
   private initializeDisplayLogo() {
     return computed(() => {
       const project = this.selectedProject();
-      return project?.logo_url || '';
+      return project?.logoUrl || '';
     });
   }
 
@@ -64,38 +65,29 @@ export class ProjectSelectorComponent {
     return computed(() => {
       const allProjects = this.projects();
       const query = this.searchQuery().toLowerCase().trim();
+      const ids = this.validProjectIds();
 
-      // Create a set of all valid project UIDs for quick lookup
-      const validProjectIds = new Set(allProjects.map((p) => p.uid));
+      const foundationList = allProjects.filter((p) => isFoundationProject(p, ids));
 
-      // A project is a foundation if:
-      // 1. It has no parent_uid OR
-      // 2. Its parent_uid doesn't exist in the projects list
-      const foundationList = allProjects.filter((p) => !p.parent_uid || p.parent_uid === '' || !validProjectIds.has(p.parent_uid));
-
-      // Apply search filter if query exists
       if (!query) {
         return foundationList;
       }
 
-      // Filter foundations that match the query
-      const matchingFoundations = foundationList.filter((f) => f.name.toLowerCase().includes(query) || f.description.toLowerCase().includes(query));
+      const matchingFoundations = foundationList.filter((f) => f.projectName?.toLowerCase().includes(query) || f.description?.toLowerCase().includes(query));
 
-      // Find foundations whose children match the query
       const foundationsWithMatchingChildren = foundationList.filter((foundation) => {
         const children = allProjects.filter(
           (p) =>
-            p.parent_uid === foundation.uid &&
-            validProjectIds.has(p.parent_uid) &&
-            (p.name.toLowerCase().includes(query) || p.description.toLowerCase().includes(query))
+            p.parentProjectUid === foundation.projectUid &&
+            ids.has(p.parentProjectUid!) &&
+            (p.projectName?.toLowerCase().includes(query) || p.description?.toLowerCase().includes(query))
         );
         return children.length > 0;
       });
 
-      // Combine and deduplicate using Set
-      const uniqueFoundations = new Map<string, Project>();
+      const uniqueFoundations = new Map<string, EnrichedPersonaProject>();
       [...matchingFoundations, ...foundationsWithMatchingChildren].forEach((f) => {
-        uniqueFoundations.set(f.uid, f);
+        uniqueFoundations.set(f.projectUid, f);
       });
 
       return Array.from(uniqueFoundations.values());
@@ -106,31 +98,25 @@ export class ProjectSelectorComponent {
     return computed(() => {
       const allProjects = this.projects();
       const query = this.searchQuery().toLowerCase().trim();
+      const ids = this.validProjectIds();
 
-      // Create a set of all valid project UIDs for quick lookup
-      const validProjectIds = new Set(allProjects.map((p) => p.uid));
+      const map = new Map<string, EnrichedPersonaProject[]>();
 
-      const map = new Map<string, Project[]>();
-
-      // Group projects by parent_uid
-      // Only include projects whose parent_uid exists in the projects list
       allProjects.forEach((project) => {
-        if (project.parent_uid && project.parent_uid !== '' && validProjectIds.has(project.parent_uid)) {
-          const children = map.get(project.parent_uid) || [];
+        if (!isFoundationProject(project, ids) && project.parentProjectUid) {
+          const children = map.get(project.parentProjectUid) || [];
           children.push(project);
-          map.set(project.parent_uid, children);
+          map.set(project.parentProjectUid, children);
         }
       });
 
-      // If no search query, return the full map
       if (!query) {
         return map;
       }
 
-      // Filter children by search query
-      const filteredMap = new Map<string, Project[]>();
+      const filteredMap = new Map<string, EnrichedPersonaProject[]>();
       map.forEach((children, parentId) => {
-        const filtered = children.filter((c) => c.name.toLowerCase().includes(query) || c.description.toLowerCase().includes(query));
+        const filtered = children.filter((c) => c.projectName?.toLowerCase().includes(query) || c.description?.toLowerCase().includes(query));
         if (filtered.length > 0) {
           filteredMap.set(parentId, filtered);
         }

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
@@ -50,7 +50,7 @@ export class ProjectSelectorComponent {
   private initializeDisplayName() {
     return computed(() => {
       const project = this.selectedProject();
-      return project?.projectName?.trim() ?? 'Select Project';
+      return project?.projectName?.trim() || 'Select Project';
     });
   }
 
@@ -77,10 +77,7 @@ export class ProjectSelectorComponent {
 
       const foundationsWithMatchingChildren = foundationList.filter((foundation) => {
         const children = allProjects.filter(
-          (p) =>
-            p.parentProjectUid === foundation.projectUid &&
-            ids.has(p.parentProjectUid!) &&
-            (p.projectName?.toLowerCase().includes(query) || p.description?.toLowerCase().includes(query))
+          (p) => p.parentProjectUid === foundation.projectUid && (p.projectName?.toLowerCase().includes(query) || p.description?.toLowerCase().includes(query))
         );
         return children.length > 0;
       });

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -3,6 +3,7 @@
 
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { Component, computed, inject, input, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { RouterModule } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { BadgeComponent } from '@components/badge/badge.component';
@@ -15,6 +16,7 @@ import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { UserService } from '@services/user.service';
+import { filter } from 'rxjs';
 
 @Component({
   selector: 'lfx-sidebar',
@@ -37,7 +39,7 @@ export class SidebarComponent {
   public readonly showMeSelector = input<boolean>(false);
   public readonly mobile = input<boolean>(false);
 
-  protected readonly projects: Signal<EnrichedPersonaProject[]> = this.initProjects();
+  protected readonly projects = computed(() => this.personaService.detectedProjects());
   protected readonly selectorProjects = this.initSelectorProjects();
   protected readonly selectedProject: Signal<EnrichedPersonaProject | null> = this.initSelectedProject();
 
@@ -68,6 +70,18 @@ export class SidebarComponent {
     }))
   );
 
+  public constructor() {
+    toObservable(this.projects)
+      .pipe(
+        filter((projects) => projects.length > 0),
+        takeUntilDestroyed()
+      )
+      .subscribe((detectedProjects) => {
+        this.projectContextService.availableProjects = detectedProjects.map(toProjectContext);
+        this.setDefaultProjectIfNeeded(detectedProjects);
+      });
+  }
+
   protected onProjectChange(project: EnrichedPersonaProject): void {
     const validProjectIds = new Set(this.projects().map((p) => p.projectUid));
 
@@ -76,19 +90,6 @@ export class SidebarComponent {
     } else {
       this.projectContextService.setProject(toProjectContext(project));
     }
-  }
-
-  private initProjects(): Signal<EnrichedPersonaProject[]> {
-    return computed(() => {
-      const detectedProjects = this.personaService.detectedProjects();
-
-      if (detectedProjects.length > 0) {
-        this.projectContextService.availableProjects = detectedProjects.map(toProjectContext);
-        this.setDefaultProjectIfNeeded(detectedProjects);
-      }
-
-      return detectedProjects;
-    });
   }
 
   private initSelectedProject(): Signal<EnrichedPersonaProject | null> {

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -3,20 +3,18 @@
 
 import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { Component, computed, inject, input, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterModule } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { BadgeComponent } from '@components/badge/badge.component';
 import { ProjectSelectorComponent } from '@components/project-selector/project-selector.component';
 import { environment } from '@environments/environment';
 import { PERSONA_OPTIONS } from '@lfx-one/shared/constants';
-import { Project, ProjectContext, SidebarMenuItem } from '@lfx-one/shared/interfaces';
+import { EnrichedPersonaProject, SidebarMenuItem } from '@lfx-one/shared/interfaces';
+import { isFoundationProject, toProjectContext } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
-import { tap } from 'rxjs';
 
 @Component({
   selector: 'lfx-sidebar',
@@ -25,7 +23,6 @@ import { tap } from 'rxjs';
   styleUrl: './sidebar.component.scss',
 })
 export class SidebarComponent {
-  private readonly projectService = inject(ProjectService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly personaService = inject(PersonaService);
   private readonly lensService = inject(LensService);
@@ -40,29 +37,9 @@ export class SidebarComponent {
   public readonly showMeSelector = input<boolean>(false);
   public readonly mobile = input<boolean>(false);
 
-  // Load all available projects
-  // so TransferState never captures it and client makes a duplicate call anyway.
-  // shareReplay(1) in ProjectService deduplicates within the client runtime.
-  protected readonly projects: Signal<Project[]> = this.initProjects();
-
-  /** Projects passed to the selector — single item triggers read-only, full list triggers dropdown */
+  protected readonly projects: Signal<EnrichedPersonaProject[]> = this.initProjects();
   protected readonly selectorProjects = this.initSelectorProjects();
-
-  protected readonly selectedProject = computed(() => {
-    // First check if a specific project is selected (child project)
-    const project = this.projectContextService.selectedProject();
-    if (project) {
-      return this.projects().find((p: Project) => p.slug === project.slug) || null;
-    }
-
-    // Otherwise check for foundation selection
-    const foundation = this.projectContextService.selectedFoundation();
-    if (!foundation) {
-      return null;
-    }
-
-    return this.projects().find((p: Project) => p.slug === foundation.slug) || null;
-  });
+  protected readonly selectedProject: Signal<EnrichedPersonaProject | null> = this.initSelectedProject();
 
   // Me selector signals
   protected readonly user = this.userService.user;
@@ -91,58 +68,45 @@ export class SidebarComponent {
     }))
   );
 
-  /**
-   * Handle project selection change - distinguish between foundation and non-foundation projects
-   */
-  protected onProjectChange(project: Project): void {
-    const allProjects = this.projects();
-    const validProjectIds = new Set(allProjects.map((p) => p.uid));
+  protected onProjectChange(project: EnrichedPersonaProject): void {
+    const validProjectIds = new Set(this.projects().map((p) => p.projectUid));
 
-    // Determine if this is a foundation project (no parent or parent doesn't exist)
-    const isFoundation = !project.parent_uid || project.parent_uid === '' || !validProjectIds.has(project.parent_uid);
-
-    const projectContext: ProjectContext = {
-      uid: project.uid,
-      name: project.name,
-      slug: project.slug,
-    };
-
-    if (isFoundation) {
-      // Foundation project selected - set as foundation and clear selected project
-      this.projectContextService.setFoundation(projectContext);
-      this.projectContextService.clearProject();
+    if (isFoundationProject(project, validProjectIds)) {
+      this.projectContextService.setFoundation(toProjectContext(project));
     } else {
-      // Child project selected - set as selected project and clear foundation
-      this.projectContextService.setProject(projectContext);
-      this.projectContextService.clearFoundation();
+      this.projectContextService.setProject(toProjectContext(project));
     }
   }
 
-  private initProjects(): Signal<Project[]> {
-    return toSignal(
-      this.projectService.getProjects().pipe(
-        tap((loadedProjects: Project[]) => {
-          this.projectContextService.availableProjects = loadedProjects;
-          const currentFoundation = this.projectContextService.selectedFoundation();
-          const currentProject = this.projectContextService.selectedProject();
-          const foundationExists = loadedProjects.some((p: Project) => p.uid === currentFoundation?.uid);
+  private initProjects(): Signal<EnrichedPersonaProject[]> {
+    return computed(() => {
+      const detectedProjects = this.personaService.detectedProjects();
 
-          if (loadedProjects.length > 0 && (!foundationExists || !currentFoundation) && !currentProject) {
-            const defaultProject = loadedProjects.find((p: Project) => p.slug === 'tlf') || loadedProjects[0];
-
-            const projectContext: ProjectContext = {
-              uid: defaultProject.uid,
-              name: defaultProject.name,
-              slug: defaultProject.slug,
-            };
-            this.projectContextService.setFoundation(projectContext);
-          }
-        })
-      ),
-      {
-        initialValue: [],
+      if (detectedProjects.length > 0) {
+        this.projectContextService.availableProjects = detectedProjects.map(toProjectContext);
+        this.setDefaultProjectIfNeeded(detectedProjects);
       }
-    );
+
+      return detectedProjects;
+    });
+  }
+
+  private initSelectedProject(): Signal<EnrichedPersonaProject | null> {
+    return computed(() => {
+      const allProjects = this.projects();
+
+      const project = this.projectContextService.selectedProject();
+      if (project) {
+        return allProjects.find((p) => p.projectSlug === project.slug) || null;
+      }
+
+      const foundation = this.projectContextService.selectedFoundation();
+      if (!foundation) {
+        return null;
+      }
+
+      return allProjects.find((p) => p.projectSlug === foundation.slug) || null;
+    });
   }
 
   private initPersonaLabel(): Signal<string> {
@@ -153,7 +117,7 @@ export class SidebarComponent {
     });
   }
 
-  private initSelectorProjects(): Signal<Project[]> {
+  private initSelectorProjects(): Signal<EnrichedPersonaProject[]> {
     return computed(() => {
       const all = this.projects();
       if (all.length === 0) {
@@ -161,12 +125,9 @@ export class SidebarComponent {
       }
 
       const activeLens = this.lensService.activeLens();
-
-      // Determine if the current lens has multi-access
       const hasMultiAccess = activeLens === 'foundation' ? this.personaService.multiFoundation() : this.personaService.multiProject();
 
       if (!hasMultiAccess) {
-        // Single access — pass only the selected project for read-only display
         const selected = this.selectedProject();
         return selected ? [selected] : [all[0]];
       }
@@ -175,24 +136,33 @@ export class SidebarComponent {
     });
   }
 
-  /**
-   * Determine if a URL is external (not starting with environment home URL and is absolute)
-   * A URL is considered external if it starts with http:// or https:// and does NOT start with the home URL
-   * Relative URLs (starting with /) are always internal
-   */
+  private setDefaultProjectIfNeeded(detectedProjects: EnrichedPersonaProject[]): void {
+    const currentFoundation = this.projectContextService.selectedFoundation();
+    const currentProject = this.projectContextService.selectedProject();
+
+    if (currentProject) {
+      return;
+    }
+
+    const foundationExists = currentFoundation && detectedProjects.some((p) => p.projectUid === currentFoundation.uid);
+
+    if (foundationExists) {
+      return;
+    }
+
+    this.projectContextService.setFoundation(toProjectContext(detectedProjects[0]));
+  }
+
   private isExternalUrl(url: string): boolean {
     if (!url) {
       return false;
     }
 
-    // Relative URLs are internal
     if (url.startsWith('/')) {
       return false;
     }
 
-    // Check if it's an absolute URL
     if (url.startsWith('http://') || url.startsWith('https://')) {
-      // External if it doesn't start with the home URL
       return !url.startsWith(environment.urls.home);
     }
 

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -150,7 +150,10 @@ export class SidebarComponent {
       return;
     }
 
-    this.projectContextService.setFoundation(toProjectContext(detectedProjects[0]));
+    const validProjectIds = new Set(detectedProjects.map((p) => p.projectUid));
+    const defaultFoundation = detectedProjects.find((p) => isFoundationProject(p, validProjectIds)) ?? detectedProjects[0];
+
+    this.projectContextService.setFoundation(toProjectContext(defaultFoundation));
   }
 
   private isExternalUrl(url: string): boolean {

--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -5,6 +5,7 @@ import { HttpClient } from '@angular/common/http';
 import { afterNextRender, computed, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
 import { PERSONA_COOKIE_KEY } from '@lfx-one/shared/constants';
 import {
+  EnrichedPersonaProject,
   isBoardScopedPersona,
   isProjectScopedPersona,
   PersistedPersonaState,
@@ -40,6 +41,9 @@ export class PersonaService {
   /** Persona-to-project mapping from the persona detection service */
   public readonly personaProjects: WritableSignal<Partial<Record<PersonaType, PersonaProject[]>>>;
 
+  /** Full enriched projects from persona detection — source of truth for sidebar hierarchy */
+  public readonly detectedProjects: WritableSignal<EnrichedPersonaProject[]>;
+
   public readonly isBoardScoped: Signal<boolean>;
 
   /** Whether the user holds any board-scoped persona (board-member, executive-director) */
@@ -55,6 +59,7 @@ export class PersonaService {
     this.multiProject = signal<boolean>(stored?.multiProject ?? false);
     this.multiFoundation = signal<boolean>(stored?.multiFoundation ?? false);
     this.personaProjects = signal<Partial<Record<PersonaType, PersonaProject[]>>>({});
+    this.detectedProjects = signal<EnrichedPersonaProject[]>([]);
     this.isBoardScoped = computed(() => isBoardScopedPersona(this.currentPersona()));
     this.hasBoardRole = this.initHasBoardRole();
     this.hasProjectRole = this.initHasProjectRole();
@@ -114,6 +119,7 @@ export class PersonaService {
 
         console.info('[PersonaService] Persona detection response:', response);
         this.personaProjects.set(response.personaProjects);
+        this.detectedProjects.set(response.projects);
 
         // Update persona state if API returned data — reuse setPersonas() for
         // consistent side effects (board-scoped project clearing, cookie persistence)

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -32,10 +32,12 @@ export class ProjectContextService {
    * Set the selected foundation-level project
    */
   public setFoundation(foundation: ProjectContext): void {
+    if (this.selectedProject()) {
+      this.clearProject();
+    }
     if (this.selectedFoundation()?.uid === foundation.uid) {
       return;
     }
-    this.clearProject();
     this.selectedFoundation.set(foundation);
     this.persistToStorage(this.foundationStorageKey, foundation);
   }
@@ -44,10 +46,12 @@ export class ProjectContextService {
    * Set the selected sub-project (child project)
    */
   public setProject(project: ProjectContext): void {
+    if (this.selectedFoundation()) {
+      this.clearFoundation();
+    }
     if (this.selectedProject()?.uid === project.uid) {
       return;
     }
-    this.clearFoundation();
     this.selectedProject.set(project);
     this.persistToStorage(this.projectStorageKey, project);
   }

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -32,6 +32,9 @@ export class ProjectContextService {
    * Set the selected foundation-level project
    */
   public setFoundation(foundation: ProjectContext): void {
+    if (this.selectedFoundation()?.uid === foundation.uid) {
+      return;
+    }
     this.clearProject();
     this.selectedFoundation.set(foundation);
     this.persistToStorage(this.foundationStorageKey, foundation);
@@ -41,6 +44,9 @@ export class ProjectContextService {
    * Set the selected sub-project (child project)
    */
   public setProject(project: ProjectContext): void {
+    if (this.selectedProject()?.uid === project.uid) {
+      return;
+    }
     this.clearFoundation();
     this.selectedProject.set(project);
     this.persistToStorage(this.projectStorageKey, project);

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -32,11 +32,11 @@ export class ProjectContextService {
    * Set the selected foundation-level project
    */
   public setFoundation(foundation: ProjectContext): void {
-    if (this.selectedProject()) {
-      this.clearProject();
-    }
     if (this.selectedFoundation()?.uid === foundation.uid) {
       return;
+    }
+    if (this.selectedProject()) {
+      this.clearProject();
     }
     this.selectedFoundation.set(foundation);
     this.persistToStorage(this.foundationStorageKey, foundation);
@@ -46,11 +46,11 @@ export class ProjectContextService {
    * Set the selected sub-project (child project)
    */
   public setProject(project: ProjectContext): void {
-    if (this.selectedFoundation()) {
-      this.clearFoundation();
-    }
     if (this.selectedProject()?.uid === project.uid) {
       return;
+    }
+    if (this.selectedFoundation()) {
+      this.clearFoundation();
     }
     this.selectedProject.set(project);
     this.persistToStorage(this.projectStorageKey, project);

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -150,10 +150,15 @@ export class PersonaDetectionService {
         let projectName: string | null = null;
         let parentProjectUid: string | null = null;
 
+        let logoUrl: string | null = null;
+        let description: string | null = null;
+
         try {
           const projectData = await this.projectService.getProjectById(req, project.project_uid, false);
           projectName = projectData?.name || null;
           parentProjectUid = projectData?.parent_uid || null;
+          logoUrl = projectData?.logo_url || null;
+          description = projectData?.description || null;
         } catch {
           logger.debug(req, 'enrich_project_name', 'Failed to fetch project data, using null', {
             project_uid: project.project_uid,
@@ -167,6 +172,8 @@ export class PersonaDetectionService {
           projectSlug: project.project_slug,
           projectName,
           parentProjectUid,
+          logoUrl,
+          description,
           detections: project.detections,
           personas,
         } as EnrichedPersonaProject;

--- a/packages/shared/src/interfaces/persona-detection.interface.ts
+++ b/packages/shared/src/interfaces/persona-detection.interface.ts
@@ -53,6 +53,10 @@ export interface EnrichedPersonaProject {
   projectName: string | null;
   /** Parent project UID (null if this is a top-level foundation) */
   parentProjectUid: string | null;
+  /** Project logo URL (null if unavailable) */
+  logoUrl: string | null;
+  /** Project description text (null if unavailable) */
+  description: string | null;
   detections: PersonaDetection[];
   personas: PersonaType[];
 }

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -16,3 +16,4 @@ export * from './vote.utils';
 export * from './committee.utils';
 export * from './number.utils';
 export * from './platform.utils';
+export * from './project.utils';

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -1,0 +1,23 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { EnrichedPersonaProject, ProjectContext } from '../interfaces';
+
+/**
+ * Convert an EnrichedPersonaProject to a ProjectContext
+ */
+export function toProjectContext(project: EnrichedPersonaProject): ProjectContext {
+  return {
+    uid: project.projectUid,
+    name: project.projectName || '',
+    slug: project.projectSlug,
+  };
+}
+
+/**
+ * Determine if a project is a foundation (top-level) within a given set of projects.
+ * A project is a foundation if its parentProjectUid is absent or not in the set.
+ */
+export function isFoundationProject(project: EnrichedPersonaProject, validProjectIds: Set<string>): boolean {
+  return !project.parentProjectUid || project.parentProjectUid === '' || !validProjectIds.has(project.parentProjectUid);
+}

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -9,7 +9,7 @@ import type { EnrichedPersonaProject, ProjectContext } from '../interfaces';
 export function toProjectContext(project: EnrichedPersonaProject): ProjectContext {
   return {
     uid: project.projectUid,
-    name: project.projectName || '',
+    name: project.projectName || project.projectSlug,
     slug: project.projectSlug,
   };
 }


### PR DESCRIPTION
## Summary
- Replace query service (`ProjectService.getProjects()`) with persona-detected projects as the source of truth for the sidebar project selector
- Carry `logoUrl` and `description` through from the persona detection backend enrichment (data was already being fetched via `GET /projects/{uid}` but discarded)
- Gate dev-toolbar project/foundation and organization selectors by active lens (hidden on "Me" lens, org selector visible only on "foundation" lens)
- Add equality guards to `setFoundation`/`setProject` to prevent redundant cookie writes
- Extract shared `toProjectContext()` and `isFoundationProject()` utilities into `@lfx-one/shared/utils`

## Upstream Dependencies
- Depends on persona detection service (PR #403) being deployed

Generated with [Claude Code](https://claude.ai/code)