### PR TITLE
feat(analytics): add ed prototype drawer endpoints

### DIFF
--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -56,6 +56,10 @@ import {
   SocialMediaResponse,
   SocialReachResponse,
   WebActivitiesSummaryResponse,
+  EventGrowthResponse,
+  BrandReachResponse,
+  BrandHealthResponse,
+  RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
 
@@ -966,6 +970,76 @@ export class AnalyticsService {
             convertedToWorkingGroup: 0,
           },
           monthlyData: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get event growth metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getEventGrowth(foundationSlug: string): Observable<EventGrowthResponse> {
+    return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          totalAttendees: 0,
+          changePercentage: 0,
+          trend: 'up' as const,
+          monthlyData: [],
+          topEvents: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get brand reach metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getBrandReach(foundationSlug: string): Observable<BrandReachResponse> {
+    return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          totalReach: 0,
+          changePercentage: 0,
+          trend: 'up' as const,
+          socialPlatforms: [],
+          websiteDomains: [],
+          dailyTrend: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get brand health metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getBrandHealth(foundationSlug: string): Observable<BrandHealthResponse> {
+    return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          shareOfVoice: 0,
+          sentimentScore: 0,
+          pressMentions: 0,
+          changePercentage: 0,
+          trend: 'up' as const,
+          monthlyMentions: [],
+          topProjects: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get marketing-attributed revenue metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getRevenueImpact(foundationSlug: string): Observable<RevenueImpactResponse> {
+    return this.http.get<RevenueImpactResponse>('/api/analytics/revenue-impact', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          totalAttributedRevenue: 0,
+          changePercentage: 0,
+          trend: 'up' as const,
+          engagementTypes: [],
         });
       })
     );

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2160,4 +2160,152 @@ export class AnalyticsController {
       next(error);
     }
   }
+
+  /**
+   * GET /api/analytics/event-growth
+   * Get event growth metrics (total attendees, top events by attendance/revenue)
+   */
+  public async getEventGrowth(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_event_growth');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_event_growth',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_event_growth',
+        });
+      }
+
+      const response = await this.projectService.getEventGrowth(foundationSlug);
+
+      logger.success(req, 'get_event_growth', startTime, {
+        foundation_slug: foundationSlug,
+        total_attendees: response.totalAttendees,
+        top_events: response.topEvents.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_event_growth', startTime, error);
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/brand-reach
+   * Get brand reach metrics (total digital reach across social + owned sites)
+   */
+  public async getBrandReach(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_brand_reach');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_brand_reach',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_brand_reach',
+        });
+      }
+
+      const response = await this.projectService.getBrandReach(foundationSlug);
+
+      logger.success(req, 'get_brand_reach', startTime, {
+        foundation_slug: foundationSlug,
+        total_reach: response.totalReach,
+        social_platforms: response.socialPlatforms.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_brand_reach', startTime, error);
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/brand-health
+   * Get brand health metrics (share of voice, sentiment, press mentions)
+   */
+  public async getBrandHealth(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_brand_health');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_brand_health',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_brand_health',
+        });
+      }
+
+      const response = await this.projectService.getBrandHealth(foundationSlug);
+
+      logger.success(req, 'get_brand_health', startTime, {
+        foundation_slug: foundationSlug,
+        share_of_voice: response.shareOfVoice,
+        top_projects: response.topProjects.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_brand_health', startTime, error);
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/revenue-impact
+   * Get marketing-attributed revenue metrics by engagement type
+   */
+  public async getRevenueImpact(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_revenue_impact');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_revenue_impact',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_revenue_impact',
+        });
+      }
+
+      const response = await this.projectService.getRevenueImpact(foundationSlug);
+
+      logger.success(req, 'get_revenue_impact', startTime, {
+        foundation_slug: foundationSlug,
+        total_revenue: response.totalAttributedRevenue,
+        engagement_types: response.engagementTypes.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_revenue_impact', startTime, error);
+      next(error);
+    }
+  }
 }

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -149,4 +149,10 @@ router.get('/member-acquisition', (req, res, next) => analyticsController.getMem
 router.get('/engaged-community', (req, res, next) => analyticsController.getEngagedCommunity(req, res, next));
 router.get('/flywheel-conversion', (req, res, next) => analyticsController.getFlywheelConversion(req, res, next));
 
+// Prototype ED dashboard endpoints (wired to stub services until dbt views land)
+router.get('/event-growth', (req, res, next) => analyticsController.getEventGrowth(req, res, next));
+router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
+router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
+router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));
+
 export default router;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -71,6 +71,10 @@ import {
   EngagedCommunitySizeResponse,
   FlywheelConversionResponse,
   NorthStarMonthlyDataPoint,
+  EventGrowthResponse,
+  BrandReachResponse,
+  BrandHealthResponse,
+  RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -2528,5 +2532,75 @@ export class ProjectService {
         monthlyData: [],
       };
     }
