### PR TITLE
ci(workflows): auto-restart k8s deployment after pr image build

### DIFF
--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -76,6 +76,9 @@ jobs:
             BUILD_ENV=development
             APP_VERSION=pr-${{ github.event.pull_request.number }}
 
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
       - name: Restart Kubernetes deployment
         env:
           KUBECONFIG_DATA: ${{ secrets.DEV_KUBECONFIG }}

--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -12,7 +12,6 @@ permissions:
   packages: write
   pull-requests: write
   issues: write
-  id-token: write
 
 env:
   REGISTRY: ghcr.io
@@ -85,13 +84,19 @@ jobs:
           KUBECONFIG_DATA: ${{ secrets.DEV_KUBECONFIG }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "$KUBECONFIG_DATA" | base64 -d > /tmp/kubeconfig
-          export KUBECONFIG=/tmp/kubeconfig
+          set -euo pipefail
+          [[ -n "${KUBECONFIG_DATA:-}" ]] || { echo "DEV_KUBECONFIG secret is empty"; exit 1; }
+
+          KUBECONFIG_PATH="$(mktemp)"
+          trap 'rm -f "$KUBECONFIG_PATH"' EXIT
+          echo "$KUBECONFIG_DATA" | base64 -d > "$KUBECONFIG_PATH"
+          export KUBECONFIG="$KUBECONFIG_PATH"
 
           NAMESPACE="ui-pr-${PR_NUMBER}"
           DEPLOYMENT="ui-pr-${PR_NUMBER}-lfx-v2-ui"
 
-          if kubectl --context lfx-v2-dev -n "$NAMESPACE" get deployment "$DEPLOYMENT" &>/dev/null; then
+          existing="$(kubectl --context lfx-v2-dev -n "$NAMESPACE" get deployment "$DEPLOYMENT" --ignore-not-found -o name)"
+          if [[ -n "$existing" ]]; then
             echo "Restarting deployment $DEPLOYMENT in namespace $NAMESPACE..."
             kubectl --context lfx-v2-dev -n "$NAMESPACE" rollout restart deployment/"$DEPLOYMENT"
             echo "Waiting for rollout to complete..."
@@ -104,8 +109,6 @@ jobs:
             echo "restarted=false" >> "$GITHUB_OUTPUT"
             echo "Deployment $DEPLOYMENT not found in $NAMESPACE — skipping restart (may be initial deploy)"
           fi
-
-          rm -f /tmp/kubeconfig
 
       - name: Comment deployment URL on PR
         env:

--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -12,6 +12,7 @@ permissions:
   packages: write
   pull-requests: write
   issues: write
+  id-token: write
 
 env:
   REGISTRY: ghcr.io
@@ -74,6 +75,27 @@ jobs:
           build-args: |
             BUILD_ENV=development
             APP_VERSION=pr-${{ github.event.pull_request.number }}
+
+      - name: Restart Kubernetes deployment
+        env:
+          KUBECONFIG_DATA: ${{ secrets.DEV_KUBECONFIG }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          echo "$KUBECONFIG_DATA" | base64 -d > /tmp/kubeconfig
+          export KUBECONFIG=/tmp/kubeconfig
+
+          NAMESPACE="ui-pr-${PR_NUMBER}"
+          DEPLOYMENT="ui-pr-${PR_NUMBER}-lfx-v2-ui"
+
+          if kubectl --context lfx-v2-dev -n "$NAMESPACE" get deployment "$DEPLOYMENT" &>/dev/null; then
+            echo "Restarting deployment $DEPLOYMENT in namespace $NAMESPACE..."
+            kubectl --context lfx-v2-dev -n "$NAMESPACE" rollout restart deployment/"$DEPLOYMENT"
+            echo "Rollout restart issued for $DEPLOYMENT"
+          else
+            echo "Deployment $DEPLOYMENT not found in $NAMESPACE — skipping restart (may be initial deploy)"
+          fi
+
+          rm -f /tmp/kubeconfig
 
       - name: Comment deployment URL on PR
         uses: actions/github-script@v7

--- a/.github/workflows/docker-build-pr.yml
+++ b/.github/workflows/docker-build-pr.yml
@@ -80,6 +80,7 @@ jobs:
         uses: azure/setup-kubectl@v4
 
       - name: Restart Kubernetes deployment
+        id: restart
         env:
           KUBECONFIG_DATA: ${{ secrets.DEV_KUBECONFIG }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -93,18 +94,30 @@ jobs:
           if kubectl --context lfx-v2-dev -n "$NAMESPACE" get deployment "$DEPLOYMENT" &>/dev/null; then
             echo "Restarting deployment $DEPLOYMENT in namespace $NAMESPACE..."
             kubectl --context lfx-v2-dev -n "$NAMESPACE" rollout restart deployment/"$DEPLOYMENT"
-            echo "Rollout restart issued for $DEPLOYMENT"
+            echo "Waiting for rollout to complete..."
+            kubectl --context lfx-v2-dev -n "$NAMESPACE" rollout status deployment/"$DEPLOYMENT" --timeout=5m
+            RESTART_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+            echo "restarted=true" >> "$GITHUB_OUTPUT"
+            echo "restart_time=${RESTART_TIME}" >> "$GITHUB_OUTPUT"
+            echo "Rollout complete at ${RESTART_TIME}"
           else
+            echo "restarted=false" >> "$GITHUB_OUTPUT"
             echo "Deployment $DEPLOYMENT not found in $NAMESPACE — skipping restart (may be initial deploy)"
           fi
 
           rm -f /tmp/kubeconfig
 
       - name: Comment deployment URL on PR
+        env:
+          RESTARTED: ${{ steps.restart.outputs.restarted }}
+          RESTART_TIME: ${{ steps.restart.outputs.restart_time }}
         uses: actions/github-script@v7
         with:
           script: |
             const deploymentUrl = `https://ui-pr-${{ github.event.pull_request.number }}.dev.v2.cluster.linuxfound.info`;
+            const restarted = process.env.RESTARTED === 'true';
+            const restartTime = process.env.RESTART_TIME;
+            const restartLine = restarted ? `\n            - Pods restarted: ${restartTime}` : '';
             const comment = `## 🚀 Deployment Status
 
             Your branch has been deployed to: ${deploymentUrl}
@@ -112,7 +125,7 @@ jobs:
             **Deployment Details:**
             - Environment: Development
             - Namespace: ui-pr-${{ github.event.pull_request.number }}
-            - ArgoCD App: ui-pr-${{ github.event.pull_request.number }}
+            - ArgoCD App: ui-pr-${{ github.event.pull_request.number }}${restartLine}
 
             The deployment will be automatically removed when this PR is closed.`;
 


### PR DESCRIPTION
## Summary

- Adds a `Restart Kubernetes deployment` step to the `Deploy Branch to Development` workflow after each successful image push
- After the image is pushed, `kubectl rollout restart` is issued against `deployment/ui-pr-{pr_number}-lfx-v2-ui` in namespace `ui-pr-{pr_number}` on the `lfx-v2-dev` cluster
- Step gracefully no-ops if the deployment doesn't exist yet (initial `labeled` event before ArgoCD provisions the app)

## Context

PRs labeled `deploy-preview` build and push a Docker image tagged `ui-pr-{pr_number}`. Because the tag is stable across pushes, the running pod does not automatically pick up the new image. This adds the missing restart step to complete the redeploy loop on every `synchronize` event.

## Prerequisite

A GitHub Actions secret named `DEV_KUBECONFIG` must exist with a base64-encoded kubeconfig granting `rollout restart` access to the `lfx-v2-dev` cluster. If the secret is named differently in the repo, update line 81 of the workflow.

## Test plan

- [ ] Push a commit to a PR that has the `deploy-preview` label
- [ ] Confirm the "Restart Kubernetes deployment" step runs and logs `Rollout restart issued`
- [ ] Confirm the pod restarts and serves the updated image
- [ ] Add the `deploy-preview` label for the first time on a new PR and confirm the step logs the skip message (deployment not yet provisioned)

Jira: [LFXV2-1467](https://linuxfoundation.atlassian.net/browse/LFXV2-1467)

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1467]: https://linuxfoundation.atlassian.net/browse/LFXV2-1467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