### PR TITLE
feat(meetings): add clickable context chips

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -109,24 +109,29 @@
                 @if (parentProject()?.name || project()?.name || meeting().project_name || (meeting().committees && meeting().committees.length > 0)) {
                   <div class="flex flex-wrap items-center gap-2" data-testid="meeting-context">
                     @if (parentProject()?.name; as foundationName) {
-                      <span
+                      <button
+                        type="button"
                         class="cursor-pointer hover:opacity-70 transition-opacity"
                         (click)="navigateToFoundation()"
                         data-testid="meeting-context-foundation">
                         <lfx-tag [value]="foundationName" severity="secondary" icon="fa-light fa-landmark" styleClass="cursor-pointer"></lfx-tag>
-                      </span>
+                      </button>
                     }
                     @if (project()?.name || meeting().project_name; as projectName) {
-                      <span class="cursor-pointer hover:opacity-70 transition-opacity" (click)="navigateToFoundation()" data-testid="meeting-context-project">
+                      <button
+                        type="button"
+                        class="cursor-pointer hover:opacity-70 transition-opacity"
+                        (click)="navigateToFoundation()"
+                        data-testid="meeting-context-project">
                         <lfx-tag
                           [value]="projectName"
                           severity="secondary"
                           icon="fa-light fa-cube"
                           styleClass="!text-teal-700 !bg-teal-50 !border-teal-200 cursor-pointer"></lfx-tag>
-                      </span>
+                      </button>
                     }
                     @for (committee of meeting().committees ?? []; track committee.uid) {
-                      @if (committee.name) {
+                      @if (committee.name && committee.uid) {
                         <a
                           [href]="'/groups/' + committee.uid"
                           target="_blank"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -109,24 +109,36 @@
                 @if (parentProject()?.name || project()?.name || meeting().project_name || (meeting().committees && meeting().committees.length > 0)) {
                   <div class="flex flex-wrap items-center gap-2" data-testid="meeting-context">
                     @if (parentProject()?.name; as foundationName) {
-                      <lfx-tag [value]="foundationName" severity="secondary" icon="fa-light fa-landmark" data-testid="meeting-context-foundation"></lfx-tag>
+                      <span
+                        class="cursor-pointer hover:opacity-70 transition-opacity"
+                        (click)="navigateToFoundation()"
+                        data-testid="meeting-context-foundation">
+                        <lfx-tag [value]="foundationName" severity="secondary" icon="fa-light fa-landmark" styleClass="cursor-pointer"></lfx-tag>
+                      </span>
                     }
                     @if (project()?.name || meeting().project_name; as projectName) {
-                      <lfx-tag
-                        [value]="projectName"
-                        severity="secondary"
-                        icon="fa-light fa-cube"
-                        styleClass="!text-teal-700 !bg-teal-50 !border-teal-200"
-                        data-testid="meeting-context-project"></lfx-tag>
+                      <span class="cursor-pointer hover:opacity-70 transition-opacity" (click)="navigateToFoundation()" data-testid="meeting-context-project">
+                        <lfx-tag
+                          [value]="projectName"
+                          severity="secondary"
+                          icon="fa-light fa-cube"
+                          styleClass="!text-teal-700 !bg-teal-50 !border-teal-200 cursor-pointer"></lfx-tag>
+                      </span>
                     }
                     @for (committee of meeting().committees ?? []; track committee.uid) {
                       @if (committee.name) {
-                        <lfx-tag
-                          [value]="committee.name"
-                          severity="secondary"
-                          icon="fa-light fa-users-rectangle"
-                          styleClass="!text-blue-700 !bg-blue-50 !border-blue-200"
-                          [attr.data-testid]="'meeting-context-committee-' + committee.uid"></lfx-tag>
+                        <a
+                          [href]="'/groups/' + committee.uid"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          class="no-underline hover:opacity-70 transition-opacity"
+                          [attr.data-testid]="'meeting-context-committee-' + committee.uid">
+                          <lfx-tag
+                            [value]="committee.name"
+                            severity="secondary"
+                            icon="fa-light fa-users-rectangle"
+                            styleClass="!text-blue-700 !bg-blue-50 !border-blue-200 cursor-pointer"></lfx-tag>
+                        </a>
                       }
                     }
                   </div>
@@ -358,7 +370,7 @@
                         [href]="primaryRecordingUrl()"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-50 transition-colors cursor-pointer"
+                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:border-gray-400 hover:shadow-sm transition-all cursor-pointer"
                         data-testid="view-recording-link">
                         <i class="fa-light fa-play text-sm"></i>
                         <span>See Recording</span>
@@ -377,7 +389,7 @@
                       <button
                         type="button"
                         (click)="openSummaryModal()"
-                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-50 transition-colors cursor-pointer w-full"
+                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:border-gray-400 hover:shadow-sm transition-all cursor-pointer w-full"
                         data-testid="past-meeting-summary">
                         <i class="fa-light fa-sparkles text-sm"></i>
                         <span>AI Summary</span>
@@ -402,7 +414,7 @@
                         [href]="transcriptUrl()"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-50 transition-colors cursor-pointer"
+                        class="flex items-center justify-center gap-2 border border-gray-200 rounded-lg py-2.5 px-4 text-sm font-medium text-gray-900 hover:bg-gray-100 hover:border-gray-400 hover:shadow-sm transition-all cursor-pointer"
                         data-testid="download-transcript-link">
                         <i class="fa-light fa-file-lines text-sm"></i>
                         <span>View Transcript</span>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -43,6 +43,8 @@ import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
 import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { LensService } from '@services/lens.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
@@ -109,6 +111,8 @@ export class MeetingJoinComponent implements OnInit {
   private readonly userService = inject(UserService);
   private readonly clipboard = inject(Clipboard);
   private readonly committeeService = inject(CommitteeService);
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly lensService = inject(LensService);
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -340,6 +344,20 @@ export class MeetingJoinComponent implements OnInit {
         this.refreshTrigger$.next();
       }
     });
+  }
+
+  public navigateToFoundation(): void {
+    const parent = this.parentProject();
+    const project = this.project();
+    const meeting = this.meeting();
+    const uid = parent?.uid || meeting?.project_uid;
+    const name = parent?.name || project?.name || meeting?.project_name || '';
+    const slug = parent?.slug || project?.slug || '';
+    if (uid) {
+      this.projectContextService.setFoundation({ uid, name, slug });
+      this.lensService.setLens('foundation');
+    }
+    window.open('/foundation/overview', '_blank', 'noopener,noreferrer');
   }
 
   public openSummaryModal(): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -44,7 +44,6 @@ import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { LensService } from '@services/lens.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
@@ -112,7 +111,6 @@ export class MeetingJoinComponent implements OnInit {
   private readonly clipboard = inject(Clipboard);
   private readonly committeeService = inject(CommitteeService);
   private readonly projectContextService = inject(ProjectContextService);
-  private readonly lensService = inject(LensService);
   private readonly dialogService = inject(DialogService);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -346,18 +344,19 @@ export class MeetingJoinComponent implements OnInit {
     });
   }
 
+  /** Sets foundation context via ProjectContextService and opens /foundation/overview in a new tab. */
   public navigateToFoundation(): void {
     const parent = this.parentProject();
     const project = this.project();
     const meeting = this.meeting();
-    const uid = parent?.uid || meeting?.project_uid;
-    const name = parent?.name || project?.name || meeting?.project_name || '';
-    const slug = parent?.slug || project?.slug || '';
+    const isTopLevelProject = !project?.parent_uid;
+    const uid = parent?.uid || project?.parent_uid || (isTopLevelProject ? project?.uid || meeting?.project_uid : undefined);
+    const name = parent?.name || (isTopLevelProject ? project?.name || meeting?.project_name || '' : '');
+    const slug = parent?.slug || (isTopLevelProject ? project?.slug || '' : '');
     if (uid) {
       this.projectContextService.setFoundation({ uid, name, slug });
-      this.lensService.setLens('foundation');
+      window.open('/foundation/overview', '_blank', 'noopener,noreferrer');
     }
-    window.open('/foundation/overview', '_blank', 'noopener,noreferrer');
   }
 
   public openSummaryModal(): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -351,8 +351,8 @@ export class MeetingJoinComponent implements OnInit {
     const meeting = this.meeting();
     const isTopLevelProject = !project?.parent_uid;
     const uid = parent?.uid || project?.parent_uid || (isTopLevelProject ? project?.uid || meeting?.project_uid : undefined);
-    const name = parent?.name || (isTopLevelProject ? project?.name || meeting?.project_name || '' : '');
-    const slug = parent?.slug || (isTopLevelProject ? project?.slug || '' : '');
+    const name = parent?.name || project?.name || meeting?.project_name || '';
+    const slug = parent?.slug || project?.slug || '';
     if (uid) {
       this.projectContextService.setFoundation({ uid, name, slug });
       window.open('/foundation/overview', '_blank', 'noopener,noreferrer');


### PR DESCRIPTION
## Summary
- Foundation/project context chips now navigate to `/foundation/overview` with the correct project context pre-set via `ProjectContextService`
- Committee context chips link to `/groups/:uid` opening in a new tab
- Added hover feedback (opacity change, border darkening, subtle shadow) on all interactive Meeting Tools buttons (See Recording, AI Summary, View Transcript)

## Test plan
- [ ] Navigate to a past meeting page (e.g., `/meetings/<id>-<timestamp>`)
- [ ] Verify foundation/project chip is clickable and opens `/foundation/overview` in a new tab with the correct foundation selected
- [ ] Verify committee/WG chip is clickable and opens `/groups/:uid` in a new tab
- [ ] Verify hover feedback on all context chips (opacity change)
- [ ] Verify hover feedback on Meeting Tools buttons (background, border, shadow)
- [ ] Verify disabled/unavailable states still look non-interactive

🤖 Generated with [Claude Code](https://claude.ai/claude-code)