+  }
+
+  /**
+   * Get event growth metrics (STUB — dbt view pending)
+   * TODO: query ANALYTICS.PLATINUM_LFX_ONE.EVENT_GROWTH when the view is live
+   */
+  public async getEventGrowth(foundationSlug: string): Promise<EventGrowthResponse> {
+    logger.warning(undefined, 'get_event_growth', 'Event growth dbt view not yet available, returning empty response', {
+      foundation_slug: foundationSlug,
+    });
+    return {
+      totalAttendees: 0,
+      changePercentage: 0,
+      trend: 'up',
+      monthlyData: [],
+      topEvents: [],
+    };
+  }
+
+  /**
+   * Get brand reach metrics (STUB — dbt view pending)
+   * TODO: query ANALYTICS.PLATINUM_LFX_ONE.BRAND_REACH when the view is live
+   */
+  public async getBrandReach(foundationSlug: string): Promise<BrandReachResponse> {
+    logger.warning(undefined, 'get_brand_reach', 'Brand reach dbt view not yet available, returning empty response', {
+      foundation_slug: foundationSlug,
+    });
+    return {
+      totalReach: 0,
+      changePercentage: 0,
+      trend: 'up',
+      socialPlatforms: [],
+      websiteDomains: [],
+      dailyTrend: [],
+    };
+  }
+
+  /**
+   * Get brand health metrics (STUB — dbt view pending)
+   * TODO: query ANALYTICS.PLATINUM_LFX_ONE.BRAND_HEALTH when the view is live
+   */
+  public async getBrandHealth(foundationSlug: string): Promise<BrandHealthResponse> {
+    logger.warning(undefined, 'get_brand_health', 'Brand health dbt view not yet available, returning empty response', {
+      foundation_slug: foundationSlug,
+    });
+    return {
+      shareOfVoice: 0,
+      sentimentScore: 0,
+      pressMentions: 0,
+      changePercentage: 0,
+      trend: 'up',
+      monthlyMentions: [],
+      topProjects: [],
+    };
+  }
+
+  /**
+   * Get marketing-attributed revenue metrics (STUB — dbt view pending)
+   * TODO: query ANALYTICS.PLATINUM_LFX_ONE.REVENUE_IMPACT when the view is live
+   */
+  public async getRevenueImpact(foundationSlug: string): Promise<RevenueImpactResponse> {
+    logger.warning(undefined, 'get_revenue_impact', 'Revenue impact dbt view not yet available, returning empty response', {
+      foundation_slug: foundationSlug,
+    });
+    return {
+      totalAttributedRevenue: 0,
+      changePercentage: 0,
+      trend: 'up',
+      engagementTypes: [],
+    };
   }
 }

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2897,3 +2897,95 @@ export interface FlywheelConversionResponse {
   };
   monthlyData: NorthStarMonthlyDataPoint[];
 }
