### PR TITLE
feat(dashboards): wire ED dashboard to live data

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -1,0 +1,140 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="brand-health-drawer">
+  <!-- Header -->
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full" data-testid="brand-health-drawer-header">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="brand-health-drawer-title">Brand Health</h2>
+        <p class="text-sm text-gray-500">Executive Director · Brand Metric</p>
+      </div>
+      <lfx-button
+        icon="fa-light fa-xmark"
+        [text]="true"
+        [rounded]="true"
+        severity="secondary"
+        ariaLabel="Close panel"
+        (onClick)="onClose()"
+        data-testid="brand-health-drawer-close" />
+    </div>
+  </ng-template>
+
+  <!-- Content -->
+  <div class="flex flex-col gap-6 pb-2" data-testid="brand-health-drawer-content">
+    <!-- Summary Stats -->
+    <div class="flex gap-4" data-testid="brand-health-drawer-stats">
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Total Mentions</span>
+          @if (data().totalMentions > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().totalMentions | number }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Positive Sentiment</span>
+          @if (data().sentiment.positive > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().sentiment.positive.toFixed(1) }}%</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">MoM Growth</span>
+          @if (data().sentimentMomChangePp !== 0) {
+            <span
+              class="text-2xl font-semibold"
+              [class.text-green-600]="data().sentimentMomChangePp > 0"
+              [class.text-red-600]="data().sentimentMomChangePp < 0">
+              {{ data().sentimentMomChangePp > 0 ? '+' : '' }}{{ data().sentimentMomChangePp.toFixed(1) }}pp
+            </span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+    </div>
+
+    <!-- Mentions Trend -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-health-drawer-mentions-trend">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Mentions Trend</h3>
+        <p class="text-sm text-gray-600">Total brand mentions over the last 6 months (Octolens)</p>
+      </div>
+      @if (data().monthlyMentions.length > 0) {
+        <div class="h-[240px]" data-testid="brand-health-drawer-mentions-chart">
+          <lfx-chart type="line" [data]="mentionsTrendData()" [options]="mentionsTrendOptions" height="100%"></lfx-chart>
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="brand-health-drawer-mentions-empty">
+          Mentions trend data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Sentiment Breakdown -->
+    <div class="flex flex-col gap-4" data-testid="brand-health-drawer-sentiment">
+      <h3 class="text-sm font-semibold text-gray-900">Sentiment Breakdown</h3>
+      @if (data().sentiment.positive + data().sentiment.neutral + data().sentiment.negative > 0) {
+        <div class="flex gap-4">
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Positive</span>
+              <span class="text-2xl font-semibold text-green-600">{{ data().sentiment.positive.toFixed(1) }}%</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Neutral</span>
+              <span class="text-2xl font-semibold text-gray-600">{{ data().sentiment.neutral.toFixed(1) }}%</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Negative</span>
+              <span class="text-2xl font-semibold text-red-600">{{ data().sentiment.negative.toFixed(1) }}%</span>
+            </div>
+          </lfx-card>
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-health-drawer-sentiment-empty">
+          Sentiment data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Top Mentioned Projects -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-health-drawer-top-projects">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Top Mentioned Projects</h3>
+        <p class="text-sm text-gray-600">Projects with the most brand mentions in the last 30 days</p>
+      </div>
+      @if (data().topProjects.length > 0) {
+        <div class="flex flex-col gap-0">
+          @for (project of data().topProjects; track project.name) {
+            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-health-drawer-project-row">
+              <span class="text-sm font-medium text-gray-900">{{ project.name }}</span>
+              <span class="text-sm font-semibold text-gray-900">{{ project.mentions | number }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-health-drawer-top-projects-empty">
+          Top projects data not yet available
+        </div>
+      }
+    </div>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -1,0 +1,90 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { ChartComponent } from '@components/chart/chart.component';
+import { lfxColors } from '@lfx-one/shared/constants';
+import { hexToRgba } from '@lfx-one/shared/utils';
+import { DrawerModule } from 'primeng/drawer';
+
+import type { ChartData, ChartOptions } from 'chart.js';
+import type { BrandHealthResponse } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-brand-health-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonComponent, CardComponent, ChartComponent, DecimalPipe, DrawerModule],
+  templateUrl: './brand-health-drawer.component.html',
+  styleUrl: './brand-health-drawer.component.scss',
+})
+export class BrandHealthDrawerComponent {
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  public readonly data = input<BrandHealthResponse>({
+    totalMentions: 0,
+    sentiment: { positive: 0, neutral: 0, negative: 0 },
+    sentimentMomChangePp: 0,
+    trend: 'up',
+    monthlyMentions: [],
+    topProjects: [],
+  });
+
+  // === Computed Signals ===
+  protected readonly mentionsTrendData: Signal<ChartData<'line'>> = computed(() => {
+    const { monthlyMentions } = this.data();
+    return {
+      labels: monthlyMentions.map((d) => d.month),
+      datasets: [
+        {
+          data: monthlyMentions.map((d) => d.value),
+          borderColor: lfxColors.blue[500],
+          backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
+          fill: true,
+          tension: 0.4,
+          borderWidth: 2,
+          pointRadius: 4,
+          pointBackgroundColor: lfxColors.blue[500],
+        },
+      ],
+    };
+  });
+
+  protected readonly mentionsTrendOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: true, mode: 'index', intersect: false },
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: { display: false },
+        ticks: { color: lfxColors.gray[500], font: { size: 11 } },
+      },
+      y: {
+        display: true,
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: false },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          callback: (value) => {
+            const num = Number(value);
+            if (num >= 1_000) return `${(num / 1_000).toFixed(1)}K`;
+            return String(num);
+          },
+        },
+      },
+    },
+  };
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
@@ -1,0 +1,129 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="brand-reach-drawer">
+  <!-- Header -->
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full" data-testid="brand-reach-drawer-header">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="brand-reach-drawer-title">Brand Reach</h2>
+        <p class="text-sm text-gray-500">Executive Director · Brand Metric</p>
+      </div>
+      <lfx-button
+        icon="fa-light fa-xmark"
+        [text]="true"
+        [rounded]="true"
+        severity="secondary"
+        ariaLabel="Close panel"
+        (onClick)="onClose()"
+        data-testid="brand-reach-drawer-close" />
+    </div>
+  </ng-template>
+
+  <!-- Content -->
+  <div class="flex flex-col gap-6 pb-2" data-testid="brand-reach-drawer-content">
+    <!-- Summary Stats -->
+    <div class="flex gap-4" data-testid="brand-reach-drawer-stats">
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Social Followers</span>
+          @if (data().totalSocialFollowers > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().totalSocialFollowers | number }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Monthly Sessions</span>
+          @if (data().totalMonthlySessions > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().totalMonthlySessions | number }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Active Platforms</span>
+          @if (data().activePlatforms > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().activePlatforms }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+    </div>
+
+    <!-- Social Followers by Platform -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-social-platforms">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Social Followers by Platform</h3>
+        <p class="text-sm text-gray-600">Follower count across active social channels</p>
+      </div>
+      @if (socialPlatformViews().length > 0) {
+        <div class="flex flex-col gap-0">
+          @for (platform of socialPlatformViews(); track platform.name) {
+            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-reach-drawer-platform-row">
+              <div class="flex items-center gap-3">
+                <i [class]="platform.icon + ' ' + platform.colorClass + ' text-lg w-5 text-center'"></i>
+                <span class="text-sm font-medium text-gray-900">{{ platform.name }}</span>
+              </div>
+              <span class="text-sm font-semibold text-gray-900">{{ platform.followers | number }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-platforms-empty">
+          Social platform data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Website Sessions by Domain -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-website-sessions">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Website Sessions by Domain</h3>
+        <p class="text-sm text-gray-600">Monthly sessions across foundation web properties</p>
+      </div>
+      @if (data().websiteDomains.length > 0) {
+        <div class="flex flex-col gap-0">
+          @for (site of data().websiteDomains; track site.domain) {
+            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-reach-drawer-domain-row">
+              <span class="text-sm font-medium text-gray-900">{{ site.domain }}</span>
+              <span class="text-sm font-semibold text-gray-900">{{ site.sessions | number }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-domains-empty">
+          Website domain data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Daily Sessions Trend -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-daily-trend">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Daily Sessions Trend</h3>
+        <p class="text-sm text-gray-600">Website sessions over the last 30 days</p>
+      </div>
+      @if (data().dailyTrend.length > 0) {
+        <div class="h-[240px]" data-testid="brand-reach-drawer-daily-chart">
+          <lfx-chart type="line" [data]="dailyTrendData()" [options]="dailyTrendOptions" height="100%"></lfx-chart>
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="brand-reach-drawer-daily-empty">
+          Daily trend data not yet available
+        </div>
+      }
+    </div>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
@@ -1,0 +1,111 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { ChartComponent } from '@components/chart/chart.component';
+import { lfxColors, MARKETING_SOCIAL_PLATFORM_MAP } from '@lfx-one/shared/constants';
+import { hexToRgba } from '@lfx-one/shared/utils';
+import { DrawerModule } from 'primeng/drawer';
+
+import type { ChartData, ChartOptions } from 'chart.js';
+import type { BrandReachResponse, BrandReachSocialPlatform } from '@lfx-one/shared/interfaces';
+
+interface SocialPlatformView extends BrandReachSocialPlatform {
+  icon: string;
+  colorClass: string;
+}
+
+@Component({
+  selector: 'lfx-brand-reach-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonComponent, CardComponent, ChartComponent, DecimalPipe, DrawerModule],
+  templateUrl: './brand-reach-drawer.component.html',
+  styleUrl: './brand-reach-drawer.component.scss',
+})
+export class BrandReachDrawerComponent {
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  public readonly data = input<BrandReachResponse>({
+    totalSocialFollowers: 0,
+    totalMonthlySessions: 0,
+    activePlatforms: 0,
+    changePercentage: 0,
+    trend: 'up',
+    socialPlatforms: [],
+    websiteDomains: [],
+    dailyTrend: [],
+  });
+
+  // === Computed Signals ===
+  protected readonly socialPlatformViews: Signal<SocialPlatformView[]> = computed(() =>
+    this.data().socialPlatforms.map((platform) => {
+      const presentation = MARKETING_SOCIAL_PLATFORM_MAP[platform.platformType] ?? MARKETING_SOCIAL_PLATFORM_MAP.other;
+      return {
+        ...platform,
+        icon: presentation.icon,
+        colorClass: presentation.colorClass,
+      };
+    })
+  );
+
+  protected readonly dailyTrendData: Signal<ChartData<'line'>> = computed(() => {
+    const { dailyTrend } = this.data();
+    return {
+      labels: dailyTrend.map((d) => d.day),
+      datasets: [
+        {
+          data: dailyTrend.map((d) => d.sessions),
+          borderColor: lfxColors.blue[500],
+          backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
+          fill: true,
+          tension: 0.4,
+          borderWidth: 2,
+          pointRadius: 0,
+        },
+      ],
+    };
+  });
+
+  protected readonly dailyTrendOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: true, mode: 'index', intersect: false },
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: { display: false },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          maxTicksLimit: 6,
+        },
+      },
+      y: {
+        display: true,
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: false },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          callback: (value) => {
+            const num = Number(value);
+            if (num >= 1_000) return `${(num / 1_000).toFixed(0)}K`;
+            return String(num);
+          },
+        },
+      },
+    },
+  };
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -44,7 +44,7 @@
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Current CTR</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ drawerData().currentCtr.toFixed(2) }}%</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ drawerData().currentCtr.toFixed(1) }}%</span>
           </div>
         </lfx-card>
         <lfx-card styleClass="flex-1">
@@ -53,7 +53,7 @@
             @if (drawerData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage }}%
+                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
                 </span>
                 <i class="text-sm" [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -42,7 +42,7 @@
           @if (data().changePercentage !== 0) {
             <div class="flex items-center gap-2">
               <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage }}%
+                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage.toFixed(1) }}%
               </span>
               <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -1,0 +1,151 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="event-growth-drawer">
+  <!-- Header -->
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full" data-testid="event-growth-drawer-header">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="event-growth-drawer-title">Event Growth</h2>
+        <p class="text-sm text-gray-500">Executive Director · North Star Metric</p>
+      </div>
+      <lfx-button
+        icon="fa-light fa-xmark"
+        [text]="true"
+        [rounded]="true"
+        severity="secondary"
+        ariaLabel="Close panel"
+        (onClick)="onClose()"
+        data-testid="event-growth-drawer-close" />
+    </div>
+  </ng-template>
+
+  <!-- Content -->
+  <div class="flex flex-col gap-6 pb-2" data-testid="event-growth-drawer-content">
+    <!-- Summary Stats -->
+    <div class="flex gap-4" data-testid="event-growth-drawer-stats">
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Total Attendees</span>
+          @if (data().totalAttendees > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().totalAttendees | number }}</span>
+            <span class="text-xs text-gray-400">YTD</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Events</span>
+          @if (data().totalEvents > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().totalEvents | number }}</span>
+            <span class="text-xs text-gray-400">YTD</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">YoY Growth</span>
+          @if (data().attendeeMomChange !== 0) {
+            <span class="text-2xl font-semibold" [class.text-green-600]="data().attendeeMomChange > 0" [class.text-red-600]="data().attendeeMomChange < 0">
+              {{ data().attendeeMomChange > 0 ? '+' : '' }}{{ data().attendeeMomChange.toFixed(1) }}%
+            </span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+    </div>
+
+    <!-- Event Revenue -->
+    <div class="flex gap-4" data-testid="event-growth-drawer-revenue-stats">
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Total Event Revenue</span>
+          @if (data().totalRevenue > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ formattedRevenue() }}</span>
+            <span class="text-xs text-gray-400">YTD</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Revenue Per Attendee</span>
+          @if (data().revenuePerAttendee > 0) {
+            <span class="text-2xl font-semibold text-gray-900">${{ data().revenuePerAttendee | number: '1.2-2' }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Revenue YoY</span>
+          @if (data().revenueMomChange !== 0) {
+            <span class="text-2xl font-semibold" [class.text-green-600]="data().revenueMomChange > 0" [class.text-red-600]="data().revenueMomChange < 0">
+              {{ data().revenueMomChange > 0 ? '+' : '' }}{{ data().revenueMomChange.toFixed(1) }}%
+            </span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+    </div>
+
+    <!-- Quarterly Attendance Trend -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="event-growth-drawer-monthly-trend">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Quarterly Attendance Trend</h3>
+        <p class="text-sm text-gray-600">Total event attendees per quarter</p>
+      </div>
+      @if (data().monthlyData.length > 0) {
+        <div class="h-[240px]" data-testid="event-growth-drawer-monthly-chart">
+          <lfx-chart type="bar" [data]="monthlyChartData()" [options]="monthlyChartOptions" height="100%"></lfx-chart>
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="event-growth-drawer-monthly-empty">
+          Quarterly trend data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Top Events -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="event-growth-drawer-top-events">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Top Events</h3>
+        <p class="text-sm text-gray-600">Highest attendance events · YTD</p>
+      </div>
+      @if (data().topEvents.length > 0) {
+        <div class="flex flex-col gap-0">
+          <div class="flex items-center justify-between py-2 px-1 text-xs font-semibold text-gray-500 uppercase border-b border-gray-200">
+            <span class="flex-1">Event</span>
+            <span class="w-24 text-right">Attendees</span>
+            <span class="w-24 text-right">Revenue</span>
+          </div>
+          @for (event of data().topEvents; track event.name) {
+            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="event-growth-drawer-event-row">
+              <span class="flex-1 text-sm font-medium text-gray-900">{{ event.name }}</span>
+              <span class="w-24 text-right text-sm font-semibold text-gray-900">{{ event.attendees | number }}</span>
+              <span class="w-24 text-right text-sm font-semibold text-gray-900">{{ formatEventRevenue(event.revenue) }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="event-growth-drawer-top-events-empty">
+          Top events data not yet available
+        </div>
+      }
+    </div>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
@@ -1,0 +1,107 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { ChartComponent } from '@components/chart/chart.component';
+import { lfxColors } from '@lfx-one/shared/constants';
+
+import { DrawerModule } from 'primeng/drawer';
+
+import type { ChartData, ChartOptions } from 'chart.js';
+import type { EventGrowthResponse } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-event-growth-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonComponent, CardComponent, ChartComponent, DecimalPipe, DrawerModule],
+  templateUrl: './event-growth-drawer.component.html',
+  styleUrl: './event-growth-drawer.component.scss',
+})
+export class EventGrowthDrawerComponent {
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  public readonly data = input<EventGrowthResponse>({
+    totalAttendees: 0,
+    totalEvents: 0,
+    totalRevenue: 0,
+    revenuePerAttendee: 0,
+    attendeeMomChange: 0,
+    revenueMomChange: 0,
+    trend: 'up',
+    monthlyData: [],
+    topEvents: [],
+  });
+
+  // === Computed Signals ===
+  protected readonly formattedRevenue = computed(() => {
+    const rev = this.data().totalRevenue;
+    if (rev >= 1_000_000) return `$${(rev / 1_000_000).toFixed(1)}M`;
+    if (rev >= 1_000) return `$${(rev / 1_000).toFixed(1)}K`;
+    return `$${rev.toLocaleString()}`;
+  });
+
+  protected readonly monthlyChartData: Signal<ChartData<'bar'>> = computed(() => {
+    const { monthlyData } = this.data();
+    const quarterLabels = monthlyData.map((d) => {
+      const [year, month] = d.month.split('-');
+      const qi = Math.ceil(Number(month) / 3);
+      return `Q${qi} ${year}`;
+    });
+    return {
+      labels: quarterLabels,
+      datasets: [
+        {
+          data: monthlyData.map((d) => d.value),
+          backgroundColor: lfxColors.blue[500],
+          borderRadius: 4,
+          barPercentage: 0.6,
+        },
+      ],
+    };
+  });
+
+  protected readonly monthlyChartOptions: ChartOptions<'bar'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: true },
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: { display: false },
+        ticks: { color: lfxColors.gray[500], font: { size: 11 } },
+      },
+      y: {
+        display: true,
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: false },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          callback: (value) => {
+            const num = Number(value);
+            if (num >= 1_000) return `${(num / 1_000).toFixed(1)}K`;
+            return String(num);
+          },
+        },
+      },
+    },
+  };
+
+  protected formatEventRevenue(revenue: number): string {
+    if (revenue >= 1_000_000) return `$${(revenue / 1_000_000).toFixed(1)}M`;
+    if (revenue >= 1_000) return `$${(revenue / 1_000).toFixed(1)}K`;
+    return `$${revenue.toLocaleString()}`;
+  }
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -33,7 +33,7 @@
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Conversion Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().conversionRate }}%</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ data().conversionRate.toFixed(1) }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
@@ -48,7 +48,7 @@
           @if (data().changePercentage !== 0) {
             <div class="flex items-center gap-2">
               <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage }}%
