### PR TITLE
feat(events): restore and extend events filter bar for me and fdn lens

### DIFF
--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.html
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.html
@@ -40,8 +40,8 @@
     </div>
   }
 
-  @if (!isFoundationFilter()) {
-    <!-- Role Filter Dropdown -->
+  <!-- Role Filter Dropdown -->
+  @if (showRoleFilter()) {
     <div class="w-full sm:w-40">
       <lfx-select
         [form]="searchForm"
@@ -53,18 +53,18 @@
         styleClass="w-full"
         data-testid="events-role-filter"></lfx-select>
     </div>
-
-    <!-- Status Filter Dropdown -->
-    <div class="w-full sm:w-40">
-      <lfx-select
-        [form]="searchForm"
-        control="status"
-        size="small"
-        [options]="statusOptions()"
-        placeholder="Status"
-        [showClear]="true"
-        styleClass="w-full"
-        data-testid="events-status-filter"></lfx-select>
-    </div>
   }
+
+  <!-- Status Filter Dropdown -->
+  <div class="w-full sm:w-40">
+    <lfx-select
+      [form]="searchForm"
+      control="status"
+      size="small"
+      [options]="statusOptions()"
+      placeholder="Status"
+      [showClear]="true"
+      styleClass="w-full"
+      data-testid="events-status-filter"></lfx-select>
+  </div>
 </div>

--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
@@ -76,7 +76,8 @@ export class EventsTopBarComponent {
       combineLatest([toObservable(this.projectName), toObservable(this.isPast), toObservable(this.isFoundationFilter)]).pipe(
         switchMap(([projectName, isPast, isFoundationFilter]) => {
           if (!isFoundationFilter) {
-            // Foundation dropdown is not rendered — skip the API call entirely.
+            // Foundation dropdown is not rendered — skip the API call and clear loading.
+            this.foundationOptionsLoading.set(false);
             return of(defaultOptions);
           }
           this.foundationOptionsLoading.set(true);

--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
@@ -7,7 +7,7 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { FilterOption } from '@lfx-one/shared/interfaces';
-import { debounceTime, map, switchMap, tap } from 'rxjs';
+import { combineLatest, debounceTime, map, switchMap, tap } from 'rxjs';
 import { EventsService } from '@app/shared/services/events.service';
 import { EVENT_ROLE_OPTIONS, MY_EVENT_STATUS_OPTIONS } from '@lfx-one/shared/constants';
 
@@ -20,7 +20,10 @@ export class EventsTopBarComponent {
   private readonly eventsService = inject(EventsService);
 
   public isFoundationFilter = input<boolean>(false);
+  public readonly showRoleFilter = input<boolean>(true);
   public readonly projectName = input<string | undefined>(undefined);
+  /** When true, foundation options are scoped to the user's registered past events */
+  public readonly isPast = input<boolean>(false);
   public readonly searchQueryChange = output<string>();
 
   public readonly searchForm: FormGroup = new FormGroup({
@@ -36,7 +39,7 @@ export class EventsTopBarComponent {
 
   protected readonly roleOptions = signal<FilterOption[]>(EVENT_ROLE_OPTIONS);
 
-  protected readonly statusOptions = signal<FilterOption[]>(MY_EVENT_STATUS_OPTIONS);
+  public readonly statusOptions = input<FilterOption[]>(MY_EVENT_STATUS_OPTIONS);
 
   protected readonly foundationOptionsLoading = signal(true);
   protected readonly searchValue = signal('');
@@ -60,9 +63,10 @@ export class EventsTopBarComponent {
 
   private initFoundationOptions(): Signal<FilterOption[]> {
     return toSignal(
-      toObservable(this.projectName).pipe(
-        switchMap((projectName) =>
-          this.eventsService.getEventOrganizations({ projectName }).pipe(
+      combineLatest([toObservable(this.projectName), toObservable(this.isPast)]).pipe(
+        tap(() => this.foundationOptionsLoading.set(true)),
+        switchMap(([projectName, isPast]) =>
+          this.eventsService.getEventOrganizations({ projectName, isPast }).pipe(
             tap(() => this.foundationOptionsLoading.set(false)),
             map(({ data }) => [{ label: 'All Foundations', value: null }, ...data.map((name) => ({ label: name, value: name }))])
           )

--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
@@ -7,7 +7,7 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { FilterOption } from '@lfx-one/shared/interfaces';
-import { combineLatest, debounceTime, map, skip, switchMap, tap } from 'rxjs';
+import { combineLatest, debounceTime, finalize, map, of, skip, switchMap } from 'rxjs';
 import { EventsService } from '@app/shared/services/events.service';
 import { EVENT_ROLE_OPTIONS, MY_EVENT_STATUS_OPTIONS } from '@lfx-one/shared/constants';
 
@@ -71,17 +71,22 @@ export class EventsTopBarComponent {
   }
 
   private initFoundationOptions(): Signal<FilterOption[]> {
+    const defaultOptions = [{ label: 'All Foundations', value: null }] as FilterOption[];
     return toSignal(
-      combineLatest([toObservable(this.projectName), toObservable(this.isPast)]).pipe(
-        tap(() => this.foundationOptionsLoading.set(true)),
-        switchMap(([projectName, isPast]) =>
-          this.eventsService.getEventOrganizations({ projectName, isPast }).pipe(
-            tap(() => this.foundationOptionsLoading.set(false)),
-            map(({ data }) => [{ label: 'All Foundations', value: null }, ...data.map((name) => ({ label: name, value: name }))])
-          )
-        )
+      combineLatest([toObservable(this.projectName), toObservable(this.isPast), toObservable(this.isFoundationFilter)]).pipe(
+        switchMap(([projectName, isPast, isFoundationFilter]) => {
+          if (!isFoundationFilter) {
+            // Foundation dropdown is not rendered — skip the API call entirely.
+            return of(defaultOptions);
+          }
+          this.foundationOptionsLoading.set(true);
+          return this.eventsService.getEventOrganizations({ projectName, isPast }).pipe(
+            map(({ data }) => [{ label: 'All Foundations', value: null }, ...data.map((name) => ({ label: name, value: name }))]),
+            finalize(() => this.foundationOptionsLoading.set(false))
+          );
+        })
       ),
-      { initialValue: [{ label: 'All Foundations', value: null }] as FilterOption[] }
+      { initialValue: defaultOptions }
     );
   }
 }

--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
@@ -7,7 +7,7 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { FilterOption } from '@lfx-one/shared/interfaces';
-import { combineLatest, debounceTime, finalize, map, of, skip, switchMap } from 'rxjs';
+import { combineLatest, debounceTime, distinctUntilChanged, finalize, map, of, shareReplay, skip, switchMap } from 'rxjs';
 import { EventsService } from '@app/shared/services/events.service';
 import { EVENT_ROLE_OPTIONS, MY_EVENT_STATUS_OPTIONS } from '@lfx-one/shared/constants';
 
@@ -74,6 +74,7 @@ export class EventsTopBarComponent {
     const defaultOptions = [{ label: 'All Foundations', value: null }] as FilterOption[];
     return toSignal(
       combineLatest([toObservable(this.projectName), toObservable(this.isPast), toObservable(this.isFoundationFilter)]).pipe(
+        distinctUntilChanged((a, b) => a[0] === b[0] && a[1] === b[1] && a[2] === b[2]),
         switchMap(([projectName, isPast, isFoundationFilter]) => {
           if (!isFoundationFilter) {
             // Foundation dropdown is not rendered — skip the API call and clear loading.
@@ -85,7 +86,8 @@ export class EventsTopBarComponent {
             map(({ data }) => [{ label: 'All Foundations', value: null }, ...data.map((name) => ({ label: name, value: name }))]),
             finalize(() => this.foundationOptionsLoading.set(false))
           );
-        })
+        }),
+        shareReplay({ bufferSize: 1, refCount: true })
       ),
       { initialValue: defaultOptions }
     );

--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
@@ -7,7 +7,7 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { FilterOption } from '@lfx-one/shared/interfaces';
-import { combineLatest, debounceTime, map, switchMap, tap } from 'rxjs';
+import { combineLatest, debounceTime, map, skip, switchMap, tap } from 'rxjs';
 import { EventsService } from '@app/shared/services/events.service';
 import { EVENT_ROLE_OPTIONS, MY_EVENT_STATUS_OPTIONS } from '@lfx-one/shared/constants';
 
@@ -19,7 +19,7 @@ import { EVENT_ROLE_OPTIONS, MY_EVENT_STATUS_OPTIONS } from '@lfx-one/shared/con
 export class EventsTopBarComponent {
   private readonly eventsService = inject(EventsService);
 
-  public isFoundationFilter = input<boolean>(false);
+  public readonly isFoundationFilter = input<boolean>(false);
   public readonly showRoleFilter = input<boolean>(true);
   public readonly projectName = input<string | undefined>(undefined);
   /** When true, foundation options are scoped to the user's registered past events */
@@ -55,6 +55,15 @@ export class EventsTopBarComponent {
     searchControl?.valueChanges.pipe(debounceTime(500), takeUntilDestroyed()).subscribe((value) => {
       this.searchQueryChange.emit(value || '');
     });
+
+    // Clear the foundation dropdown when the tab changes (isPast flips).
+    // emitEvent: false prevents a spurious foundationChange output that would conflict
+    // with the dashboard's own selectedFoundation reset.
+    toObservable(this.isPast)
+      .pipe(skip(1), takeUntilDestroyed())
+      .subscribe(() => {
+        this.searchForm.get('foundation')?.setValue(null, { emitEvent: false });
+      });
   }
 
   public clearSearch(): void {

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
@@ -8,7 +8,7 @@ import { EventsService } from '@app/shared/services/events.service';
 import { DEFAULT_EVENTS_PAGE_SIZE, EMPTY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
 import { EventStatusFilter, EventsResponse, EventTab, EventTabId, PageChangeEvent, SortChangeEvent } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
-import { catchError, combineLatest, finalize, of, skip, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, finalize, of, skip, switchMap, tap } from 'rxjs';
 import { EventsTableComponent } from '../events-table/events-table.component';
 
 @Component({
@@ -120,6 +120,7 @@ export class EventsListComponent {
           sortOrder: sortOrderSignal(),
         }))
       ).pipe(
+        debounceTime(0),
         tap(() => loadingSignal.set(true)),
         switchMap(({ offset, pageSize, foundation, searchQuery, status, sortField, sortOrder }) =>
           this.eventsService

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
@@ -6,7 +6,7 @@ import { Component, computed, inject, input, Signal, signal, WritableSignal } fr
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { EventsService } from '@app/shared/services/events.service';
 import { DEFAULT_EVENTS_PAGE_SIZE, EMPTY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
-import { EventsResponse, EventTab, EventTabId, PageChangeEvent, SortChangeEvent } from '@lfx-one/shared/interfaces';
+import { EventStatusFilter, EventsResponse, EventTab, EventTabId, PageChangeEvent, SortChangeEvent } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { catchError, combineLatest, finalize, of, skip, switchMap, tap } from 'rxjs';
 import { EventsTableComponent } from '../events-table/events-table.component';
@@ -115,7 +115,7 @@ export class EventsListComponent {
           ...pageSignal(),
           foundation: this.foundation(),
           searchQuery: this.searchQuery() || undefined,
-          status: this.status() ?? undefined,
+          status: (this.status() ?? undefined) as EventStatusFilter | undefined,
           sortField: sortFieldSignal(),
           sortOrder: sortOrderSignal(),
         }))

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-list/events-list.component.ts
@@ -22,6 +22,7 @@ export class EventsListComponent {
 
   public readonly foundation = input<string | null>(null);
   public readonly searchQuery = input<string>('');
+  public readonly status = input<string | null>(null);
 
   protected readonly activeTab = signal<EventTabId>('upcoming');
 
@@ -51,7 +52,7 @@ export class EventsListComponent {
 
   public constructor() {
     // Reset both tabs to page 1 when shared filters change
-    combineLatest([toObservable(this.foundation), toObservable(this.searchQuery)])
+    combineLatest([toObservable(this.foundation), toObservable(this.searchQuery), toObservable(this.status)])
       .pipe(skip(1), takeUntilDestroyed())
       .subscribe(() => {
         this.upcomingEventsPage.set({ offset: 0, pageSize: this.upcomingEventsPage().pageSize });
@@ -114,12 +115,13 @@ export class EventsListComponent {
           ...pageSignal(),
           foundation: this.foundation(),
           searchQuery: this.searchQuery() || undefined,
+          status: this.status() ?? undefined,
           sortField: sortFieldSignal(),
           sortOrder: sortOrderSignal(),
         }))
       ).pipe(
         tap(() => loadingSignal.set(true)),
-        switchMap(({ offset, pageSize, foundation, searchQuery, sortField, sortOrder }) =>
+        switchMap(({ offset, pageSize, foundation, searchQuery, status, sortField, sortOrder }) =>
           this.eventsService
             .getEvents({
               isPast,
@@ -127,6 +129,7 @@ export class EventsListComponent {
               pageSize,
               projectNames: foundation ? [foundation] : undefined,
               searchQuery,
+              status,
               sortField,
               sortOrder,
             })

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.html
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.html
@@ -94,7 +94,7 @@
         </td>
       } @else {
         <td>
-          <lfx-tag [value]="event.status" [severity]="statusSeverityMap[event.status] ?? 'secondary'" [attr.data-testid]="'event-status-' + event.id" />
+          <lfx-tag [value]="event.displayStatus" [severity]="statusSeverityMap[event.displayStatus] ?? 'secondary'" [attr.data-testid]="'event-status-' + event.id" />
         </td>
       }
 

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.ts
@@ -25,10 +25,9 @@ export class EventsTableComponent {
   public readonly sortChange = output<SortChangeEvent>();
 
   protected readonly statusSeverityMap: Partial<Record<string, TagSeverity>> = {
-    Planned: 'secondary',
-    Pending: 'secondary',
-    Completed: 'success',
-    Active: 'info',
+    [FoundationEventStatus.REGISTRATION_OPEN]: 'warn',
+    [FoundationEventStatus.COMING_SOON]: 'secondary',
+    [FoundationEventStatus.COMPLETED]: 'success',
   };
 
   protected readonly sortIcons = computed(() => {
@@ -50,7 +49,7 @@ export class EventsTableComponent {
     return this.eventsResponse().data.map((event) => ({
       ...event,
       actionLabel: isPast ? 'View Recap' : this.resolveActionLabel(event.status),
-      isOutlined: !isPast && (event.status === FoundationEventStatus.PLANNED || event.status === FoundationEventStatus.PENDING),
+      isOutlined: !isPast && event.status === FoundationEventStatus.COMING_SOON,
     }));
   });
 
@@ -64,8 +63,7 @@ export class EventsTableComponent {
 
   private resolveActionLabel(status: string | null): string {
     switch (status) {
-      case FoundationEventStatus.PLANNED:
-      case FoundationEventStatus.PENDING:
+      case FoundationEventStatus.COMING_SOON:
         return 'Notify Me';
       case FoundationEventStatus.COMPLETED:
         return 'View Recap';

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.ts
@@ -46,11 +46,15 @@ export class EventsTableComponent {
 
   protected readonly eventsWithActions = computed<FoundationEventWithActions[]>(() => {
     const isPast = this.isPastEvents();
-    return this.eventsResponse().data.map((event) => ({
-      ...event,
-      actionLabel: isPast ? 'View Recap' : this.resolveActionLabel(event.status),
-      isOutlined: !isPast && event.status === FoundationEventStatus.COMING_SOON,
-    }));
+    return this.eventsResponse().data.map((event) => {
+      const displayStatus = this.mapFoundationEventStatus(event.status);
+      return {
+        ...event,
+        displayStatus,
+        actionLabel: isPast ? 'View Recap' : this.resolveActionLabel(displayStatus),
+        isOutlined: !isPast && displayStatus === FoundationEventStatus.COMING_SOON,
+      };
+    });
   });
 
   protected onPageChange(event: { first: number; rows: number }): void {
@@ -61,14 +65,26 @@ export class EventsTableComponent {
     this.sortChange.emit({ field });
   }
 
-  private resolveActionLabel(status: string | null): string {
-    switch (status) {
+  private resolveActionLabel(displayStatus: string | null): string {
+    switch (displayStatus) {
       case FoundationEventStatus.COMING_SOON:
         return 'Notify Me';
       case FoundationEventStatus.COMPLETED:
         return 'View Recap';
       default:
         return 'Register';
+    }
+  }
+
+  private mapFoundationEventStatus(raw: string | null): string | null {
+    switch (raw) {
+      case FoundationEventStatus.ACTIVE:
+        return FoundationEventStatus.REGISTRATION_OPEN;
+      case FoundationEventStatus.PENDING:
+      case FoundationEventStatus.PLANNED:
+        return FoundationEventStatus.COMING_SOON;
+      default:
+        return raw;
     }
   }
 }

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.ts
@@ -6,8 +6,9 @@ import { Component, computed, input, output } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
+import { FOUNDATION_EVENT_STATUS_SEVERITY_MAP } from '@lfx-one/shared/constants';
 import { FoundationEventStatus } from '@lfx-one/shared/enums';
-import { EventsResponse, FoundationEventWithActions, PageChangeEvent, SortChangeEvent, TagSeverity } from '@lfx-one/shared/interfaces';
+import { EventsResponse, FoundationEventWithActions, PageChangeEvent, SortChangeEvent } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-foundation-events-table',
@@ -24,11 +25,7 @@ export class EventsTableComponent {
   public readonly pageChange = output<PageChangeEvent>();
   public readonly sortChange = output<SortChangeEvent>();
 
-  protected readonly statusSeverityMap: Partial<Record<string, TagSeverity>> = {
-    [FoundationEventStatus.REGISTRATION_OPEN]: 'warn',
-    [FoundationEventStatus.COMING_SOON]: 'secondary',
-    [FoundationEventStatus.COMPLETED]: 'success',
-  };
+  protected readonly statusSeverityMap = FOUNDATION_EVENT_STATUS_SEVERITY_MAP;
 
   protected readonly sortIcons = computed(() => {
     const field = this.sortField();

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.html
@@ -13,10 +13,14 @@
 
     <!-- Search and Filters -->
     <div class="bg-white rounded-lg border border-gray-200 p-4">
-      <lfx-events-top-bar [isFoundationFilter]="true" (searchQueryChange)="onSearchQueryChange($event)" />
+      <lfx-events-top-bar
+        [showRoleFilter]="false"
+        [statusOptions]="foundationStatusOptions"
+        (searchQueryChange)="onSearchQueryChange($event)"
+        (statusChange)="onStatusChange($event)" />
     </div>
 
     <!-- Events List (Tabs + Table) -->
-    <lfx-foundation-events-list [foundation]="userFoundation()" [searchQuery]="selectedSearchQuery()" />
+    <lfx-foundation-events-list [foundation]="userFoundation()" [searchQuery]="selectedSearchQuery()" [status]="selectedStatus()" />
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.ts
@@ -3,6 +3,7 @@
 
 import { Component, computed, inject, signal } from '@angular/core';
 import { ProjectContextService } from '@app/shared/services/project-context.service';
+import { FOUNDATION_EVENT_STATUS_OPTIONS } from '@lfx-one/shared/constants';
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
 import { EventsTopBarComponent } from '../components/events-top-bar/events-top-bar.component';
 import { EventsListComponent } from './components/events-list/events-list.component';
@@ -16,10 +17,17 @@ import { EventsListComponent } from './components/events-list/events-list.compon
 export class FoundationEventDashboardComponent {
   private readonly projectContextService = inject(ProjectContextService);
 
+  protected readonly foundationStatusOptions = FOUNDATION_EVENT_STATUS_OPTIONS;
+
   protected readonly selectedSearchQuery = signal('');
+  protected readonly selectedStatus = signal<string | null>(null);
   protected readonly userFoundation = computed(() => this.projectContextService.selectedFoundation()?.name ?? null);
 
   protected onSearchQueryChange(value: string): void {
     this.selectedSearchQuery.set(value);
+  }
+
+  protected onStatusChange(value: string | null): void {
+    this.selectedStatus.set(value);
   }
 }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
@@ -8,7 +8,7 @@ import { EventsService } from '@app/shared/services/events.service';
 import { DEFAULT_EVENTS_PAGE_SIZE, EMPTY_MY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
 import { EventTab, EventTabId, MyEventsResponse, PageChangeEvent, SortChangeEvent } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
-import { catchError, combineLatest, finalize, of, skip, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, finalize, of, skip, switchMap, tap } from 'rxjs';
 import { EventsTableComponent } from '../events-table/events-table.component';
 
 @Component({
@@ -127,6 +127,7 @@ export class EventsListComponent {
           sortOrder: sortOrderSignal(),
         }))
       ).pipe(
+        debounceTime(0),
         tap(() => loadingSignal.set(true)),
         switchMap(({ offset, pageSize, projectName, searchQuery, role, status, sortField, sortOrder }) =>
           this.eventsService.getMyEvents({ isPast, offset, pageSize, projectName, searchQuery, role, status, sortField, sortOrder }).pipe(

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, inject, input, Signal, signal, WritableSignal } from '@angular/core';
+import { Component, computed, inject, input, output, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { EventsService } from '@app/shared/services/events.service';
 import { DEFAULT_EVENTS_PAGE_SIZE, EMPTY_MY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
@@ -24,6 +24,8 @@ export class EventsListComponent {
   public readonly searchQuery = input<string>('');
   public readonly role = input<string | null>(null);
   public readonly status = input<string | null>(null);
+
+  public readonly activeTabChange = output<EventTabId>();
 
   protected readonly activeTab = signal<EventTabId>('upcoming');
 
@@ -65,6 +67,7 @@ export class EventsListComponent {
 
   protected setActiveTab(tab: EventTabId): void {
     this.activeTab.set(tab);
+    this.activeTabChange.emit(tab);
   }
 
   protected onUpcomingPageChange(event: PageChangeEvent): void {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -20,12 +20,18 @@
     <div class="bg-white rounded-lg border border-gray-200 p-4">
       <lfx-events-top-bar
         [isFoundationFilter]="true"
+        [isPast]="isPast()"
         (searchQueryChange)="onSearchQueryChange($event)"
         (foundationChange)="onFoundationChange($event)"
         (roleChange)="onRoleChange($event)"
         (statusChange)="onStatusChange($event)" />
     </div>
     <!-- Events List (Tabs + Table) -->
-    <lfx-events-list [foundation]="selectedFoundation()" [searchQuery]="selectedSearchQuery()" [role]="selectedRole()" [status]="selectedStatus()" />
+    <lfx-events-list
+      [foundation]="selectedFoundation()"
+      [searchQuery]="selectedSearchQuery()"
+      [role]="selectedRole()"
+      [status]="selectedStatus()"
+      (activeTabChange)="onActiveTabChange($event)" />
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -6,6 +6,7 @@ import { TagComponent } from '@app/shared/components/tag/tag.component';
 import { PersonaService } from '@app/shared/services/persona.service';
 import { ProjectContextService } from '@app/shared/services/project-context.service';
 import { LINKS_CONFIG } from '@lfx-one/shared/constants';
+import { EventTabId } from '@lfx-one/shared/interfaces';
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
 import { EventsTopBarComponent } from '../components/events-top-bar/events-top-bar.component';
 import { EventsInfoBannersComponent } from './components/events-info-banners/events-info-banners.component';
@@ -22,6 +23,9 @@ export class MyEventsDashboardComponent {
   private readonly projectContextService = inject(ProjectContextService);
 
   protected readonly linksConfig = LINKS_CONFIG;
+
+  protected readonly activeTab = signal<EventTabId>('upcoming');
+  protected readonly isPast = computed(() => this.activeTab() === 'past');
 
   protected readonly selectedFoundation = signal<string | null>(null);
   protected readonly selectedRole = signal<string | null>(null);
@@ -44,6 +48,12 @@ export class MyEventsDashboardComponent {
 
   protected onSearchQueryChange(value: string): void {
     this.selectedSearchQuery.set(value);
+  }
+
+  protected onActiveTabChange(tab: EventTabId): void {
+    this.activeTab.set(tab);
+    // Reset foundation filter when switching tabs — each tab has a different foundation list
+    this.selectedFoundation.set(null);
   }
 
   private initFoundationLabel(): Signal<string> {

--- a/apps/lfx-one/src/app/shared/services/events.service.ts
+++ b/apps/lfx-one/src/app/shared/services/events.service.ts
@@ -51,6 +51,7 @@ export class EventsService {
       });
     }
     if (params.searchQuery) httpParams = httpParams.set('searchQuery', params.searchQuery);
+    if (params.status) httpParams = httpParams.set('status', params.status);
     if (params.sortField) httpParams = httpParams.set('sortField', params.sortField);
     if (params.pageSize) httpParams = httpParams.set('pageSize', String(params.pageSize));
     if (params.offset !== undefined) httpParams = httpParams.set('offset', String(params.offset));
@@ -63,6 +64,7 @@ export class EventsService {
     let httpParams = new HttpParams();
 
     if (params.projectName) httpParams = httpParams.set('projectName', params.projectName);
+    if (params.isPast !== undefined) httpParams = httpParams.set('isPast', String(params.isPast));
 
     return this.http
       .get<MyEventOrganizationsResponse>('/api/events/organizations', { params: httpParams })

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -8,7 +8,7 @@ import { NextFunction, Request, Response } from 'express';
 import { AuthenticationError, ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
 import { CertificateService } from '../services/certificate.service';
-import { DEFAULT_EVENTS_PAGE_SIZE, MAX_EVENTS_PAGE_SIZE, VALID_EVENT_SORT_ORDERS, VALID_EVENT_STATUS_VALUES } from '@lfx-one/shared/constants';
+import { DEFAULT_EVENTS_PAGE_SIZE, MAX_EVENTS_PAGE_SIZE, VALID_EVENT_SORT_ORDERS, VALID_EVENT_STATUS_VALUES, VALID_MY_EVENT_STATUS_VALUES } from '@lfx-one/shared/constants';
 import { EventSortOrder, EventStatusFilter, GetEventOrganizationsOptions, GetEventsOptions } from '@lfx-one/shared/interfaces';
 import { EventsService } from '../services/events.service';
 
@@ -43,7 +43,8 @@ export class EventsController {
       const projectName = req.query['projectName'] ? String(req.query['projectName']) : undefined;
       const searchQuery = req.query['searchQuery'] ? String(req.query['searchQuery']).trim() : undefined;
       const role = req.query['role'] ? String(req.query['role']) : undefined;
-      const status = req.query['status'] ? String(req.query['status']) : undefined;
+      const rawMyEventStatus = req.query['status'] ? String(req.query['status']) : undefined;
+      const status = rawMyEventStatus && VALID_MY_EVENT_STATUS_VALUES.has(rawMyEventStatus) ? rawMyEventStatus : undefined;
       const sortField = req.query['sortField'] ? String(req.query['sortField']) : undefined;
 
       const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 && rawPageSize <= MAX_EVENTS_PAGE_SIZE ? rawPageSize : DEFAULT_EVENTS_PAGE_SIZE;

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -8,7 +8,7 @@ import { NextFunction, Request, Response } from 'express';
 import { AuthenticationError, ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
 import { CertificateService } from '../services/certificate.service';
-import { DEFAULT_EVENTS_PAGE_SIZE, MAX_EVENTS_PAGE_SIZE, VALID_EVENT_SORT_ORDERS } from '@lfx-one/shared/constants';
+import { DEFAULT_EVENTS_PAGE_SIZE, MAX_EVENTS_PAGE_SIZE, VALID_EVENT_SORT_ORDERS, VALID_EVENT_STATUS_VALUES } from '@lfx-one/shared/constants';
 import { EventSortOrder, GetEventOrganizationsOptions, GetEventsOptions } from '@lfx-one/shared/interfaces';
 import { EventsService } from '../services/events.service';
 
@@ -105,7 +105,8 @@ export class EventsController {
         projectNames = [String(rawProjectNames)];
       }
       const searchQuery = req.query['searchQuery'] ? String(req.query['searchQuery']).trim() : undefined;
-      const status = req.query['status'] ? String(req.query['status']) : undefined;
+      const rawStatus = req.query['status'] ? String(req.query['status']) : undefined;
+      const status = rawStatus && VALID_EVENT_STATUS_VALUES.has(rawStatus) ? rawStatus : undefined;
       const sortField = req.query['sortField'] ? String(req.query['sortField']) : undefined;
 
       const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 && rawPageSize <= MAX_EVENTS_PAGE_SIZE ? rawPageSize : DEFAULT_EVENTS_PAGE_SIZE;

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -9,7 +9,7 @@ import { AuthenticationError, ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
 import { CertificateService } from '../services/certificate.service';
 import { DEFAULT_EVENTS_PAGE_SIZE, MAX_EVENTS_PAGE_SIZE, VALID_EVENT_SORT_ORDERS, VALID_EVENT_STATUS_VALUES } from '@lfx-one/shared/constants';
-import { EventSortOrder, GetEventOrganizationsOptions, GetEventsOptions } from '@lfx-one/shared/interfaces';
+import { EventSortOrder, EventStatusFilter, GetEventOrganizationsOptions, GetEventsOptions } from '@lfx-one/shared/interfaces';
 import { EventsService } from '../services/events.service';
 
 export class EventsController {
@@ -106,7 +106,7 @@ export class EventsController {
       }
       const searchQuery = req.query['searchQuery'] ? String(req.query['searchQuery']).trim() : undefined;
       const rawStatus = req.query['status'] ? String(req.query['status']) : undefined;
-      const status = rawStatus && VALID_EVENT_STATUS_VALUES.has(rawStatus) ? rawStatus : undefined;
+      const status = rawStatus && VALID_EVENT_STATUS_VALUES.has(rawStatus) ? (rawStatus as EventStatusFilter) : undefined;
       const sortField = req.query['sortField'] ? String(req.query['sortField']) : undefined;
 
       const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 && rawPageSize <= MAX_EVENTS_PAGE_SIZE ? rawPageSize : DEFAULT_EVENTS_PAGE_SIZE;

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -105,6 +105,7 @@ export class EventsController {
         projectNames = [String(rawProjectNames)];
       }
       const searchQuery = req.query['searchQuery'] ? String(req.query['searchQuery']).trim() : undefined;
+      const status = req.query['status'] ? String(req.query['status']) : undefined;
       const sortField = req.query['sortField'] ? String(req.query['sortField']) : undefined;
 
       const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 && rawPageSize <= MAX_EVENTS_PAGE_SIZE ? rawPageSize : DEFAULT_EVENTS_PAGE_SIZE;
@@ -122,6 +123,7 @@ export class EventsController {
         eventId,
         projectNames,
         searchQuery,
+        status,
         sortField,
         pageSize,
         offset,
@@ -160,11 +162,20 @@ export class EventsController {
         });
       }
 
+      const rawIsPast = req.query['isPast'];
+      let isPast: boolean | undefined;
+      if (rawIsPast === 'true') {
+        isPast = true;
+      } else if (rawIsPast === 'false') {
+        isPast = false;
+      }
+
       const options: GetEventOrganizationsOptions = {
         projectName: req.query['projectName'] ? String(req.query['projectName']) : undefined,
+        isPast,
       };
 
-      const response = await this.eventsService.getEventOrganizations(req, options);
+      const response = await this.eventsService.getEventOrganizations(req, userEmail, options);
 
       logger.success(req, 'get_event_organizations', startTime, {
         result_count: response.data.length,

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -3,8 +3,7 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
-import { DEFAULT_EVENT_SORT_FIELD, VALID_EVENT_SORT_FIELDS } from '@lfx-one/shared/constants';
-import { FoundationEventStatus } from '@lfx-one/shared/enums';
+import { COMING_SOON_SENTINEL, DEFAULT_EVENT_SORT_FIELD, VALID_EVENT_SORT_FIELDS } from '@lfx-one/shared/constants';
 import {
   EventRow,
   EventSortOrder,
@@ -242,7 +241,7 @@ export class EventsService {
     const projectNamesFilter = projectNames && projectNames.length > 0 ? `AND PROJECT_NAME IN (${projectNames.map(() => '?').join(', ')})` : '';
     const searchQueryFilter = searchQuery ? 'AND EVENT_NAME ILIKE ?' : '';
     let statusFilter = '';
-    if (status === 'coming-soon') {
+    if (status === COMING_SOON_SENTINEL) {
       statusFilter = "AND EVENT_STATUS IN ('Pending', 'Planned')";
     } else if (status) {
       statusFilter = 'AND EVENT_STATUS = ?';
@@ -293,7 +292,7 @@ export class EventsService {
     if (eventId) binds.push(eventId);
     if (projectNames && projectNames.length > 0) binds.push(...projectNames);
     if (searchQuery) binds.push(`%${searchQuery}%`);
-    if (status && status !== 'coming-soon') binds.push(status);
+    if (status && status !== COMING_SOON_SENTINEL) binds.push(status);
 
     logger.debug(req, 'get_events', 'Executing events query', { bind_count: binds.length });
 
@@ -451,22 +450,10 @@ export class EventsService {
       registrationUrl: row.EVENT_REGISTRATION_URL ?? null,
       date: this.formatDateRange(row.EVENT_START_DATE, row.EVENT_END_DATE),
       location: this.formatLocation(row.EVENT_LOCATION, row.EVENT_CITY, row.EVENT_COUNTRY),
-      status: this.mapEventStatus(row.EVENT_STATUS),
+      status: row.EVENT_STATUS ?? null,
       isPast: row.IS_PAST_EVENT,
       attendees: row.ATTENDEES ?? null,
     };
-  }
-
-  private mapEventStatus(raw: string | null): string | null {
-    switch (raw) {
-      case FoundationEventStatus.ACTIVE:
-        return FoundationEventStatus.REGISTRATION_OPEN;
-      case FoundationEventStatus.PENDING:
-      case FoundationEventStatus.PLANNED:
-        return FoundationEventStatus.COMING_SOON;
-      default:
-        return raw;
-    }
   }
 
   private mapRowToEvent(row: MyEventRow): MyEvent {

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -4,6 +4,7 @@
 // Generated with [Claude Code](https://claude.ai/code)
 
 import { DEFAULT_EVENT_SORT_FIELD, VALID_EVENT_SORT_FIELDS } from '@lfx-one/shared/constants';
+import { FoundationEventStatus } from '@lfx-one/shared/enums';
 import {
   EventRow,
   EventSortOrder,
@@ -458,11 +459,11 @@ export class EventsService {
 
   private mapEventStatus(raw: string | null): string | null {
     switch (raw) {
-      case 'Active':
-        return 'Registration Open';
-      case 'Pending':
-      case 'Planned':
-        return 'Coming Soon';
+      case FoundationEventStatus.ACTIVE:
+        return FoundationEventStatus.REGISTRATION_OPEN;
+      case FoundationEventStatus.PENDING:
+      case FoundationEventStatus.PLANNED:
+        return FoundationEventStatus.COMING_SOON;
       default:
         return raw;
     }

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -219,7 +219,7 @@ export class EventsService {
   }
 
   public async getEvents(req: Request, options: GetEventsOptions): Promise<EventsResponse> {
-    const { isPast, eventId, projectNames, searchQuery, sortField: rawSortField, pageSize, offset, sortOrder } = options;
+    const { isPast, eventId, projectNames, searchQuery, status, sortField: rawSortField, pageSize, offset, sortOrder } = options;
     const sortField = rawSortField && VALID_EVENT_SORT_FIELDS.has(rawSortField) ? rawSortField : DEFAULT_EVENT_SORT_FIELD;
     const normalizedSortOrder: EventSortOrder = sortOrder === 'DESC' ? 'DESC' : 'ASC';
     const normalizedPageSize = Number.isInteger(pageSize) && pageSize > 0 ? pageSize : 10;
@@ -230,6 +230,7 @@ export class EventsService {
       has_event_id: !!eventId,
       project_names_count: projectNames?.length ?? 0,
       has_search_query: !!searchQuery,
+      status,
       page_size: normalizedPageSize,
       offset: normalizedOffset,
       sort_order: normalizedSortOrder,
@@ -239,6 +240,12 @@ export class EventsService {
     const eventIdFilter = eventId ? 'AND EVENT_ID = ?' : '';
     const projectNamesFilter = projectNames && projectNames.length > 0 ? `AND PROJECT_NAME IN (${projectNames.map(() => '?').join(', ')})` : '';
     const searchQueryFilter = searchQuery ? 'AND EVENT_NAME ILIKE ?' : '';
+    let statusFilter = '';
+    if (status === 'coming-soon') {
+      statusFilter = "AND EVENT_STATUS IN ('Pending', 'Planned')";
+    } else if (status) {
+      statusFilter = 'AND EVENT_STATUS = ?';
+    }
 
     const sql = `
       SELECT
@@ -265,6 +272,7 @@ export class EventsService {
         ${eventIdFilter}
         ${projectNamesFilter}
         ${searchQueryFilter}
+        ${statusFilter}
       GROUP BY
         E.EVENT_ID,
         EVENT_NAME,
@@ -284,6 +292,7 @@ export class EventsService {
     if (eventId) binds.push(eventId);
     if (projectNames && projectNames.length > 0) binds.push(...projectNames);
     if (searchQuery) binds.push(`%${searchQuery}%`);
+    if (status && status !== 'coming-soon') binds.push(status);
 
     logger.debug(req, 'get_events', 'Executing events query', { bind_count: binds.length });
 
@@ -307,27 +316,47 @@ export class EventsService {
     return { data, total, pageSize: normalizedPageSize, offset: normalizedOffset };
   }
 
-  public async getEventOrganizations(req: Request, options: GetEventOrganizationsOptions): Promise<MyEventOrganizationsResponse> {
-    const { projectName } = options;
+  public async getEventOrganizations(
+    req: Request,
+    userEmail: string,
+    options: GetEventOrganizationsOptions
+  ): Promise<MyEventOrganizationsResponse> {
+    const { projectName, isPast } = options;
 
     logger.debug(req, 'get_event_organizations', 'Building organizations query', {
       has_project_name: !!projectName,
+      is_past: isPast,
     });
 
-    // Return all distinct project names from upcoming events so the foundation filter dropdown
-    // includes both the user's registered foundations and discoverable ones.
-    const projectNameFilter = projectName ? 'AND PROJECT_NAME = ?' : '';
-
-    const sql = `
-      SELECT DISTINCT PROJECT_NAME
-      FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
-      WHERE IS_PAST_EVENT = FALSE
-        ${projectNameFilter}
-      ORDER BY PROJECT_NAME
-    `;
-
+    let sql: string;
     const binds: string[] = [];
-    if (projectName) binds.push(projectName);
+
+    if (isPast === true) {
+      // Past tab: return only foundations from the authenticated user's registered past events.
+      const projectNameFilter = projectName ? 'AND PROJECT_NAME = ?' : '';
+      sql = `
+        SELECT DISTINCT PROJECT_NAME
+        FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
+        WHERE USER_EMAIL = ?
+          AND IS_PAST_EVENT = TRUE
+          ${projectNameFilter}
+        ORDER BY PROJECT_NAME
+      `;
+      binds.push(userEmail);
+      if (projectName) binds.push(projectName);
+    } else {
+      // Upcoming tab: return all distinct project names from upcoming events so the foundation
+      // filter dropdown includes both the user's registered foundations and discoverable ones.
+      const projectNameFilter = projectName ? 'AND PROJECT_NAME = ?' : '';
+      sql = `
+        SELECT DISTINCT PROJECT_NAME
+        FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
+        WHERE IS_PAST_EVENT = FALSE
+          ${projectNameFilter}
+        ORDER BY PROJECT_NAME
+      `;
+      if (projectName) binds.push(projectName);
+    }
 
     logger.debug(req, 'get_event_organizations', 'Executing organizations query', { bind_count: binds.length });
 
@@ -421,10 +450,22 @@ export class EventsService {
       registrationUrl: row.EVENT_REGISTRATION_URL ?? null,
       date: this.formatDateRange(row.EVENT_START_DATE, row.EVENT_END_DATE),
       location: this.formatLocation(row.EVENT_LOCATION, row.EVENT_CITY, row.EVENT_COUNTRY),
-      status: row.EVENT_STATUS,
+      status: this.mapEventStatus(row.EVENT_STATUS),
       isPast: row.IS_PAST_EVENT,
       attendees: row.ATTENDEES ?? null,
     };
+  }
+
+  private mapEventStatus(raw: string | null): string | null {
+    switch (raw) {
+      case 'Active':
+        return 'Registration Open';
+      case 'Pending':
+      case 'Planned':
+        return 'Coming Soon';
+      default:
+        return raw;
+    }
   }
 
   private mapRowToEvent(row: MyEventRow): MyEvent {

--- a/packages/shared/src/constants/events.constants.ts
+++ b/packages/shared/src/constants/events.constants.ts
@@ -30,7 +30,11 @@ export const FOUNDATION_EVENT_STATUS_OPTIONS: FilterOption[] = [
   { label: 'Registration Open', value: 'Active' }, // raw DB value; displayed as 'Registration Open'
 ];
 
-export const VALID_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['Active', 'Planned', 'Pending', 'Completed', 'coming-soon']);
+/** Sentinel status value that maps server-side to `EVENT_STATUS IN ('Pending', 'Planned')`. */
+export const COMING_SOON_SENTINEL = 'coming-soon';
+
+export const VALID_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['Active', 'Planned', 'Pending', 'Completed', COMING_SOON_SENTINEL]);
+export const VALID_MY_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['registered', 'attended', 'not-registered']);
 export const VALID_EVENT_SORT_FIELDS: ReadonlySet<string> = new Set(['EVENT_NAME', 'PROJECT_NAME', 'EVENT_START_DATE', 'EVENT_CITY']);
 export const DEFAULT_EVENT_SORT_FIELD = 'EVENT_START_DATE';
 export const VALID_EVENT_SORT_ORDERS: readonly string[] = ['ASC', 'DESC'];

--- a/packages/shared/src/constants/events.constants.ts
+++ b/packages/shared/src/constants/events.constants.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { FilterOption, MyEventsResponse, EventsResponse, MyEventOrganizationsResponse } from '../interfaces';
+import { FoundationEventStatus } from '../enums';
+import { FilterOption, MyEventsResponse, EventsResponse, MyEventOrganizationsResponse, TagSeverity } from '../interfaces';
 
 export const EVENT_ROLE_OPTIONS: FilterOption[] = [
   { label: 'All Roles', value: null },
@@ -35,6 +36,13 @@ export const COMING_SOON_SENTINEL = 'coming-soon';
 
 export const VALID_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['Active', 'Planned', 'Pending', 'Completed', COMING_SOON_SENTINEL]);
 export const VALID_MY_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['registered', 'attended', 'not-registered']);
+/** Severity map for foundation event display statuses, used by the events table tag component. */
+export const FOUNDATION_EVENT_STATUS_SEVERITY_MAP: Partial<Record<string, TagSeverity>> = {
+  [FoundationEventStatus.REGISTRATION_OPEN]: 'warn',
+  [FoundationEventStatus.COMING_SOON]: 'secondary',
+  [FoundationEventStatus.COMPLETED]: 'success',
+};
+
 export const VALID_EVENT_SORT_FIELDS: ReadonlySet<string> = new Set(['EVENT_NAME', 'PROJECT_NAME', 'EVENT_START_DATE', 'EVENT_CITY']);
 export const DEFAULT_EVENT_SORT_FIELD = 'EVENT_START_DATE';
 export const VALID_EVENT_SORT_ORDERS: readonly string[] = ['ASC', 'DESC'];

--- a/packages/shared/src/constants/events.constants.ts
+++ b/packages/shared/src/constants/events.constants.ts
@@ -18,6 +18,13 @@ export const MY_EVENT_STATUS_OPTIONS: FilterOption[] = [
   { label: 'Not Registered', value: 'not-registered' },
 ];
 
+export const FOUNDATION_EVENT_STATUS_OPTIONS: FilterOption[] = [
+  { label: 'All Statuses', value: null },
+  { label: 'Coming Soon', value: 'coming-soon' },
+  { label: 'Completed', value: 'Completed' },
+  { label: 'Registration Open', value: 'Active' },
+];
+
 export const VALID_EVENT_SORT_FIELDS: ReadonlySet<string> = new Set(['EVENT_NAME', 'PROJECT_NAME', 'EVENT_START_DATE', 'EVENT_CITY']);
 export const DEFAULT_EVENT_SORT_FIELD = 'EVENT_START_DATE';
 export const VALID_EVENT_SORT_ORDERS: readonly string[] = ['ASC', 'DESC'];

--- a/packages/shared/src/constants/events.constants.ts
+++ b/packages/shared/src/constants/events.constants.ts
@@ -18,13 +18,19 @@ export const MY_EVENT_STATUS_OPTIONS: FilterOption[] = [
   { label: 'Not Registered', value: 'not-registered' },
 ];
 
+/**
+ * Status filter options for Foundation Lens events.
+ * Values are raw EVENT_STATUS DB values except 'coming-soon', which is a sentinel
+ * that the server maps to `IN ('Pending', 'Planned')` rather than a parameterized bind.
+ */
 export const FOUNDATION_EVENT_STATUS_OPTIONS: FilterOption[] = [
   { label: 'All Statuses', value: null },
-  { label: 'Coming Soon', value: 'coming-soon' },
+  { label: 'Coming Soon', value: 'coming-soon' }, // sentinel — maps to Pending + Planned in SQL
   { label: 'Completed', value: 'Completed' },
-  { label: 'Registration Open', value: 'Active' },
+  { label: 'Registration Open', value: 'Active' }, // raw DB value; displayed as 'Registration Open'
 ];
 
+export const VALID_EVENT_STATUS_VALUES: ReadonlySet<string> = new Set(['Active', 'Planned', 'Pending', 'Completed', 'coming-soon']);
 export const VALID_EVENT_SORT_FIELDS: ReadonlySet<string> = new Set(['EVENT_NAME', 'PROJECT_NAME', 'EVENT_START_DATE', 'EVENT_CITY']);
 export const DEFAULT_EVENT_SORT_FIELD = 'EVENT_START_DATE';
 export const VALID_EVENT_SORT_ORDERS: readonly string[] = ['ASC', 'DESC'];

--- a/packages/shared/src/enums/event.enum.ts
+++ b/packages/shared/src/enums/event.enum.ts
@@ -1,13 +1,30 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+/**
+ * Event status values used across the Foundation Lens events feature.
+ *
+ * This enum intentionally covers two conceptual groups:
+ *
+ * **Raw DB values** (EVENT_STATUS column in SILVER_DIM.EVENTS) — used only in the
+ * server-side SQL query and in `EventStatusFilter` type for API param validation:
+ *   - ACTIVE, PLANNED, PENDING, COMPLETED
+ *
+ * **Display labels** (shown in the UI after client-side mapping) — used in the
+ * events-table component for severity lookups, action labels, and outline logic:
+ *   - REGISTRATION_OPEN (maps from ACTIVE)
+ *   - COMING_SOON       (maps from PENDING and PLANNED)
+ *   - COMPLETED         (same value as the raw DB status)
+ *
+ * Raw values are never compared against display labels in the same context.
+ */
 export enum FoundationEventStatus {
+  /** Raw DB values — used for SQL filtering only */
   PLANNED = 'Planned',
   PENDING = 'Pending',
   COMPLETED = 'Completed',
   ACTIVE = 'Active',
-  /** Display label for Active events (registration is open) */
+  /** Display labels — used in UI comparisons after client-side mapping */
   REGISTRATION_OPEN = 'Registration Open',
-  /** Display label for Pending/Planned events (not yet open) */
   COMING_SOON = 'Coming Soon',
 }

--- a/packages/shared/src/enums/event.enum.ts
+++ b/packages/shared/src/enums/event.enum.ts
@@ -6,4 +6,8 @@ export enum FoundationEventStatus {
   PENDING = 'Pending',
   COMPLETED = 'Completed',
   ACTIVE = 'Active',
+  /** Display label for Active events (registration is open) */
+  REGISTRATION_OPEN = 'Registration Open',
+  /** Display label for Pending/Planned events (not yet open) */
+  COMING_SOON = 'Coming Soon',
 }

--- a/packages/shared/src/interfaces/my-event.interface.ts
+++ b/packages/shared/src/interfaces/my-event.interface.ts
@@ -188,6 +188,8 @@ export interface GetMyEventsParams {
  */
 export interface GetEventOrganizationsParams {
   projectName?: string;
+  /** When true, returns only foundations from the user's registered past events */
+  isPast?: boolean;
 }
 
 /**
@@ -198,6 +200,8 @@ export interface GetEventsParams {
   eventId?: string;
   projectNames?: string[];
   searchQuery?: string;
+  /** Filter by EVENT_STATUS value (e.g. "Active", "Planned", "Completed", "Pending") */
+  status?: string;
   sortField?: string;
   pageSize?: number;
   offset?: number;
@@ -267,6 +271,8 @@ export interface GetEventsOptions {
   eventId?: string;
   projectNames?: string[];
   searchQuery?: string;
+  /** Filter by EVENT_STATUS value (e.g. "Active", "Planned", "Completed", "Pending") */
+  status?: string;
   sortField?: string;
   pageSize: number;
   offset: number;
@@ -278,4 +284,6 @@ export interface GetEventsOptions {
  */
 export interface GetEventOrganizationsOptions {
   projectName?: string;
+  /** When true, returns only foundations from the authenticated user's registered past events */
+  isPast?: boolean;
 }

--- a/packages/shared/src/interfaces/my-event.interface.ts
+++ b/packages/shared/src/interfaces/my-event.interface.ts
@@ -4,6 +4,14 @@
 import { OffsetPaginatedResponse } from './api.interface';
 
 /**
+ * The set of valid status filter values for foundation events.
+ * Raw EVENT_STATUS DB values ('Active', 'Planned', 'Pending', 'Completed') are passed
+ * directly as SQL bind parameters. 'coming-soon' is a synthetic sentinel that the server
+ * maps to `EVENT_STATUS IN ('Pending', 'Planned')`.
+ */
+export type EventStatusFilter = 'Active' | 'Planned' | 'Pending' | 'Completed' | 'coming-soon';
+
+/**
  * Event item for the My Events dashboard
  */
 export interface MyEvent {
@@ -200,8 +208,8 @@ export interface GetEventsParams {
   eventId?: string;
   projectNames?: string[];
   searchQuery?: string;
-  /** Filter by EVENT_STATUS value (e.g. "Active", "Planned", "Completed", "Pending") */
-  status?: string;
+  /** Filter by event status. See {@link EventStatusFilter} for supported values. */
+  status?: EventStatusFilter;
   sortField?: string;
   pageSize?: number;
   offset?: number;
@@ -271,8 +279,8 @@ export interface GetEventsOptions {
   eventId?: string;
   projectNames?: string[];
   searchQuery?: string;
-  /** Filter by EVENT_STATUS value (e.g. "Active", "Planned", "Completed", "Pending") */
-  status?: string;
+  /** Filter by event status. See {@link EventStatusFilter} for supported values. */
+  status?: EventStatusFilter;
   sortField?: string;
   pageSize: number;
   offset: number;

--- a/packages/shared/src/interfaces/my-event.interface.ts
+++ b/packages/shared/src/interfaces/my-event.interface.ts
@@ -118,7 +118,7 @@ export interface FoundationEvent {
   date: string;
   /** Human-readable location string (e.g. "Salt Lake City, UT") */
   location: string;
-  /** Event status (e.g. "Published", "Cancelled") */
+  /** Raw EVENT_STATUS value from the database (e.g. 'Active', 'Planned', 'Completed') */
   status: string | null;
   /** Whether the event is in the past */
   isPast: boolean;
@@ -130,6 +130,8 @@ export interface FoundationEvent {
  * Foundation event with computed action properties for the events table
  */
 export interface FoundationEventWithActions extends FoundationEvent {
+  /** Display label derived from raw status (e.g. 'Active' → 'Registration Open') */
+  displayStatus: string | null;
   actionLabel: string;
   isOutlined: boolean;
 }


### PR DESCRIPTION
## Summary

- **Me Lens (My Events):** Restores the Foundation, Role, and Status filters accidentally dropped in a prior merge. Foundation filter is now tab-aware — upcoming tab shows all upcoming event foundations; past tab scopes to the authenticated user's registered past foundations only. Active tab state is lifted to the dashboard so `isPast` can be passed to the top bar, and the foundation filter resets on tab switch.
- **Foundation Lens (Events):** Removes the Foundation and Role filters (not applicable to single-project foundation events). Adds a fully wired Status filter backed by `EVENT_STATUS` with user-friendly display labels (`Registration Open`, `Coming Soon`, `Completed`). The `coming-soon` filter value maps to `IN ('Pending', 'Planned')` in SQL. Raw DB status values are mapped to display labels server-side.
- **Shared:** `statusOptions` on `EventsTopBarComponent` is now a configurable `input()` (defaults to `MY_EVENT_STATUS_OPTIONS`, unaffected on Me Lens). Added `showRoleFilter` input for per-lens control.

## Test plan

- [ ] Me Lens — My Events: verify Foundation, All Roles, All Statuses filters all render
- [ ] Me Lens — Upcoming tab: Foundation dropdown lists all upcoming event foundations
- [ ] Me Lens — Past tab: Foundation dropdown lists only user's registered past foundations; resets when switching tabs
- [ ] Me Lens — Role and Status filters apply correctly to both tabs
- [ ] Foundation Lens — Events: Foundation and Role filters are absent
- [ ] Foundation Lens — Status filter shows: All Statuses, Coming Soon, Completed, Registration Open
- [ ] Foundation Lens — Selecting "Registration Open" filters to `EVENT_STATUS = 'Active'`
- [ ] Foundation Lens — Selecting "Coming Soon" filters to `EVENT_STATUS IN ('Pending', 'Planned')`
- [ ] Foundation Lens — Status tag in table shows "Registration Open" (amber) / "Coming Soon" (gray)
- [ ] Foundation Lens — Action button shows "Register" for Registration Open, "Notify Me" for Coming Soon

🤖 Generated with [Claude Code](https://claude.ai/code)