+
+/**
+ * Top event row for Event Growth drill-down
+ */
+export interface EventGrowthTopEvent {
+  name: string;
+  date: string;
+  attendees: number;
+  revenue: number;
+}
+
+/**
+ * API response for Event Growth metric
+ * Total event attendees, MoM growth, top events by attendance/revenue
+ */
+export interface EventGrowthResponse {
+  totalAttendees: number;
+  changePercentage: number;
+  trend: 'up' | 'down';
+  monthlyData: NorthStarMonthlyDataPoint[];
+  topEvents: EventGrowthTopEvent[];
+}
+
+/**
+ * Social platform row for Brand Reach drill-down
+ */
+export interface BrandReachSocialPlatform {
+  name: string;
+  followers: number;
+}
+
+/**
+ * Website domain row for Brand Reach drill-down
+ */
+export interface BrandReachWebsiteDomain {
+  domain: string;
+  sessions: number;
+}
+
+/**
+ * API response for Brand Reach metric
+ * Total digital reach across social platforms and owned websites
+ */
+export interface BrandReachResponse {
+  totalReach: number;
+  changePercentage: number;
+  trend: 'up' | 'down';
+  socialPlatforms: BrandReachSocialPlatform[];
+  websiteDomains: BrandReachWebsiteDomain[];
+  dailyTrend: NorthStarMonthlyDataPoint[];
+}
+
+/**
+ * Top project row for Brand Health drill-down
+ */
+export interface BrandHealthTopProject {
+  name: string;
+  mentions: number;
+}
+
+/**
+ * API response for Brand Health metric
+ * Share of voice, sentiment, press mentions, top projects by mentions
+ */
+export interface BrandHealthResponse {
+  shareOfVoice: number;
+  sentimentScore: number;
+  pressMentions: number;
+  changePercentage: number;
+  trend: 'up' | 'down';
+  monthlyMentions: NorthStarMonthlyDataPoint[];
+  topProjects: BrandHealthTopProject[];
+}
+
+/**
+ * Engagement-type revenue attribution row for Revenue Impact drill-down
+ */
+export interface RevenueImpactEngagementType {
+  type: string;
+  percentage: number;
+}
+
+/**
+ * API response for Revenue Impact metric
+ * Revenue attribution across marketing engagement channels
+ */
+export interface RevenueImpactResponse {
+  totalAttributedRevenue: number;
+  changePercentage: number;
+  trend: 'up' | 'down';
+  engagementTypes: RevenueImpactEngagementType[];
+}


### PR DESCRIPTION
## Summary

Adds the backend wiring for 4 new ED dashboard drawers (event-growth, brand-reach, brand-health, revenue-impact). Pure additive backend — no existing endpoints or frontend behavior change.

- **Interfaces** (`packages/shared/src/interfaces/analytics-data.interface.ts`, +92 LOC) — 4 Response types + 5 row/nested types
- **Controller** (`apps/lfx-one/src/server/controllers/analytics.controller.ts`, +148 LOC) — 4 methods following existing North Star pattern (`SLUG_PATTERN` validation, `logger.startOperation/success/error`)
- **Routes** (`apps/lfx-one/src/server/routes/analytics.route.ts`, +6 LOC) — 4 route registrations
- **Service stubs** (`apps/lfx-one/src/server/services/project.service.ts`, +74 LOC) — return empty typed responses with a `logger.warning` until the dbt views land
- **Frontend service** (`apps/lfx-one/src/app/shared/services/analytics.service.ts`, +74 LOC) — 4 methods with `catchError` defaults

## Why stubs now

The 4 dbt views (`PLATINUM_LFX_ONE.EVENT_GROWTH`, `BRAND_REACH`, `BRAND_HEALTH`, `REVENUE_IMPACT`) are in flight. This PR unblocks the frontend drawer refactor (#421) — PR1 can now consume `input()` data sourced from real endpoints instead of hardcoded mock data. When the dbt views deploy, only the 4 service methods in `project.service.ts` need to be updated to swap the empty default for a Snowflake query. Interfaces, routes, controllers, and frontend stay untouched.

## Endpoints

- `GET /api/analytics/event-growth?foundationSlug=<slug>`
- `GET /api/analytics/brand-reach?foundationSlug=<slug>`
- `GET /api/analytics/brand-health?foundationSlug=<slug>`
- `GET /api/analytics/revenue-impact?foundationSlug=<slug>`

All validate `foundationSlug` via `SLUG_PATTERN` and return the typed response shape.

## Test plan

- [x] \`yarn lint\` passes
- [x] \`yarn build\` passes (both \`@lfx-one/shared\` + \`lfx-one-ui\`)
- [ ] Hit each endpoint with an authenticated session and \`foundationSlug=the-linux-foundation\` — expect 200 with empty typed default
- [ ] Hit each endpoint without \`foundationSlug\` — expect 400 validation error
- [ ] Hit each endpoint with an invalid slug format — expect 400 validation error
- [ ] Check server logs for the \`get_event_growth\` / \`get_brand_reach\` / \`get_brand_health\` / \`get_revenue_impact\` INFO operation lines and WARNING stub lines
- [ ] Confirm TypeScript strict mode accepts all new types

## Related

- Depends on: nothing (pure additive, clean against main)
- Blocks: #421 (PR1 shell refactor — will consume these endpoints)
- Part of: LFXV2-1468 ED Marketing Dashboard

🤖 Generated with [Claude Code](https://claude.ai/code)