+                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage.toFixed(1) }}%
               </span>
               <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>
@@ -133,11 +133,11 @@
       </div>
     }
 
-    <!-- Conversion Funnel Chart -->
+    <!-- Re-engagement Funnel Chart -->
     <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="flywheel-conversion-drawer-funnel-section">
       <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Conversion Funnel (90-day window)</h3>
-        <p class="text-sm text-gray-600">Event attendees converting to community or working group membership</p>
+        <h3 class="text-sm font-semibold text-gray-900">Re-engagement Funnel</h3>
+        <p class="text-sm text-gray-600">Event attendees re-engaging with community, working groups, and newsletter</p>
       </div>
       <div class="h-[200px]" data-testid="flywheel-conversion-drawer-funnel-chart">
         <lfx-chart type="bar" [data]="funnelChartData()" [options]="funnelChartOptions" height="100%"></lfx-chart>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
@@ -36,11 +36,20 @@ export class FlywheelConversionDrawerComponent {
     changePercentage: 0,
     trend: 'up',
     funnel: { eventAttendees: 0, convertedToNewsletter: 0, convertedToCommunity: 0, convertedToWorkingGroup: 0 },
+    reengagement: {
+      totalReengaged: 0,
+      reengagementRate: 0,
+      reengagementMomChange: 0,
+      reengagedToNewsletter: 0,
+      reengagedToCommunity: 0,
+      reengagedToWorkingGroup: 0,
+    },
     monthlyData: [],
   });
 
   // === Computed Signals ===
   protected readonly formattedEventAttendees: Signal<string> = computed(() => formatNumber(this.data().funnel.eventAttendees));
+  protected readonly reengagementRate: Signal<string> = computed(() => `${this.data().reengagement.reengagementRate.toFixed(1)}%`);
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
   protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
