### PR TITLE
fix(ed-dashboard): standardize decimal formatting in drawer stats LFXV2-1468

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -44,7 +44,7 @@
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Current CTR</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ drawerData().currentCtr.toFixed(2) }}%</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ drawerData().currentCtr.toFixed(1) }}%</span>
           </div>
         </lfx-card>
         <lfx-card styleClass="flex-1">
@@ -53,7 +53,7 @@
             @if (drawerData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage }}%
+                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
                 </span>
                 <i class="text-sm" [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -42,7 +42,7 @@
           @if (data().changePercentage !== 0) {
             <div class="flex items-center gap-2">
               <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage }}%
+                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage.toFixed(1) }}%
               </span>
               <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
@@ -52,11 +52,11 @@
             <div class="flex flex-col gap-1">
               <span class="text-sm text-gray-500">ROAS</span>
               <div class="flex items-center gap-2">
-                <span class="text-2xl font-semibold text-gray-900">{{ drawerData().roas.toFixed(2) }}x</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ drawerData().roas.toFixed(1) }}x</span>
                 @if (drawerData().changePercentage !== 0) {
                   <span class="text-sm font-medium" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
                     <i [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up' : 'fa-light fa-arrow-down'"></i>
-                    {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage }}%
+                    {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
                   </span>
                 }
               </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -59,7 +59,7 @@
             @if (drawerData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage }}%
+                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
                 </span>
                 <i class="text-sm" [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>
@@ -164,7 +164,7 @@
                   </div>
                 </td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ formatNumber(platform.followers) }}</td>
-                <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.engagementRate }}%</td>
+                <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.engagementRate.toFixed(1) }}%</td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.postsLast30Days }}</td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ formatNumber(platform.impressions) }}</td>
               </tr>

--- a/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
@@ -22,7 +22,10 @@
           <div class="flex items-center gap-2 flex-wrap">
             <h3 class="text-sm font-semibold text-gray-900 leading-snug" data-testid="training-card-name">{{ training().name }}</h3>
             @if (training().level) {
-              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" [ngClass]="levelClasses()" data-testid="training-card-level-badge">
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                [ngClass]="levelClasses()"
+                data-testid="training-card-level-badge">
                 {{ training().level }}
               </span>
             }

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
@@ -107,7 +107,7 @@
               <div data-testid="trainings-ongoing-section">
                 <h2 class="text-base font-semibold text-gray-800 pb-3 mb-4 border-b border-gray-200">Ongoing trainings</h2>
                 <div class="flex flex-col gap-4" data-testid="trainings-ongoing-list">
-                  @for (enrollment of (enrollments() ?? []); track enrollment.id) {
+                  @for (enrollment of enrollments() ?? []; track enrollment.id) {
                     <lfx-training-card [training]="enrollment" variant="ongoing" data-testid="training-card-item" />
                   }
                 </div>
@@ -118,7 +118,7 @@
               <div data-testid="trainings-completed-section">
                 <h2 class="text-base font-semibold text-gray-800 pb-3 mb-4 border-b border-gray-200">Completed trainings</h2>
                 <div class="flex flex-col gap-4" data-testid="trainings-completed-list">
-                  @for (cert of (completedTrainings() ?? []); track cert.id) {
+                  @for (cert of completedTrainings() ?? []; track cert.id) {
                     <lfx-training-card [training]="cert" variant="completed" data-testid="training-completed-item" />
                   }
                 </div>


### PR DESCRIPTION
## Summary
- Standardize all percentage displays to `.toFixed(1)` across 4 ED dashboard drawer components
- Fixes inconsistent decimal precision (some showed `.toFixed(2)`, others had no formatting)

### Files changed:
- `engaged-community-drawer.component.html` — `changePercentage` `.toFixed(1)`
- `email-ctr-drawer.component.html` — `currentCtr` and `changePercentage` `.toFixed(1)`
- `paid-social-reach-drawer.component.html` — `roas` and `changePercentage` `.toFixed(1)`
- `social-media-drawer.component.html` — `changePercentage` and `engagementRate` `.toFixed(1)`

## Test plan
- [ ] Verify each drawer displays percentages with exactly 1 decimal place
- [ ] Confirm no layout shifts from formatting changes
- [ ] Check edge cases: 0%, negative values, large numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)