### PR TITLE
feat(meetings): dashboard card UX and occurrence nav

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -137,7 +137,7 @@
             severity="secondary"
             size="small"
             styleClass="w-full"
-            label="See Meeting Details"
+            label="View details"
             [href]="meetingDetailHref()"
             target="_blank"
             type="button"
@@ -150,27 +150,27 @@
             severity="secondary"
             size="small"
             styleClass="w-full"
-            label="See Meeting Details"
+            label="View details"
             [routerLink]="meetingDetailUrl()"
             [queryParams]="meetingDetailQueryParams()"
             type="button"
             [outlined]="true"
+            icon="fa-light fa-eye text-xs"
             data-testid="dashboard-meeting-card-see-button" />
         }
       }
 
-      <!-- See Recording button -->
+      <!-- Watch Recording button -->
       @if (recordingShareUrl()) {
         <lfx-button
           class="w-full"
-          severity="secondary"
+          severity="success"
           size="small"
           styleClass="w-full"
-          label="See Recording"
+          label="Watch Recording"
           [href]="recordingShareUrl()!"
           target="_blank"
           type="button"
-          [outlined]="true"
           icon="fa-light fa-play text-xs"
           data-testid="dashboard-meeting-card-recording-button" />
       }

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.html
@@ -3,31 +3,29 @@
 
 <section class="flex flex-col gap-4" data-testid="dashboard-my-meetings-section">
   <!-- Header -->
-  <div class="flex items-center justify-between h-8">
+  <div class="flex items-center h-8">
     <h2 class="flex items-center gap-2">
       <i class="fa-light fa-calendar text-lg"></i>
       <span>{{ sectionTitle() }}</span>
     </h2>
-    <lfx-button
-      label="View All"
-      icon="fa-light fa-chevron-right"
-      iconPos="right"
-      [routerLink]="['/meetings']"
-      styleClass="!text-sm !font-normal"
-      [text]="true"
-      size="small"
-      data-testid="dashboard-my-meetings-view-all" />
   </div>
 
   <!-- Meeting Cards: Last Meeting + Next Meeting -->
   <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
     <!-- Left Column: Last Meeting -->
     <div class="flex flex-col gap-2">
-      <div class="flex items-center gap-2">
+      <div class="flex items-center justify-between">
         <h3 class="text-sm font-normal text-gray-500 flex items-center gap-1.5">
           <i class="fa-light fa-clock-rotate-left text-gray-400"></i>
           Last Meeting
         </h3>