@@ -132,21 +141,21 @@ export class FlywheelConversionDrawerComponent {
   // === Private Initializers ===
   private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
     return computed(() => {
-      const { conversionRate, changePercentage, funnel, monthlyData } = this.data();
+      const { conversionRate, funnel, reengagement, monthlyData } = this.data();
       const actions: MarketingRecommendedAction[] = [];
 
       if (conversionRate === 0 && funnel.eventAttendees === 0 && monthlyData.length === 0) {
         return actions;
       }
 
-      // Low WG conversion relative to community conversion
-      if (funnel.eventAttendees > 0 && funnel.convertedToWorkingGroup > 0 && funnel.convertedToCommunity > 0) {
-        const wgRate = (funnel.convertedToWorkingGroup / funnel.eventAttendees) * 100;
-        const communityRate = (funnel.convertedToCommunity / funnel.eventAttendees) * 100;
+      // Low WG re-engagement relative to community re-engagement
+      if (funnel.eventAttendees > 0 && reengagement.reengagedToWorkingGroup > 0 && reengagement.reengagedToCommunity > 0) {
+        const wgRate = (reengagement.reengagedToWorkingGroup / funnel.eventAttendees) * 100;
+        const communityRate = (reengagement.reengagedToCommunity / funnel.eventAttendees) * 100;
         if (wgRate < communityRate * 0.5) {
           actions.push({
-            title: 'Improve working group conversion path',
-            description: `WG conversion at ${wgRate.toFixed(1)}% vs ${communityRate.toFixed(1)}% for community — attendees need clearer path to participate`,
+            title: 'Improve working group re-engagement path',
+            description: `WG re-engagement at ${wgRate.toFixed(1)}% vs ${communityRate.toFixed(1)}% for community — attendees need clearer path to participate`,
             priority: 'high',
             dueLabel: 'This quarter',
             actionType: 'conversion',
@@ -154,22 +163,22 @@ export class FlywheelConversionDrawerComponent {
         }
       }
 
-      // Declining conversion rate
-      if (changePercentage < -5) {
+      // Declining re-engagement rate
+      if (reengagement.reengagementMomChange < -5) {
         actions.push({
-          title: 'Address conversion rate decline',
-          description: `Flywheel conversion dropped ${Math.abs(changePercentage)}% — review post-event follow-up effectiveness`,
+          title: 'Address re-engagement rate decline',
+          description: `Re-engagement dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% MoM — review post-event follow-up effectiveness`,
           priority: 'high',
           dueLabel: 'This month',
           actionType: 'decline',
         });
       }
 
-      // Low overall conversion
-      if (conversionRate > 0 && conversionRate < 10 && funnel.eventAttendees > 0) {
+      // Low overall re-engagement
+      if (reengagement.reengagementRate > 0 && reengagement.reengagementRate < 10 && funnel.eventAttendees > 0) {
         actions.push({
           title: 'Add post-event engagement CTAs',
-          description: `Only ${conversionRate}% overall conversion — add community join and working group prompts to event follow-ups`,
+          description: `Only ${reengagement.reengagementRate.toFixed(1)}% re-engagement — add community join and working group prompts to event follow-ups`,
           priority: 'medium',
           dueLabel: 'Next event',
           actionType: 'content',
@@ -179,7 +188,7 @@ export class FlywheelConversionDrawerComponent {
       if (actions.length === 0) {
         actions.push({
           title: 'Continue flywheel optimization',
-          description: `${conversionRate}% conversion rate${changePercentage > 0 ? ` — improving ${changePercentage}%` : ''} across ${formatNumber(funnel.eventAttendees)} attendees`,
+          description: `${reengagement.reengagementRate.toFixed(1)}% re-engagement rate${reengagement.reengagementMomChange > 0 ? ` — improving ${reengagement.reengagementMomChange.toFixed(1)}%` : ''} across ${formatNumber(funnel.eventAttendees)} attendees`,
           priority: 'low',
           dueLabel: 'Ongoing',
           actionType: 'growth',
@@ -192,39 +201,43 @@ export class FlywheelConversionDrawerComponent {
 
   private initKeyInsights(): Signal<MarketingKeyInsight[]> {
     return computed(() => {
-      const { conversionRate, changePercentage, funnel, monthlyData } = this.data();
+      const { conversionRate, funnel, reengagement, monthlyData } = this.data();
       const insights: MarketingKeyInsight[] = [];
 
       if (conversionRate === 0 && funnel.eventAttendees === 0 && monthlyData.length === 0) {
         return insights;
       }
 
-      // Best conversion path
+      // Best re-engagement path
       if (funnel.eventAttendees > 0) {
         const paths = [
-          { name: 'Community', value: funnel.convertedToCommunity },
-          { name: 'Working group', value: funnel.convertedToWorkingGroup },
+          { name: 'Community', value: reengagement.reengagedToCommunity },
+          { name: 'Working group', value: reengagement.reengagedToWorkingGroup },
+          { name: 'Newsletter', value: reengagement.reengagedToNewsletter },
         ]
           .filter((p) => p.value > 0)
           .sort((a, b) => b.value - a.value);
 
         if (paths.length > 0) {
           const bestRate = (paths[0].value / funnel.eventAttendees) * 100;
-          insights.push({ text: `${paths[0].name} is the highest conversion path at ${bestRate.toFixed(1)}% of attendees`, type: 'driver' });
+          insights.push({ text: `${paths[0].name} is the highest re-engagement path at ${bestRate.toFixed(1)}% of attendees`, type: 'driver' });
         }
 
         // Weakest path
         if (paths.length > 1) {
           const worstRate = (paths[paths.length - 1].value / funnel.eventAttendees) * 100;
-          insights.push({ text: `${paths[paths.length - 1].name} conversion lowest at ${worstRate.toFixed(1)}%`, type: 'warning' });
+          insights.push({ text: `${paths[paths.length - 1].name} re-engagement lowest at ${worstRate.toFixed(1)}%`, type: 'warning' });
         }
       }
 
-      // Conversion trend
-      if (changePercentage > 3) {
-        insights.push({ text: `Conversion rate trending up ${changePercentage}% — flywheel is accelerating`, type: 'driver' });
-      } else if (changePercentage < -3) {
-        insights.push({ text: `Conversion rate dropped ${Math.abs(changePercentage)}% — flywheel is slowing`, type: 'warning' });
+      // Re-engagement MoM trend
+      if (reengagement.reengagementMomChange > 3) {
+        insights.push({ text: `Re-engagement rate trending up ${reengagement.reengagementMomChange.toFixed(1)}% — flywheel is accelerating`, type: 'driver' });
+      } else if (reengagement.reengagementMomChange < -3) {
+        insights.push({
+          text: `Re-engagement rate dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% — flywheel is slowing`,
+          type: 'warning',
+        });
       }
 
       // Monthly trend consistency
@@ -266,12 +279,12 @@ export class FlywheelConversionDrawerComponent {
 
   private initFunnelChartData(): Signal<ChartData<'bar'>> {
     return computed(() => {
-      const { funnel } = this.data();
+      const { funnel, reengagement } = this.data();
       return {
-        labels: ['Event Attendees', 'Converted to Community', 'Converted to WG'],
+        labels: ['Event Attendees', 'Re-engaged to Community', 'Re-engaged to WG', 'Re-engaged to Newsletter'],
         datasets: [
           {
-            data: [funnel.eventAttendees, funnel.convertedToCommunity, funnel.convertedToWorkingGroup],
+            data: [funnel.eventAttendees, reengagement.reengagedToCommunity, reengagement.reengagedToWorkingGroup, reengagement.reengagedToNewsletter],
             backgroundColor: [lfxColors.blue[700], lfxColors.blue[500], lfxColors.blue[400], lfxColors.blue[300]],
             borderRadius: { topLeft: 0, bottomLeft: 0, topRight: 4, bottomRight: 4 },
             borderSkipped: 'start',

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -1,145 +1,306 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<section data-testid="marketing-overview-section">
+<section data-testid="ed-evolution-section">
   <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
     <div class="flex flex-col gap-1">
       <h2 class="mb-0">Executive Director Overview</h2>
-      <p class="text-sm text-gray-500 mb-0">North Star KPIs · Marketing Metrics</p>
+      <p class="text-sm text-gray-500 mb-0">North Star KPIs · Brand · Influence</p>
     </div>
 
-    <!-- Carousel Controls -->
-    <div class="flex items-center gap-2">
-      <lfx-button
-        icon="fa-light fa-chevron-left"
-        [outlined]="true"
-        severity="secondary"
-        size="small"
-        ariaLabel="Scroll left"
-        (onClick)="scrollShadowDirective()?.scrollLeft()"
-        data-testid="marketing-overview-carousel-prev" />
-      <lfx-button
-        icon="fa-light fa-chevron-right"
-        [outlined]="true"
-        severity="secondary"
-        size="small"
-        ariaLabel="Scroll right"
-        (onClick)="scrollShadowDirective()?.scrollRight()"
-        data-testid="marketing-overview-carousel-next" />
+    <div class="flex items-center gap-4">
+      <!-- Filter Pills -->
+      <lfx-filter-pills
+        [options]="filterOptions"
+        [selectedFilter]="selectedFilter()"
+        (filterChange)="selectedFilter.set($any($event))"
+        data-testid="ed-evolution-filters" />
+
+      <!-- Carousel Controls -->
+      <div class="flex items-center gap-2">
+        <lfx-button
+          icon="fa-light fa-chevron-left"
+          [outlined]="true"
+          severity="secondary"
+          size="small"
+          ariaLabel="Scroll left"
+          (onClick)="scrollShadowDirective()?.scrollLeft()"
+          data-testid="ed-evolution-carousel-prev" />
+        <lfx-button
+          icon="fa-light fa-chevron-right"
+          [outlined]="true"
+          severity="secondary"
+          size="small"
+          ariaLabel="Scroll right"
+          (onClick)="scrollShadowDirective()?.scrollRight()"
+          data-testid="ed-evolution-carousel-next" />
+      </div>
     </div>
   </div>
 
   <!-- Carousel Container -->
   <div class="relative overflow-hidden">
-    <div lfxScrollShadow [scrollDistance]="320" class="flex gap-4 overflow-x-auto hide-scrollbar scroll-smooth" data-testid="marketing-overview-carousel">
-      <!-- North Star Metrics -->
-      <lfx-metric-card
-        title="Flywheel Conversion"
-        icon="fa-light fa-arrows-spin"
-        chartType="line"
-        [chartData]="flywheelChartData()"
-        [chartOptions]="noTooltipChartOptions"
-        [value]="marketingData().flywheelConversion.conversionRate > 0 ? marketingData().flywheelConversion.conversionRate + '%' : undefined"
-        [changePercentage]="
-          marketingData().flywheelConversion.changePercentage !== 0
-            ? (marketingData().flywheelConversion.changePercentage > 0 ? '+' : '') + marketingData().flywheelConversion.changePercentage + '%'
-            : undefined
-        "
-        [trend]="marketingData().flywheelConversion.trend"
-        subtitle="Event attendee → community/WG within 90 days"
-        testId="flywheel-pulse-conversion"
-        [loading]="marketingDataLoading()"
-        [clickable]="true"
-        (cardClick)="handleCardClick(DashboardDrawerType.NorthStarFlywheelConversion)"></lfx-metric-card>
+    <div lfxScrollShadow [scrollDistance]="320" class="flex gap-4 overflow-x-auto hide-scrollbar scroll-smooth" data-testid="ed-evolution-carousel">
+      @for (card of northStarCards(); track card.testId) {
+        @switch (card.customContentType) {
+          @case ('dual-signal') {
+            <!-- Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact) -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [clickable]="!!card.drawerType"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+                (cardClick)="handleCardClick(card.drawerType!)">
+                <ng-template #customContent>
+                  <div class="flex flex-col gap-0 flex-1">
+                    @if (card.dualSignals) {
+                      @for (row of card.dualSignals; track row.label; let last = $last) {
+                        <div class="flex flex-col gap-1 py-2">
+                          <div class="flex items-center justify-between">
+                            <span class="text-xs text-gray-500">{{ row.label }}</span>
+                            @if (row.changePercentage) {
+                              <span class="text-xs font-medium" [class.text-emerald-600]="row.trend === 'up'" [class.text-red-600]="row.trend === 'down'">
+                                {{ row.changePercentage }}
+                              </span>
+                            }
+                          </div>
+                          <div class="flex items-center gap-3">
+                            <span class="text-lg font-semibold text-gray-900 flex-shrink-0">{{ row.value }}</span>
+                            @if (row.chartData) {
+                              <div class="flex-1 h-8">
+                                <lfx-chart type="line" [data]="row.chartData" [options]="noTooltipChartOptions" height="100%"></lfx-chart>
+                              </div>
+                            }
+                          </div>
+                        </div>
+                        @if (!last) {
+                          <div class="border-t border-gray-100"></div>
+                        }
+                      }
+                    }
+                    @if (card.caption) {
+                      <div class="text-[10px] text-gray-400 mt-1">{{ card.caption }}</div>
+                    }
+                  </div>
+                </ng-template>
+              </lfx-metric-card>
+            </div>
+          }
+          @case ('funnel') {
+            <!-- Funnel Card (Flywheel Conversion) -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [clickable]="!!card.drawerType"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+                (cardClick)="handleCardClick(card.drawerType!)">
+                <ng-template #customContent>
+                  <div class="flex flex-col gap-2 flex-1">
+                    <!-- Primary Value + Trend -->
+                    <div class="flex items-center gap-2">
+                      <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
+                      @if (card.changePercentage) {
+                        <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
+                          {{ card.changePercentage }}
+                        </span>
+                      }
+                    </div>
 
-      <lfx-metric-card
-        title="Member Growth"
-        icon="fa-light fa-user-group"
-        chartType="line"
-        [chartData]="memberGrowthChartData()"
-        [chartOptions]="noTooltipChartOptions"
-        [value]="marketingData().memberAcquisition.totalMembers > 0 ? formatNumber(marketingData().memberAcquisition.totalMembers) : undefined"
-        [changePercentage]="
-          marketingData().memberAcquisition.newMembersThisQuarter > 0
-            ? '+' + marketingData().memberAcquisition.newMembersThisQuarter + ' this quarter'
-            : undefined
-        "
-        trend="up"
-        [subtitle]="
-          marketingData().memberRetention.renewalRate > 0
-            ? marketingData().memberRetention.renewalRate + '% retention · NRR ' + marketingData().memberRetention.netRevenueRetention + '%'
-            : undefined
-        "
-        testId="flywheel-pulse-member-growth"
-        [loading]="marketingDataLoading()"
-        [clickable]="true"
-        (cardClick)="handleCardClick(DashboardDrawerType.NorthStarMemberAcquisition)"></lfx-metric-card>
+                    <!-- Mini Funnel Step-Down -->
+                    @if (card.funnelSteps) {
+                      <div class="flex items-center gap-1">
+                        @for (step of card.funnelSteps; track step.label; let last = $last) {
+                          <div class="flex flex-col items-center gap-0 flex-1 min-w-0">
+                            <span class="text-[10px] text-gray-400 truncate">{{ step.label }}</span>
+                            <span class="text-xs font-semibold text-gray-700">{{ step.value }}</span>
+                          </div>
+                          @if (!last) {
+                            <i class="fa-light fa-chevron-right text-[8px] text-gray-300 flex-shrink-0"></i>
+                          }
+                        }
+                      </div>
+                    }
 
-      <lfx-metric-card
-        title="Engaged Community"
-        icon="fa-light fa-people-group"
-        chartType="line"
-        [chartData]="engagedCommunityChartData()"
-        [chartOptions]="noTooltipChartOptions"
-        [value]="marketingData().engagedCommunity.totalMembers > 0 ? formatNumber(marketingData().engagedCommunity.totalMembers) : undefined"
-        [changePercentage]="
-          marketingData().engagedCommunity.changePercentage !== 0
-            ? (marketingData().engagedCommunity.changePercentage > 0 ? '↑ +' : '↓ ') + marketingData().engagedCommunity.changePercentage + '%'
-            : undefined
-        "
-        [trend]="marketingData().engagedCommunity.trend"
-        subtitle="Community + Working Groups + Certified"
-        testId="flywheel-pulse-share-of-voice"
-        [loading]="marketingDataLoading()"
-        [clickable]="true"
-        (cardClick)="handleCardClick(DashboardDrawerType.NorthStarEngagedCommunity)"></lfx-metric-card>
+                    @if (card.subtitle) {
+                      <div class="text-[10px] text-gray-400">{{ card.subtitle }}</div>
+                    }
+                  </div>
+                </ng-template>
+              </lfx-metric-card>
+            </div>
+          }
+          @default {
+            <!-- Standard Single-Signal Card -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [chartData]="card.chartData"
+                [chartOptions]="card.chartOptions"
+                [value]="card.value"
+                [subtitle]="card.subtitle"
+                [trend]="card.trend"
+                [changePercentage]="card.changePercentage"
+                [clickable]="!!card.drawerType"
+                (cardClick)="handleCardClick(card.drawerType!)">
+              </lfx-metric-card>
+            </div>
+          }
+        }
+      }
 
-      <!-- Marketing Metrics Key Insights Card -->
-      <lfx-card styleClass="flex-shrink-0 w-[calc(100vw-3rem)] md:w-80 h-full" data-testid="marketing-overview-key-insights">
-        <div class="flex flex-col h-full">
-          <div class="flex items-center gap-2 mb-3">
-            <i class="fa-light fa-lightbulb w-4 h-4 text-gray-500 flex-shrink-0"></i>
-            <h5 class="text-sm font-medium">Marketing Metrics</h5>
+      <!-- Marketing Metrics Key Insights Card (between North Star and Brand/Influence) -->
+      @if (showInsightsCard()) {
+        <lfx-card styleClass="flex-shrink-0 w-[calc(100vw-3rem)] md:w-80 h-full" data-testid="marketing-overview-key-insights">
+          <div class="flex flex-col h-full">
+            <div class="flex items-center gap-2 mb-3">
+              <i class="fa-light fa-lightbulb w-4 h-4 text-gray-500 flex-shrink-0"></i>
+              <h5 class="text-sm font-medium">Marketing Metrics</h5>
+            </div>
+            <div class="flex-1 flex flex-col gap-1.5 p-3 bg-gray-50 rounded-lg">
+              <h6 class="flex items-center gap-1.5 text-xs font-semibold text-gray-900 mb-1">
+                <i class="fa-light fa-lightbulb text-gray-400"></i>
+                Key Insights
+              </h6>
+              @for (insight of marketingInsights(); track insight) {
+                <div class="flex items-start gap-1.5 text-xs text-gray-700 leading-snug">
+                  <span class="mt-1.5 w-1 h-1 rounded-full bg-gray-400 flex-shrink-0"></span>
+                  <span>{{ insight }}</span>
+                </div>
+              }
+            </div>
+            <div class="mt-2 text-right">
+              <lfx-button
+                label="View details"
+                [link]="true"
+                size="small"
+                (onClick)="handleCardClick(DashboardDrawerType.NorthStarEngagedCommunity)"
+                data-testid="marketing-overview-insights-view-details" />
+            </div>
           </div>
-          <div class="flex-1 flex flex-col gap-1.5 p-3 bg-gray-50 rounded-lg">
-            <h6 class="flex items-center gap-1.5 text-xs font-semibold text-gray-900 mb-1">
-              <i class="fa-light fa-lightbulb text-gray-400"></i>
-              Key Insights
-            </h6>
-            @for (insight of marketingInsights(); track insight) {
-              <div class="flex items-start gap-1.5 text-xs text-gray-700 leading-snug">
-                <span class="mt-1.5 w-1 h-1 rounded-full bg-gray-400 flex-shrink-0"></span>
-                <span>{{ insight }}</span>
-              </div>
-            }
-          </div>
-          <div class="mt-2 text-right">
-            <lfx-button
-              label="View details"
-              [link]="true"
-              size="small"
-              (onClick)="handleCardClick(DashboardDrawerType.MarketingEmailCtr)"
-              data-testid="marketing-overview-insights-view-details" />
-          </div>
-        </div>
-      </lfx-card>
+        </lfx-card>
+      }
 
-      <!-- Marketing Cards -->
-      @for (card of marketingCards(); track card.testId) {
-        <lfx-metric-card
-          [title]="card.title"
-          [icon]="card.icon"
-          [testId]="card.testId"
-          [chartType]="card.chartType"
-          [chartData]="card.chartData"
-          [chartOptions]="card.chartOptions"
-          [value]="card.value"
-          [subtitle]="card.subtitle"
-          [trend]="card.trend"
-          [changePercentage]="card.changePercentage"
-          [loading]="card.loading"
-          [clickable]="!!card.drawerType"
-          (cardClick)="handleCardClick(card.drawerType!)"></lfx-metric-card>
+      @for (card of nonNorthStarCards(); track card.testId) {
+        @switch (card.customContentType) {
+          @case ('dual-signal') {
+            <!-- Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact) -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [clickable]="!!card.drawerType"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+                (cardClick)="handleCardClick(card.drawerType!)">
+                <ng-template #customContent>
+                  <div class="flex flex-col gap-0 flex-1">
+                    @if (card.dualSignals) {
+                      @for (row of card.dualSignals; track row.label; let last = $last) {
+                        <div class="flex flex-col gap-1 py-2">
+                          <div class="flex items-center justify-between">
+                            <span class="text-xs text-gray-500">{{ row.label }}</span>
+                            @if (row.changePercentage) {
+                              <span class="text-xs font-medium" [class.text-emerald-600]="row.trend === 'up'" [class.text-red-600]="row.trend === 'down'">
+                                {{ row.changePercentage }}
+                              </span>
+                            }
+                          </div>
+                          <div class="flex items-center gap-3">
+                            <span class="text-lg font-semibold text-gray-900 flex-shrink-0">{{ row.value }}</span>
+                            @if (row.chartData) {
+                              <div class="flex-1 h-8">
+                                <lfx-chart type="line" [data]="row.chartData" [options]="noTooltipChartOptions" height="100%"></lfx-chart>
+                              </div>
+                            }
+                          </div>
+                        </div>
+                        @if (!last) {
+                          <div class="border-t border-gray-100"></div>
+                        }
+                      }
+                    }
+                    @if (card.caption) {
+                      <div class="text-[10px] text-gray-400 mt-1">{{ card.caption }}</div>
+                    }
+                  </div>
+                </ng-template>
+              </lfx-metric-card>
+            </div>
+          }
+          @case ('funnel') {
+            <!-- Funnel Card (Flywheel Conversion) -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [clickable]="!!card.drawerType"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+                (cardClick)="handleCardClick(card.drawerType!)">
+                <ng-template #customContent>
+                  <div class="flex flex-col gap-2 flex-1">
+                    <div class="flex items-center gap-2">
+                      <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
+                      @if (card.changePercentage) {
+                        <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
+                          {{ card.changePercentage }}
+                        </span>
+                      }
+                    </div>
+
+                    @if (card.funnelSteps) {
+                      <div class="flex items-center gap-1">
+                        @for (step of card.funnelSteps; track step.label; let last = $last) {
+                          <div class="flex flex-col items-center gap-0 flex-1 min-w-0">
+                            <span class="text-[10px] text-gray-400 truncate">{{ step.label }}</span>
+                            <span class="text-xs font-semibold text-gray-700">{{ step.value }}</span>
+                          </div>
+                          @if (!last) {
+                            <i class="fa-light fa-chevron-right text-[8px] text-gray-300 flex-shrink-0"></i>
+                          }
+                        }
+                      </div>
+                    }
+
+                    @if (card.subtitle) {
+                      <div class="text-[10px] text-gray-400">{{ card.subtitle }}</div>
+                    }
+                  </div>
+                </ng-template>
+              </lfx-metric-card>
+            </div>
+          }
+          @default {
+            <!-- Standard Single-Signal Card -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [chartData]="card.chartData"
+                [chartOptions]="card.chartOptions"
+                [value]="card.value"
+                [subtitle]="card.subtitle"
+                [trend]="card.trend"
+                [changePercentage]="card.changePercentage"
+                [clickable]="!!card.drawerType"
+                (cardClick)="handleCardClick(card.drawerType!)">
+              </lfx-metric-card>
+            </div>
+          }
+        }
       }
     </div>
 
@@ -147,23 +308,66 @@
     <div
       class="absolute top-0 bottom-0 right-0 w-32 z-10 pointer-events-none bg-[linear-gradient(to_right,transparent,#f9fafb)] transition-opacity duration-200"
       [class.opacity-0]="!scrollShadowDirective()?.showRightShadow()"
-      data-testid="marketing-overview-shadow-right"
+      data-testid="ed-evolution-shadow-right"
       aria-hidden="true"></div>
 
     <!-- Left shadow fade -->
     <div
       class="absolute top-0 bottom-0 left-0 w-32 z-10 pointer-events-none bg-[linear-gradient(to_left,transparent,#f9fafb)] transition-opacity duration-200"
       [class.opacity-0]="!scrollShadowDirective()?.showLeftShadow()"
-      data-testid="marketing-overview-shadow-left"
+      data-testid="ed-evolution-shadow-left"
       aria-hidden="true"></div>
+  </div>
+
+  <!-- Prototype indicator -->
+  <div class="flex items-center gap-1 mt-2 text-xs text-gray-400">
+    <i class="fa-light fa-circle-info"></i>
+    <span>Hover over any card for data source details · Prototype with dummy data</span>
   </div>
 </section>
 
-<!-- Drill-Down Drawers
-  Note: [visible] uses a computed expression from activeDrawer() signal.
-  This matches the established pattern in foundation-health and organization-involvement drawers.
-  Signal updates are synchronous — handleDrawerClose() sets activeDrawer(null) in the same
-  change detection cycle, so no flicker occurs on backdrop dismiss. -->
+<!-- Drill-Down Drawers -->
+
+<!-- North Star Drawers -->
+<lfx-flywheel-conversion-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.NorthStarFlywheelConversion"
+  [data]="flywheelData()"
+  (visibleChange)="handleDrawerClose()"></lfx-flywheel-conversion-drawer>
+
+<lfx-member-acquisition-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.NorthStarMemberAcquisition"
+  [data]="memberAcquisitionData()"
+  [retentionData]="memberRetentionData()"
+  (visibleChange)="handleDrawerClose()"></lfx-member-acquisition-drawer>
+
+<lfx-engaged-community-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.NorthStarEngagedCommunity"
+  [data]="engagedCommunityData()"
+  (visibleChange)="handleDrawerClose()"></lfx-engaged-community-drawer>
+
+<lfx-event-growth-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.NorthStarEventGrowth"
+  [data]="eventGrowthData()"
+  (visibleChange)="handleDrawerClose()"></lfx-event-growth-drawer>
+
+<!-- Brand Drawers -->
+<lfx-brand-reach-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.BrandReach"
+  [data]="brandReachData()"
+  (visibleChange)="handleDrawerClose()"></lfx-brand-reach-drawer>
+
+<lfx-brand-health-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.BrandHealth"
+  [data]="brandHealthData()"
+  (visibleChange)="handleDrawerClose()"></lfx-brand-health-drawer>
+
+<!-- Influence Drawer -->
+<lfx-revenue-impact-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.RevenueImpact"
+  [data]="revenueImpactData()"
+  (visibleChange)="handleDrawerClose()"></lfx-revenue-impact-drawer>
+
+<!-- Existing Marketing Drawers (accessible from Brand Reach / Engaged Community drawers in future) -->
 <lfx-website-visits-drawer
   [visible]="activeDrawer() === DashboardDrawerType.MarketingWebsiteVisits"
   (visibleChange)="handleDrawerClose()"></lfx-website-visits-drawer>
@@ -177,20 +381,3 @@
 <lfx-social-media-drawer
   [visible]="activeDrawer() === DashboardDrawerType.MarketingSocialMedia"
   (visibleChange)="handleDrawerClose()"></lfx-social-media-drawer>
-
-<!-- North Star Drawers -->
-<lfx-engaged-community-drawer
-  [visible]="activeDrawer() === DashboardDrawerType.NorthStarEngagedCommunity"
-  (visibleChange)="handleDrawerClose()"
-  [data]="marketingData().engagedCommunity"></lfx-engaged-community-drawer>
-
-<lfx-member-acquisition-drawer
-  [visible]="activeDrawer() === DashboardDrawerType.NorthStarMemberAcquisition"
-  (visibleChange)="handleDrawerClose()"
-  [data]="marketingData().memberAcquisition"
-  [retentionData]="marketingData().memberRetention"></lfx-member-acquisition-drawer>
-
-<lfx-flywheel-conversion-drawer
-  [visible]="activeDrawer() === DashboardDrawerType.NorthStarFlywheelConversion"
-  (visibleChange)="handleDrawerClose()"
-  [data]="marketingData().flywheelConversion"></lfx-flywheel-conversion-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -1,40 +1,130 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { afterNextRender, ChangeDetectionStrategy, Component, computed, inject, signal, Signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal, viewChild } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { ChartComponent } from '@components/chart/chart.component';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { MetricCardComponent } from '@components/metric-card/metric-card.component';
 
-import { MARKETING_OVERVIEW_METRICS, NO_TOOLTIP_CHART_OPTIONS } from '@lfx-one/shared/constants';
-import { lfxColors } from '@lfx-one/shared/constants';
+import { buildEdEvolutionMetrics, ED_EVOLUTION_FILTER_OPTIONS, NO_TOOLTIP_CHART_OPTIONS } from '@lfx-one/shared/constants';
 import {
+  BrandHealthResponse,
+  BrandReachResponse,
   DashboardDrawerType,
   DashboardMetricCard,
-  EmailCtrResponse,
+  EdEvolutionData,
   EngagedCommunitySizeResponse,
+  EventGrowthResponse,
   FlywheelConversionResponse,
   MemberAcquisitionResponse,
   MemberRetentionResponse,
-  SocialMediaResponse,
-  SocialReachResponse,
-  WebActivitiesSummaryResponse,
+  MetricCategory,
+  RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
-import { formatNumber, hexToRgba } from '@lfx-one/shared/utils';
+import { formatNumber } from '@lfx-one/shared/utils';
+
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
-
 import { ScrollShadowDirective } from '@shared/directives/scroll-shadow.directive';
-import { catchError, combineLatest, filter, finalize, forkJoin, map, of, switchMap, tap } from 'rxjs';
+import { TooltipModule } from 'primeng/tooltip';
+import { filter, forkJoin, map, switchMap } from 'rxjs';
 
+import { BrandHealthDrawerComponent } from '../brand-health-drawer/brand-health-drawer.component';
+import { BrandReachDrawerComponent } from '../brand-reach-drawer/brand-reach-drawer.component';
 import { EmailCtrDrawerComponent } from '../email-ctr-drawer/email-ctr-drawer.component';
 import { EngagedCommunityDrawerComponent } from '../engaged-community-drawer/engaged-community-drawer.component';
+import { EventGrowthDrawerComponent } from '../event-growth-drawer/event-growth-drawer.component';
 import { FlywheelConversionDrawerComponent } from '../flywheel-conversion-drawer/flywheel-conversion-drawer.component';
 import { MemberAcquisitionDrawerComponent } from '../member-acquisition-drawer/member-acquisition-drawer.component';
 import { PaidSocialReachDrawerComponent } from '../paid-social-reach-drawer/paid-social-reach-drawer.component';
+import { RevenueImpactDrawerComponent } from '../revenue-impact-drawer/revenue-impact-drawer.component';
 import { SocialMediaDrawerComponent } from '../social-media-drawer/social-media-drawer.component';
 import { WebsiteVisitsDrawerComponent } from '../website-visits-drawer/website-visits-drawer.component';
+
+const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
+  flywheel: {
+    conversionRate: 0,
+    changePercentage: 0,
+    trend: 'up',
+    funnel: { eventAttendees: 0, convertedToNewsletter: 0, convertedToCommunity: 0, convertedToWorkingGroup: 0 },
+    reengagement: {
+      totalReengaged: 0,
+      reengagementRate: 0,
+      reengagementMomChange: 0,
+      reengagedToNewsletter: 0,
+      reengagedToCommunity: 0,
+      reengagedToWorkingGroup: 0,
+    },
+    monthlyData: [],
+  },
+  memberAcquisition: {
+    totalMembers: 0,
+    totalMembersMonthlyData: [],
+    totalMembersMonthlyLabels: [],
+    newMembersThisQuarter: 0,
+    newMemberRevenue: 0,
+    changePercentage: 0,
+    trend: 'up',
+    quarterlyData: [],
+  },
+  memberRetention: {
+    renewalRate: 0,
+    netRevenueRetention: 0,
+    changePercentage: 0,
+    trend: 'up',
+    target: 0,
+    monthlyData: [],
+  },
+  engagedCommunity: {
+    totalMembers: 0,
+    changePercentage: 0,
+    trend: 'up',
+    breakdown: { newsletterSubscribers: 0, communityMembers: 0, workingGroupMembers: 0, certifiedIndividuals: 0 },
+    monthlyData: [],
+  },
+  eventGrowth: {
+    totalAttendees: 0,
+    totalEvents: 0,
+    totalRevenue: 0,
+    revenuePerAttendee: 0,
+    attendeeMomChange: 0,
+    revenueMomChange: 0,
+    trend: 'up',
+    monthlyData: [],
+    topEvents: [],
+  },
+  brandReach: {
+    totalSocialFollowers: 0,
+    totalMonthlySessions: 0,
+    activePlatforms: 0,
+    changePercentage: 0,
+    trend: 'up',
+    socialPlatforms: [],
+    websiteDomains: [],
+    dailyTrend: [],
+  },
+  brandHealth: {
+    totalMentions: 0,
+    sentiment: { positive: 0, neutral: 0, negative: 0 },
+    sentimentMomChangePp: 0,
+    trend: 'up',
+    monthlyMentions: [],
+    topProjects: [],
+  },
+  revenueImpact: {
+    pipelineInfluenced: 0,
+    revenueAttributed: 0,
+    matchRate: 0,
+    changePercentage: 0,
+    trend: 'up',
+    attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+    engagementTypes: [],
+    paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0 },
+  },
+};
 
 @Component({
   selector: 'lfx-marketing-overview',
@@ -42,9 +132,13 @@ import { WebsiteVisitsDrawerComponent } from '../website-visits-drawer/website-v
   imports: [
     ButtonComponent,
     CardComponent,
+    ChartComponent,
+    FilterPillsComponent,
     MetricCardComponent,
     ScrollShadowDirective,
+    TooltipModule,
 
+    // Existing drawers
     WebsiteVisitsDrawerComponent,
     EmailCtrDrawerComponent,
     PaidSocialReachDrawerComponent,
@@ -52,109 +146,56 @@ import { WebsiteVisitsDrawerComponent } from '../website-visits-drawer/website-v
     EngagedCommunityDrawerComponent,
     MemberAcquisitionDrawerComponent,
     FlywheelConversionDrawerComponent,
+
+    // New prototype drawers
+    EventGrowthDrawerComponent,
+    BrandReachDrawerComponent,
+    BrandHealthDrawerComponent,
+    RevenueImpactDrawerComponent,
   ],
   templateUrl: './marketing-overview.component.html',
   styleUrl: './marketing-overview.component.scss',
 })
 export class MarketingOverviewComponent {
-  public readonly scrollShadowDirective = viewChild(ScrollShadowDirective);
-
   // === Services ===
   private readonly analyticsService = inject(AnalyticsService);
   private readonly projectContextService = inject(ProjectContextService);
 
-  // === WritableSignals ===
-  protected readonly marketingDataLoading = signal(true);
-  private readonly browserReady = signal(false);
-  public readonly activeDrawer = signal<DashboardDrawerType | null>(null);
-
-  // === Observables ===
-  private readonly selectedFoundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(
-    map((foundation) => ({ slug: foundation?.slug || '', name: foundation?.name || '' }))
-  );
+  public readonly scrollShadowDirective = viewChild(ScrollShadowDirective);
 
   // === Constants ===
+  protected readonly filterOptions = ED_EVOLUTION_FILTER_OPTIONS;
+  protected readonly noTooltipChartOptions = NO_TOOLTIP_CHART_OPTIONS;
   protected readonly DashboardDrawerType = DashboardDrawerType;
 
+  // === WritableSignals ===
+  public readonly selectedFilter = signal<'all' | MetricCategory>('all');
+  public readonly activeDrawer = signal<DashboardDrawerType | null>(null);
+
   // === Computed Signals ===
+  protected readonly edEvolutionData: Signal<EdEvolutionData> = this.initEdEvolutionData();
+
+  protected readonly flywheelData = computed<FlywheelConversionResponse>(() => this.edEvolutionData().flywheel);
+  protected readonly memberAcquisitionData = computed<MemberAcquisitionResponse>(() => this.edEvolutionData().memberAcquisition);
+  protected readonly memberRetentionData = computed<MemberRetentionResponse>(() => this.edEvolutionData().memberRetention);
+  protected readonly engagedCommunityData = computed<EngagedCommunitySizeResponse>(() => this.edEvolutionData().engagedCommunity);
+  protected readonly eventGrowthData = computed<EventGrowthResponse>(() => this.edEvolutionData().eventGrowth);
+  protected readonly brandReachData = computed<BrandReachResponse>(() => this.edEvolutionData().brandReach);
+  protected readonly brandHealthData = computed<BrandHealthResponse>(() => this.edEvolutionData().brandHealth);
+  protected readonly revenueImpactData = computed<RevenueImpactResponse>(() => this.edEvolutionData().revenueImpact);
+
+  protected readonly filteredCards = computed<DashboardMetricCard[]>(() => {
+    const cards = buildEdEvolutionMetrics(this.edEvolutionData());
+    const filterKey = this.selectedFilter();
+    if (filterKey === 'all') return cards;
+    return cards.filter((card) => card.category === filterKey);
+  });
+
+  protected readonly northStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category === 'memberships'));
+  protected readonly nonNorthStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category !== 'memberships'));
+  protected readonly showInsightsCard = computed<boolean>(() => this.northStarCards().length > 0);
+
   protected readonly marketingInsights: Signal<string[]> = this.initMarketingInsights();
-  protected readonly marketingData: Signal<{
-    webActivities: WebActivitiesSummaryResponse;
-    emailCtr: EmailCtrResponse;
-    socialReach: SocialReachResponse;
-    socialMedia: SocialMediaResponse;
-    memberRetention: MemberRetentionResponse;
-    memberAcquisition: MemberAcquisitionResponse;
-    engagedCommunity: EngagedCommunitySizeResponse;
-    flywheelConversion: FlywheelConversionResponse;
-  }> = this.initMarketingData();
-  protected readonly marketingCards: Signal<DashboardMetricCard[]> = this.initMarketingCards();
-  protected readonly formatNumber = formatNumber;
-  protected readonly noTooltipChartOptions = NO_TOOLTIP_CHART_OPTIONS;
-
-  // North Star sparkline chart data
-  protected readonly memberGrowthChartData = computed(() => {
-    const { totalMembersMonthlyData, totalMembersMonthlyLabels } = this.marketingData().memberAcquisition;
-    if (totalMembersMonthlyData.length === 0) return undefined;
-    return {
-      labels: totalMembersMonthlyLabels,
-      datasets: [
-        {
-          data: totalMembersMonthlyData,
-          borderColor: lfxColors.blue[500],
-          backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-          fill: true,
-          tension: 0.4,
-          borderWidth: 2,
-          pointRadius: 0,
-        },
-      ],
-    };
-  });
-
-  protected readonly flywheelChartData = computed(() => {
-    const { monthlyData } = this.marketingData().flywheelConversion;
-    if (monthlyData.length === 0) return undefined;
-    return {
-      labels: monthlyData.map((d) => d.month),
-      datasets: [
-        {
-          data: monthlyData.map((d) => d.value),
-          borderColor: lfxColors.blue[500],
-          backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-          fill: true,
-          tension: 0.4,
-          borderWidth: 2,
-          pointRadius: 0,
-        },
-      ],
-    };
-  });
-
-  protected readonly engagedCommunityChartData = computed(() => {
-    const { monthlyData } = this.marketingData().engagedCommunity;
-    if (monthlyData.length === 0) return undefined;
-    return {
-      labels: monthlyData.map((d) => d.month),
-      datasets: [
-        {
-          data: monthlyData.map((d) => d.value),
-          borderColor: lfxColors.blue[500],
-          backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-          fill: true,
-          tension: 0.4,
-          borderWidth: 2,
-          pointRadius: 0,
-        },
-      ],
-    };
-  });
-
-  public constructor() {
-    afterNextRender(() => {
-      this.browserReady.set(true);
-    });
-  }
 
   // === Public Methods ===
   public handleCardClick(drawerType: DashboardDrawerType): void {
@@ -166,364 +207,63 @@ export class MarketingOverviewComponent {
   }
 
   // === Private Initializers ===
-  private initMarketingCards(): Signal<DashboardMetricCard[]> {
-    return computed(() => {
-      const { webActivities, emailCtr, socialReach, socialMedia } = this.marketingData();
-      const loading = this.marketingDataLoading();
-
-      return MARKETING_OVERVIEW_METRICS.map((card) => {
-        switch (card.drawerType) {
-          case DashboardDrawerType.MarketingWebsiteVisits:
-            return this.transformWebsiteVisits(card, webActivities, loading);
-          case DashboardDrawerType.MarketingEmailCtr:
-            return this.transformEmailCtr(card, emailCtr, loading);
-          case DashboardDrawerType.MarketingPaidSocialReach:
-            return this.transformSocialReach(card, socialReach, loading);
-          case DashboardDrawerType.MarketingSocialMedia:
-            return this.transformSocialMedia(card, socialMedia, loading);
-          default:
-            return card;
-        }
-      });
-    });
-  }
-
-  private initMarketingData(): Signal<{
-    webActivities: WebActivitiesSummaryResponse;
-    emailCtr: EmailCtrResponse;
-    socialReach: SocialReachResponse;
-    socialMedia: SocialMediaResponse;
-    memberRetention: MemberRetentionResponse;
-    memberAcquisition: MemberAcquisitionResponse;
-    engagedCommunity: EngagedCommunitySizeResponse;
-    flywheelConversion: FlywheelConversionResponse;
-  }> {
-    const defaultWebActivities: WebActivitiesSummaryResponse = {
-      totalSessions: 0,
-      totalPageViews: 0,
-      domainGroups: [],
-      dailyData: [],
-      dailyLabels: [],
-    };
-
-    const defaultEmailCtr: EmailCtrResponse = {
-      currentCtr: 0,
-      changePercentage: 0,
-      trend: 'up',
-      monthlyData: [],
-      monthlyLabels: [],
-      campaignGroups: [],
-      monthlySends: [],
-      monthlyOpens: [],
-    };
-
-    const defaultSocialReach: SocialReachResponse = {
-      totalReach: 0,
-      roas: 0,
-      totalSpend: 0,
-      totalRevenue: 0,
-      changePercentage: 0,
-      trend: 'up',
-      monthlyData: [],
-      monthlyLabels: [],
-      monthlyRoas: [],
-      channelGroups: [],
-    };
-
-    const defaultSocialMedia: SocialMediaResponse = {
-      totalFollowers: 0,
-      totalPlatforms: 0,
-      changePercentage: 0,
-      trend: 'up',
-      platforms: [],
-      monthlyData: [],
-    };
-
-    const defaultMemberRetention: MemberRetentionResponse = {
-      renewalRate: 0,
-      netRevenueRetention: 0,
-      changePercentage: 0,
-      trend: 'up',
-      target: 85,
-      monthlyData: [],
-    };
-
-    const defaultMemberAcquisition: MemberAcquisitionResponse = {
-      totalMembers: 0,
-      totalMembersMonthlyData: [],
-      totalMembersMonthlyLabels: [],
-      newMembersThisQuarter: 0,
-      newMemberRevenue: 0,
-      changePercentage: 0,
-      trend: 'up',
-      quarterlyData: [],
-    };
-
-    const defaultEngagedCommunity: EngagedCommunitySizeResponse = {
-      totalMembers: 0,
-      changePercentage: 0,
-      trend: 'up',
-      breakdown: {
-        newsletterSubscribers: 0,
-        communityMembers: 0,
-        workingGroupMembers: 0,
-        certifiedIndividuals: 0,
-      },
-      monthlyData: [],
-    };
-
-    const defaultFlywheelConversion: FlywheelConversionResponse = {
-      conversionRate: 0,
-      changePercentage: 0,
-      trend: 'up',
-      funnel: {
-        eventAttendees: 0,
-        convertedToNewsletter: 0,
-        convertedToCommunity: 0,
-        convertedToWorkingGroup: 0,
-      },
-      monthlyData: [],
-    };
-
-    const defaultValue = {
-      webActivities: defaultWebActivities,
-      emailCtr: defaultEmailCtr,
-      socialReach: defaultSocialReach,
-      socialMedia: defaultSocialMedia,
-      memberRetention: defaultMemberRetention,
-      memberAcquisition: defaultMemberAcquisition,
-      engagedCommunity: defaultEngagedCommunity,
-      flywheelConversion: defaultFlywheelConversion,
-    };
+  private initEdEvolutionData(): Signal<EdEvolutionData> {
+    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(
+      map((f) => f?.slug || ''),
+      filter((slug) => !!slug)
+    );
 
     return toSignal(
-      combineLatest([toObservable(this.browserReady), this.selectedFoundation$]).pipe(
-        filter(([ready, foundation]) => ready && !!foundation.slug),
-        map(([, foundation]) => foundation),
-        tap(() => {
-          this.marketingDataLoading.set(true);
-          this.activeDrawer.set(null);
-        }),
-        switchMap((foundation) =>
+      foundation$.pipe(
+        switchMap((slug) =>
           forkJoin({
-            webActivities: this.analyticsService.getWebActivitiesSummary(foundation.slug).pipe(catchError(() => of(defaultWebActivities))),
-            emailCtr: this.analyticsService.getEmailCtr(foundation.name).pipe(catchError(() => of(defaultEmailCtr))),
-            socialReach: this.analyticsService.getSocialReach(foundation.name).pipe(catchError(() => of(defaultSocialReach))),
-            socialMedia: this.analyticsService.getSocialMedia(foundation.name).pipe(catchError(() => of(defaultSocialMedia))),
-            memberRetention: this.analyticsService.getMemberRetention(foundation.slug).pipe(catchError(() => of(defaultMemberRetention))),
-            memberAcquisition: this.analyticsService.getMemberAcquisition(foundation.slug).pipe(catchError(() => of(defaultMemberAcquisition))),
-            engagedCommunity: this.analyticsService.getEngagedCommunity(foundation.slug).pipe(catchError(() => of(defaultEngagedCommunity))),
-            flywheelConversion: this.analyticsService.getFlywheelConversion(foundation.slug).pipe(catchError(() => of(defaultFlywheelConversion))),
-          }).pipe(tap(() => this.marketingDataLoading.set(false)))
-        ),
-        finalize(() => this.marketingDataLoading.set(false))
+            flywheel: this.analyticsService.getFlywheelConversion(slug),
+            memberAcquisition: this.analyticsService.getMemberAcquisition(slug),
+            memberRetention: this.analyticsService.getMemberRetention(slug),
+            engagedCommunity: this.analyticsService.getEngagedCommunity(slug),
+            eventGrowth: this.analyticsService.getEventGrowth(slug),
+            brandReach: this.analyticsService.getBrandReach(slug),
+            brandHealth: this.analyticsService.getBrandHealth(slug),
+            revenueImpact: this.analyticsService.getRevenueImpact(slug),
+          })
+        )
       ),
-      { initialValue: defaultValue }
-    );
+      { initialValue: EMPTY_ED_EVOLUTION_DATA }
+    ) as Signal<EdEvolutionData>;
   }
 
   private initMarketingInsights(): Signal<string[]> {
     return computed(() => {
-      const data = this.marketingData();
-      if (this.marketingDataLoading()) {
-        return [];
-      }
-
-      // Collect all metrics that have meaningful data and a change percentage
-      const signals: { label: string; change: number; detail: string }[] = [];
-
-      if (data.socialMedia.totalFollowers > 0) {
-        signals.push({
-          label: 'Social followers',
-          change: data.socialMedia.changePercentage,
-          detail: formatNumber(data.socialMedia.totalFollowers),
-        });
-      }
-
-      if (data.socialReach.totalReach > 0) {
-        signals.push({
-          label: 'Paid social reach',
-          change: data.socialReach.changePercentage,
-          detail: formatNumber(data.socialReach.totalReach),
-        });
-      }
-
-      if (data.engagedCommunity.totalMembers > 0) {
-        signals.push({
+      const data = this.edEvolutionData();
+      const signals: { label: string; change: number; detail: string }[] = [
+        {
           label: 'Engaged community',
           change: data.engagedCommunity.changePercentage,
           detail: formatNumber(data.engagedCommunity.totalMembers),
-        });
-      }
-
-      if (data.memberAcquisition.totalMembers > 0) {
-        signals.push({
+        },
+        {
           label: 'Member base',
           change: data.memberAcquisition.changePercentage,
           detail: formatNumber(data.memberAcquisition.totalMembers),
-        });
-      }
-
-      if (data.flywheelConversion.conversionRate > 0) {
-        signals.push({
+        },
+        {
           label: 'Flywheel conversion',
-          change: data.flywheelConversion.changePercentage,
-          detail: `${data.flywheelConversion.conversionRate}%`,
-        });
-      }
-
-      if (data.memberRetention.renewalRate > 0) {
-        signals.push({
+          change: data.flywheel.reengagement.reengagementMomChange,
+          detail: `${data.flywheel.reengagement.reengagementRate.toFixed(1)}%`,
+        },
+        {
           label: 'Member retention',
           change: data.memberRetention.changePercentage,
-          detail: `${data.memberRetention.renewalRate}%`,
-        });
-      }
+          detail: `${data.memberRetention.renewalRate.toFixed(1)}%`,
+        },
+      ];
 
-      // Sort by absolute change magnitude — biggest movers first
       const sorted = signals.filter((s) => s.change !== 0).sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
 
-      const insights: string[] = [];
-
-      // Top movers — up to 3, biggest changes across all metrics
-      for (const signal of sorted.slice(0, 3)) {
-        const direction = signal.change > 0 ? 'up' : 'down';
-        insights.push(`${signal.label} is ${direction} ${Math.abs(signal.change)}% — now at ${signal.detail}`);
-      }
-
-      // If fewer than 2 insights from movers, add a steady-state summary
-      if (insights.length < 2 && data.webActivities.totalSessions > 0) {
-        insights.push(`${formatNumber(data.webActivities.totalSessions)} website sessions in the last 30 days`);
-      }
-
-      return insights;
+      return sorted.slice(0, 3).map((s) => {
+        const direction = s.change > 0 ? 'up' : 'down';
+        return `${s.label} is ${direction} ${Math.abs(s.change).toFixed(1)}% — now at ${s.detail}`;
+      });
     });
-  }
-
-  // === Private Helpers ===
-  private transformWebsiteVisits(card: DashboardMetricCard, data: WebActivitiesSummaryResponse, loading: boolean): DashboardMetricCard {
-    return {
-      ...card,
-      loading,
-      value: data.totalSessions > 0 ? formatNumber(data.totalSessions) : undefined,
-      subtitle: data.totalSessions > 0 ? `Last 30 days · ${formatNumber(data.totalPageViews)} page views` : undefined,
-      chartData:
-        data.dailyData.length > 0
-          ? {
-              labels: data.dailyLabels,
-              datasets: [
-                {
-                  data: data.dailyData,
-                  borderColor: lfxColors.blue[500],
-                  backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-                  fill: true,
-                  tension: 0.4,
-                  borderWidth: 2,
-                  pointRadius: 0,
-                },
-              ],
-            }
-          : card.chartData,
-      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-    };
-  }
-
-  private transformEmailCtr(card: DashboardMetricCard, data: EmailCtrResponse, loading: boolean): DashboardMetricCard {
-    return {
-      ...card,
-      loading,
-      value: data.currentCtr > 0 ? `${data.currentCtr.toFixed(1)}%` : undefined,
-      subtitle: data.currentCtr > 0 ? 'Last 6 months' : undefined,
-      changePercentage: data.changePercentage !== 0 ? `${data.changePercentage}%` : undefined,
-      trend: data.trend,
-      chartData:
-        data.monthlyData.length > 0
-          ? {
-              labels: data.monthlyLabels,
-              datasets: [
-                {
-                  data: data.monthlyData,
-                  borderColor: lfxColors.blue[500],
-                  backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-                  fill: true,
-                  tension: 0.4,
-                  borderWidth: 2,
-                  pointRadius: 0,
-                },
-              ],
-            }
-          : card.chartData,
-      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-    };
-  }
-
-  private transformSocialReach(card: DashboardMetricCard, data: SocialReachResponse, loading: boolean): DashboardMetricCard {
-    return {
-      ...card,
-      loading,
-      value: this.getSocialReachValue(data),
-      subtitle: this.getSocialReachSubtitle(data),
-      changePercentage: data.changePercentage !== 0 ? `${data.changePercentage > 0 ? '+' : ''}${data.changePercentage}%` : undefined,
-      trend: data.trend,
-      chartData:
-        data.monthlyRoas && data.monthlyRoas.length > 0
-          ? {
-              labels: data.monthlyLabels,
-              datasets: [
-                {
-                  data: data.monthlyRoas,
-                  borderColor: lfxColors.blue[500],
-                  backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-                  fill: true,
-                  tension: 0.4,
-                  borderWidth: 2,
-                  pointRadius: 0,
-                },
-              ],
-            }
-          : card.chartData,
-      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-    };
-  }
-
-  private transformSocialMedia(card: DashboardMetricCard, data: SocialMediaResponse, loading: boolean): DashboardMetricCard {
-    return {
-      ...card,
-      loading,
-      value: data.totalFollowers > 0 ? formatNumber(data.totalFollowers) : undefined,
-      subtitle: data.totalFollowers > 0 ? `${data.totalPlatforms} platforms · Last 6 months` : undefined,
-      changePercentage: data.changePercentage !== 0 ? `${data.changePercentage > 0 ? '+' : ''}${data.changePercentage}%` : undefined,
-      trend: data.trend,
-      chartData:
-        data.monthlyData.length > 0
-          ? {
-              labels: data.monthlyData.map((d) => d.month),
-              datasets: [
-                {
-                  data: data.monthlyData.map((d) => d.totalFollowers),
-                  borderColor: lfxColors.blue[500],
-                  backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-                  fill: true,
-                  tension: 0.4,
-                  borderWidth: 2,
-                  pointRadius: 0,
-                },
-              ],
-            }
-          : card.chartData,
-      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-    };
-  }
-
-  private getSocialReachValue(data: SocialReachResponse): string | undefined {
-    if (data.roas > 0) return `${data.roas.toFixed(2)}x`;
-    if (data.totalReach > 0) return formatNumber(data.totalReach);
-    return undefined;
-  }
-
-  private getSocialReachSubtitle(data: SocialReachResponse): string | undefined {
-    if (data.roas > 0) return 'ROAS · Last 6 months';
-    if (data.totalReach > 0) return 'Last 6 months';
-    return undefined;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -56,13 +56,13 @@
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Renewal Rate</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().renewalRate }}%</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().renewalRate.toFixed(1) }}%</span>
           </div>
         </lfx-card>
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Net Revenue Retention</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().netRevenueRetention }}%</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().netRevenueRetention.toFixed(1) }}%</span>
           </div>
         </lfx-card>
         <lfx-card styleClass="flex-1">
@@ -71,7 +71,7 @@
             @if (retentionData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="retentionData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ retentionData().changePercentage > 0 ? '+' : '' }}{{ retentionData().changePercentage }}%
+                  {{ retentionData().changePercentage > 0 ? '+' : '' }}{{ retentionData().changePercentage.toFixed(1) }}%
                 </span>
                 <i class="text-sm" [class]="retentionData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -33,13 +33,13 @@
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Renewal Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().renewalRate }}%</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ data().renewalRate.toFixed(1) }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Net Revenue Retention</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().netRevenueRetention }}%</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ data().netRevenueRetention.toFixed(1) }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
@@ -48,7 +48,7 @@
           @if (data().changePercentage !== 0) {
             <div class="flex items-center gap-2">
               <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage }}%
+                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage.toFixed(1) }}%
               </span>
               <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
@@ -52,11 +52,11 @@
             <div class="flex flex-col gap-1">
               <span class="text-sm text-gray-500">ROAS</span>
               <div class="flex items-center gap-2">
-                <span class="text-2xl font-semibold text-gray-900">{{ drawerData().roas.toFixed(2) }}x</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ drawerData().roas.toFixed(1) }}x</span>
                 @if (drawerData().changePercentage !== 0) {
                   <span class="text-sm font-medium" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
                     <i [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up' : 'fa-light fa-arrow-down'"></i>
-                    {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage }}%
+                    {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
                   </span>
                 }
               </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.html
@@ -1,0 +1,171 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="revenue-impact-drawer">
+  <!-- Header -->
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full" data-testid="revenue-impact-drawer-header">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="revenue-impact-drawer-title">Attribution</h2>
+        <p class="text-sm text-gray-500">Executive Director · Influence Metric</p>
+      </div>
+      <lfx-button
+        icon="fa-light fa-xmark"
+        [text]="true"
+        [rounded]="true"
+        severity="secondary"
+        ariaLabel="Close panel"
+        (onClick)="onClose()"
+        data-testid="revenue-impact-drawer-close" />
+    </div>
+  </ng-template>
+
+  <!-- Content -->
+  <div class="flex flex-col gap-6 pb-2" data-testid="revenue-impact-drawer-content">
+    <!-- SECTION 1: Membership Growth Pipeline -->
+    <div class="flex flex-col gap-4" data-testid="revenue-impact-drawer-pipeline-section">
+      <h3 class="text-sm font-semibold text-gray-900">Membership Growth Pipeline</h3>
+      <div class="flex gap-4" data-testid="revenue-impact-drawer-stats">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Pipeline Influenced</span>
+            @if (data().pipelineInfluenced > 0) {
+              <span class="text-2xl font-semibold text-gray-900">${{ data().pipelineInfluenced / 1000000 | number: '1.1-1' }}M</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Revenue Attributed</span>
+            @if (data().revenueAttributed > 0) {
+              <span class="text-2xl font-semibold text-gray-900">${{ data().revenueAttributed / 1000000 | number: '1.1-1' }}M</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Match Rate</span>
+            @if (data().matchRate > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ data().matchRate.toFixed(1) }}%</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+    </div>
+
+    <!-- Deal Pipeline Breakdown -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="revenue-impact-drawer-engagement">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Deal Pipeline Breakdown</h3>
+        <p class="text-sm text-gray-600">Deal status distribution across the membership pipeline</p>
+      </div>
+      @if (data().engagementTypes.length > 0) {
+        <div class="flex flex-col gap-3">
+          @for (engagement of data().engagementTypes; track engagement.type) {
+            <div class="flex flex-col gap-1" data-testid="revenue-impact-drawer-engagement-row">
+              <div class="flex items-center justify-between">
+                <span class="text-sm font-medium text-gray-900">{{ engagement.type }}</span>
+                <span class="text-sm font-semibold text-gray-900">{{ engagement.percentage.toFixed(1) }}%</span>
+              </div>
+              <div class="w-full h-2 bg-gray-100 rounded-full">
+                <div class="h-2 bg-blue-500 rounded-full" [style.width.%]="engagement.percentage"></div>
+              </div>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="revenue-impact-drawer-engagement-empty">
+          Deal pipeline data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Attribution Model Comparison -->
+    @if (data().attributionModels.linear + data().attributionModels.firstTouch + data().attributionModels.lastTouch > 0) {
+      <div class="flex flex-col gap-4" data-testid="revenue-impact-drawer-attribution">
+        <h3 class="text-sm font-semibold text-gray-900">Attribution Model Comparison</h3>
+        <div class="flex gap-4">
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">First-Touch</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formatRevenue(data().attributionModels.firstTouch) }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Linear</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formatRevenue(data().attributionModels.linear) }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Last-Touch</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formatRevenue(data().attributionModels.lastTouch) }}</span>
+            </div>
+          </lfx-card>
+        </div>
+      </div>
+    }
+
+    <!-- SECTION 2: Paid Media (Marketing Attribution) -->
+    <div class="flex flex-col gap-4" data-testid="revenue-impact-drawer-paid-media">
+      <h3 class="text-sm font-semibold text-gray-900">Paid Media</h3>
+      <div class="flex gap-4">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">ROAS</span>
+            @if (data().paidMedia.roas > 0) {
+              <span class="text-2xl font-semibold text-green-600">{{ data().paidMedia.roas | number: '1.1-1' }}x</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Ad Revenue</span>
+            @if (data().paidMedia.adRevenue > 0) {
+              <span class="text-2xl font-semibold text-gray-900">${{ data().paidMedia.adRevenue | number }}</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+      <div class="flex gap-4">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Impressions</span>
+            @if (data().paidMedia.impressions > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ data().paidMedia.impressions | number }}</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Ad Spend</span>
+            @if (data().paidMedia.adSpend > 0) {
+              <span class="text-2xl font-semibold text-gray-900">${{ data().paidMedia.adSpend | number }}</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+    </div>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, input, model } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { DrawerModule } from 'primeng/drawer';
+
+import type { RevenueImpactResponse } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-revenue-impact-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule],
+  templateUrl: './revenue-impact-drawer.component.html',
+  styleUrl: './revenue-impact-drawer.component.scss',
+})
+export class RevenueImpactDrawerComponent {
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  public readonly data = input<RevenueImpactResponse>({
+    pipelineInfluenced: 0,
+    revenueAttributed: 0,
+    matchRate: 0,
+    changePercentage: 0,
+    trend: 'up',
+    attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+    engagementTypes: [],
+    paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0 },
+  });
+
+  protected formatRevenue(value: number): string {
+    if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+    return `$${value.toLocaleString()}`;
+  }
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -59,7 +59,7 @@
             @if (drawerData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage }}%
+                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
                 </span>
                 <i class="text-sm" [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>
@@ -164,7 +164,7 @@
                   </div>
                 </td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ formatNumber(platform.followers) }}</td>
-                <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.engagementRate }}%</td>
+                <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.engagementRate.toFixed(1) }}%</td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.postsLast30Days }}</td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ formatNumber(platform.impressions) }}</td>
               </tr>

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -56,6 +56,10 @@ import {
   SocialMediaResponse,
   SocialReachResponse,
   WebActivitiesSummaryResponse,
+  EventGrowthResponse,
+  BrandReachResponse,
+  BrandHealthResponse,
+  RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
 
@@ -965,7 +969,94 @@ export class AnalyticsService {
             convertedToCommunity: 0,
             convertedToWorkingGroup: 0,
           },
+          reengagement: {
+            totalReengaged: 0,
+            reengagementRate: 0,
+            reengagementMomChange: 0,
+            reengagedToNewsletter: 0,
+            reengagedToCommunity: 0,
+            reengagedToWorkingGroup: 0,
+          },
           monthlyData: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get event growth metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getEventGrowth(foundationSlug: string): Observable<EventGrowthResponse> {
+    return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          totalAttendees: 0,
+          totalEvents: 0,
+          totalRevenue: 0,
+          revenuePerAttendee: 0,
+          attendeeMomChange: 0,
+          revenueMomChange: 0,
+          trend: 'up' as const,
+          monthlyData: [],
+          topEvents: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get brand reach metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getBrandReach(foundationSlug: string): Observable<BrandReachResponse> {
+    return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          totalSocialFollowers: 0,
+          totalMonthlySessions: 0,
+          activePlatforms: 0,
+          changePercentage: 0,
+          trend: 'up' as const,
+          socialPlatforms: [],
+          websiteDomains: [],
+          dailyTrend: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get brand health metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getBrandHealth(foundationSlug: string): Observable<BrandHealthResponse> {
+    return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          totalMentions: 0,
+          sentiment: { positive: 0, neutral: 0, negative: 0 },
+          sentimentMomChangePp: 0,
+          trend: 'up' as const,
+          monthlyMentions: [],
+          topProjects: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get marketing-attributed revenue metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getRevenueImpact(foundationSlug: string): Observable<RevenueImpactResponse> {
+    return this.http.get<RevenueImpactResponse>('/api/analytics/revenue-impact', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          pipelineInfluenced: 0,
+          revenueAttributed: 0,
+          matchRate: 0,
+          changePercentage: 0,
+          trend: 'up' as const,
+          attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+          engagementTypes: [],
+          paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0 },
         });
       })
     );

