### PR TITLE
feat(surveys): add me lens support for user survey participation

### DIFF
--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
@@ -5,10 +5,16 @@
   <!-- Page Header -->
   <div class="flex items-center justify-between mb-8">
     <div>
-      <h1 data-testid="surveys-dashboard-title">{{ surveyLabelPlural }}</h1>
-      <p class="mt-2 text-gray-500" data-testid="surveys-dashboard-description">Create and manage surveys to gather feedback from your community.</p>
+      <h1 data-testid="surveys-dashboard-title">{{ isMeLens() ? 'My ' + surveyLabelPlural : surveyLabelPlural }}</h1>
+      <p class="mt-2 text-gray-500" data-testid="surveys-dashboard-description">
+        {{
+          isMeLens()
+            ? surveyLabelPlural + ' you have been invited to across all foundations and projects.'
+            : 'Create and manage surveys to gather feedback from your community.'
+        }}
+      </p>
     </div>
-    @if (hasPMOAccess()) {
+    @if (!isMeLens() && hasPMOAccess()) {
       <lfx-button
         [label]="'Create ' + surveyLabel"
         size="small"
@@ -20,8 +26,30 @@
     }
   </div>
 
-  <!-- Surveys Table or Empty State -->
-  @if (!loading() && surveys().length === 0) {
+  <!-- Loading State -->
+  @if ((isMeLens() && mySurveysLoading()) || (!isMeLens() && loading())) {
+    <div class="flex justify-center items-center min-h-96">
+      <div class="text-center">
+        <i class="fa-light fa-spinner-third fa-spin text-3xl text-violet-600 mb-4"></i>
+        <p class="text-gray-600">Loading {{ surveyLabel | lowercase }} details...</p>
+      </div>
+    </div>
+  } @else if (isMeLens() && mySurveys().length === 0) {
+    <!-- Me lens empty state -->
+    <lfx-card data-testid="surveys-empty-state-card">
+      <div class="p-8 md:p-12">
+        <div class="max-w-2xl mx-auto text-center flex flex-col gap-6">
+          <div class="flex justify-center">
+            <div class="w-20 h-20 rounded-full bg-violet-100 flex items-center justify-center">
+              <i class="fa-light fa-clipboard-list text-4xl text-violet-600"></i>
+            </div>
+          </div>
+          <h2 class="text-xl font-semibold text-gray-900">You don't have any {{ surveyLabelPlural | lowercase }} yet</h2>
+        </div>
+      </div>
+    </lfx-card>
+  } @else if (!isMeLens() && surveys().length === 0) {
+    <!-- Project empty state -->
     <lfx-card data-testid="surveys-empty-state-card">
       <div class="p-8 md:p-12">
         <div class="max-w-2xl mx-auto text-center flex flex-col gap-6">
@@ -37,9 +65,9 @@
     </lfx-card>
   } @else {
     <lfx-surveys-table
-      [surveys]="surveys()"
-      [hasPMOAccess]="hasPMOAccess()"
-      [loading]="loading()"
+      [surveys]="isMeLens() ? mySurveys() : surveys()"
+      [hasPMOAccess]="!isMeLens() && hasPMOAccess()"
+      [loading]="isMeLens() ? mySurveysLoading() : loading()"
       (viewResults)="onViewResults($event)"
       (rowClick)="onRowClick($event)"
       (refresh)="refreshSurveys()"

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
@@ -113,7 +113,8 @@ export class SurveysDashboardComponent {
     return computed(() => {
       const surveyId = this.selectedSurveyId();
       if (!surveyId) return null;
-      return this.surveys().find((s) => s.uid === surveyId) ?? null;
+      const source = this.isMeLens() ? this.mySurveys() : this.surveys();
+      return source.find((s) => s.uid === surveyId) ?? null;
     });
   }
 

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 import { LowerCasePipe } from '@angular/common';
-import { Component, computed, inject, signal, Signal } from '@angular/core';
+import { Component, computed, inject, Signal, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { SURVEY_LABEL } from '@lfx-one/shared';
 import { ProjectContext, Survey } from '@lfx-one/shared/interfaces';
+import { LensService } from '@services/lens.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { SurveyService } from '@services/survey.service';
 import { BehaviorSubject, catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
@@ -25,6 +26,7 @@ import { SurveysTableComponent } from '../components/surveys-table/surveys-table
 export class SurveysDashboardComponent {
   // === Services ===
   private readonly surveyService = inject(SurveyService);
+  private readonly lensService = inject(LensService);
   private readonly projectContextService = inject(ProjectContextService);
 
   // === Constants ===
@@ -39,11 +41,16 @@ export class SurveysDashboardComponent {
   protected readonly hasPMOAccess = signal<boolean>(true);
   protected readonly resultsDrawerVisible = signal<boolean>(false);
   protected readonly selectedSurveyId = signal<string | null>(null);
+  protected readonly mySurveysLoading = signal<boolean>(true);
 
-  // === Computed Signals ===
+  // === Lens ===
+  protected readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+
+  // === Computed / toSignal Signals ===
   protected readonly project: Signal<ProjectContext | null> = this.initProject();
   protected readonly surveys: Signal<Survey[]> = this.initSurveys();
   protected readonly selectedListSurvey: Signal<Survey | null> = this.initSelectedListSurvey();
+  protected readonly mySurveys: Signal<Survey[]> = this.initMySurveys();
 
   protected onViewResults(surveyId: string): void {
     this.selectedSurveyId.set(surveyId);
@@ -78,11 +85,12 @@ export class SurveysDashboardComponent {
 
   private initSurveys(): Signal<Survey[]> {
     const project$ = toObservable(this.project);
+    const lens$ = toObservable(this.lensService.activeLens);
 
     return toSignal(
-      combineLatest([project$, this.refresh$]).pipe(
-        switchMap(([project]) => {
-          if (!project?.uid) {
+      combineLatest([project$, this.refresh$, lens$]).pipe(
+        switchMap(([project, , lens]) => {
+          if (lens === 'me' || !project?.uid) {
             this.loading.set(false);
             return of([]);
           }
@@ -107,5 +115,29 @@ export class SurveysDashboardComponent {
       if (!surveyId) return null;
       return this.surveys().find((s) => s.uid === surveyId) ?? null;
     });
+  }
+
+  private initMySurveys(): Signal<Survey[]> {
+    const lens$ = toObservable(this.lensService.activeLens);
+
+    return toSignal(
+      combineLatest([lens$, this.refresh$]).pipe(
+        switchMap(([lens]) => {
+          if (lens !== 'me') {
+            this.mySurveysLoading.set(false);
+            return of([] as Survey[]);
+          }
+          this.mySurveysLoading.set(true);
+          return this.surveyService.getMySurveys().pipe(
+            catchError(() => {
+              this.mySurveysLoading.set(false);
+              return of([] as Survey[]);
+            }),
+            finalize(() => this.mySurveysLoading.set(false))
+          );
+        })
+      ),
+      { initialValue: [] }
+    );
   }
 }

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
@@ -26,7 +26,6 @@ export class ProjectSelectorComponent {
 
   protected readonly searchQuery = signal<string>('');
 
-  private readonly validProjectIds = computed(() => new Set(this.projects().map((p) => p.projectUid)));
   protected readonly displayName = this.initializeDisplayName();
   protected readonly displayLogo = this.initializeDisplayLogo();
   protected readonly foundations = this.initializeFoundations();
@@ -65,9 +64,8 @@ export class ProjectSelectorComponent {
     return computed(() => {
       const allProjects = this.projects();
       const query = this.searchQuery().toLowerCase().trim();
-      const ids = this.validProjectIds();
 
-      const foundationList = allProjects.filter((p) => isFoundationProject(p, ids));
+      const foundationList = allProjects.filter((p) => isFoundationProject(p));
 
       if (!query) {
         return foundationList;
@@ -95,12 +93,11 @@ export class ProjectSelectorComponent {
     return computed(() => {
       const allProjects = this.projects();
       const query = this.searchQuery().toLowerCase().trim();
-      const ids = this.validProjectIds();
 
       const map = new Map<string, EnrichedPersonaProject[]>();
 
       allProjects.forEach((project) => {
-        if (!isFoundationProject(project, ids) && project.parentProjectUid) {
+        if (!isFoundationProject(project) && project.parentProjectUid) {
           const children = map.get(project.parentProjectUid) || [];
           children.push(project);
           map.set(project.parentProjectUid, children);

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -86,15 +86,13 @@ export class ProjectContextService {
    * Called by sidebar when persona detection first populates.
    */
   public ensureDefaultSelection(detectedProjects: EnrichedPersonaProject[]): void {
-    const validProjectIds = new Set(detectedProjects.map((p) => p.projectUid));
     const personaProjects = this.personaService.personaProjects();
 
     // Foundation slot — pick from board-scoped persona projects
     if (!this.foundationSelection() || !detectedProjects.some((p) => p.projectUid === this.foundationSelection()?.uid)) {
       const boardUids = this.getPersonaProjectUids(personaProjects, BOARD_SCOPED_PERSONAS);
       const defaultFoundation =
-        detectedProjects.find((p) => boardUids.has(p.projectUid) && isFoundationProject(p, validProjectIds)) ??
-        detectedProjects.find((p) => isFoundationProject(p, validProjectIds));
+        detectedProjects.find((p) => boardUids.has(p.projectUid) && isFoundationProject(p)) ?? detectedProjects.find((p) => isFoundationProject(p));
       if (defaultFoundation) {
         this.setFoundation(toProjectContext(defaultFoundation));
       }
@@ -104,7 +102,7 @@ export class ProjectContextService {
     if (!this.projectSelection() || !detectedProjects.some((p) => p.projectUid === this.projectSelection()?.uid)) {
       const projectUids = this.getPersonaProjectUids(personaProjects, PROJECT_SCOPED_PERSONAS);
       const defaultProject =
-        detectedProjects.find((p) => projectUids.has(p.projectUid) && !isFoundationProject(p, validProjectIds)) ??
+        detectedProjects.find((p) => projectUids.has(p.projectUid) && !isFoundationProject(p)) ??
         detectedProjects.find((p) => projectUids.has(p.projectUid)) ??
         detectedProjects[0];
       if (defaultProject) {

--- a/apps/lfx-one/src/app/shared/services/survey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/survey.service.ts
@@ -45,6 +45,10 @@ export class SurveyService {
     return this.getSurveys(params);
   }
 
+  public getMySurveys(): Observable<Survey[]> {
+    return this.http.get<Survey[]>('/api/surveys/my-surveys');
+  }
+
   public getSurvey(surveyUid: string, projectId?: string): Observable<Survey> {
     let params = new HttpParams();
     if (projectId) {

--- a/apps/lfx-one/src/server/controllers/survey.controller.ts
+++ b/apps/lfx-one/src/server/controllers/survey.controller.ts
@@ -67,6 +67,25 @@ export class SurveyController {
   }
 
   /**
+   * GET /surveys/my-surveys
+   */
+  public async getMySurveys(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_my_surveys');
+
+    try {
+      const mySurveys = await this.surveyService.getMySurveys(req);
+
+      logger.success(req, 'get_my_surveys', startTime, {
+        survey_count: mySurveys.length,
+      });
+
+      res.json(mySurveys);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /surveys/:uid
    */
   public async getSurveyById(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/routes/surveys.route.ts
+++ b/apps/lfx-one/src/server/routes/surveys.route.ts
@@ -15,7 +15,7 @@ router.post('/', (req, res, next) => surveyController.createSurvey(req, res, nex
 // GET /surveys - get all surveys
 router.get('/', (req, res, next) => surveyController.getSurveys(req, res, next));
 
-// GET /surveys/my-surveys - get surveys the current user has responded to
+// GET /surveys/my-surveys - get surveys the current user has been invited to
 router.get('/my-surveys', (req, res, next) => surveyController.getMySurveys(req, res, next));
 
 // GET /surveys/:uid - get a single survey

--- a/apps/lfx-one/src/server/routes/surveys.route.ts
+++ b/apps/lfx-one/src/server/routes/surveys.route.ts
@@ -15,6 +15,9 @@ router.post('/', (req, res, next) => surveyController.createSurvey(req, res, nex
 // GET /surveys - get all surveys
 router.get('/', (req, res, next) => surveyController.getSurveys(req, res, next));
 
+// GET /surveys/my-surveys - get surveys the current user has responded to
+router.get('/my-surveys', (req, res, next) => surveyController.getMySurveys(req, res, next));
+
 // GET /surveys/:uid - get a single survey
 router.get('/:uid', (req, res, next) => surveyController.getSurveyById(req, res, next));
 

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NatsSubjects } from '@lfx-one/shared/enums';
-import { EnrichedPersonaProject, PersonaApiResponse, PersonaDetectionResponse, PersonaProject, PersonaType } from '@lfx-one/shared/interfaces';
+import { EnrichedPersonaProject, PersonaApiResponse, PersonaDetectionResponse, PersonaProject, PersonaType, Project } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
 import { logger } from './logger.service';
@@ -89,7 +89,7 @@ export class PersonaDetectionService {
     const uniqueProjectUids = new Set(enrichedProjects.map((p) => p.projectUid));
     const multiProject = uniqueProjectUids.size > 1;
 
-    const foundationUids = new Set(enrichedProjects.map((p) => p.parentProjectUid || p.projectUid));
+    const foundationUids = new Set(enrichedProjects.map((p) => (p.isFoundation ? p.projectUid : p.parentProjectUid || p.projectUid)));
     const multiFoundation = foundationUids.size > 1;
 
     logger.debug(req, 'get_personas', 'Persona detection complete', {
@@ -149,7 +149,7 @@ export class PersonaDetectionService {
       response.projects.map(async (project) => {
         let projectName: string | null = null;
         let parentProjectUid: string | null = null;
-
+        let isFoundation = false;
         let logoUrl: string | null = null;
         let description: string | null = null;
 
@@ -157,6 +157,7 @@ export class PersonaDetectionService {
           const projectData = await this.projectService.getProjectById(req, project.project_uid, false);
           projectName = projectData?.name || null;
           parentProjectUid = projectData?.parent_uid || null;
+          isFoundation = this.computeIsFoundation(projectData);
           logoUrl = projectData?.logo_url || null;
           description = projectData?.description || null;
         } catch {
@@ -172,6 +173,7 @@ export class PersonaDetectionService {
           projectSlug: project.project_slug,
           projectName,
           parentProjectUid,
+          isFoundation,
           logoUrl,
           description,
           detections: project.detections,
@@ -255,5 +257,25 @@ export class PersonaDetectionService {
     }
 
     return PERSONA_PRIORITY.filter((p) => allPersonas.has(p));
+  }
+
+  /**
+   * Compute whether a project is foundation-level using business criteria.
+   * Mirrors the lfx-pcc hasHealthMetricDashboard logic mapped to V2 project fields:
+   * - Stage must be 'Active'
+   * - Legal entity type must not be 'Internal Allocation'
+   * - Funding model must include 'Membership'
+   */
+  private computeIsFoundation(project: Project | null): boolean {
+    if (!project) {
+      return false;
+    }
+
+    return (
+      project.stage === 'Active' &&
+      project.legal_entity_type !== 'Internal Allocation' &&
+      Array.isArray(project.funding_model) &&
+      project.funding_model.includes('Membership')
+    );
   }
 }

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -6,6 +6,8 @@ import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
+import { fetchAllQueryResources } from '../helpers/query-service.helper';
+import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { ETagService } from './etag.service';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -157,5 +159,86 @@ export class SurveyService {
 
     // Step 2: Delete survey with ETag
     await this.etagService.deleteWithETag(req, 'LFX_V2_SERVICE', `/surveys/${surveyUid}`, etag, 'delete_survey');
+  }
+
+  // ============================================
+  // My Surveys (Me Lens)
+  // ============================================
+
+  /**
+   * Fetches surveys the current user has responded to.
+   * Queries survey_response records by email and username using filters_or.
+   */
+  public async getMySurveys(req: Request): Promise<Survey[]> {
+    const rawUsername = await getUsernameFromAuth(req);
+    const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
+    const email = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+
+    logger.debug(req, 'get_my_surveys', 'Fetching surveys for current user', {
+      username,
+      has_email: !!email,
+    });
+
+    if (!username && !email) {
+      return [];
+    }
+
+    // Build filters_or array for email and/or username
+    const filtersOr: string[] = [];
+    if (email) {
+      filtersOr.push(`email:${email}`);
+    }
+    if (username) {
+      filtersOr.push(`username:${username}`);
+    }
+
+    // Query survey_response records using filters_or (OR logic on data fields)
+    const responses = await fetchAllQueryResources<{ survey_uid: string }>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<{ survey_uid: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        v: '1',
+        type: 'survey_response',
+        page_size: 100,
+        filters_or: filtersOr,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+
+    // Extract unique survey UIDs
+    const surveyUids = [...new Set(responses.filter((r) => r.survey_uid).map((r) => r.survey_uid))];
+
+    if (surveyUids.length === 0) {
+      return [];
+    }
+
+    logger.debug(req, 'get_my_surveys', 'Found user survey responses', {
+      response_count: responses.length,
+      unique_survey_count: surveyUids.length,
+    });
+
+    // Fetch survey details in parallel
+    const surveys = await Promise.all(
+      surveyUids.map(async (uid) => {
+        try {
+          const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+            type: 'survey',
+            tags: uid,
+          });
+
+          if (!resources || resources.length === 0) {
+            return null;
+          }
+
+          return resources[0].data;
+        } catch (error) {
+          logger.warning(req, 'get_my_surveys', 'Failed to fetch survey details, skipping', {
+            survey_uid: uid,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+          return null;
+        }
+      })
+    );
+
+    return surveys.filter((s): s is Survey => s !== null);
   }
 }

--- a/packages/shared/src/interfaces/persona-detection.interface.ts
+++ b/packages/shared/src/interfaces/persona-detection.interface.ts
@@ -53,6 +53,8 @@ export interface EnrichedPersonaProject {
   projectName: string | null;
   /** Parent project UID (null if this is a top-level foundation) */
   parentProjectUid: string | null;
+  /** Whether this project is a foundation (top-level) */
+  isFoundation: boolean;
   /** Project logo URL (null if unavailable) */
   logoUrl: string | null;
   /** Project description text (null if unavailable) */

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -15,8 +15,9 @@ export function toProjectContext(project: EnrichedPersonaProject): ProjectContex
 }
 
 /**
- * Determine if a project is a foundation (top-level).
- * Uses the `isFoundation` field from the upstream project service.
+ * Determine if a project should be treated as a foundation (top-level).
+ * Uses the computed `isFoundation` flag attached during persona enrichment
+ * on `EnrichedPersonaProject`, rather than a raw field from the upstream project model.
  */
 export function isFoundationProject(project: EnrichedPersonaProject): boolean {
   return project.isFoundation;

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -15,9 +15,9 @@ export function toProjectContext(project: EnrichedPersonaProject): ProjectContex
 }
 
 /**
- * Determine if a project is a foundation (top-level) within a given set of projects.
- * A project is a foundation if its parentProjectUid is absent or not in the set.
+ * Determine if a project is a foundation (top-level).
+ * Uses the `isFoundation` field from the upstream project service.
  */
-export function isFoundationProject(project: EnrichedPersonaProject, validProjectIds: Set<string>): boolean {
-  return !project.parentProjectUid || project.parentProjectUid === '' || !validProjectIds.has(project.parentProjectUid);
+export function isFoundationProject(project: EnrichedPersonaProject): boolean {
+  return project.isFoundation;
 }


### PR DESCRIPTION
## Summary
- Add "me" lens to surveys dashboard showing only surveys the current user has been invited to
- Query `survey_response` records by both email and username using `filters_or` (OR logic on data fields) with full pagination via `fetchAllQueryResources`
- Add backend endpoint (`GET /my-surveys`), frontend service method, and lens-aware dashboard with conditional loading, empty states, and hidden create button
- Include persona detection and project context improvements

Generated with [Claude Code](https://claude.ai/code)