+        <a
+          routerLink="/meetings"
+          [queryParams]="{ time: 'past' }"
+          class="text-sm text-blue-600 hover:text-blue-800 font-normal"
+          data-testid="dashboard-last-meeting-view-all"
+          >View All</a
+        >
       </div>
       @if (pastLoading()) {
         <lfx-card>
@@ -55,11 +53,12 @@
 
     <!-- Right Column: Next Meeting -->
     <div class="flex flex-col gap-2">
-      <div class="flex items-center gap-2">
+      <div class="flex items-center justify-between">
         <h3 class="text-sm font-normal text-gray-500 flex items-center gap-1.5">
           <i class="fa-light fa-calendar text-gray-400"></i>
           Next Meeting
         </h3>
+        <a routerLink="/meetings" class="text-sm text-blue-600 hover:text-blue-800 font-normal" data-testid="dashboard-next-meeting-view-all">View All</a>
       </div>
       @if (upcomingLoading()) {
         <lfx-card>

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, inject, signal, Signal, WritableSignal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { DashboardMeetingCardComponent } from '@app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { ButtonComponent } from '@components/button/button.component';
@@ -18,7 +19,7 @@ import type { Meeting, MeetingWithOccurrence, PastMeeting } from '@lfx-one/share
 
 @Component({
   selector: 'lfx-my-meetings',
-  imports: [DashboardMeetingCardComponent, ButtonComponent, CardComponent, SkeletonModule],
+  imports: [DashboardMeetingCardComponent, ButtonComponent, CardComponent, SkeletonModule, RouterLink],
   templateUrl: './my-meetings.component.html',
   styleUrl: './my-meetings.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
@@ -5,7 +5,6 @@ import { Component, computed, inject, signal, Signal, WritableSignal } from '@an
 import { RouterLink } from '@angular/router';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { DashboardMeetingCardComponent } from '@app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
-import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { getActiveOccurrences } from '@lfx-one/shared';
 import { LensService } from '@services/lens.service';
@@ -19,7 +18,7 @@ import type { Meeting, MeetingWithOccurrence, PastMeeting } from '@lfx-one/share
 
 @Component({
   selector: 'lfx-my-meetings',
-  imports: [DashboardMeetingCardComponent, ButtonComponent, CardComponent, SkeletonModule, RouterLink],
+  imports: [DashboardMeetingCardComponent, CardComponent, SkeletonModule, RouterLink],
   templateUrl: './my-meetings.component.html',
   styleUrl: './my-meetings.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -151,12 +151,47 @@
 
                 <!-- Date/Time Badge -->
                 @if (currentOccurrence()?.start_time || meeting().start_time; as startTime) {
-                  <div class="flex items-center">
+                  <div class="flex items-center gap-3">
                     <lfx-tag
                       [value]="startTime | meetingTime: currentOccurrence()?.duration || meeting().duration : 'compact'"
                       severity="secondary"
                       icon="fa-light fa-calendar-days"
                       [attr.data-testid]="'meeting-badge-datetime'"></lfx-tag>
+                  </div>
+                }
+
+                <!-- Occurrence Navigation (recurring meetings only) -->
+                @if (meeting().recurrence && occurrenceLabel()) {
+                  <div class="flex items-center gap-3" data-testid="occurrence-navigation">
+                    @if (previousOccurrenceUrl(); as prevUrl) {
+                      <a
+                        [href]="prevUrl"
+                        class="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 transition-colors"
+                        data-testid="occurrence-nav-prev">
+                        <i class="fa-light fa-chevron-left text-xs"></i>
+                        <span>Previous</span>
+                      </a>
+                    } @else {
+                      <span class="flex items-center gap-1 text-sm text-gray-300">
+                        <i class="fa-light fa-chevron-left text-xs"></i>
+                        <span>Previous</span>
+                      </span>
+                    }
+                    <span class="text-xs text-gray-500 font-medium" data-testid="occurrence-counter">{{ occurrenceLabel() }}</span>
+                    @if (nextOccurrenceUrl(); as nextUrl) {
+                      <a
+                        [href]="nextUrl"
+                        class="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-800 transition-colors"
+                        data-testid="occurrence-nav-next">
+                        <span>Next</span>
+                        <i class="fa-light fa-chevron-right text-xs"></i>
+                      </a>
+                    } @else {
+                      <span class="flex items-center gap-1 text-sm text-gray-300">
+                        <span>Next</span>
+                        <i class="fa-light fa-chevron-right text-xs"></i>
+                      </span>
+                    }
                   </div>
                 }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -122,6 +122,7 @@ export class MeetingJoinComponent implements OnInit {
   public project: WritableSignal<Partial<Project> | null> = signal<Partial<Project> | null>(null);
   public meeting: Signal<Meeting & { project: Partial<Project> }>;
   public currentOccurrence: Signal<MeetingOccurrence | null>;
+  private occurrenceContext: Signal<{ sorted: MeetingOccurrence[]; currentIdx: number }>;
   protected previousOccurrenceUrl: Signal<string | null>;
   protected nextOccurrenceUrl: Signal<string | null>;
   protected occurrenceLabel: Signal<string | null>;
@@ -213,6 +214,7 @@ export class MeetingJoinComponent implements OnInit {
     this.authenticated = this.userService.authenticated;
     this.meeting = this.initializeMeeting();
     this.currentOccurrence = this.initializeCurrentOccurrence();
+    this.occurrenceContext = this.initializeOccurrenceContext();
     this.previousOccurrenceUrl = this.initializePreviousOccurrenceUrl();
     this.nextOccurrenceUrl = this.initializeNextOccurrenceUrl();
     this.occurrenceLabel = this.initializeOccurrenceLabel();
@@ -519,36 +521,36 @@ export class MeetingJoinComponent implements OnInit {
     });
   }
 
-  private getOccurrenceContext(): { sorted: MeetingOccurrence[]; currentIdx: number } {
-    const meeting = this.meeting();
-    if (!meeting?.occurrences?.length) return { sorted: [], currentIdx: -1 };
-    const sorted = getActiveOccurrences(meeting.occurrences).sort(
-      (a: MeetingOccurrence, b: MeetingOccurrence) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
-    );
-    const current = this.currentOccurrence();
-    let currentTime: number;
-    if (current) {
-      currentTime = new Date(current.start_time).getTime();
-    } else {
-      // For past meetings loaded via /meetings/{id}-{timestamp}, extract timestamp from route
-      const routeId = this.activatedRoute.snapshot.paramMap.get('id') ?? '';
-      const parts = routeId.split('-');
-      currentTime = parts.length === 2 && /^\d{13}$/.test(parts[1]) ? parseInt(parts[1], 10) : Date.now();
-    }
-    // Find exact match first, then closest
-    let currentIdx = sorted.findIndex((o: MeetingOccurrence) => new Date(o.start_time).getTime() === currentTime);
-    if (currentIdx < 0) {
-      currentIdx = sorted.findIndex((o: MeetingOccurrence) => new Date(o.start_time).getTime() >= currentTime);
-    }
-    if (currentIdx < 0) currentIdx = sorted.length - 1;
-    return { sorted, currentIdx };
+  private initializeOccurrenceContext(): Signal<{ sorted: MeetingOccurrence[]; currentIdx: number }> {
+    return computed(() => {
+      const meeting = this.meeting();
+      if (!meeting?.occurrences?.length) return { sorted: [], currentIdx: -1 };
+      const sorted = getActiveOccurrences(meeting.occurrences).sort(
+        (a: MeetingOccurrence, b: MeetingOccurrence) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+      );
+      const current = this.currentOccurrence();
+      let currentTime: number;
+      if (current) {
+        currentTime = new Date(current.start_time).getTime();
+      } else {
+        // For past meetings loaded via /meetings/{id}-{timestamp}, extract timestamp from route
+        const routeId = this.activatedRoute.snapshot.paramMap.get('id') ?? '';
+        const parts = routeId.split('-');
+        currentTime = parts.length === 2 && /^\d{13}$/.test(parts[1]) ? parseInt(parts[1], 10) : Date.now();
+      }
+      let currentIdx = sorted.findIndex((o: MeetingOccurrence) => new Date(o.start_time).getTime() === currentTime);
+      if (currentIdx < 0) {
+        currentIdx = sorted.findIndex((o: MeetingOccurrence) => new Date(o.start_time).getTime() >= currentTime);
+      }
+      if (currentIdx < 0) currentIdx = sorted.length - 1;
+      return { sorted, currentIdx };
+    });
   }
 
   private buildOccurrenceUrl(meetingId: string, occurrence: MeetingOccurrence): string {
     const timestamp = new Date(occurrence.start_time).getTime();
     const meeting = this.meeting();
-    const bufferMs = (meeting?.duration ?? 0) * 60 * 1000 + 40 * 60 * 1000;
-    const isPast = timestamp + bufferMs < Date.now();
+    const isPast = hasMeetingEnded(meeting, occurrence);
     const password = this.password();
     const params = new URLSearchParams();
     if (password) params.set('password', password);
@@ -565,7 +567,7 @@ export class MeetingJoinComponent implements OnInit {
     return computed(() => {
       const meeting = this.meeting();
       if (!meeting?.recurrence) return null;
-      const { sorted, currentIdx } = this.getOccurrenceContext();
+      const { sorted, currentIdx } = this.occurrenceContext();
       if (currentIdx <= 0) return null;
       return this.buildOccurrenceUrl(meeting.id, sorted[currentIdx - 1]);
     });
@@ -575,7 +577,7 @@ export class MeetingJoinComponent implements OnInit {
     return computed(() => {
       const meeting = this.meeting();
       if (!meeting?.recurrence) return null;
-      const { sorted, currentIdx } = this.getOccurrenceContext();
+      const { sorted, currentIdx } = this.occurrenceContext();
       if (currentIdx < 0 || currentIdx >= sorted.length - 1) return null;
       return this.buildOccurrenceUrl(meeting.id, sorted[currentIdx + 1]);
     });
@@ -585,7 +587,7 @@ export class MeetingJoinComponent implements OnInit {
     return computed(() => {
       const meeting = this.meeting();
       if (!meeting?.recurrence) return null;
-      const { sorted, currentIdx } = this.getOccurrenceContext();
+      const { sorted, currentIdx } = this.occurrenceContext();
       if (sorted.length === 0) return null;
       return `${currentIdx + 1} of ${sorted.length}`;
     });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -526,23 +526,37 @@ export class MeetingJoinComponent implements OnInit {
       (a: MeetingOccurrence, b: MeetingOccurrence) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
     );
     const current = this.currentOccurrence();
-    const currentTime = current ? new Date(current.start_time).getTime() : Date.now();
-    // Find closest occurrence to current time
-    let currentIdx = sorted.findIndex((o: MeetingOccurrence) => new Date(o.start_time).getTime() >= currentTime);
+    let currentTime: number;
+    if (current) {
+      currentTime = new Date(current.start_time).getTime();
+    } else {
+      // For past meetings loaded via /meetings/{id}-{timestamp}, extract timestamp from route
+      const routeId = this.activatedRoute.snapshot.paramMap.get('id') ?? '';
+      const parts = routeId.split('-');
+      currentTime = parts.length === 2 && /^\d{13}$/.test(parts[1]) ? parseInt(parts[1], 10) : Date.now();
+    }
+    // Find exact match first, then closest
+    let currentIdx = sorted.findIndex((o: MeetingOccurrence) => new Date(o.start_time).getTime() === currentTime);
+    if (currentIdx < 0) {
+      currentIdx = sorted.findIndex((o: MeetingOccurrence) => new Date(o.start_time).getTime() >= currentTime);
+    }
     if (currentIdx < 0) currentIdx = sorted.length - 1;
     return { sorted, currentIdx };
   }
 
   private buildOccurrenceUrl(meetingId: string, occurrence: MeetingOccurrence): string {
     const timestamp = new Date(occurrence.start_time).getTime();
-    const isPast = timestamp < Date.now();
+    const meeting = this.meeting();
+    const bufferMs = (meeting?.duration ?? 0) * 60 * 1000 + 40 * 60 * 1000;
+    const isPast = timestamp + bufferMs < Date.now();
     const password = this.password();
-    if (isPast) {
-      const base = `/meetings/${meetingId}-${timestamp}`;
-      return password ? `${base}?password=${password}` : base;
-    }
     const params = new URLSearchParams();
     if (password) params.set('password', password);
+    if (isPast) {
+      const base = `/meetings/${meetingId}-${timestamp}`;
+      const qs = params.toString();
+      return qs ? `${base}?${qs}` : base;
+    }
     params.set('occurrence', timestamp.toString());
     return `/meetings/${meetingId}?${params.toString()}`;
   }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -21,6 +21,7 @@ import {
   canJoinMeeting,
   CommitteeMember,
   DEFAULT_MEETING_TYPE_CONFIG,
+  getActiveOccurrences,
   getCurrentOrNextOccurrence,
   hasMeetingEnded,
   Meeting,
@@ -121,6 +122,9 @@ export class MeetingJoinComponent implements OnInit {
   public project: WritableSignal<Partial<Project> | null> = signal<Partial<Project> | null>(null);
   public meeting: Signal<Meeting & { project: Partial<Project> }>;
   public currentOccurrence: Signal<MeetingOccurrence | null>;
+  protected previousOccurrenceUrl: Signal<string | null>;
+  protected nextOccurrenceUrl: Signal<string | null>;
+  protected occurrenceLabel: Signal<string | null>;
   public meetingTypeBadge: Signal<{
     severity: TagSeverity;
     styleClass: string;
@@ -209,6 +213,9 @@ export class MeetingJoinComponent implements OnInit {
     this.authenticated = this.userService.authenticated;
     this.meeting = this.initializeMeeting();
     this.currentOccurrence = this.initializeCurrentOccurrence();
+    this.previousOccurrenceUrl = this.initializePreviousOccurrenceUrl();
+    this.nextOccurrenceUrl = this.initializeNextOccurrenceUrl();
+    this.occurrenceLabel = this.initializeOccurrenceLabel();
     this.joinForm = this.initializeJoinForm();
     this.formValues = this.initializeFormValues();
     this.meetingTypeBadge = this.initializeMeetingTypeBadge();
@@ -500,7 +507,73 @@ export class MeetingJoinComponent implements OnInit {
   private initializeCurrentOccurrence(): Signal<MeetingOccurrence | null> {
     return computed(() => {
       const meeting = this.meeting();
+      // Check if a specific occurrence was requested via query param
+      const requestedOccurrence = this.activatedRoute.snapshot.queryParamMap.get('occurrence');
+      if (requestedOccurrence && meeting?.occurrences?.length) {
+        const requestedTime = parseInt(requestedOccurrence, 10);
+        const active = getActiveOccurrences(meeting.occurrences);
+        const match = active.find((o: MeetingOccurrence) => new Date(o.start_time).getTime() === requestedTime);
+        if (match) return match;
+      }
       return getCurrentOrNextOccurrence(meeting);
+    });
+  }
+
+  private getOccurrenceContext(): { sorted: MeetingOccurrence[]; currentIdx: number } {
+    const meeting = this.meeting();
+    if (!meeting?.occurrences?.length) return { sorted: [], currentIdx: -1 };
+    const sorted = getActiveOccurrences(meeting.occurrences).sort(
+      (a: MeetingOccurrence, b: MeetingOccurrence) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
+    );
+    const current = this.currentOccurrence();
+    const currentTime = current ? new Date(current.start_time).getTime() : Date.now();
+    // Find closest occurrence to current time
+    let currentIdx = sorted.findIndex((o: MeetingOccurrence) => new Date(o.start_time).getTime() >= currentTime);
+    if (currentIdx < 0) currentIdx = sorted.length - 1;
+    return { sorted, currentIdx };
+  }
+
+  private buildOccurrenceUrl(meetingId: string, occurrence: MeetingOccurrence): string {
+    const timestamp = new Date(occurrence.start_time).getTime();
+    const isPast = timestamp < Date.now();
+    const password = this.password();
+    if (isPast) {
+      const base = `/meetings/${meetingId}-${timestamp}`;
+      return password ? `${base}?password=${password}` : base;
+    }
+    const params = new URLSearchParams();
+    if (password) params.set('password', password);
+    params.set('occurrence', timestamp.toString());
+    return `/meetings/${meetingId}?${params.toString()}`;
+  }
+
+  private initializePreviousOccurrenceUrl(): Signal<string | null> {
+    return computed(() => {
+      const meeting = this.meeting();
+      if (!meeting?.recurrence) return null;
+      const { sorted, currentIdx } = this.getOccurrenceContext();
+      if (currentIdx <= 0) return null;
+      return this.buildOccurrenceUrl(meeting.id, sorted[currentIdx - 1]);
+    });
+  }
+
+  private initializeNextOccurrenceUrl(): Signal<string | null> {
+    return computed(() => {
+      const meeting = this.meeting();
+      if (!meeting?.recurrence) return null;
+      const { sorted, currentIdx } = this.getOccurrenceContext();
+      if (currentIdx < 0 || currentIdx >= sorted.length - 1) return null;
+      return this.buildOccurrenceUrl(meeting.id, sorted[currentIdx + 1]);
+    });
+  }
+
+  private initializeOccurrenceLabel(): Signal<string | null> {
+    return computed(() => {
+      const meeting = this.meeting();
+      if (!meeting?.recurrence) return null;
+      const { sorted, currentIdx } = this.getOccurrenceContext();
+      if (sorted.length === 0) return null;
+      return `${currentIdx + 1} of ${sorted.length}`;
     });
   }
 


### PR DESCRIPTION
## Summary
- Split "View All" into per-section links on Me Dashboard: Last Meeting → `/meetings?time=past`, Next Meeting → `/meetings`
- Renamed meeting card buttons: "See Meeting Details" → "View details" (with eye icon), "See Recording" → "Watch Recording" (green success style)
- Added Previous/Next occurrence navigation for recurring meetings on the meeting join page with occurrence counter ("1 of 50")
- Past occurrences navigate via `/meetings/{id}-{timestamp}` (full page reload)
- Future occurrences navigate via `/meetings/{id}?occurrence={timestamp}` (query param, full page reload)

## Test plan
- [ ] Navigate to Me Dashboard — verify "View All" links next to Last Meeting and Next Meeting headings
- [ ] Click "View All" on Last Meeting — should open `/meetings?time=past`
- [ ] Click "View All" on Next Meeting — should open `/meetings`
- [ ] Verify button labels on meeting cards: "View details" and "Watch Recording" (green)
- [ ] Navigate to a recurring meeting (e.g., `/meetings/94138952063?password=9dd06eff-8433-4752-a213-2b8c04d6a6ef`)
- [ ] Verify occurrence counter shows (e.g., "1 of 50")
- [ ] Click Next — page reloads with next occurrence date
- [ ] Click Previous — page reloads with previous occurrence
- [ ] Verify Previous is disabled on first occurrence, Next on last

🤖 Generated with [Claude Code](https://claude.ai/claude-code)