--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -17,7 +17,23 @@ import {
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
 import { catchError, of, take } from 'rxjs';
 
+import { environment } from '../../../environments/environment';
 import { CookieRegistryService } from './cookie-registry.service';
+
+/**
+ * Dev-mode fallback project used when NATS persona detection is unavailable.
+ * Allows the ED Evolution dashboard to load real Snowflake data locally.
+ */
+const DEV_FALLBACK_FOUNDATION: EnrichedPersonaProject = {
+  projectUid: 'a27394a3-7a6c-4d0f-9e0f-692d8753924f',
+  projectSlug: 'tlf',
+  projectName: 'The Linux Foundation',
+  parentProjectUid: null,
+  logoUrl: null,
+  description: null,
+  detections: [{ source: 'executive_director' }],
+  personas: ['executive-director' as PersonaType],
+};
 
 @Injectable({
   providedIn: 'root',
@@ -108,6 +124,23 @@ export class PersonaService {
             currentPersona: this.currentPersona(),
             allPersonas: this.allPersonas(),
           });
+
+          // In dev mode, provide a fallback foundation so the ED dashboard
+          // can load real Snowflake data even when NATS is unavailable.
+          if (!environment.production && this.detectedProjects().length === 0) {
+            console.info('[PersonaService] Dev mode: using fallback TLF foundation for ED dashboard');
+            this.detectedProjects.set([DEV_FALLBACK_FOUNDATION]);
+            this.personaProjects.set({
+              'executive-director': [
+                {
+                  projectUid: DEV_FALLBACK_FOUNDATION.projectUid,
+                  projectSlug: DEV_FALLBACK_FOUNDATION.projectSlug,
+                  projectName: DEV_FALLBACK_FOUNDATION.projectName,
+                },
+              ],
+            });
+            this.setPersonas('executive-director', ['executive-director'], false, false);
+          }
           return;
         }
 

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2160,4 +2160,156 @@ export class AnalyticsController {
       next(error);
     }
   }
