### PR TITLE
feat(mailing-lists): add me lens support for user subscriptions

### DIFF
--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
@@ -2,14 +2,14 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-  @if (mailingListsLoading() || !servicesLoaded()) {
+  @if ((isMeLens() && myMailingListsLoading()) || (!isMeLens() && (mailingListsLoading() || !servicesLoaded()))) {
     <div class="flex justify-center items-center min-h-96">
       <div class="text-center">
         <i class="fa-light fa-spinner-third fa-spin text-3xl text-blue-600 mb-4"></i>
         <p class="text-gray-600">Loading {{ mailingListLabel.toLowerCase() }} details...</p>
       </div>
     </div>
-  } @else if (hasNoServices()) {
+  } @else if (!isMeLens() && hasNoServices()) {
     <!-- No Services Empty State -->
     <div class="mb-8">
       <h1>{{ mailingListLabelPlural }}</h1>
@@ -42,7 +42,7 @@
       <div class="mb-8">
         <!-- Page Title with Add Mailing List Button -->
         <div class="flex justify-between items-center w-full gap-4">
-          <h1>{{ mailingListLabelPlural }}</h1>
+          <h1>{{ isMeLens() ? 'My ' + mailingListLabelPlural : mailingListLabelPlural }}</h1>
           @if (canCreateMailingList()) {
             <lfx-button
               [label]="'Add ' + mailingListLabel"
@@ -54,48 +54,80 @@
             </lfx-button>
           }
         </div>
-        <p class="mt-2 text-gray-500" data-testid="mailing-list-dashboard-description">Manage communication channels for your project community.</p>
+        <p class="mt-2 text-gray-500" data-testid="mailing-list-dashboard-description">
+          {{
+            isMeLens()
+              ? mailingListLabelPlural + ' you are subscribed to across all foundations and projects.'
+              : 'Manage communication channels for your project community.'
+          }}
+        </p>
       </div>
     </div>
 
-    <!-- Content Area - Table -->
+    <!-- Content Area -->
     <div class="min-h-[400px]">
-      @if (mailingLists().length === 0 && project()?.uid) {
-        <!-- Empty state: No mailing lists exist -->
-        <lfx-card>
-          <div class="flex items-center justify-center p-16">
-            <div class="text-center max-w-md">
-              <div class="text-gray-400 mb-4">
-                <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
-                <h3 class="text-gray-600 mt-2">Your project has no {{ mailingListLabelPlural.toLowerCase() }}, yet.</h3>
+      @if (isMeLens()) {
+        @if (myMailingLists().length === 0) {
+          <lfx-card>
+            <div class="flex items-center justify-center p-16">
+              <div class="text-center max-w-md">
+                <div class="text-gray-400 mb-4">
+                  <i class="fa-light fa-envelope text-[2rem] mb-4"></i>
+                  <h3 class="text-gray-600 mt-2">You are not subscribed to any {{ mailingListLabelPlural.toLowerCase() }} yet.</h3>
+                </div>
               </div>
             </div>
-          </div>
-        </lfx-card>
-      } @else if (filteredMailingLists().length === 0) {
-        <!-- Empty state: Mailing lists exist but filters returned no results -->
-        <lfx-card>
-          <div class="flex items-center justify-center p-16">
-            <div class="text-center max-w-md">
-              <div class="text-gray-400 mb-4">
-                <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
-              </div>
-              <h3 class="text-xl font-semibold text-gray-900 mt-4">No {{ mailingListLabelPlural.toLowerCase() }} Found</h3>
-              <p class="text-gray-600 mt-2">Try adjusting your search or filter criteria</p>
-            </div>
-          </div>
-        </lfx-card>
+          </lfx-card>
+        } @else {
+          <lfx-mailing-list-table
+            [mailingLists]="myMailingLists()"
+            [isMaintainer]="isMaintainer()"
+            [mailingListLabel]="mailingListLabel"
+            [searchForm]="searchForm"
+            [committeeFilterOptions]="committeeOptions()"
+            [statusFilterOptions]="statusOptions()"
+            (refresh)="refreshMailingLists()"
+            (rowClick)="onMailingListClick($event)">
+          </lfx-mailing-list-table>
+        }
       } @else {
-        <lfx-mailing-list-table
-          [mailingLists]="filteredMailingLists()"
-          [isMaintainer]="isMaintainer()"
-          [mailingListLabel]="mailingListLabel"
-          [searchForm]="searchForm"
-          [committeeFilterOptions]="committeeOptions()"
-          [statusFilterOptions]="statusOptions()"
-          (refresh)="refreshMailingLists()"
-          (rowClick)="onMailingListClick($event)">
-        </lfx-mailing-list-table>
+        @if (mailingLists().length === 0 && project()?.uid) {
+          <!-- Empty state: No mailing lists exist -->
+          <lfx-card>
+            <div class="flex items-center justify-center p-16">
+              <div class="text-center max-w-md">
+                <div class="text-gray-400 mb-4">
+                  <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
+                  <h3 class="text-gray-600 mt-2">Your project has no {{ mailingListLabelPlural.toLowerCase() }}, yet.</h3>
+                </div>
+              </div>
+            </div>
+          </lfx-card>
+        } @else if (filteredMailingLists().length === 0) {
+          <!-- Empty state: Mailing lists exist but filters returned no results -->
+          <lfx-card>
+            <div class="flex items-center justify-center p-16">
+              <div class="text-center max-w-md">
+                <div class="text-gray-400 mb-4">
+                  <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
+                </div>
+                <h3 class="text-xl font-semibold text-gray-900 mt-4">No {{ mailingListLabelPlural.toLowerCase() }} Found</h3>
+                <p class="text-gray-600 mt-2">Try adjusting your search or filter criteria</p>
+              </div>
+            </div>
+          </lfx-card>
+        } @else {
+          <lfx-mailing-list-table
+            [mailingLists]="filteredMailingLists()"
+            [isMaintainer]="isMaintainer()"
+            [mailingListLabel]="mailingListLabel"
+            [searchForm]="searchForm"
+            [committeeFilterOptions]="committeeOptions()"
+            [statusFilterOptions]="statusOptions()"
+            (refresh)="refreshMailingLists()"
+            (rowClick)="onMailingListClick($event)">
+          </lfx-mailing-list-table>
+        }
       }
     </div>
   }

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
@@ -66,68 +66,54 @@
 
     <!-- Content Area -->
     <div class="min-h-[400px]">
-      @if (isMeLens()) {
-        @if (myMailingLists().length === 0) {
-          <lfx-card>
-            <div class="flex items-center justify-center p-16">
-              <div class="text-center max-w-md">
-                <div class="text-gray-400 mb-4">
-                  <i class="fa-light fa-envelope text-[2rem] mb-4"></i>
-                  <h3 class="text-gray-600 mt-2">You are not subscribed to any {{ mailingListLabelPlural.toLowerCase() }} yet.</h3>
-                </div>
+      @if (isMeLens() && myMailingLists().length === 0) {
+        <!-- Me lens empty state -->
+        <lfx-card>
+          <div class="flex items-center justify-center p-16">
+            <div class="text-center max-w-md">
+              <div class="text-gray-400 mb-4">
+                <i class="fa-light fa-envelope text-[2rem] mb-4"></i>
+                <h3 class="text-gray-600 mt-2">You are not subscribed to any {{ mailingListLabelPlural.toLowerCase() }} yet.</h3>
               </div>
             </div>
-          </lfx-card>
-        } @else {
-          <lfx-mailing-list-table
-            [mailingLists]="myMailingLists()"
-            [isMaintainer]="isMaintainer()"
-            [mailingListLabel]="mailingListLabel"
-            [searchForm]="searchForm"
-            [committeeFilterOptions]="committeeOptions()"
-            [statusFilterOptions]="statusOptions()"
-            (refresh)="refreshMailingLists()"
-            (rowClick)="onMailingListClick($event)">
-          </lfx-mailing-list-table>
-        }
+          </div>
+        </lfx-card>
+      } @else if (!isMeLens() && mailingLists().length === 0 && project()?.uid) {
+        <!-- Empty state: No mailing lists exist -->
+        <lfx-card>
+          <div class="flex items-center justify-center p-16">
+            <div class="text-center max-w-md">
+              <div class="text-gray-400 mb-4">
+                <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
+                <h3 class="text-gray-600 mt-2">Your project has no {{ mailingListLabelPlural.toLowerCase() }}, yet.</h3>
+              </div>
+            </div>
+          </div>
+        </lfx-card>
+      } @else if (filteredMailingLists().length === 0) {
+        <!-- Empty state: Filters returned no results -->
+        <lfx-card>
+          <div class="flex items-center justify-center p-16">
+            <div class="text-center max-w-md">
+              <div class="text-gray-400 mb-4">
+                <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
+              </div>
+              <h3 class="text-xl font-semibold text-gray-900 mt-4">No {{ mailingListLabelPlural.toLowerCase() }} Found</h3>
+              <p class="text-gray-600 mt-2">Try adjusting your search or filter criteria</p>
+            </div>
+          </div>
+        </lfx-card>
       } @else {
-        @if (mailingLists().length === 0 && project()?.uid) {
-          <!-- Empty state: No mailing lists exist -->
-          <lfx-card>
-            <div class="flex items-center justify-center p-16">
-              <div class="text-center max-w-md">
-                <div class="text-gray-400 mb-4">
-                  <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
-                  <h3 class="text-gray-600 mt-2">Your project has no {{ mailingListLabelPlural.toLowerCase() }}, yet.</h3>
-                </div>
-              </div>
-            </div>
-          </lfx-card>
-        } @else if (filteredMailingLists().length === 0) {
-          <!-- Empty state: Mailing lists exist but filters returned no results -->
-          <lfx-card>
-            <div class="flex items-center justify-center p-16">
-              <div class="text-center max-w-md">
-                <div class="text-gray-400 mb-4">
-                  <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
-                </div>
-                <h3 class="text-xl font-semibold text-gray-900 mt-4">No {{ mailingListLabelPlural.toLowerCase() }} Found</h3>
-                <p class="text-gray-600 mt-2">Try adjusting your search or filter criteria</p>
-              </div>
-            </div>
-          </lfx-card>
-        } @else {
-          <lfx-mailing-list-table
-            [mailingLists]="filteredMailingLists()"
-            [isMaintainer]="isMaintainer()"
-            [mailingListLabel]="mailingListLabel"
-            [searchForm]="searchForm"
-            [committeeFilterOptions]="committeeOptions()"
-            [statusFilterOptions]="statusOptions()"
-            (refresh)="refreshMailingLists()"
-            (rowClick)="onMailingListClick($event)">
-          </lfx-mailing-list-table>
-        }
+        <lfx-mailing-list-table
+          [mailingLists]="filteredMailingLists()"
+          [isMaintainer]="isMaintainer()"
+          [mailingListLabel]="mailingListLabel"
+          [searchForm]="searchForm"
+          [committeeFilterOptions]="committeeOptions()"
+          [statusFilterOptions]="statusOptions()"
+          (refresh)="refreshMailingLists()"
+          (rowClick)="onMailingListClick($event)">
+        </lfx-mailing-list-table>
       }
     </div>
   }

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -212,7 +212,7 @@ export class MailingListDashboardComponent {
 
   private initFilteredMailingLists(): Signal<GroupsIOMailingList[]> {
     return computed(() => {
-      let filtered = this.mailingLists();
+      let filtered: GroupsIOMailingList[] = this.isMeLens() ? this.myMailingLists() : this.mailingLists();
 
       // Apply search filter
       const searchTerm = this.searchTerm()?.toLowerCase() || '';

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -8,13 +8,14 @@ import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { COMMITTEE_LABEL, MAILING_LIST_LABEL } from '@lfx-one/shared/constants';
-import { CommitteeReference, FilterOption, GroupsIOMailingList, GroupsIOService, ProjectContext } from '@lfx-one/shared/interfaces';
+import { CommitteeReference, FilterOption, GroupsIOMailingList, GroupsIOService, MyMailingList, ProjectContext } from '@lfx-one/shared/interfaces';
+import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { MessageService } from 'primeng/api';
-import { BehaviorSubject, catchError, combineLatest, debounceTime, distinctUntilChanged, filter, finalize, of, startWith, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, of, startWith, switchMap, tap } from 'rxjs';
 
 import { MailingListTableComponent } from '../components/mailing-list-table/mailing-list-table.component';
 
@@ -31,6 +32,7 @@ export class MailingListDashboardComponent {
   private readonly mailingListService = inject(MailingListService);
   private readonly personaService = inject(PersonaService);
   private readonly router = inject(Router);
+  private readonly lensService = inject(LensService);
   private readonly messageService = inject(MessageService);
 
   // Protected constants
@@ -50,12 +52,22 @@ export class MailingListDashboardComponent {
   private readonly committeeFilter: Signal<string | null> = this.initCommitteeFilter();
   private readonly statusFilter: Signal<string | null> = this.initStatusFilter();
 
+  // Lens
+  public readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+  public myMailingListsLoading = signal<boolean>(true);
+
   // Complex computed/toSignal signals
   public readonly project: Signal<ProjectContext | null> = this.initProject();
   public readonly isMaintainer: Signal<boolean> = this.initIsMaintainer();
   public readonly isFoundationContext: Signal<boolean> = this.initIsFoundationContext();
   public readonly canCreateMailingList: Signal<boolean> = this.initCanCreateMailingList();
   public readonly mailingLists: Signal<GroupsIOMailingList[]> = this.initMailingLists();
+  public readonly myMailingLists: Signal<MyMailingList[]> = this.initMyMailingLists();
+
+  // Me lens statistics
+  public readonly myTotalMailingLists: Signal<number> = computed(() => this.myMailingLists().length);
+  public readonly myPublicMailingLists: Signal<number> = computed(() => this.myMailingLists().filter((ml) => ml.public).length);
+
   public readonly committeeOptions: Signal<FilterOption[]> = this.initCommitteeOptions();
   public readonly statusOptions: Signal<FilterOption[]> = this.initStatusOptions();
   public readonly filteredMailingLists: Signal<GroupsIOMailingList[]> = this.initFilteredMailingLists();
@@ -132,16 +144,17 @@ export class MailingListDashboardComponent {
   }
 
   private initCanCreateMailingList(): Signal<boolean> {
-    return computed(() => this.isMaintainer() && !this.isFoundationContext());
+    return computed(() => !this.isMeLens() && this.isMaintainer() && !this.isFoundationContext());
   }
 
   private initMailingLists(): Signal<GroupsIOMailingList[]> {
     const project$ = toObservable(this.project);
+    const lens$ = toObservable(this.lensService.activeLens);
 
     return toSignal(
-      combineLatest([project$, this.refresh]).pipe(
-        switchMap(([project]) => {
-          if (!project?.uid) {
+      combineLatest([project$, this.refresh, lens$]).pipe(
+        switchMap(([project, , lens]) => {
+          if (lens === 'me' || !project?.uid) {
             this.mailingListsLoading.set(false);
             return of([]);
           }
@@ -244,13 +257,23 @@ export class MailingListDashboardComponent {
 
   private initServices(): Signal<GroupsIOService[]> {
     const project$ = toObservable(this.project);
+    const lens$ = toObservable(this.lensService.activeLens);
 
     return toSignal(
-      project$.pipe(
+      combineLatest([project$, lens$]).pipe(
         tap(() => this.servicesLoaded.set(false)),
-        filter((project): project is NonNullable<typeof project> => project !== null),
-        switchMap((project) =>
-          this.mailingListService.getServicesByProject(project.uid).pipe(
+        switchMap(([project, lens]) => {
+          if (lens === 'me') {
+            this.servicesLoaded.set(true);
+            return of([]);
+          }
+
+          if (!project) {
+            this.servicesLoaded.set(true);
+            return of([]);
+          }
+
+          return this.mailingListService.getServicesByProject(project.uid).pipe(
             switchMap((services) => {
               if (services.length > 0) {
                 return of(services);
@@ -273,8 +296,8 @@ export class MailingListDashboardComponent {
               this.servicesLoaded.set(true);
               return of([]);
             })
-          )
-        )
+          );
+        })
       ),
       { initialValue: [] }
     );
@@ -282,5 +305,31 @@ export class MailingListDashboardComponent {
 
   private initHasNoServices(): Signal<boolean> {
     return computed(() => this.servicesLoaded() && this.availableServices().length === 0);
+  }
+
+  private initMyMailingLists(): Signal<MyMailingList[]> {
+    const project$ = toObservable(this.project);
+    const lens$ = toObservable(this.lensService.activeLens);
+
+    return toSignal(
+      combineLatest([project$, this.refresh, lens$]).pipe(
+        switchMap(([project, , lens]) => {
+          this.myMailingListsLoading.set(true);
+          if (lens !== 'me' && !project?.uid) {
+            this.myMailingListsLoading.set(false);
+            return of([] as MyMailingList[]);
+          }
+          const projectUid = lens === 'me' ? undefined : project!.uid;
+          return this.mailingListService.getMyMailingLists(projectUid).pipe(
+            catchError(() => {
+              this.myMailingListsLoading.set(false);
+              return of([] as MyMailingList[]);
+            }),
+            finalize(() => this.myMailingListsLoading.set(false))
+          );
+        })
+      ),
+      { initialValue: [] }
+    );
   }
 }

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -63,11 +63,6 @@ export class MailingListDashboardComponent {
   public readonly canCreateMailingList: Signal<boolean> = this.initCanCreateMailingList();
   public readonly mailingLists: Signal<GroupsIOMailingList[]> = this.initMailingLists();
   public readonly myMailingLists: Signal<MyMailingList[]> = this.initMyMailingLists();
-
-  // Me lens statistics
-  public readonly myTotalMailingLists: Signal<number> = computed(() => this.myMailingLists().length);
-  public readonly myPublicMailingLists: Signal<number> = computed(() => this.myMailingLists().filter((ml) => ml.public).length);
-
   public readonly committeeOptions: Signal<FilterOption[]> = this.initCommitteeOptions();
   public readonly statusOptions: Signal<FilterOption[]> = this.initStatusOptions();
   public readonly filteredMailingLists: Signal<GroupsIOMailingList[]> = this.initFilteredMailingLists();
@@ -172,7 +167,7 @@ export class MailingListDashboardComponent {
 
   private initCommitteeOptions(): Signal<FilterOption[]> {
     return computed(() => {
-      const mailingListsData = this.mailingLists();
+      const mailingListsData = this.isMeLens() ? this.myMailingLists() : this.mailingLists();
 
       // Collect unique committees from all mailing lists
       const committeeMap = new Map<string, CommitteeReference>();
@@ -201,7 +196,7 @@ export class MailingListDashboardComponent {
 
   private initStatusOptions(): Signal<FilterOption[]> {
     return computed(() => {
-      const mailingListsData = this.mailingLists();
+      const mailingListsData = this.isMeLens() ? this.myMailingLists() : this.mailingLists();
 
       // Count mailing lists by visibility status
       const publicCount = mailingListsData.filter((ml) => ml.public).length;
@@ -308,19 +303,17 @@ export class MailingListDashboardComponent {
   }
 
   private initMyMailingLists(): Signal<MyMailingList[]> {
-    const project$ = toObservable(this.project);
     const lens$ = toObservable(this.lensService.activeLens);
 
     return toSignal(
-      combineLatest([project$, this.refresh, lens$]).pipe(
-        switchMap(([project, , lens]) => {
-          this.myMailingListsLoading.set(true);
-          if (lens !== 'me' && !project?.uid) {
+      combineLatest([lens$, this.refresh]).pipe(
+        switchMap(([lens]) => {
+          if (lens !== 'me') {
             this.myMailingListsLoading.set(false);
             return of([] as MyMailingList[]);
           }
-          const projectUid = lens === 'me' ? undefined : project!.uid;
-          return this.mailingListService.getMyMailingLists(projectUid).pipe(
+          this.myMailingListsLoading.set(true);
+          return this.mailingListService.getMyMailingLists().pipe(
             catchError(() => {
               this.myMailingListsLoading.set(false);
               return of([] as MyMailingList[]);

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
@@ -10,10 +10,11 @@ import {
   GroupsIOMailingList,
   GroupsIOService,
   MailingListMember,
+  MyMailingList,
   QueryServiceCountResponse,
   UpdateMailingListMemberRequest,
 } from '@lfx-one/shared/interfaces';
-import { map, Observable } from 'rxjs';
+import { catchError, map, Observable, of } from 'rxjs';
 
 /**
  * Service for managing mailing list data
@@ -38,6 +39,14 @@ export class MailingListService {
 
   public getMailingLists(): Observable<GroupsIOMailingList[]> {
     return this.http.get<GroupsIOMailingList[]>(this.baseUrl);
+  }
+
+  public getMyMailingLists(projectUid?: string): Observable<MyMailingList[]> {
+    let params = new HttpParams();
+    if (projectUid) {
+      params = params.set('project_uid', projectUid);
+    }
+    return this.http.get<MyMailingList[]>(`${this.baseUrl}/my-mailing-lists`, { params }).pipe(catchError(() => of([])));
   }
 
   public getMailingList(uid: string): Observable<GroupsIOMailingList> {

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
@@ -14,7 +14,7 @@ import {
   QueryServiceCountResponse,
   UpdateMailingListMemberRequest,
 } from '@lfx-one/shared/interfaces';
-import { catchError, map, Observable, of } from 'rxjs';
+import { map, Observable } from 'rxjs';
 
 /**
  * Service for managing mailing list data
@@ -46,7 +46,7 @@ export class MailingListService {
     if (projectUid) {
       params = params.set('project_uid', projectUid);
     }
-    return this.http.get<MyMailingList[]>(`${this.baseUrl}/my-mailing-lists`, { params }).pipe(catchError(() => of([])));
+    return this.http.get<MyMailingList[]>(`${this.baseUrl}/my-mailing-lists`, { params });
   }
 
   public getMailingList(uid: string): Observable<GroupsIOMailingList> {

--- a/apps/lfx-one/src/server/controllers/mailing-list.controller.ts
+++ b/apps/lfx-one/src/server/controllers/mailing-list.controller.ts
@@ -238,6 +238,26 @@ export class MailingListController {
   }
 
   /**
+   * GET /mailing-lists/my-mailing-lists
+   */
+  public async getMyMailingLists(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const projectUid = req.query['project_uid'] as string | undefined;
+    const startTime = logger.startOperation(req, 'get_my_mailing_lists', { project_uid: projectUid });
+
+    try {
+      const myMailingLists = await this.mailingListService.getMyMailingLists(req, projectUid);
+
+      logger.success(req, 'get_my_mailing_lists', startTime, {
+        mailing_list_count: myMailingLists.length,
+      });
+
+      res.json(myMailingLists);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /mailing-lists/:id
    */
   public async getMailingListById(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/routes/mailing-lists.route.ts
+++ b/apps/lfx-one/src/server/routes/mailing-lists.route.ts
@@ -20,6 +20,7 @@ router.delete('/services/:id', (req, res, next) => mailingListController.deleteS
 // Mailing List routes
 router.get('/', (req, res, next) => mailingListController.getMailingLists(req, res, next));
 router.get('/count', (req, res, next) => mailingListController.getMailingListsCount(req, res, next));
+router.get('/my-mailing-lists', (req, res, next) => mailingListController.getMyMailingLists(req, res, next));
 router.get('/:id', (req, res, next) => mailingListController.getMailingListById(req, res, next));
 router.post('/', (req, res, next) => mailingListController.createMailingList(req, res, next));
 router.put('/:id', (req, res, next) => mailingListController.updateMailingList(req, res, next));

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -8,14 +8,17 @@ import {
   GroupsIOMailingList,
   GroupsIOService,
   MailingListMember,
+  MyMailingList,
   QueryServiceCountResponse,
   QueryServiceResponse,
   UpdateGroupsIOServiceRequest,
   UpdateMailingListMemberRequest,
 } from '@lfx-one/shared/interfaces';
+import { MailingListMemberDeliveryMode, MailingListMemberModStatus } from '@lfx-one/shared/enums';
 import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
+import { getUsernameFromAuth } from '../utils/auth-helper';
 import { pollEndpoint, pollUntilIndexed } from '../helpers/poll-endpoint.helper';
 import { AccessCheckService } from './access-check.service';
 import { logger } from './logger.service';
@@ -326,6 +329,136 @@ export class MailingListService {
     await this.pollUntilResourceRemoved(req, 'delete_mailing_list', 'groupsio_mailing_list', 'groupsio_mailing_list_uid', mailingListId, {
       mailing_list_uid: mailingListId,
     });
+  }
+
+  // ============================================
+  // My Mailing Lists (Me Lens)
+  // ============================================
+
+  /**
+   * Fetches mailing lists the current user is a member of.
+   * Queries by both email and username to ensure complete coverage.
+   */
+  public async getMyMailingLists(req: Request, projectUid?: string): Promise<MyMailingList[]> {
+    // Get user identity from auth context
+    const username = await getUsernameFromAuth(req);
+    const email = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+
+    logger.debug(req, 'get_my_mailing_lists', 'Fetching mailing lists for current user', {
+      username,
+      has_email: !!email,
+      project_uid: projectUid,
+    });
+
+    if (!username && !email) {
+      return [];
+    }
+
+    // Query groupsio_member records by both email and username in parallel
+    const memberQueries: Promise<MailingListMember[]>[] = [];
+
+    if (email) {
+      memberQueries.push(
+        this.microserviceProxy
+          .proxyRequest<QueryServiceResponse<MailingListMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+            v: '1',
+            type: 'groupsio_member',
+            tags_all: [`email:${email}`],
+          })
+          .then((res) => res.resources.map((r) => r.data))
+      );
+    }
+
+    if (username) {
+      memberQueries.push(
+        this.microserviceProxy
+          .proxyRequest<QueryServiceResponse<MailingListMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+            v: '1',
+            type: 'groupsio_member',
+            tags_all: [`username:${username}`],
+          })
+          .then((res) => res.resources.map((r) => r.data))
+      );
+    }
+
+    const results = await Promise.all(memberQueries);
+
+    // Deduplicate members by uid (a member might match both email and username)
+    const memberMap = new Map<string, MailingListMember>();
+    for (const members of results) {
+      for (const member of members) {
+        memberMap.set(member.uid, member);
+      }
+    }
+
+    const allMembers = Array.from(memberMap.values());
+
+    if (allMembers.length === 0) {
+      return [];
+    }
+
+    logger.debug(req, 'get_my_mailing_lists', 'Found user memberships', {
+      username,
+      has_email: !!email,
+      membership_count: allMembers.length,
+    });
+
+    // Build a map of mailing_list_uid → member details for quick lookup
+    const membershipMap = new Map<string, { delivery_mode: MailingListMemberDeliveryMode; mod_status: MailingListMemberModStatus; member_uid: string }>();
+    for (const m of allMembers) {
+      membershipMap.set(m.mailing_list_uid, {
+        delivery_mode: m.delivery_mode || MailingListMemberDeliveryMode.NORMAL,
+        mod_status: m.mod_status || MailingListMemberModStatus.NONE,
+        member_uid: m.uid,
+      });
+    }
+
+    // Fetch mailing list details for each membership in parallel
+    const mailingListUids = Array.from(membershipMap.keys());
+    const mailingLists = await Promise.all(
+      mailingListUids.map(async (uid) => {
+        try {
+          const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<GroupsIOMailingList>>(
+            req,
+            'LFX_V2_SERVICE',
+            '/query/resources',
+            'GET',
+            {
+              type: 'groupsio_mailing_list',
+              tags: `groupsio_mailing_list_uid:${uid}`,
+            }
+          );
+
+          if (!resources || resources.length === 0) {
+            return null;
+          }
+
+          const mailingList = resources[0].data;
+          const membership = membershipMap.get(uid)!;
+          return {
+            ...mailingList,
+            my_delivery_mode: membership.delivery_mode,
+            my_mod_status: membership.mod_status,
+            my_member_uid: membership.member_uid,
+          } as MyMailingList;
+        } catch (error) {
+          logger.warning(req, 'get_my_mailing_lists', 'Failed to enrich mailing list membership, skipping', {
+            mailing_list_uid: uid,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+          return null;
+        }
+      })
+    );
+
+    const result = mailingLists.filter((ml): ml is MyMailingList => ml !== null);
+
+    // Filter by project_uid server-side if provided
+    if (projectUid) {
+      return result.filter((ml) => ml.project_uid === projectUid);
+    }
+
+    return result;
   }
 
   // ============================================

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -18,7 +18,7 @@ import { MailingListMemberDeliveryMode, MailingListMemberModStatus } from '@lfx-
 import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
-import { getUsernameFromAuth } from '../utils/auth-helper';
+import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { pollEndpoint, pollUntilIndexed } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { AccessCheckService } from './access-check.service';
@@ -342,7 +342,8 @@ export class MailingListService {
    */
   public async getMyMailingLists(req: Request, projectUid?: string): Promise<MyMailingList[]> {
     // Get user identity from auth context
-    const username = await getUsernameFromAuth(req);
+    const rawUsername = await getUsernameFromAuth(req);
+    const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
     const email = (req.oidc?.user?.['email'] as string)?.toLowerCase();
 
     logger.debug(req, 'get_my_mailing_lists', 'Fetching mailing lists for current user', {
@@ -456,14 +457,13 @@ export class MailingListService {
       })
     );
 
-    const result = mailingLists.filter((ml): ml is MyMailingList => ml !== null);
+    const filtered = mailingLists.filter((ml): ml is MyMailingList => ml !== null);
 
     // Filter by project_uid server-side if provided
-    if (projectUid) {
-      return result.filter((ml) => ml.project_uid === projectUid);
-    }
+    const result = projectUid ? filtered.filter((ml) => ml.project_uid === projectUid) : filtered;
 
-    return result;
+    // Enrich with service data for correct email display in UI
+    return (await this.enrichWithServices(req, result)) as MyMailingList[];
   }
 
   // ============================================

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -20,6 +20,7 @@ import { Request } from 'express';
 import { ResourceNotFoundError } from '../errors';
 import { getUsernameFromAuth } from '../utils/auth-helper';
 import { pollEndpoint, pollUntilIndexed } from '../helpers/poll-endpoint.helper';
+import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { AccessCheckService } from './access-check.service';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -354,30 +355,34 @@ export class MailingListService {
       return [];
     }
 
-    // Query groupsio_member records by both email and username in parallel
+    // Query groupsio_member records by both email and username in parallel (with full pagination)
     const memberQueries: Promise<MailingListMember[]>[] = [];
 
     if (email) {
       memberQueries.push(
-        this.microserviceProxy
-          .proxyRequest<QueryServiceResponse<MailingListMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        fetchAllQueryResources<MailingListMember>(req, (pageToken) =>
+          this.microserviceProxy.proxyRequest<QueryServiceResponse<MailingListMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
             v: '1',
             type: 'groupsio_member',
+            page_size: 100,
             tags_all: [`email:${email}`],
+            ...(pageToken && { page_token: pageToken }),
           })
-          .then((res) => res.resources.map((r) => r.data))
+        )
       );
     }
 
     if (username) {
       memberQueries.push(
-        this.microserviceProxy
-          .proxyRequest<QueryServiceResponse<MailingListMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        fetchAllQueryResources<MailingListMember>(req, (pageToken) =>
+          this.microserviceProxy.proxyRequest<QueryServiceResponse<MailingListMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
             v: '1',
             type: 'groupsio_member',
+            page_size: 100,
             tags_all: [`username:${username}`],
+            ...(pageToken && { page_token: pageToken }),
           })
-          .then((res) => res.resources.map((r) => r.data))
+        )
       );
     }
 

--- a/packages/shared/src/interfaces/mailing-list.interface.ts
+++ b/packages/shared/src/interfaces/mailing-list.interface.ts
@@ -127,6 +127,19 @@ export interface GroupsIOMailingList {
 }
 
 /**
+ * Mailing list with current user's membership details
+ * @description Extended mailing list data including the user's subscription info for "me" lens views
+ */
+export interface MyMailingList extends GroupsIOMailingList {
+  /** User's delivery mode in this mailing list (e.g., "Normal", "Digest", "None") */
+  my_delivery_mode: MailingListMemberDeliveryMode;
+  /** User's moderation status in this mailing list (e.g., "none", "moderator", "owner") */
+  my_mod_status: MailingListMemberModStatus;
+  /** User's member UID in this mailing list */
+  my_member_uid?: string;
+}
+
+/**
  * Request payload for creating a new mailing list
  * @description Maps to Groups.io API create endpoint
  */


### PR DESCRIPTION
## Summary
- Add "me" lens to mailing list dashboard showing only mailing lists the current user is subscribed to
- Query groupsio_member records by both email and username tags for complete coverage, with deduplication
- Add `MyMailingList` interface, backend endpoint (`GET /my-mailing-lists`), and lens-aware frontend dashboard

Generated with [Claude Code](https://claude.ai/code)