### PR TITLE
feat(events): filter upcoming events by persona-affiliated projects

### DIFF
--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
@@ -82,10 +82,15 @@ export class EventsTopBarComponent {
             return of(defaultOptions);
           }
           this.foundationOptionsLoading.set(true);
-          return this.eventsService.getEventOrganizations({ projectName, isPast }).pipe(
-            map(({ data }) => [{ label: 'All Foundations', value: null }, ...data.map((name) => ({ label: name, value: name }))]),
-            finalize(() => this.foundationOptionsLoading.set(false))
-          );
+          return this.eventsService
+            .getEventOrganizations({
+              projectName,
+              isPast,
+            })
+            .pipe(
+              map(({ data }) => [{ label: 'All Foundations', value: null }, ...data.map((name) => ({ label: name, value: name }))]),
+              finalize(() => this.foundationOptionsLoading.set(false))
+            );
         }),
         shareReplay({ bufferSize: 1, refCount: true })
       ),

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -17,10 +17,12 @@ import {
 } from '@lfx-one/shared/constants';
 import { EventSortOrder, EventStatusFilter, GetEventOrganizationsOptions, GetEventsOptions } from '@lfx-one/shared/interfaces';
 import { EventsService } from '../services/events.service';
+import { PersonaDetectionService } from '../services/persona-detection.service';
 
 export class EventsController {
   private readonly eventsService = new EventsService();
   private readonly certificateService = new CertificateService();
+  private readonly personaDetectionService = new PersonaDetectionService();
 
   /**
    * GET /api/events
@@ -63,6 +65,13 @@ export class EventsController {
         isPast = false;
       }
 
+      // For upcoming events, fetch affiliated project IDs server-side from the persona service.
+      // This ensures client-supplied values cannot be used to access events from arbitrary projects.
+      let affiliatedProjectIds: string[] | undefined;
+      if (isPast === false) {
+        affiliatedProjectIds = await this.personaDetectionService.getAffiliatedProjectUids(req);
+      }
+
       const response = await this.eventsService.getMyEvents(req, userEmail, {
         isPast,
         eventId,
@@ -74,6 +83,7 @@ export class EventsController {
         pageSize,
         offset,
         sortOrder,
+        affiliatedProjectIds,
       });
 
       logger.success(req, 'get_my_events', startTime, {
@@ -178,9 +188,16 @@ export class EventsController {
         isPast = false;
       }
 
+      // For upcoming events, fetch affiliated project IDs server-side from the persona service.
+      let affiliatedProjectIds: string[] | undefined;
+      if (isPast !== true) {
+        affiliatedProjectIds = await this.personaDetectionService.getAffiliatedProjectUids(req);
+      }
+
       const options: GetEventOrganizationsOptions = {
         projectName: req.query['projectName'] ? String(req.query['projectName']) : undefined,
         isPast,
+        affiliatedProjectIds,
       };
 
       const response = await this.eventsService.getEventOrganizations(req, userEmail, options);

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -190,7 +190,7 @@ export class EventsController {
 
       // For upcoming events, fetch affiliated project IDs server-side from the persona service.
       let affiliatedProjectIds: string[] | undefined;
-      if (isPast !== true) {
+      if (isPast === false) {
         affiliatedProjectIds = await this.personaDetectionService.getAffiliatedProjectUids(req);
       }
 

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -65,11 +65,12 @@ export class EventsController {
         isPast = false;
       }
 
-      // For upcoming events, fetch affiliated project IDs server-side from the persona service.
+      // For upcoming events, fetch affiliated project slugs server-side from the persona service.
+      // Slugs are used because PROJECT_SLUG is the shared key between the persona service and datalake.
       // This ensures client-supplied values cannot be used to access events from arbitrary projects.
-      let affiliatedProjectIds: string[] | undefined;
+      let affiliatedProjectSlugs: string[] | undefined;
       if (isPast === false) {
-        affiliatedProjectIds = await this.personaDetectionService.getAffiliatedProjectUids(req);
+        affiliatedProjectSlugs = await this.personaDetectionService.getAffiliatedProjectSlugs(req);
       }
 
       const response = await this.eventsService.getMyEvents(req, userEmail, {
@@ -83,7 +84,7 @@ export class EventsController {
         pageSize,
         offset,
         sortOrder,
-        affiliatedProjectIds,
+        affiliatedProjectSlugs,
       });
 
       logger.success(req, 'get_my_events', startTime, {
@@ -188,16 +189,16 @@ export class EventsController {
         isPast = false;
       }
 
-      // For upcoming events, fetch affiliated project IDs server-side from the persona service.
-      let affiliatedProjectIds: string[] | undefined;
+      // For upcoming events, fetch affiliated project slugs server-side from the persona service.
+      let affiliatedProjectSlugs: string[] | undefined;
       if (isPast === false) {
-        affiliatedProjectIds = await this.personaDetectionService.getAffiliatedProjectUids(req);
+        affiliatedProjectSlugs = await this.personaDetectionService.getAffiliatedProjectSlugs(req);
       }
 
       const options: GetEventOrganizationsOptions = {
         projectName: req.query['projectName'] ? String(req.query['projectName']) : undefined,
         isPast,
-        affiliatedProjectIds,
+        affiliatedProjectSlugs,
       };
 
       const response = await this.eventsService.getEventOrganizations(req, userEmail, options);

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -107,6 +107,7 @@ export class EventsService {
           FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
           WHERE USER_EMAIL = ?
             AND IS_PAST_EVENT = FALSE
+            AND REGISTRATION_STATUS = 'Accepted'
             ${eventIdFilter}
           QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY EVENT_START_DATE) = 1
         ),
@@ -124,6 +125,7 @@ export class EventsService {
           FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
           WHERE USER_EMAIL = ?
             AND IS_PAST_EVENT = FALSE
+            AND REGISTRATION_STATUS = 'Accepted'
         ),
         combined AS (
           SELECT *, 1 AS source_priority FROM registered_events

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -30,7 +30,7 @@ export class EventsService {
   }
 
   public async getMyEvents(req: Request, userEmail: string, options: GetMyEventsOptions): Promise<MyEventsResponse> {
-    const { isPast, eventId, projectName, searchQuery, role, status, sortField: rawSortField, pageSize, offset, sortOrder } = options;
+    const { isPast, eventId, projectName, searchQuery, role, status, sortField: rawSortField, pageSize, offset, sortOrder, affiliatedProjectIds } = options;
     const sortField = rawSortField && VALID_EVENT_SORT_FIELDS.has(rawSortField) ? rawSortField : DEFAULT_EVENT_SORT_FIELD;
     const normalizedSortOrder: EventSortOrder = sortOrder === 'DESC' ? 'DESC' : 'ASC';
     const normalizedPageSize = Number.isInteger(pageSize) && pageSize > 0 ? pageSize : 10;
@@ -42,6 +42,7 @@ export class EventsService {
       has_project_name: !!projectName,
       has_search_query: !!searchQuery,
       role,
+      affiliated_project_count: affiliatedProjectIds?.length ?? 0,
       page_size: normalizedPageSize,
       offset: normalizedOffset,
       sort_order: normalizedSortOrder,
@@ -51,16 +52,20 @@ export class EventsService {
     let binds: string[];
 
     if (isPast === false) {
-      // Upcoming tab: show all upcoming events (registered by current user OR discoverable),
-      // LEFT JOIN user's registrations so unregistered events show with null user-specific fields.
+      // Upcoming tab: show events from affiliated projects UNION user's registered events.
+      // When affiliatedProjectIds is empty, use AND 1=0 so only registered events appear
+      // until persona data loads on the frontend.
       const eventIdFilter = eventId ? 'AND EVENT_ID = ?' : '';
       const projectNameFilter = projectName ? 'AND e.PROJECT_NAME = ?' : '';
       const searchQueryFilter = searchQuery ? 'AND e.EVENT_NAME ILIKE ?' : '';
       const roleFilterResult = role ? this.buildUpcomingRoleFilter(role) : { filter: '', binds: [] as string[] };
       const statusFilterResult = status ? this.buildUpcomingStatusFilter(status) : { filter: '', binds: [] as string[] };
 
+      const hasAffiliatedIds = affiliatedProjectIds && affiliatedProjectIds.length > 0;
+      const affiliatedFilter = hasAffiliatedIds ? `AND PROJECT_ID IN (${affiliatedProjectIds!.map(() => '?').join(', ')})` : 'AND 1=0';
+
       sql = `
-        WITH all_upcoming AS (
+        WITH affiliated_upcoming AS (
           SELECT
             EVENT_ID,
             EVENT_NAME,
@@ -79,6 +84,29 @@ export class EventsService {
           FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
           WHERE IS_PAST_EVENT = FALSE
             ${eventIdFilter}
+            ${affiliatedFilter}
+          QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY EVENT_START_DATE) = 1
+        ),
+        registered_events AS (
+          SELECT
+            EVENT_ID,
+            EVENT_NAME,
+            EVENT_START_DATE,
+            EVENT_END_DATE,
+            EVENT_LOCATION,
+            EVENT_CITY,
+            EVENT_COUNTRY,
+            PROJECT_ID,
+            PROJECT_NAME,
+            PROJECT_SLUG,
+            ACCOUNT_NAME,
+            ACCOUNT_LOGO_URL,
+            EVENT_URL,
+            EVENT_REGISTRATION_URL
+          FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
+          WHERE USER_EMAIL = ?
+            AND IS_PAST_EVENT = FALSE
+            ${eventIdFilter}
           QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY EVENT_START_DATE) = 1
         ),
         user_reg AS (
@@ -95,6 +123,11 @@ export class EventsService {
           FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
           WHERE USER_EMAIL = ?
             AND IS_PAST_EVENT = FALSE
+        ),
+        combined AS (
+          SELECT * FROM affiliated_upcoming
+          UNION
+          SELECT * FROM registered_events
         )
         SELECT
           e.EVENT_ID,
@@ -122,7 +155,7 @@ export class EventsService {
           (r.EVENT_ID IS NOT NULL) AS IS_REGISTERED,
           FALSE AS IS_PAST_EVENT,
           COUNT(*) OVER() AS TOTAL_RECORDS
-        FROM all_upcoming e
+        FROM combined e
         LEFT JOIN user_reg r ON e.EVENT_ID = r.EVENT_ID
         WHERE 1=1
           ${projectNameFilter}
@@ -134,8 +167,15 @@ export class EventsService {
       `;
 
       binds = [];
+      // affiliated_upcoming CTE binds
       if (eventId) binds.push(eventId);
+      if (hasAffiliatedIds) binds.push(...affiliatedProjectIds!);
+      // registered_events CTE binds
       binds.push(userEmail);
+      if (eventId) binds.push(eventId);
+      // user_reg CTE binds
+      binds.push(userEmail);
+      // main WHERE clause binds
       if (projectName) binds.push(projectName);
       if (searchQuery) binds.push(`%${searchQuery}%`);
       binds.push(...roleFilterResult.binds);
@@ -317,11 +357,12 @@ export class EventsService {
   }
 
   public async getEventOrganizations(req: Request, userEmail: string, options: GetEventOrganizationsOptions): Promise<MyEventOrganizationsResponse> {
-    const { projectName, isPast } = options;
+    const { projectName, isPast, affiliatedProjectIds } = options;
 
     logger.debug(req, 'get_event_organizations', 'Building organizations query', {
       has_project_name: !!projectName,
       is_past: isPast,
+      affiliated_project_count: affiliatedProjectIds?.length ?? 0,
     });
 
     let sql: string;
@@ -341,16 +382,22 @@ export class EventsService {
       binds.push(userEmail);
       if (projectName) binds.push(projectName);
     } else {
-      // Upcoming tab: return all distinct project names from upcoming events so the foundation
-      // filter dropdown includes both the user's registered foundations and discoverable ones.
+      // Upcoming tab: return foundations from events the user has registered for OR that belong
+      // to affiliated projects. When affiliatedProjectIds is empty, show only registered foundations.
       const projectNameFilter = projectName ? 'AND PROJECT_NAME = ?' : '';
+      const hasAffiliatedIds = affiliatedProjectIds && affiliatedProjectIds.length > 0;
+      const affiliatedFilter = hasAffiliatedIds ? `OR PROJECT_ID IN (${affiliatedProjectIds!.map(() => '?').join(', ')})` : '';
+
       sql = `
         SELECT DISTINCT PROJECT_NAME
         FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
         WHERE IS_PAST_EVENT = FALSE
+          AND (USER_EMAIL = ? ${affiliatedFilter})
           ${projectNameFilter}
         ORDER BY PROJECT_NAME
       `;
+      binds.push(userEmail);
+      if (hasAffiliatedIds) binds.push(...affiliatedProjectIds!);
       if (projectName) binds.push(projectName);
     }
 

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -54,15 +54,16 @@ export class EventsService {
     if (isPast === false) {
       // Upcoming tab: show events from affiliated projects UNION user's registered events.
       // When affiliatedProjectIds is empty, use AND 1=0 so only registered events appear
-      // until persona data loads on the frontend.
+      // (persona detection returned no affiliations or encountered an error).
       const eventIdFilter = eventId ? 'AND EVENT_ID = ?' : '';
       const projectNameFilter = projectName ? 'AND e.PROJECT_NAME = ?' : '';
       const searchQueryFilter = searchQuery ? 'AND e.EVENT_NAME ILIKE ?' : '';
       const roleFilterResult = role ? this.buildUpcomingRoleFilter(role) : { filter: '', binds: [] as string[] };
       const statusFilterResult = status ? this.buildUpcomingStatusFilter(status) : { filter: '', binds: [] as string[] };
 
-      const hasAffiliatedIds = affiliatedProjectIds && affiliatedProjectIds.length > 0;
-      const affiliatedFilter = hasAffiliatedIds ? `AND PROJECT_ID IN (${affiliatedProjectIds!.map(() => '?').join(', ')})` : 'AND 1=0';
+      const ids = affiliatedProjectIds ?? [];
+      const hasAffiliatedIds = ids.length > 0;
+      const affiliatedFilter = hasAffiliatedIds ? `AND PROJECT_ID IN (${ids.map(() => '?').join(', ')})` : 'AND 1=0';
 
       sql = `
         WITH affiliated_upcoming AS (
@@ -125,9 +126,10 @@ export class EventsService {
             AND IS_PAST_EVENT = FALSE
         ),
         combined AS (
-          SELECT * FROM affiliated_upcoming
-          UNION
-          SELECT * FROM registered_events
+          SELECT *, 1 AS source_priority FROM registered_events
+          UNION ALL
+          SELECT *, 2 AS source_priority FROM affiliated_upcoming
+          QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY source_priority) = 1
         )
         SELECT
           e.EVENT_ID,
@@ -166,20 +168,16 @@ export class EventsService {
         LIMIT ${normalizedPageSize} OFFSET ${normalizedOffset}
       `;
 
-      binds = [];
-      // affiliated_upcoming CTE binds
-      if (eventId) binds.push(eventId);
-      if (hasAffiliatedIds) binds.push(...affiliatedProjectIds!);
-      // registered_events CTE binds
-      binds.push(userEmail);
-      if (eventId) binds.push(eventId);
-      // user_reg CTE binds
-      binds.push(userEmail);
-      // main WHERE clause binds
-      if (projectName) binds.push(projectName);
-      if (searchQuery) binds.push(`%${searchQuery}%`);
-      binds.push(...roleFilterResult.binds);
-      binds.push(...statusFilterResult.binds);
+      const affiliatedUpcomingBinds: string[] = [...(eventId ? [eventId] : []), ...ids];
+      const registeredEventsBinds: string[] = [userEmail, ...(eventId ? [eventId] : [])];
+      const userRegBinds: string[] = [userEmail];
+      const whereBinds: string[] = [
+        ...(projectName ? [projectName] : []),
+        ...(searchQuery ? [`%${searchQuery}%`] : []),
+        ...roleFilterResult.binds,
+        ...statusFilterResult.binds,
+      ];
+      binds = [...affiliatedUpcomingBinds, ...registeredEventsBinds, ...userRegBinds, ...whereBinds];
     } else {
       // Past tab (or no isPast filter): show only the user's own registered events.
       const isPastFilter = isPast !== undefined ? `AND IS_PAST_EVENT = ${isPast ? 'TRUE' : 'FALSE'}` : '';
@@ -385,19 +383,20 @@ export class EventsService {
       // Upcoming tab: return foundations from events the user has registered for OR that belong
       // to affiliated projects. When affiliatedProjectIds is empty, show only registered foundations.
       const projectNameFilter = projectName ? 'AND PROJECT_NAME = ?' : '';
-      const hasAffiliatedIds = affiliatedProjectIds && affiliatedProjectIds.length > 0;
-      const affiliatedFilter = hasAffiliatedIds ? `OR PROJECT_ID IN (${affiliatedProjectIds!.map(() => '?').join(', ')})` : '';
+      const ids = affiliatedProjectIds ?? [];
+      const hasAffiliatedIds = ids.length > 0;
+      const affiliatedFilter = hasAffiliatedIds ? `OR PROJECT_ID IN (${ids.map(() => '?').join(', ')})` : '';
 
       sql = `
         SELECT DISTINCT PROJECT_NAME
         FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
         WHERE IS_PAST_EVENT = FALSE
-          AND (USER_EMAIL = ? ${affiliatedFilter})
+          AND ((USER_EMAIL = ? AND REGISTRATION_STATUS = 'Accepted') ${affiliatedFilter})
           ${projectNameFilter}
         ORDER BY PROJECT_NAME
       `;
       binds.push(userEmail);
-      if (hasAffiliatedIds) binds.push(...affiliatedProjectIds!);
+      if (hasAffiliatedIds) binds.push(...ids);
       if (projectName) binds.push(projectName);
     }
 

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -30,7 +30,7 @@ export class EventsService {
   }
 
   public async getMyEvents(req: Request, userEmail: string, options: GetMyEventsOptions): Promise<MyEventsResponse> {
-    const { isPast, eventId, projectName, searchQuery, role, status, sortField: rawSortField, pageSize, offset, sortOrder, affiliatedProjectIds } = options;
+    const { isPast, eventId, projectName, searchQuery, role, status, sortField: rawSortField, pageSize, offset, sortOrder, affiliatedProjectSlugs } = options;
     const sortField = rawSortField && VALID_EVENT_SORT_FIELDS.has(rawSortField) ? rawSortField : DEFAULT_EVENT_SORT_FIELD;
     const normalizedSortOrder: EventSortOrder = sortOrder === 'DESC' ? 'DESC' : 'ASC';
     const normalizedPageSize = Number.isInteger(pageSize) && pageSize > 0 ? pageSize : 10;
@@ -42,7 +42,7 @@ export class EventsService {
       has_project_name: !!projectName,
       has_search_query: !!searchQuery,
       role,
-      affiliated_project_count: affiliatedProjectIds?.length ?? 0,
+      affiliated_project_count: affiliatedProjectSlugs?.length ?? 0,
       page_size: normalizedPageSize,
       offset: normalizedOffset,
       sort_order: normalizedSortOrder,
@@ -53,7 +53,7 @@ export class EventsService {
 
     if (isPast === false) {
       // Upcoming tab: show events from affiliated projects UNION user's registered events.
-      // When affiliatedProjectIds is empty, use AND 1=0 so only registered events appear
+      // When affiliatedProjectSlugs is empty, use AND 1=0 so only registered events appear
       // (persona detection returned no affiliations or encountered an error).
       const eventIdFilter = eventId ? 'AND EVENT_ID = ?' : '';
       const projectNameFilter = projectName ? 'AND e.PROJECT_NAME = ?' : '';
@@ -61,9 +61,9 @@ export class EventsService {
       const roleFilterResult = role ? this.buildUpcomingRoleFilter(role) : { filter: '', binds: [] as string[] };
       const statusFilterResult = status ? this.buildUpcomingStatusFilter(status) : { filter: '', binds: [] as string[] };
 
-      const ids = affiliatedProjectIds ?? [];
-      const hasAffiliatedIds = ids.length > 0;
-      const affiliatedFilter = hasAffiliatedIds ? `AND PROJECT_ID IN (${ids.map(() => '?').join(', ')})` : 'AND 1=0';
+      const slugs = affiliatedProjectSlugs ?? [];
+      const hasAffiliatedSlugs = slugs.length > 0;
+      const affiliatedFilter = hasAffiliatedSlugs ? `AND LOWER(PROJECT_SLUG) IN (${slugs.map(() => '?').join(', ')})` : 'AND 1=0';
 
       sql = `
         WITH affiliated_upcoming AS (
@@ -168,7 +168,7 @@ export class EventsService {
         LIMIT ${normalizedPageSize} OFFSET ${normalizedOffset}
       `;
 
-      const affiliatedUpcomingBinds: string[] = [...(eventId ? [eventId] : []), ...ids];
+      const affiliatedUpcomingBinds: string[] = [...(eventId ? [eventId] : []), ...slugs];
       const registeredEventsBinds: string[] = [userEmail, ...(eventId ? [eventId] : [])];
       const userRegBinds: string[] = [userEmail];
       const whereBinds: string[] = [
@@ -178,6 +178,13 @@ export class EventsService {
         ...statusFilterResult.binds,
       ];
       binds = [...affiliatedUpcomingBinds, ...registeredEventsBinds, ...userRegBinds, ...whereBinds];
+
+      logger.debug(req, 'get_my_events', 'Upcoming events query binds', {
+        affiliated_project_slugs: slugs,
+        affiliated_filter_active: hasAffiliatedSlugs,
+        user_email: '***',
+        bind_count: binds.length,
+      });
     } else {
       // Past tab (or no isPast filter): show only the user's own registered events.
       const isPastFilter = isPast !== undefined ? `AND IS_PAST_EVENT = ${isPast ? 'TRUE' : 'FALSE'}` : '';
@@ -355,12 +362,12 @@ export class EventsService {
   }
 
   public async getEventOrganizations(req: Request, userEmail: string, options: GetEventOrganizationsOptions): Promise<MyEventOrganizationsResponse> {
-    const { projectName, isPast, affiliatedProjectIds } = options;
+    const { projectName, isPast, affiliatedProjectSlugs } = options;
 
     logger.debug(req, 'get_event_organizations', 'Building organizations query', {
       has_project_name: !!projectName,
       is_past: isPast,
-      affiliated_project_count: affiliatedProjectIds?.length ?? 0,
+      affiliated_project_count: affiliatedProjectSlugs?.length ?? 0,
     });
 
     let sql: string;
@@ -381,11 +388,11 @@ export class EventsService {
       if (projectName) binds.push(projectName);
     } else {
       // Upcoming tab: return foundations from events the user has registered for OR that belong
-      // to affiliated projects. When affiliatedProjectIds is empty, show only registered foundations.
+      // to affiliated projects. When affiliatedProjectSlugs is empty, show only registered foundations.
       const projectNameFilter = projectName ? 'AND PROJECT_NAME = ?' : '';
-      const ids = affiliatedProjectIds ?? [];
-      const hasAffiliatedIds = ids.length > 0;
-      const affiliatedFilter = hasAffiliatedIds ? `OR PROJECT_ID IN (${ids.map(() => '?').join(', ')})` : '';
+      const slugs = affiliatedProjectSlugs ?? [];
+      const hasAffiliatedSlugs = slugs.length > 0;
+      const affiliatedFilter = hasAffiliatedSlugs ? `OR LOWER(PROJECT_SLUG) IN (${slugs.map(() => '?').join(', ')})` : '';
 
       sql = `
         SELECT DISTINCT PROJECT_NAME
@@ -396,7 +403,7 @@ export class EventsService {
         ORDER BY PROJECT_NAME
       `;
       binds.push(userEmail);
-      if (hasAffiliatedIds) binds.push(...ids);
+      if (hasAffiliatedSlugs) binds.push(...slugs);
       if (projectName) binds.push(projectName);
     }
 

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -18,6 +18,14 @@ const DETECTION_SOURCE_MAP: Record<string, PersonaType> = {
 /** Persona priority order (highest first) for sorting */
 const PERSONA_PRIORITY: PersonaType[] = ['board-member', 'executive-director', 'maintainer', 'contributor'];
 
+/** TTL for the affiliated-project-UIDs cache, in milliseconds */
+const AFFILIATED_PROJECT_UIDS_CACHE_TTL_MS = 15_000;
+
+interface AffiliatedProjectUidsCacheEntry {
+  result: string[];
+  expiresAt: number;
+}
+
 /**
  * Service for detecting user personas via the persona detection NATS RPC
  * and enriching results with project data for UI consumption
@@ -25,6 +33,13 @@ const PERSONA_PRIORITY: PersonaType[] = ['board-member', 'executive-director', '
 export class PersonaDetectionService {
   private readonly natsService: NatsService;
   private readonly projectService: ProjectService;
+
+  /**
+   * Short-lived per-user cache for affiliated project UIDs.
+   * Keyed by lowercase email. Prevents duplicate NATS calls from concurrent
+   * requests on the same page load (e.g. events list + foundation dropdown).
+   */
+  private readonly affiliatedUidsCache = new Map<string, AffiliatedProjectUidsCacheEntry>();
 
   public constructor() {
     this.natsService = new NatsService();
@@ -35,19 +50,39 @@ export class PersonaDetectionService {
    * Return only the project UIDs the authenticated user is affiliated with.
    * Uses a single NATS call (no project-name enrichment) — suitable for
    * authorization checks in data-fetching endpoints.
+   * Results are cached per-user for 15 s to absorb concurrent page-load
+   * requests without redundant NATS round-trips.
    * Returns an empty array on error so callers degrade gracefully.
    */
   public async getAffiliatedProjectUids(req: Request): Promise<string[]> {
     const username = req.oidc?.user?.['nickname'] || '';
-    const email = (req.oidc?.user?.['email'] as string) || '';
+    const email = ((req.oidc?.user?.['email'] as string) || '').toLowerCase();
+
+    const cached = this.affiliatedUidsCache.get(email);
+    if (cached && Date.now() < cached.expiresAt) {
+      logger.debug(req, 'get_affiliated_project_uids', 'Returning cached affiliated project UIDs', {
+        email: email ? '***' : 'empty',
+        count: cached.result.length,
+      });
+      return cached.result;
+    }
 
     const detectionResponse = await this.fetchPersonaDetections(req, username, email);
 
-    if (detectionResponse.error || detectionResponse.projects.length === 0) {
-      return [];
+    let result: string[];
+    if (detectionResponse.error) {
+      logger.warning(req, 'get_affiliated_project_uids', 'Persona detection returned an error, returning empty affiliation list', {
+        error_code: detectionResponse.error.code,
+        error_message: detectionResponse.error.message,
+      });
+      result = [];
+    } else {
+      result = [...new Set(detectionResponse.projects.map((p) => p.project_uid).filter(Boolean))];
     }
 
-    return detectionResponse.projects.map((p) => p.project_uid).filter(Boolean);
+    this.affiliatedUidsCache.set(email, { result, expiresAt: Date.now() + AFFILIATED_PROJECT_UIDS_CACHE_TTL_MS });
+
+    return result;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -22,7 +22,8 @@ const PERSONA_PRIORITY: PersonaType[] = ['board-member', 'executive-director', '
 const AFFILIATED_PROJECT_UIDS_CACHE_TTL_MS = 15_000;
 
 interface AffiliatedProjectUidsCacheEntry {
-  result: string[];
+  /** In-flight (or resolved) promise — stored before awaiting to collapse concurrent lookups */
+  promise: Promise<string[]>;
   expiresAt: number;
 }
 
@@ -36,53 +37,76 @@ export class PersonaDetectionService {
 
   /**
    * Short-lived per-user cache for affiliated project UIDs.
-   * Keyed by lowercase email. Prevents duplicate NATS calls from concurrent
-   * requests on the same page load (e.g. events list + foundation dropdown).
+   * Keyed by username (nickname claim) with email as fallback.
+   * Stores the in-flight Promise so concurrent requests on the same page load
+   * (e.g. events list + foundation dropdown) share a single NATS round-trip.
    */
   private readonly affiliatedUidsCache = new Map<string, AffiliatedProjectUidsCacheEntry>();
 
   public constructor() {
     this.natsService = new NatsService();
     this.projectService = new ProjectService();
+
+    // Sweep expired cache entries every 60 s — well above the 15 s TTL — so
+    // entries that are never re-requested don't accumulate indefinitely.
+    setInterval(() => {
+      const now = Date.now();
+      for (const [key, entry] of this.affiliatedUidsCache) {
+        if (now >= entry.expiresAt) {
+          this.affiliatedUidsCache.delete(key);
+        }
+      }
+    }, 60_000).unref();
   }
 
   /**
    * Return only the project UIDs the authenticated user is affiliated with.
    * Uses a single NATS call (no project-name enrichment) — suitable for
    * authorization checks in data-fetching endpoints.
-   * Results are cached per-user for 15 s to absorb concurrent page-load
-   * requests without redundant NATS round-trips.
+   *
+   * Cache strategy:
+   * - Keyed by username (nickname) with email as fallback; skips cache entirely
+   *   when no stable identifier is present (prevents cross-user data leaks).
+   * - Stores the in-flight Promise before awaiting so concurrent requests for
+   *   the same user share a single NATS round-trip rather than each triggering
+   *   their own (addresses the "events list + foundation dropdown" concurrency).
+   * - Evicts stale entries eagerly on cache miss and on rejection to prevent
+   *   memory growth and poisoned entries.
+   *
    * Returns an empty array on error so callers degrade gracefully.
    */
   public async getAffiliatedProjectUids(req: Request): Promise<string[]> {
     const username = req.oidc?.user?.['nickname'] || '';
     const email = ((req.oidc?.user?.['email'] as string) || '').toLowerCase();
+    const cacheKey = username || email;
 
-    const cached = this.affiliatedUidsCache.get(email);
-    if (cached && Date.now() < cached.expiresAt) {
-      logger.debug(req, 'get_affiliated_project_uids', 'Returning cached affiliated project UIDs', {
-        email: email ? '***' : 'empty',
-        count: cached.result.length,
-      });
-      return cached.result;
+    // No stable identifier — bypass cache to prevent cross-user data leaks.
+    if (!cacheKey) {
+      logger.debug(req, 'get_affiliated_project_uids', 'No stable cache key, bypassing cache');
+      return this.fetchAndResolveAffiliatedUids(req, username, email);
     }
 
-    const detectionResponse = await this.fetchPersonaDetections(req, username, email);
-
-    let result: string[];
-    if (detectionResponse.error) {
-      logger.warning(req, 'get_affiliated_project_uids', 'Persona detection returned an error, returning empty affiliation list', {
-        error_code: detectionResponse.error.code,
-        error_message: detectionResponse.error.message,
-      });
-      result = [];
-    } else {
-      result = [...new Set(detectionResponse.projects.map((p) => p.project_uid).filter(Boolean))];
+    const cached = this.affiliatedUidsCache.get(cacheKey);
+    if (cached) {
+      if (Date.now() < cached.expiresAt) {
+        logger.debug(req, 'get_affiliated_project_uids', 'Returning cached affiliated project UIDs', {
+          cacheKey: '***',
+        });
+        return cached.promise;
+      }
+      // Stale — evict eagerly so the next caller fetches fresh data.
+      this.affiliatedUidsCache.delete(cacheKey);
     }
 
-    this.affiliatedUidsCache.set(email, { result, expiresAt: Date.now() + AFFILIATED_PROJECT_UIDS_CACHE_TTL_MS });
+    // Store the Promise *before* awaiting so concurrent callers retrieve and
+    // await the same Promise instead of each triggering a separate NATS call.
+    const promise = this.fetchAndResolveAffiliatedUids(req, username, email);
+    this.affiliatedUidsCache.set(cacheKey, { promise, expiresAt: Date.now() + AFFILIATED_PROJECT_UIDS_CACHE_TTL_MS });
 
-    return result;
+    // Remove on rejection so a failed lookup doesn't poison the cache.
+    promise.catch(() => this.affiliatedUidsCache.delete(cacheKey));
+
+    return promise;
   }
 
   /**
@@ -161,6 +185,21 @@ export class PersonaDetectionService {
       multiFoundation,
       error: null,
     };
+  }
+
+  /** Fetch persona detections and resolve to a deduplicated list of project UIDs. */
+  private async fetchAndResolveAffiliatedUids(req: Request, username: string, email: string): Promise<string[]> {
+    const detectionResponse = await this.fetchPersonaDetections(req, username, email);
+
+    if (detectionResponse.error) {
+      logger.warning(req, 'get_affiliated_project_uids', 'Persona detection returned an error, returning empty affiliation list', {
+        error_code: detectionResponse.error.code,
+        error_message: detectionResponse.error.message,
+      });
+      return [];
+    }
+
+    return [...new Set(detectionResponse.projects.map((p) => p.project_uid).filter(Boolean))];
   }
 
   /**

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -60,9 +60,9 @@ export class PersonaDetectionService {
   }
 
   /**
-   * Return only the project UIDs the authenticated user is affiliated with.
-   * Uses a single NATS call (no project-name enrichment) — suitable for
-   * authorization checks in data-fetching endpoints.
+   * Return only the project slugs the authenticated user is affiliated with.
+   * Slugs are used (rather than persona-service UIDs) because PROJECT_SLUG is
+   * the shared cross-reference key between the persona service and the datalake.
    *
    * Cache strategy:
    * - Keyed by username (nickname) with email as fallback; skips cache entirely
@@ -75,21 +75,21 @@ export class PersonaDetectionService {
    *
    * Returns an empty array on error so callers degrade gracefully.
    */
-  public async getAffiliatedProjectUids(req: Request): Promise<string[]> {
+  public async getAffiliatedProjectSlugs(req: Request): Promise<string[]> {
     const username = req.oidc?.user?.['nickname'] || '';
     const email = ((req.oidc?.user?.['email'] as string) || '').toLowerCase();
     const cacheKey = username || email;
 
     // No stable identifier — bypass cache to prevent cross-user data leaks.
     if (!cacheKey) {
-      logger.debug(req, 'get_affiliated_project_uids', 'No stable cache key, bypassing cache');
-      return this.fetchAndResolveAffiliatedUids(req, username, email);
+      logger.debug(req, 'get_affiliated_project_slugs', 'No stable cache key, bypassing cache');
+      return this.fetchAndResolveAffiliatedSlugs(req, username, email);
     }
 
     const cached = this.affiliatedUidsCache.get(cacheKey);
     if (cached) {
       if (Date.now() < cached.expiresAt) {
-        logger.debug(req, 'get_affiliated_project_uids', 'Returning cached affiliated project UIDs', {
+        logger.debug(req, 'get_affiliated_project_slugs', 'Returning cached affiliated project slugs', {
           cacheKey: '***',
         });
         return cached.promise;
@@ -100,7 +100,7 @@ export class PersonaDetectionService {
 
     // Store the Promise *before* awaiting so concurrent callers retrieve and
     // await the same Promise instead of each triggering a separate NATS call.
-    const promise = this.fetchAndResolveAffiliatedUids(req, username, email);
+    const promise = this.fetchAndResolveAffiliatedSlugs(req, username, email);
     this.affiliatedUidsCache.set(cacheKey, { promise, expiresAt: Date.now() + AFFILIATED_PROJECT_UIDS_CACHE_TTL_MS });
 
     // Remove on rejection so a failed lookup doesn't poison the cache.
@@ -187,35 +187,54 @@ export class PersonaDetectionService {
     };
   }
 
-  /** Fetch persona detections and resolve to a deduplicated list of project UIDs. */
-  private async fetchAndResolveAffiliatedUids(req: Request, username: string, email: string): Promise<string[]> {
+  /** Fetch persona detections and resolve to a deduplicated list of project slugs. */
+  private async fetchAndResolveAffiliatedSlugs(req: Request, username: string, email: string): Promise<string[]> {
     const detectionResponse = await this.fetchPersonaDetections(req, username, email);
 
     if (detectionResponse.error) {
-      logger.warning(req, 'get_affiliated_project_uids', 'Persona detection returned an error, returning empty affiliation list', {
+      logger.warning(req, 'get_affiliated_project_slugs', 'Persona detection returned an error, returning empty affiliation list', {
         error_code: detectionResponse.error.code,
         error_message: detectionResponse.error.message,
       });
       return [];
     }
 
-    return [...new Set(detectionResponse.projects.map((p) => p.project_uid).filter(Boolean))];
+    const slugs = [...new Set(detectionResponse.projects.map((p) => p.project_slug?.toLowerCase()).filter(Boolean))];
+
+    logger.debug(req, 'get_affiliated_project_slugs', 'Resolved affiliated project slugs', {
+      slug_count: slugs.length,
+      project_slugs: slugs,
+    });
+
+    return slugs;
   }
 
   /**
    * Call the persona detection service via NATS RPC
    */
   private async fetchPersonaDetections(req: Request, username: string, email: string): Promise<PersonaDetectionResponse> {
+    logger.debug(req, 'fetch_persona_detections', 'Sending NATS persona request', {
+      subject: NatsSubjects.PERSONAS_GET,
+      has_username: !!username,
+      has_email: !!email,
+      email: email ? '***' : 'empty',
+    });
+
     try {
       const codec = this.natsService.getCodec();
       const payload = JSON.stringify({ username, email });
       const response = await this.natsService.request(NatsSubjects.PERSONAS_GET, codec.encode(payload), { timeout: 5000 });
       const decoded = codec.decode(response.data);
 
+      logger.debug(req, 'fetch_persona_detections', 'Raw NATS persona response received', {
+        response_length: decoded.length,
+        raw_response: decoded.length <= 2000 ? decoded : decoded.slice(0, 2000) + '...[truncated]',
+      });
+
       const parsed = JSON.parse(decoded);
 
       // Validate response shape — normalize malformed fields to prevent downstream crashes
-      return {
+      const normalized = {
         projects: Array.isArray(parsed?.projects)
           ? parsed.projects.map((p: Record<string, unknown>) => ({
               project_uid: p['project_uid'] || '',
@@ -225,9 +244,19 @@ export class PersonaDetectionService {
           : [],
         error: parsed?.error ?? null,
       } as PersonaDetectionResponse;
+
+      logger.debug(req, 'fetch_persona_detections', 'Persona detection normalized', {
+        project_count: normalized.projects.length,
+        project_uids: normalized.projects.map((p) => p.project_uid),
+        has_error: !!normalized.error,
+        error_code: normalized.error?.code ?? null,
+      });
+
+      return normalized;
     } catch (error) {
       logger.warning(req, 'fetch_persona_detections', 'NATS persona detection failed', {
         error: error instanceof Error ? error.message : 'Unknown error',
+        error_name: error instanceof Error ? error.constructor.name : 'Unknown',
       });
 
       return { projects: [], error: { code: 'nats_error', message: 'Failed to fetch persona detections' } };

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -32,6 +32,25 @@ export class PersonaDetectionService {
   }
 
   /**
+   * Return only the project UIDs the authenticated user is affiliated with.
+   * Uses a single NATS call (no project-name enrichment) — suitable for
+   * authorization checks in data-fetching endpoints.
+   * Returns an empty array on error so callers degrade gracefully.
+   */
+  public async getAffiliatedProjectUids(req: Request): Promise<string[]> {
+    const username = req.oidc?.user?.['nickname'] || '';
+    const email = (req.oidc?.user?.['email'] as string) || '';
+
+    const detectionResponse = await this.fetchPersonaDetections(req, username, email);
+
+    if (detectionResponse.error || detectionResponse.projects.length === 0) {
+      return [];
+    }
+
+    return detectionResponse.projects.map((p) => p.project_uid).filter(Boolean);
+  }
+
+  /**
    * Get enriched persona data for the authenticated user
    * Calls the persona detection service via NATS, enriches with project names,
    * and maps detections to persona types

--- a/packages/shared/src/interfaces/my-event.interface.ts
+++ b/packages/shared/src/interfaces/my-event.interface.ts
@@ -271,8 +271,8 @@ export interface GetMyEventsOptions {
   pageSize: number;
   offset: number;
   sortOrder: EventSortOrder;
-  /** Project IDs from persona detection — scopes upcoming events to affiliated projects */
-  affiliatedProjectIds?: string[];
+  /** Project slugs from persona detection — scopes upcoming events to affiliated projects */
+  affiliatedProjectSlugs?: string[];
 }
 
 /**
@@ -298,6 +298,6 @@ export interface GetEventOrganizationsOptions {
   projectName?: string;
   /** When true, returns only foundations from the authenticated user's registered past events */
   isPast?: boolean;
-  /** Project IDs from persona detection — scopes upcoming foundations to affiliated projects */
-  affiliatedProjectIds?: string[];
+  /** Project slugs from persona detection — scopes upcoming foundations to affiliated projects */
+  affiliatedProjectSlugs?: string[];
 }

--- a/packages/shared/src/interfaces/my-event.interface.ts
+++ b/packages/shared/src/interfaces/my-event.interface.ts
@@ -271,6 +271,8 @@ export interface GetMyEventsOptions {
   pageSize: number;
   offset: number;
   sortOrder: EventSortOrder;
+  /** Project IDs from persona detection — scopes upcoming events to affiliated projects */
+  affiliatedProjectIds?: string[];
 }
 
 /**
@@ -296,4 +298,6 @@ export interface GetEventOrganizationsOptions {
   projectName?: string;
   /** When true, returns only foundations from the authenticated user's registered past events */
   isPast?: boolean;
+  /** Project IDs from persona detection — scopes upcoming foundations to affiliated projects */
+  affiliatedProjectIds?: string[];
 }


### PR DESCRIPTION
## Summary

- Scopes My Events > Upcoming tab to show only events the user has registered for **or** belongs to an affiliated project (via Persona Detection Service)
- Affiliation resolved server-side via NATS RPC — client-supplied project IDs are never trusted, preventing authorization bypass
- SQL uses a `UNION` of an `affiliated_upcoming` CTE and a `registered_events` CTE; safe default (registered-only) when NATS returns empty
- Foundation filter dropdown (`getEventOrganizations`) scoped by the same affiliation logic
- Past events unaffected

## Changes

```
 .../events-top-bar/events-top-bar.component.ts     | 13 +++--
 .../src/server/controllers/events.controller.ts    | 17 ++++++
 apps/lfx-one/src/server/services/events.service.ts | 63 +++++++++++++++++++---
 .../server/services/persona-detection.service.ts   | 19 +++++++
 .../shared/src/interfaces/my-event.interface.ts    |  4 ++
 5 files changed, 104 insertions(+), 12 deletions(-)
```

Jira: [LFXV2-1473](https://linuxfoundation.atlassian.net/browse/LFXV2-1473)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-1473]: https://linuxfoundation.atlassian.net/browse/LFXV2-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