+
+  /**
+   * GET /api/analytics/event-growth
+   * Get event growth metrics (total attendees, top events by attendance/revenue)
+   */
+  public async getEventGrowth(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_event_growth');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_event_growth',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_event_growth',
+        });
+      }
+
+      const response = await this.projectService.getEventGrowth(foundationSlug);
+
+      logger.success(req, 'get_event_growth', startTime, {
+        foundation_slug: foundationSlug,
+        total_attendees: response.totalAttendees,
+        total_events: response.totalEvents,
+        top_events: response.topEvents.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_event_growth', startTime, error);
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/brand-reach
+   * Get brand reach metrics (total digital reach across social + owned sites)
+   */
+  public async getBrandReach(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_brand_reach');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_brand_reach',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_brand_reach',
+        });
+      }
+
+      const response = await this.projectService.getBrandReach(foundationSlug);
+
+      logger.success(req, 'get_brand_reach', startTime, {
+        foundation_slug: foundationSlug,
+        total_social_followers: response.totalSocialFollowers,
+        total_monthly_sessions: response.totalMonthlySessions,
+        social_platforms: response.socialPlatforms.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_brand_reach', startTime, error);
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/brand-health
+   * Get brand health metrics (share of voice, sentiment, press mentions)
+   */
+  public async getBrandHealth(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_brand_health');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_brand_health',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_brand_health',
+        });
+      }
+
+      const response = await this.projectService.getBrandHealth(foundationSlug);
+
+      logger.success(req, 'get_brand_health', startTime, {
+        foundation_slug: foundationSlug,
+        total_mentions: response.totalMentions,
+        positive_sentiment: response.sentiment.positive,
+        top_projects: response.topProjects.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_brand_health', startTime, error);
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/revenue-impact
+   * Get marketing-attributed revenue metrics by engagement type
+   */
+  public async getRevenueImpact(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_revenue_impact');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_revenue_impact',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_revenue_impact',
+        });
+      }
+
+      const response = await this.projectService.getRevenueImpact(foundationSlug);
+
+      logger.success(req, 'get_revenue_impact', startTime, {
+        foundation_slug: foundationSlug,
+        pipeline_influenced: response.pipelineInfluenced,
+        revenue_attributed: response.revenueAttributed,
+        engagement_types: response.engagementTypes.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_revenue_impact', startTime, error);
+      next(error);
+    }
+  }
 }

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -149,4 +149,10 @@ router.get('/member-acquisition', (req, res, next) => analyticsController.getMem
 router.get('/engaged-community', (req, res, next) => analyticsController.getEngagedCommunity(req, res, next));
 router.get('/flywheel-conversion', (req, res, next) => analyticsController.getFlywheelConversion(req, res, next));
 
+// Prototype ED dashboard endpoints (wired to stub services until dbt views land)
+router.get('/event-growth', (req, res, next) => analyticsController.getEventGrowth(req, res, next));
+router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
+router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
+router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));
+
 export default router;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -71,6 +71,13 @@ import {
   EngagedCommunitySizeResponse,
   FlywheelConversionResponse,
   NorthStarMonthlyDataPoint,
+  EventGrowthResponse,
+  EventGrowthTopEvent,
+  BrandReachResponse,
+  BrandReachPlatformType,
+  BrandHealthResponse,
+  BrandHealthTopProject,
+  RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -82,6 +89,13 @@ import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { NatsService } from './nats.service';
 import { SnowflakeService } from './snowflake.service';
+
+/**
+ * Schema prefix for ED dashboard dbt views.
+ * Defaults to production; set SNOWFLAKE_ED_SCHEMA env var to use dev views for testing.
+ * Example: SNOWFLAKE_ED_SCHEMA=ANALYTICS_DEV.DEV_MRAUTELA_PLATINUM_LFX_ONE
+ */
+const ED_SCHEMA = process.env['SNOWFLAKE_ED_SCHEMA'] || 'ANALYTICS.PLATINUM_LFX_ONE';
 
 /**
  * Service for handling project business logic
@@ -2184,7 +2198,7 @@ export class ProjectService {
 
   /**
    * Get member retention metrics from Snowflake
-   * Queries ANALYTICS.PLATINUM_LFX_ONE.NORTH_STAR_MEMBER_RETENTION
+   * Queries ${ED_SCHEMA}.NORTH_STAR_MEMBER_RETENTION
    */
   public async getMemberRetention(foundationSlug: string): Promise<MemberRetentionResponse> {
     logger.debug(undefined, 'get_member_retention', 'Fetching member retention from Snowflake', { foundation_slug: foundationSlug });
@@ -2196,7 +2210,7 @@ export class ProjectService {
           RENEWAL_RATE,
           NET_REVENUE_RETENTION,
           MOM_CHANGE_PERCENTAGE
-        FROM ANALYTICS.PLATINUM_LFX_ONE.NORTH_STAR_MEMBER_RETENTION
+        FROM ${ED_SCHEMA}.NORTH_STAR_MEMBER_RETENTION
         WHERE FOUNDATION_SLUG = ?
         ORDER BY MONTH_START_DATE DESC
         LIMIT 12
@@ -2257,7 +2271,7 @@ export class ProjectService {
 
   /**
    * Get member acquisition metrics from Snowflake
-   * Queries ANALYTICS.PLATINUM_LFX_ONE.NORTH_STAR_MEMBER_ACQUISITION
+   * Queries ${ED_SCHEMA}.NORTH_STAR_MEMBER_ACQUISITION
    */
   public async getMemberAcquisition(foundationSlug: string): Promise<MemberAcquisitionResponse> {
     logger.debug(undefined, 'get_member_acquisition', 'Fetching member acquisition from Snowflake', { foundation_slug: foundationSlug });
@@ -2281,7 +2295,7 @@ export class ProjectService {
           NEW_MEMBERS,
           NEW_MEMBER_REVENUE,
           QOQ_CHANGE_PERCENTAGE
-        FROM ANALYTICS.PLATINUM_LFX_ONE.NORTH_STAR_MEMBER_ACQUISITION
+        FROM ${ED_SCHEMA}.NORTH_STAR_MEMBER_ACQUISITION
         WHERE FOUNDATION_SLUG = ?
         ORDER BY QUARTER_START_DATE DESC
         LIMIT 8
@@ -2338,7 +2352,7 @@ export class ProjectService {
 
   /**
    * Get engaged community size metrics from Snowflake
-   * Queries ANALYTICS.PLATINUM_LFX_ONE.NORTH_STAR_ENGAGED_COMMUNITY
+   * Queries ${ED_SCHEMA}.NORTH_STAR_ENGAGED_COMMUNITY
    */
   public async getEngagedCommunity(foundationSlug: string): Promise<EngagedCommunitySizeResponse> {
     logger.debug(undefined, 'get_engaged_community', 'Fetching engaged community from Snowflake', { foundation_slug: foundationSlug });
@@ -2353,7 +2367,7 @@ export class ProjectService {
           CERTIFIED_INDIVIDUALS,
           TOTAL_ENGAGED_MEMBERS,
           MOM_CHANGE_PERCENTAGE
-        FROM ANALYTICS.PLATINUM_LFX_ONE.NORTH_STAR_ENGAGED_COMMUNITY
+        FROM ${ED_SCHEMA}.NORTH_STAR_ENGAGED_COMMUNITY
         WHERE FOUNDATION_SLUG = ?
         ORDER BY MONTH_START_DATE DESC
         LIMIT 12
@@ -2441,22 +2455,38 @@ export class ProjectService {
 
   /**
    * Get flywheel conversion rate metrics from Snowflake
-   * Queries ANALYTICS.PLATINUM_LFX_ONE.NORTH_STAR_FLYWHEEL_CONVERSION
+   * Queries ${ED_SCHEMA}.NORTH_STAR_FLYWHEEL_CONVERSION
    */
   public async getFlywheelConversion(foundationSlug: string): Promise<FlywheelConversionResponse> {
     logger.debug(undefined, 'get_flywheel_conversion', 'Fetching flywheel conversion from Snowflake', { foundation_slug: foundationSlug });
+
+    const emptyReengagement = {
+      totalReengaged: 0,
+      reengagementRate: 0,
+      reengagementMomChange: 0,
+      reengagedToNewsletter: 0,
+      reengagedToCommunity: 0,
+      reengagedToWorkingGroup: 0,
+    };
 
     try {
       const query = `
         SELECT
           MONTH_START_DATE,
           EVENT_ATTENDEES,
+          CONVERSION_RATE,
+          MOM_CHANGE_PERCENTAGE,
+          TOTAL_CONVERTED,
+          REENGAGEMENT_RATE,
+          REENGAGEMENT_MOM_CHANGE,
+          TOTAL_REENGAGED,
           CONVERTED_TO_NEWSLETTER,
           CONVERTED_TO_COMMUNITY,
           CONVERTED_TO_WORKING_GROUP,
-          CONVERSION_RATE,
-          MOM_CHANGE_PERCENTAGE
-        FROM ANALYTICS.PLATINUM_LFX_ONE.NORTH_STAR_FLYWHEEL_CONVERSION
+          REENGAGED_TO_NEWSLETTER,
+          REENGAGED_TO_COMMUNITY,
+          REENGAGED_TO_WORKING_GROUP
+        FROM ${ED_SCHEMA}.NORTH_STAR_FLYWHEEL_CONVERSION
         WHERE FOUNDATION_SLUG = ?
         ORDER BY MONTH_START_DATE DESC
         LIMIT 12
@@ -2465,11 +2495,18 @@ export class ProjectService {
       const result = await this.snowflakeService.execute<{
         MONTH_START_DATE: string;
         EVENT_ATTENDEES: number;
+        CONVERSION_RATE: number;
+        MOM_CHANGE_PERCENTAGE: number;
+        TOTAL_CONVERTED: number;
+        REENGAGEMENT_RATE: number;
+        REENGAGEMENT_MOM_CHANGE: number;
+        TOTAL_REENGAGED: number;
         CONVERTED_TO_NEWSLETTER: number;
         CONVERTED_TO_COMMUNITY: number;
         CONVERTED_TO_WORKING_GROUP: number;
-        CONVERSION_RATE: number;
-        MOM_CHANGE_PERCENTAGE: number;
+        REENGAGED_TO_NEWSLETTER: number;
+        REENGAGED_TO_COMMUNITY: number;
+        REENGAGED_TO_WORKING_GROUP: number;
       }>(query, [foundationSlug]);
 
       if (result.rows.length === 0) {
@@ -2483,6 +2520,7 @@ export class ProjectService {
             convertedToCommunity: 0,
             convertedToWorkingGroup: 0,
           },
+          reengagement: emptyReengagement,
           monthlyData: [],
         };
       }
@@ -2508,6 +2546,14 @@ export class ProjectService {
           convertedToCommunity: latest.CONVERTED_TO_COMMUNITY ?? 0,
           convertedToWorkingGroup: latest.CONVERTED_TO_WORKING_GROUP ?? 0,
         },
+        reengagement: {
+          totalReengaged: latest.TOTAL_REENGAGED ?? 0,
+          reengagementRate: latest.REENGAGEMENT_RATE ?? 0,
+          reengagementMomChange: latest.REENGAGEMENT_MOM_CHANGE ?? 0,
+          reengagedToNewsletter: latest.REENGAGED_TO_NEWSLETTER ?? 0,
+          reengagedToCommunity: latest.REENGAGED_TO_COMMUNITY ?? 0,
+          reengagedToWorkingGroup: latest.REENGAGED_TO_WORKING_GROUP ?? 0,
+        },
         monthlyData,
       };
     } catch (error) {
@@ -2525,8 +2571,462 @@ export class ProjectService {
           convertedToCommunity: 0,
           convertedToWorkingGroup: 0,
         },
+        reengagement: emptyReengagement,
         monthlyData: [],
       };
+    }
+  }
+
+  /**
+   * Get event growth metrics from Snowflake
+   * Queries ${ED_SCHEMA}.NORTH_STAR_EVENT_GROWTH (single row YTD) and EVENT_GROWTH_TOP_EVENTS
+   */
+  public async getEventGrowth(foundationSlug: string): Promise<EventGrowthResponse> {
+    logger.debug(undefined, 'get_event_growth', 'Fetching event growth from Snowflake', { foundation_slug: foundationSlug });
+
+    const defaultResponse: EventGrowthResponse = {
+      totalAttendees: 0,
+      totalEvents: 0,
+      totalRevenue: 0,
+      revenuePerAttendee: 0,
+      attendeeMomChange: 0,
+      revenueMomChange: 0,
+      trend: 'up',
+      monthlyData: [],
+      topEvents: [],
+    };
+
+    try {
+      const summaryQuery = `
+        SELECT EVENT_COUNT_YTD, ATTENDEE_COUNT_YTD, REGISTRANT_COUNT_YTD,
+               TOTAL_NET_REVENUE_YTD,
+               EVENT_COUNT_YOY_CHANGE_PCT, ATTENDEE_COUNT_YOY_CHANGE_PCT,
+               REVENUE_YOY_CHANGE_PCT
+        FROM ${ED_SCHEMA}.NORTH_STAR_EVENT_GROWTH
+        WHERE FOUNDATION_SLUG = ?
+      `;
+
+      const topEventsQuery = `
+        SELECT QUARTER_START_DATE, EVENT_NAME, EVENT_DATE,
+               ATTENDEE_COUNT, REGISTRANT_COUNT, EVENT_REVENUE, EVENT_RANK
+        FROM ${ED_SCHEMA}.EVENT_GROWTH_TOP_EVENTS
+        WHERE FOUNDATION_SLUG = ?
+        ORDER BY QUARTER_START_DATE DESC, EVENT_RANK
+        LIMIT 10
+      `;
+
+      const [summaryResult, topEventsResult] = await Promise.all([
+        this.snowflakeService.execute<{
+          EVENT_COUNT_YTD: number;
+          ATTENDEE_COUNT_YTD: number;
+          REGISTRANT_COUNT_YTD: number;
+          TOTAL_NET_REVENUE_YTD: number;
+          EVENT_COUNT_YOY_CHANGE_PCT: number;
+          ATTENDEE_COUNT_YOY_CHANGE_PCT: number;
+          REVENUE_YOY_CHANGE_PCT: number;
+        }>(summaryQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          QUARTER_START_DATE: string | Date;
+          EVENT_NAME: string;
+          EVENT_DATE: string;
+          ATTENDEE_COUNT: number;
+          REGISTRANT_COUNT: number;
+          EVENT_REVENUE: number;
+          EVENT_RANK: number;
+        }>(topEventsQuery, [foundationSlug]),
+      ]);
+
+      if (summaryResult.rows.length === 0) {
+        return defaultResponse;
+      }
+
+      const summary = summaryResult.rows[0];
+      const totalAttendees = summary.ATTENDEE_COUNT_YTD ?? 0;
+      const totalEvents = summary.EVENT_COUNT_YTD ?? 0;
+      const totalRevenue = summary.TOTAL_NET_REVENUE_YTD ?? 0;
+      const yoyAttendeeChange = summary.ATTENDEE_COUNT_YOY_CHANGE_PCT ?? 0;
+      const yoyRevenueChange = summary.REVENUE_YOY_CHANGE_PCT ?? 0;
+
+      const topEvents: EventGrowthTopEvent[] = topEventsResult.rows.map((row) => ({
+        name: row.EVENT_NAME ?? '',
+        date: row.EVENT_DATE ?? '',
+        attendees: row.ATTENDEE_COUNT ?? 0,
+        revenue: row.EVENT_REVENUE ?? 0,
+      }));
+
+      // Aggregate attendees by quarter for sparkline
+      const quarterMap = new Map<string, number>();
+      for (const row of topEventsResult.rows) {
+        const raw = row.QUARTER_START_DATE;
+        const q = raw instanceof Date ? raw.toISOString().substring(0, 10) : String(raw ?? '');
+        if (q) {
+          quarterMap.set(q, (quarterMap.get(q) ?? 0) + (row.ATTENDEE_COUNT ?? 0));
+        }
+      }
+      const monthlyData = [...quarterMap.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([quarter, value]) => ({ month: quarter.substring(0, 7), value }));
+
+      return {
+        totalAttendees,
+        totalEvents,
+        totalRevenue,
+        revenuePerAttendee: totalAttendees > 0 ? Number((totalRevenue / totalAttendees).toFixed(2)) : 0,
+        attendeeMomChange: yoyAttendeeChange,
+        revenueMomChange: yoyRevenueChange,
+        trend: yoyAttendeeChange >= 0 ? 'up' : 'down',
+        monthlyData,
+        topEvents,
+      };
+    } catch (error) {
+      logger.warning(undefined, 'get_event_growth', 'Failed to fetch event growth from Snowflake', {
+        foundation_slug: foundationSlug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return defaultResponse;
+    }
+  }
+
+  /**
+   * Get brand reach metrics from Snowflake
+   * Combines SOCIAL_MEDIA_OVERVIEW (followers) and WEB_ACTIVITIES_SUMMARY (sessions)
+   */
+  public async getBrandReach(foundationSlug: string): Promise<BrandReachResponse> {
+    logger.debug(undefined, 'get_brand_reach', 'Fetching brand reach from Snowflake', { foundation_slug: foundationSlug });
+
+    const defaultResponse: BrandReachResponse = {
+      totalSocialFollowers: 0,
+      totalMonthlySessions: 0,
+      activePlatforms: 0,
+      changePercentage: 0,
+      trend: 'up',
+      socialPlatforms: [],
+      websiteDomains: [],
+      dailyTrend: [],
+    };
+
+    try {
+      const webQuery = `
+        SELECT LF_SUB_DOMAIN_CLASSIFICATION,
+               SUM(TOTAL_SESSIONS_LAST_30_DAYS) AS TOTAL_SESSIONS
+        FROM ${ED_SCHEMA}.WEB_ACTIVITIES_SUMMARY
+        WHERE FOUNDATION_SLUG = ?
+        GROUP BY LF_SUB_DOMAIN_CLASSIFICATION
+        ORDER BY TOTAL_SESSIONS DESC
+      `;
+
+      const dailyQuery = `
+        SELECT ACTIVITY_DATE, SUM(DAILY_SESSIONS) AS DAILY_SESSIONS
+        FROM ${ED_SCHEMA}.WEB_ACTIVITIES_BY_PROJECT
+        WHERE FOUNDATION_SLUG = ?
+          AND ACTIVITY_DATE >= DATEADD('DAY', -30, CURRENT_DATE())
+        GROUP BY ACTIVITY_DATE
+        ORDER BY ACTIVITY_DATE ASC
+      `;
+
+      const [webResult, dailyResult] = await Promise.all([
+        this.snowflakeService.execute<{ LF_SUB_DOMAIN_CLASSIFICATION: string; TOTAL_SESSIONS: number }>(webQuery, [foundationSlug]),
+        this.snowflakeService.execute<{ ACTIVITY_DATE: string; DAILY_SESSIONS: number }>(dailyQuery, [foundationSlug]),
+      ]);
+
+      let totalSocialFollowers = 0;
+      let socialPlatforms: BrandReachResponse['socialPlatforms'] = [];
+      try {
+        const [socialResult, socialPlatformResult] = await Promise.all([
+          this.snowflakeService.execute<{ TOTAL_FOLLOWERS: number; PLATFORMS_ACTIVE: number }>(
+            `SELECT TOTAL_FOLLOWERS, PLATFORMS_ACTIVE
+             FROM ${ED_SCHEMA}.SOCIAL_MEDIA_OVERVIEW WHERE FOUNDATION_SLUG = ?`,
+            [foundationSlug]
+          ),
+          this.snowflakeService.execute<{ PLATFORM_NAME: string; FOLLOWERS: number }>(
+            `SELECT PLATFORM_NAME, FOLLOWERS
+             FROM ${ED_SCHEMA}.SOCIAL_MEDIA_PLATFORM_BREAKDOWN WHERE FOUNDATION_SLUG = ?
+             ORDER BY FOLLOWERS DESC`,
+            [foundationSlug]
+          ),
+        ]);
+
+        totalSocialFollowers = socialResult.rows.length > 0 ? (socialResult.rows[0].TOTAL_FOLLOWERS ?? 0) : 0;
+
+        const platformMap: Record<string, BrandReachPlatformType> = {
+          LinkedIn: 'linkedin',
+          Twitter: 'twitter',
+          'Twitter/X': 'twitter',
+          YouTube: 'youtube',
+          Facebook: 'facebook',
+          Mastodon: 'mastodon',
+        };
+        socialPlatforms = socialPlatformResult.rows.map((row) => ({
+          name: row.PLATFORM_NAME ?? 'Other',
+          platformType: platformMap[row.PLATFORM_NAME] || ('other' as BrandReachPlatformType),
+          followers: row.FOLLOWERS ?? 0,
+        }));
+      } catch (socialError) {
+        logger.debug(undefined, 'get_brand_reach', 'Social media query failed, returning web-only data', {
+          error: socialError instanceof Error ? socialError.message : 'Unknown error',
+        });
+      }
+
+      const websiteDomains = webResult.rows.map((row) => ({
+        domain: row.LF_SUB_DOMAIN_CLASSIFICATION || 'Other',
+        sessions: row.TOTAL_SESSIONS ?? 0,
+      }));
+
+      const totalMonthlySessions = websiteDomains.reduce((sum, d) => sum + d.sessions, 0);
+
+      const dailyTrend = dailyResult.rows.map((row) => {
+        const date = new Date(row.ACTIVITY_DATE);
+        return {
+          day: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+          sessions: row.DAILY_SESSIONS ?? 0,
+        };
+      });
+
+      return {
+        totalSocialFollowers,
+        totalMonthlySessions,
+        activePlatforms: socialPlatforms.length,
+        changePercentage: 0,
+        trend: 'up',
+        socialPlatforms,
+        websiteDomains,
+        dailyTrend,
+      };
+    } catch (error) {
+      logger.warning(undefined, 'get_brand_reach', 'Failed to fetch brand reach from Snowflake', {
+        foundation_slug: foundationSlug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return defaultResponse;
+    }
+  }
+
+  /**
+   * Get brand health metrics from Snowflake (Share of Voice)
+   * Queries ${ED_SCHEMA}.SHARE_OF_VOICE, SHARE_OF_VOICE_MONTHLY_TREND, SHARE_OF_VOICE_TOP_PROJECTS
+   */
+  public async getBrandHealth(foundationSlug: string): Promise<BrandHealthResponse> {
+    logger.debug(undefined, 'get_brand_health', 'Fetching brand health (Share of Voice) from Snowflake', { foundation_slug: foundationSlug });
+
+    const defaultResponse: BrandHealthResponse = {
+      totalMentions: 0,
+      sentiment: { positive: 0, neutral: 0, negative: 0 },
+      sentimentMomChangePp: 0,
+      trend: 'up',
+      monthlyMentions: [],
+      topProjects: [],
+    };
+
+    try {
+      // SHARE_OF_VOICE has per-platform rows with raw mention counts and sentiment percentages
+      const sovSummaryQuery = `
+        SELECT SUM(TOTAL_MENTIONS_30D) AS TOTAL_MENTIONS,
+               SUM(POSITIVE_MENTIONS_30D) AS POSITIVE,
+               SUM(NEGATIVE_MENTIONS_30D) AS NEGATIVE,
+               SUM(NEUTRAL_MENTIONS_30D) AS NEUTRAL,
+               CASE WHEN SUM(TOTAL_MENTIONS_30D) > 0
+                   THEN ROUND(SUM(POSITIVE_MENTIONS_30D)::FLOAT / SUM(TOTAL_MENTIONS_30D)::FLOAT * 100, 2)
+                   ELSE 0
+               END AS POSITIVE_PCT,
+               CASE WHEN SUM(TOTAL_MENTIONS_30D) > 0
+                   THEN ROUND(SUM(NEGATIVE_MENTIONS_30D)::FLOAT / SUM(TOTAL_MENTIONS_30D)::FLOAT * 100, 2)
+                   ELSE 0
+               END AS NEGATIVE_PCT
+        FROM ${ED_SCHEMA}.SHARE_OF_VOICE
+        WHERE FOUNDATION_SLUG = ?
+      `;
+
+      const monthlyTrendQuery = `
+        SELECT MONTH_START_DATE, MENTION_COUNT, MOM_CHANGE_PCT
+        FROM ${ED_SCHEMA}.SHARE_OF_VOICE_MONTHLY_TREND
+        WHERE FOUNDATION_SLUG = ?
+        ORDER BY MONTH_START_DATE DESC
+        LIMIT 12
+      `;
+
+      const topProjectsQuery = `
+        SELECT PROJECT_NAME, MENTION_COUNT_30D, PROJECT_RANK
+        FROM ${ED_SCHEMA}.SHARE_OF_VOICE_TOP_PROJECTS
+        WHERE FOUNDATION_SLUG = ?
+        ORDER BY PROJECT_RANK
+        LIMIT 5
+      `;
+
+      const [summaryResult, trendResult, projectsResult] = await Promise.all([
+        this.snowflakeService.execute<{
+          TOTAL_MENTIONS: number;
+          POSITIVE: number;
+          NEGATIVE: number;
+          NEUTRAL: number;
+          POSITIVE_PCT: number;
+          NEGATIVE_PCT: number;
+        }>(sovSummaryQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          MONTH_START_DATE: string;
+          MENTION_COUNT: number;
+          MOM_CHANGE_PCT: number;
+        }>(monthlyTrendQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          PROJECT_NAME: string;
+          MENTION_COUNT_30D: number;
+          PROJECT_RANK: number;
+        }>(topProjectsQuery, [foundationSlug]),
+      ]);
+
+      if (summaryResult.rows.length === 0) {
+        return defaultResponse;
+      }
+
+      const summary = summaryResult.rows[0];
+      const totalMentions = summary.TOTAL_MENTIONS ?? 0;
+      const positivePct = summary.POSITIVE_PCT ?? 0;
+      const negativePct = summary.NEGATIVE_PCT ?? 0;
+      const neutralPct = Number(Math.max(0, 100 - positivePct - negativePct).toFixed(1));
+
+      const sentimentMomChangePp = trendResult.rows.length > 0 ? (trendResult.rows[0].MOM_CHANGE_PCT ?? 0) : 0;
+
+      const monthlyMentions: NorthStarMonthlyDataPoint[] = [...trendResult.rows].reverse().map((row) => {
+        const date = new Date(row.MONTH_START_DATE);
+        return {
+          month: date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' }),
+          value: row.MENTION_COUNT ?? 0,
+        };
+      });
+
+      const topProjects: BrandHealthTopProject[] = projectsResult.rows.map((row) => ({
+        name: row.PROJECT_NAME ?? '',
+        mentions: row.MENTION_COUNT_30D ?? 0,
+      }));
+
+      return {
+        totalMentions,
+        sentiment: { positive: positivePct, neutral: neutralPct, negative: negativePct },
+        sentimentMomChangePp,
+        trend: sentimentMomChangePp >= 0 ? 'up' : 'down',
+        monthlyMentions,
+        topProjects,
+      };
+    } catch (error) {
+      logger.warning(undefined, 'get_brand_health', 'Failed to fetch brand health from Snowflake', {
+        foundation_slug: foundationSlug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return defaultResponse;
+    }
+  }
+
+  /**
+   * Get marketing-attributed revenue metrics from Snowflake
+   * Queries ${ED_SCHEMA}.PIPELINE_SUMMARY and PAID_ADS_ATTRIBUTION
+   */
+  public async getRevenueImpact(foundationSlug: string): Promise<RevenueImpactResponse> {
+    logger.debug(undefined, 'get_revenue_impact', 'Fetching revenue impact from Snowflake', { foundation_slug: foundationSlug });
+
+    const defaultResponse: RevenueImpactResponse = {
+      pipelineInfluenced: 0,
+      revenueAttributed: 0,
+      matchRate: 0,
+      changePercentage: 0,
+      trend: 'up',
+      attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+      engagementTypes: [],
+      paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0 },
+    };
+
+    try {
+      // PIPELINE_SUMMARY is a single row per foundation with full YTD + prior year data
+      const pipelineQuery = `
+        SELECT TOTAL_PIPELINE_YTD, WON_REVENUE_YTD, LOST_REVENUE_YTD, OPEN_PIPELINE_YTD,
+               TOTAL_DEALS_YTD, WON_DEALS_YTD, LOST_DEALS_YTD, OPEN_DEALS_YTD,
+               AVG_WON_DEAL_SIZE_YTD, CONVERSION_RATE_YTD,
+               WON_REVENUE_PRIOR_YEAR, WON_REVENUE_YOY_CHANGE_PCT
+        FROM ${ED_SCHEMA}.PIPELINE_SUMMARY
+        WHERE FOUNDATION_SLUG = ?
+      `;
+
+      // PAID_ADS_ATTRIBUTION is a single row per foundation with YTD totals
+      const paidAdsQuery = `
+        SELECT TOTAL_SPEND_YTD, TOTAL_IMPRESSIONS_YTD, TOTAL_CLICKS_YTD,
+               LINEAR_ROAS_YTD, AVG_CPC_YTD, CTR_YTD, CONVERSION_RATE_YTD,
+               FIRST_TOUCH_REVENUE_YTD, LAST_TOUCH_REVENUE_YTD,
+               LINEAR_REVENUE_YTD, TIME_DECAY_REVENUE_YTD,
+               SPEND_YOY_CHANGE_PCT, IMPRESSIONS_YOY_CHANGE_PCT
+        FROM ${ED_SCHEMA}.PAID_ADS_ATTRIBUTION
+        WHERE FOUNDATION_SLUG = ?
+      `;
+
+      const [pipelineResult, adsResult] = await Promise.all([
+        this.snowflakeService.execute<{
+          TOTAL_PIPELINE_YTD: number;
+          WON_REVENUE_YTD: number;
+          LOST_REVENUE_YTD: number;
+          OPEN_PIPELINE_YTD: number;
+          TOTAL_DEALS_YTD: number;
+          WON_DEALS_YTD: number;
+          LOST_DEALS_YTD: number;
+          OPEN_DEALS_YTD: number;
+          AVG_WON_DEAL_SIZE_YTD: number;
+          CONVERSION_RATE_YTD: number;
+          WON_REVENUE_PRIOR_YEAR: number;
+          WON_REVENUE_YOY_CHANGE_PCT: number;
+        }>(pipelineQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          TOTAL_SPEND_YTD: number;
+          TOTAL_IMPRESSIONS_YTD: number;
+          TOTAL_CLICKS_YTD: number;
+          LINEAR_ROAS_YTD: number;
+          AVG_CPC_YTD: number;
+          CTR_YTD: number;
+          CONVERSION_RATE_YTD: number;
+          FIRST_TOUCH_REVENUE_YTD: number;
+          LAST_TOUCH_REVENUE_YTD: number;
+          LINEAR_REVENUE_YTD: number;
+          TIME_DECAY_REVENUE_YTD: number;
+          SPEND_YOY_CHANGE_PCT: number;
+          IMPRESSIONS_YOY_CHANGE_PCT: number;
+        }>(paidAdsQuery, [foundationSlug]),
+      ]);
+
+      const pipeline = pipelineResult.rows.length > 0 ? pipelineResult.rows[0] : null;
+      const ads = adsResult.rows.length > 0 ? adsResult.rows[0] : null;
+
+      const pipelineInfluenced = pipeline?.TOTAL_PIPELINE_YTD ?? 0;
+      const wonRevenue = pipeline?.WON_REVENUE_YTD ?? 0;
+      const changePercentage = pipeline?.WON_REVENUE_YOY_CHANGE_PCT ?? 0;
+      const matchRate = pipeline?.CONVERSION_RATE_YTD ?? 0;
+      const totalDeals = pipeline?.TOTAL_DEALS_YTD ?? 0;
+
+      return {
+        pipelineInfluenced,
+        revenueAttributed: wonRevenue,
+        matchRate,
+        changePercentage,
+        trend: changePercentage >= 0 ? 'up' : 'down',
+        attributionModels: {
+          linear: ads?.LINEAR_REVENUE_YTD ?? 0,
+          firstTouch: ads?.FIRST_TOUCH_REVENUE_YTD ?? 0,
+          lastTouch: ads?.LAST_TOUCH_REVENUE_YTD ?? 0,
+        },
+        engagementTypes: pipeline
+          ? [
+              { type: 'Won', percentage: totalDeals > 0 ? Number(((pipeline.WON_DEALS_YTD / totalDeals) * 100).toFixed(1)) : 0 },
+              { type: 'Lost', percentage: totalDeals > 0 ? Number(((pipeline.LOST_DEALS_YTD / totalDeals) * 100).toFixed(1)) : 0 },
+              { type: 'Open', percentage: totalDeals > 0 ? Number(((pipeline.OPEN_DEALS_YTD / totalDeals) * 100).toFixed(1)) : 0 },
+            ]
+          : [],
+        paidMedia: {
+          roas: ads?.LINEAR_ROAS_YTD ?? 0,
+          impressions: ads?.TOTAL_IMPRESSIONS_YTD ?? 0,
+          adSpend: ads?.TOTAL_SPEND_YTD ?? 0,
+          adRevenue: (ads?.LINEAR_ROAS_YTD ?? 0) * (ads?.TOTAL_SPEND_YTD ?? 0),
+        },
+      };
+    } catch (error) {
+      logger.warning(undefined, 'get_revenue_impact', 'Failed to fetch revenue impact from Snowflake', {
+        foundation_slug: foundationSlug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return defaultResponse;
     }
   }
 }

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -1,12 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DashboardDrawerType, MarketingActionType } from '../interfaces';
-import { hexToRgba } from '../utils';
+import { BrandReachPlatformType, DashboardDrawerType, MarketingActionType } from '../interfaces';
+import { formatCurrency, formatNumber, hexToRgba } from '../utils';
 import { EMPTY_CHART_DATA, NO_TOOLTIP_CHART_OPTIONS } from './chart-options.constants';
 import { lfxColors } from './colors.constants';
 
-import type { DashboardMetricCard } from '../interfaces';
+import type { DashboardMetricCard, DualSignalRow, EdEvolutionData, FilterPillOption } from '../interfaces';
 // ============================================
 // Marketing Action Icon Map
 // ============================================
@@ -27,6 +27,19 @@ export const MARKETING_ACTION_ICON_MAP: Record<MarketingActionType, string> = {
   optimize: 'fa-light fa-bullseye-pointer',
   investigate: 'fa-light fa-magnifying-glass-chart',
   monitor: 'fa-light fa-circle-info',
+};
+
+/**
+ * Maps social platform types to Font Awesome icon + Tailwind color classes.
+ * Keeps presentation out of Brand Reach data interfaces.
+ */
+export const MARKETING_SOCIAL_PLATFORM_MAP: Record<BrandReachPlatformType, { icon: string; colorClass: string }> = {
+  linkedin: { icon: 'fa-brands fa-linkedin', colorClass: 'text-blue-700' },
+  twitter: { icon: 'fa-brands fa-x-twitter', colorClass: 'text-gray-900' },
+  youtube: { icon: 'fa-brands fa-youtube', colorClass: 'text-red-600' },
+  facebook: { icon: 'fa-brands fa-facebook', colorClass: 'text-blue-600' },
+  mastodon: { icon: 'fa-brands fa-mastodon', colorClass: 'text-purple-600' },
+  other: { icon: 'fa-light fa-hashtag', colorClass: 'text-gray-500' },
 };
 
 // ============================================
@@ -466,3 +479,216 @@ export const MAINTAINER_PROGRESS_METRICS: DashboardMetricCard[] = [
     chartOptions: NO_TOOLTIP_CHART_OPTIONS,
   },
 ];
+
+// ============================================
+// ED Dashboard Evolution Prototype (8 Cards)
+// ============================================
+
+/** Helper to build a prototype sparkline dataset */
+function protoSparkline(data: number[], color: string) {
+  return {
+    labels: data.map((_, i) => `M${i + 1}`),
+    datasets: [
+      {
+        data,
+        borderColor: color,
+        backgroundColor: hexToRgba(color, 0.1),
+        fill: true,
+        tension: 0.4,
+        borderWidth: 2,
+        pointRadius: 0,
+      },
+    ],
+  };
+}
+
+/** Helper to build a dual-signal row with sparkline */
+function protoDualSignal(label: string, value: string, data: number[], color: string, change?: string, trend?: 'up' | 'down'): DualSignalRow {
+  return {
+    label,
+    value,
+    changePercentage: change,
+    trend,
+    chartData: protoSparkline(data, color),
+  };
+}
+
+/**
+ * Filter options for the ED Evolution prototype dashboard
+ */
+export const ED_EVOLUTION_FILTER_OPTIONS: FilterPillOption[] = [
+  { id: 'all', label: 'All' },
+  { id: 'memberships', label: 'North Star' },
+  { id: 'brand', label: 'Brand' },
+  { id: 'influence', label: 'Influence' },
+];
+
+/** Format a MoM change as a display string */
+function formatMomChange(change: number): string {
+  const sign = change >= 0 ? '+' : '';
+  return `${sign}${change.toFixed(1)}% MoM`;
+}
+
+/** Extract values from NorthStarMonthlyDataPoint[] */
+function monthlyValues(data: { month: string; value: number }[]): number[] {
+  return data.map((d) => d.value);
+}
+
+/**
+ * Build ED Evolution dashboard cards from live API data.
+ * 4 North Star + 2 Brand + 1 Influence.
+ * Member Retention is merged into the Member Growth drawer.
+ */
+export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricCard[] {
+  const { flywheel, memberAcquisition, memberRetention, engagedCommunity, eventGrowth, brandReach, brandHealth, revenueImpact } = data;
+
+  return [
+    // === North Star (4 cards — retention merged into Member Growth drawer) ===
+    {
+      title: 'Flywheel Conversion',
+      icon: 'fa-light fa-arrows-spin',
+      chartType: 'line',
+      category: 'memberships',
+      testId: 'ed-evo-flywheel-conversion',
+      customContentType: 'funnel',
+      value: `${flywheel.reengagement.reengagementRate.toFixed(1)}%`,
+      changePercentage: formatMomChange(flywheel.reengagement.reengagementMomChange),
+      trend: flywheel.reengagement.reengagementMomChange >= 0 ? 'up' : 'down',
+      subtitle: 'Re-engagement within 90 days · Last 6 months',
+      funnelSteps: [
+        { label: 'Attendees', value: formatNumber(flywheel.funnel.eventAttendees) },
+        { label: 'Newsletter', value: formatNumber(flywheel.reengagement.reengagedToNewsletter) },
+        { label: 'Community', value: formatNumber(flywheel.reengagement.reengagedToCommunity) },
+        { label: 'WG', value: formatNumber(flywheel.reengagement.reengagedToWorkingGroup) },
+      ],
+      tooltipText: 'Percentage of event attendees who engage with newsletter, community, or working groups within 90 days post-event.',
+      drawerType: DashboardDrawerType.NorthStarFlywheelConversion,
+    } as DashboardMetricCard,
+    {
+      title: 'Member Growth',
+      icon: 'fa-light fa-user-group',
+      chartType: 'line',
+      category: 'memberships',
+      testId: 'ed-evo-member-growth',
+      value: formatNumber(memberAcquisition.totalMembers),
+      changePercentage: formatMomChange(memberAcquisition.changePercentage),
+      trend: memberAcquisition.trend,
+      subtitle: `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · Last 6 months`,
+      chartData: protoSparkline(memberAcquisition.totalMembersMonthlyData.length > 0 ? memberAcquisition.totalMembersMonthlyData : [0], lfxColors.blue[500]),
+      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
+      tooltipText: 'Total paying corporate members with monthly net new over the last 6 months. Source: Salesforce B2B memberships.',
+      drawerType: DashboardDrawerType.NorthStarMemberAcquisition,
+    } as DashboardMetricCard,
+    {
+      title: 'Engaged Community',
+      icon: 'fa-light fa-people-group',
+      chartType: 'line',
+      category: 'memberships',
+      testId: 'ed-evo-engaged-community',
+      value: formatNumber(engagedCommunity.totalMembers),
+      changePercentage: formatMomChange(engagedCommunity.changePercentage),
+      trend: engagedCommunity.trend,
+      subtitle: `${Object.values(engagedCommunity.breakdown).filter((v) => v > 0).length} channels · Last 6 months`,
+      chartData: protoSparkline(engagedCommunity.monthlyData.length > 0 ? monthlyValues(engagedCommunity.monthlyData) : [0], lfxColors.blue[500]),
+      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
+      tooltipText: 'Unique individuals active across Slack, Discord, GitHub, and mailing lists in the last 90 days.',
+      drawerType: DashboardDrawerType.NorthStarEngagedCommunity,
+    } as DashboardMetricCard,
+    {
+      title: 'Event Growth',
+      icon: 'fa-light fa-calendar-star',
+      chartType: 'line',
+      category: 'memberships',
+      testId: 'ed-evo-event-growth',
+      value: formatNumber(eventGrowth.totalAttendees),
+      changePercentage: formatMomChange(eventGrowth.attendeeMomChange),
+      trend: eventGrowth.trend,
+      subtitle: `${formatNumber(eventGrowth.totalEvents)} events · YTD attendees`,
+      chartData: eventGrowth.monthlyData.length > 0 ? protoSparkline(monthlyValues(eventGrowth.monthlyData), lfxColors.blue[500]) : EMPTY_CHART_DATA,
+      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
+      tooltipText: 'Year-to-date event attendees and YoY change. Source: Event registrations.',
+      drawerType: DashboardDrawerType.NorthStarEventGrowth,
+    } as DashboardMetricCard,
+
+    // === Brand (2 dual-signal cards) ===
+    {
+      title: 'Brand Reach',
+      icon: 'fa-light fa-signal-bars',
+      chartType: 'line',
+      category: 'brand',
+      testId: 'ed-evo-brand-reach',
+      customContentType: 'dual-signal',
+      dualSignals: [
+        protoDualSignal(
+          'Social Followers',
+          formatNumber(brandReach.totalSocialFollowers),
+          brandReach.dailyTrend.length > 0 ? brandReach.dailyTrend.map((d) => d.sessions) : [0],
+          lfxColors.blue[500],
+          formatMomChange(brandReach.changePercentage),
+          brandReach.trend
+        ),
+        protoDualSignal(
+          'Monthly Sessions',
+          formatNumber(brandReach.totalMonthlySessions),
+          brandReach.dailyTrend.length > 0 ? brandReach.dailyTrend.map((d) => d.sessions) : [0],
+          lfxColors.violet[500]
+        ),
+      ],
+      tooltipText: 'Social followers across all platforms (stock) and monthly website sessions (flow). Shown separately — these are different metric types.',
+      drawerType: DashboardDrawerType.BrandReach,
+    } as DashboardMetricCard,
+    {
+      title: 'Brand Health',
+      icon: 'fa-light fa-heart-pulse',
+      chartType: 'line',
+      category: 'brand',
+      testId: 'ed-evo-brand-health',
+      customContentType: 'dual-signal',
+      dualSignals: [
+        protoDualSignal(
+          'Mentions',
+          formatNumber(brandHealth.totalMentions),
+          brandHealth.monthlyMentions.length > 0 ? monthlyValues(brandHealth.monthlyMentions) : [0],
+          lfxColors.blue[500],
+          formatMomChange(brandHealth.sentimentMomChangePp),
+          brandHealth.trend
+        ),
+        protoDualSignal(
+          'Positive Sentiment',
+          `${brandHealth.sentiment.positive.toFixed(1)}%`,
+          brandHealth.monthlyMentions.length > 0 ? monthlyValues(brandHealth.monthlyMentions) : [0],
+          lfxColors.emerald[500],
+          `${brandHealth.sentimentMomChangePp >= 0 ? '+' : ''}${brandHealth.sentimentMomChangePp.toFixed(1)}pp MoM`,
+          brandHealth.sentimentMomChangePp >= 0 ? 'up' : 'down'
+        ),
+      ],
+      tooltipText: 'Total brand mentions across social and web (Octolens) with sentiment breakdown.',
+      drawerType: DashboardDrawerType.BrandHealth,
+    } as DashboardMetricCard,
+
+    // === Influence (1 dual-signal card) ===
+    {
+      title: 'Attribution',
+      icon: 'fa-light fa-money-bill-trend-up',
+      chartType: 'line',
+      category: 'influence',
+      testId: 'ed-evo-revenue-impact',
+      customContentType: 'dual-signal',
+      caption: `${formatCurrency(revenueImpact.revenueAttributed)} attributed of ${formatCurrency(revenueImpact.pipelineInfluenced + revenueImpact.revenueAttributed)} total (${revenueImpact.matchRate.toFixed(1)}% match rate)`,
+      dualSignals: [
+        protoDualSignal(
+          'Membership Growth Pipeline',
+          formatCurrency(revenueImpact.pipelineInfluenced),
+          [0],
+          lfxColors.blue[500],
+          formatMomChange(revenueImpact.changePercentage),
+          revenueImpact.trend
+        ),
+        protoDualSignal('Paid Media', formatCurrency(revenueImpact.paidMedia.adSpend), [0], lfxColors.emerald[500]),
+      ],
+      tooltipText:
+        'Membership growth pipeline influenced by marketing, with paid media spend and return on ad spend (ROAS). Match rate shows measurement confidence.',
+      drawerType: DashboardDrawerType.RevenueImpact,
+    } as DashboardMetricCard,
+  ];
+}

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2895,5 +2895,174 @@ export interface FlywheelConversionResponse {
     convertedToCommunity: number;
     convertedToWorkingGroup: number;
   };
+  reengagement: {
+    totalReengaged: number;
+    reengagementRate: number;
+    reengagementMomChange: number;
+    reengagedToNewsletter: number;
+    reengagedToCommunity: number;
+    reengagedToWorkingGroup: number;
+  };
   monthlyData: NorthStarMonthlyDataPoint[];
+}
+
+/**
+ * Top event row for Event Growth drill-down
+ */
+export interface EventGrowthTopEvent {
+  name: string;
+  date: string;
+  attendees: number;
+  revenue: number;
+}
+
+/**
+ * API response for Event Growth metric
+ * Total event attendees, event count, revenue, MoM growth, top events
+ */
+export interface EventGrowthResponse {
+  totalAttendees: number;
+  totalEvents: number;
+  totalRevenue: number;
+  revenuePerAttendee: number;
+  attendeeMomChange: number;
+  revenueMomChange: number;
+  trend: 'up' | 'down';
+  monthlyData: NorthStarMonthlyDataPoint[];
+  topEvents: EventGrowthTopEvent[];
+}
+
+/**
+ * Social platform identifier — maps to a presentation icon + color in the component layer
+ * New platforms must be added to MARKETING_SOCIAL_PLATFORM_MAP in the component constants
+ */
+export type BrandReachPlatformType = 'linkedin' | 'twitter' | 'youtube' | 'facebook' | 'mastodon' | 'other';
+
+/**
+ * Social platform row for Brand Reach drill-down
+ * Icon + color mapping is handled in the component, not the data layer
+ */
+export interface BrandReachSocialPlatform {
+  name: string;
+  platformType: BrandReachPlatformType;
+  followers: number;
+}
+
+/**
+ * Website domain row for Brand Reach drill-down
+ */
+export interface BrandReachWebsiteDomain {
+  domain: string;
+  sessions: number;
+}
+
+/**
+ * Daily sessions data point for Brand Reach drill-down
+ */
+export interface BrandReachDailyDataPoint {
+  day: string;
+  sessions: number;
+}
+
+/**
+ * API response for Brand Reach metric
+ * Digital reach across social platforms and owned websites
+ */
+export interface BrandReachResponse {
+  totalSocialFollowers: number;
+  totalMonthlySessions: number;
+  activePlatforms: number;
+  changePercentage: number;
+  trend: 'up' | 'down';
+  socialPlatforms: BrandReachSocialPlatform[];
+  websiteDomains: BrandReachWebsiteDomain[];
+  dailyTrend: BrandReachDailyDataPoint[];
+}
+
+/**
+ * Top project row for Brand Health drill-down
+ */
+export interface BrandHealthTopProject {
+  name: string;
+  mentions: number;
+}
+
+/**
+ * Sentiment breakdown for Brand Health drill-down
+ * Percentages out of 100
+ */
+export interface BrandHealthSentimentBreakdown {
+  positive: number;
+  neutral: number;
+  negative: number;
+}
+
+/**
+ * API response for Brand Health metric
+ * Total mentions, sentiment breakdown, monthly mentions trend, top projects
+ */
+export interface BrandHealthResponse {
+  totalMentions: number;
+  sentiment: BrandHealthSentimentBreakdown;
+  sentimentMomChangePp: number;
+  trend: 'up' | 'down';
+  monthlyMentions: NorthStarMonthlyDataPoint[];
+  topProjects: BrandHealthTopProject[];
+}
+
+/**
+ * Engagement-type attribution row for Revenue Impact drill-down
+ */
+export interface RevenueImpactEngagementType {
+  type: string;
+  percentage: number;
+}
+
+/**
+ * Attribution model comparison for Revenue Impact drill-down
+ */
+export interface RevenueImpactAttributionModels {
+  linear: number;
+  firstTouch: number;
+  lastTouch: number;
+}
+
+/**
+ * Paid media metrics for Revenue Impact drill-down
+ */
+export interface RevenueImpactPaidMedia {
+  roas: number;
+  impressions: number;
+  adSpend: number;
+  adRevenue: number;
+}
+
+/**
+ * API response for Revenue Impact (Marketing Attribution) metric
+ * Pipeline, revenue, attribution models, engagement channels, paid media
+ */
+export interface RevenueImpactResponse {
+  pipelineInfluenced: number;
+  revenueAttributed: number;
+  matchRate: number;
+  changePercentage: number;
+  trend: 'up' | 'down';
+  attributionModels: RevenueImpactAttributionModels;
+  engagementTypes: RevenueImpactEngagementType[];
+  paidMedia: RevenueImpactPaidMedia;
+}
+
+/**
+ * Aggregated response for all ED Evolution dashboard API calls.
+ * Used by buildEdEvolutionMetrics() to convert API data into card UI models.
+ */
+export interface EdEvolutionData {
+  flywheel: FlywheelConversionResponse;
+  memberAcquisition: MemberAcquisitionResponse;
+  memberRetention: MemberRetentionResponse;
+  engagedCommunity: EngagedCommunitySizeResponse;
+  eventGrowth: EventGrowthResponse;
+  brandReach: BrandReachResponse;
+  brandHealth: BrandHealthResponse;
+  revenueImpact: RevenueImpactResponse;
 }

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -20,6 +20,8 @@ export type MetricCategory =
   | 'code'
   | 'projectHealth'
   | 'marketing'
+  | 'brand'
+  | 'influence'
   // Reserved for future ED dashboard categories
   | 'memberships'
   | 'education'
@@ -29,7 +31,7 @@ export type MetricCategory =
  * Custom content type for specialized metric cards
  * @description Determines what type of custom content to render in the metric card
  */
-export type CustomContentType = 'bar-chart' | 'top-projects' | 'bus-factor' | 'health-scores';
+export type CustomContentType = 'bar-chart' | 'top-projects' | 'bus-factor' | 'health-scores' | 'dual-signal' | 'funnel';
 
 /**
  * Unified dashboard metric card interface
@@ -100,6 +102,23 @@ export interface DashboardMetricCard {
 
   /** Loading state for the card - when true, shows skeleton UI */
   loading?: boolean;
+
+  // ============================================
+  // Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact)
+  // ============================================
+
+  /** Two-signal rows for dual-signal cards (e.g., Brand Reach, Brand Health, Revenue Impact) */
+  dualSignals?: DualSignalRow[];
+
+  /** Caption text below dual-signal card (e.g., "$X attributed of $Y total (Z% match rate)") */
+  caption?: string;
+
+  // ============================================
+  // Funnel Card (Flywheel Conversion)
+  // ============================================
+
+  /** Steps for the funnel card (e.g., Attendees → Newsletter → Community → WG) */
+  funnelSteps?: FunnelStep[];
 
   // ============================================
   // Foundation Health Specific
@@ -213,6 +232,10 @@ export enum DashboardDrawerType {
   NorthStarMemberAcquisition = 'north-star-member-acquisition',
   NorthStarMemberRetention = 'north-star-member-retention',
   NorthStarFlywheelConversion = 'north-star-flywheel-conversion',
+  NorthStarEventGrowth = 'north-star-event-growth',
+  BrandReach = 'brand-reach',
+  BrandHealth = 'brand-health',
+  RevenueImpact = 'revenue-impact',
 }
 
 /** Lifecycle stage of a foundation project */
@@ -247,6 +270,34 @@ export interface FilterPillOption {
   id: string;
   /** Display label for the filter pill */
   label: string;
+}
+
+/**
+ * A single signal row within a dual-signal metric card
+ * @description Used for cards that show two independent metrics stacked vertically (e.g., Brand Reach, Revenue Impact)
+ */
+export interface DualSignalRow {
+  /** Label for this signal (e.g., "Social Followers", "Monthly Sessions") */
+  label: string;
+  /** Display value (e.g., "474K", "$2.1M") */
+  value: string;
+  /** Change percentage display (e.g., "+8.2% MoM") */
+  changePercentage?: string;
+  /** Trend direction */
+  trend?: 'up' | 'down';
+  /** Sparkline chart data for this signal */
+  chartData?: ChartData<ChartType>;
+}
+
+/**
+ * A single step in a funnel visualization on a metric card
+ * @description Used for the Flywheel Conversion card to show the step-down funnel
+ */
+export interface FunnelStep {
+  /** Short label (e.g., "Attendees", "Newsletter") */
+  label: string;
+  /** Display value (e.g., "8.2K", "1.4K") */
+  value: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Wire all 7 ED marketing dashboard cards to live Snowflake data (replacing prototype dummy data)
- Add 8 backend Snowflake query endpoints: flywheel, member acquisition/retention, engaged community, event growth, brand reach/health, revenue impact
- Refactor 4 drawers (event-growth, brand-health, brand-reach, revenue-impact) from hardcoded to `input()`-driven with live API data
- Build cards dynamically via `buildEdEvolutionMetrics()` from aggregated API responses
- Attribution drawer: split into Membership Growth Pipeline + Paid Media sections, wire attribution model comparison from `PAID_ADS_ATTRIBUTION` (first-touch, linear, last-touch)
- Fix event growth sparkline crash (Snowflake returns Date objects, not strings)
- Smart revenue formatting ($14.4K instead of $0.0M for small amounts)
- Consistent `.toFixed(1)` on all displayed percentages across 10 drawers
- Type filter signal with `MetricCategory` union type
- Correct YTD/YoY labels (was incorrectly showing "Last 6 months" / "MoM")

## Test plan
- [ ] Verify ED dashboard loads with live data at `/dashboards/executive-director`
- [ ] Click each of the 7 cards and verify drawers open with real data
- [ ] Verify filter pills (All, North Star, Marketing, Social) filter cards correctly
- [ ] Verify Attribution drawer shows Membership Pipeline + Paid Media sections
- [ ] Verify Event Growth drawer shows quarterly bar chart + correct YTD labels
- [ ] Verify all percentages display with 1 decimal place

LFXV2-1468

🤖 Generated with [Claude Code](https://claude.ai/code)