### PR TITLE
feat(ed-dashboard): add event growth card (LFXV2-1468)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -1,0 +1,151 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="event-growth-drawer">
+  <!-- Header -->
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full" data-testid="event-growth-drawer-header">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="event-growth-drawer-title">Event Growth</h2>
+        <p class="text-sm text-gray-500">Executive Director · North Star Metric</p>
+      </div>
+      <lfx-button
+        icon="fa-light fa-xmark"
+        [text]="true"
+        [rounded]="true"
+        severity="secondary"
+        ariaLabel="Close panel"
+        (onClick)="onClose()"
+        data-testid="event-growth-drawer-close" />
+    </div>
+  </ng-template>
+
+  <!-- Content -->
+  <div class="flex flex-col gap-6 pb-2" data-testid="event-growth-drawer-content">
+    <!-- Summary Stats -->
+    <div class="flex gap-4" data-testid="event-growth-drawer-stats">
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Total Attendees</span>
+          @if (data().totalAttendees > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().totalAttendees | number }}</span>
+            <span class="text-xs text-gray-400">YTD</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Events</span>
+          @if (data().totalEvents > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().totalEvents | number }}</span>
+            <span class="text-xs text-gray-400">YTD</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">YoY Growth</span>
+          @if (data().attendeeMomChange !== 0) {
+            <span class="text-2xl font-semibold" [class.text-green-600]="data().attendeeMomChange > 0" [class.text-red-600]="data().attendeeMomChange < 0">
+              {{ data().attendeeMomChange > 0 ? '+' : '' }}{{ data().attendeeMomChange.toFixed(1) }}%
+            </span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+    </div>
+
+    <!-- Event Revenue -->
+    <div class="flex gap-4" data-testid="event-growth-drawer-revenue-stats">
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Total Event Revenue</span>
+          @if (data().totalRevenue > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ formattedRevenue() }}</span>
+            <span class="text-xs text-gray-400">YTD</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Revenue Per Attendee</span>
+          @if (data().revenuePerAttendee > 0) {
+            <span class="text-2xl font-semibold text-gray-900">${{ data().revenuePerAttendee | number: '1.2-2' }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Revenue YoY</span>
+          @if (data().revenueMomChange !== 0) {
+            <span class="text-2xl font-semibold" [class.text-green-600]="data().revenueMomChange > 0" [class.text-red-600]="data().revenueMomChange < 0">
+              {{ data().revenueMomChange > 0 ? '+' : '' }}{{ data().revenueMomChange.toFixed(1) }}%
+            </span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+    </div>
+
+    <!-- Quarterly Attendance Trend -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="event-growth-drawer-monthly-trend">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Quarterly Attendance Trend</h3>
+        <p class="text-sm text-gray-600">Total event attendees per quarter</p>
+      </div>
+      @if (data().monthlyData.length > 0) {
+        <div class="h-[240px]" data-testid="event-growth-drawer-monthly-chart">
+          <lfx-chart type="bar" [data]="monthlyChartData()" [options]="monthlyChartOptions" height="100%"></lfx-chart>
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="event-growth-drawer-monthly-empty">
+          Quarterly trend data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Top Events -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="event-growth-drawer-top-events">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Top Events</h3>
+        <p class="text-sm text-gray-600">Highest attendance events · YTD</p>
+      </div>
+      @if (data().topEvents.length > 0) {
+        <div class="flex flex-col gap-0">
+          <div class="flex items-center justify-between py-2 px-1 text-xs font-semibold text-gray-500 uppercase border-b border-gray-200">
+            <span class="flex-1">Event</span>
+            <span class="w-24 text-right">Attendees</span>
+            <span class="w-24 text-right">Revenue</span>
+          </div>
+          @for (event of data().topEvents; track event.name) {
+            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="event-growth-drawer-event-row">
+              <span class="flex-1 text-sm font-medium text-gray-900">{{ event.name }}</span>
+              <span class="w-24 text-right text-sm font-semibold text-gray-900">{{ event.attendees | number }}</span>
+              <span class="w-24 text-right text-sm font-semibold text-gray-900">{{ formatEventRevenue(event.revenue) }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="event-growth-drawer-top-events-empty">
+          Top events data not yet available
+        </div>
+      }
+    </div>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
@@ -1,0 +1,107 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { ChartComponent } from '@components/chart/chart.component';
+import { lfxColors } from '@lfx-one/shared/constants';
+
+import { DrawerModule } from 'primeng/drawer';
+
+import type { ChartData, ChartOptions } from 'chart.js';
+import type { EventGrowthResponse } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-event-growth-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonComponent, CardComponent, ChartComponent, DecimalPipe, DrawerModule],
+  templateUrl: './event-growth-drawer.component.html',
+  styleUrl: './event-growth-drawer.component.scss',
+})
+export class EventGrowthDrawerComponent {
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  public readonly data = input<EventGrowthResponse>({
+    totalAttendees: 0,
+    totalEvents: 0,
+    totalRevenue: 0,
+    revenuePerAttendee: 0,
+    attendeeMomChange: 0,
+    revenueMomChange: 0,
+    trend: 'up',
+    monthlyData: [],
+    topEvents: [],
+  });
+
+  // === Computed Signals ===
+  protected readonly formattedRevenue = computed(() => {
+    const rev = this.data().totalRevenue;
+    if (rev >= 1_000_000) return `$${(rev / 1_000_000).toFixed(1)}M`;
+    if (rev >= 1_000) return `$${(rev / 1_000).toFixed(1)}K`;
+    return `$${rev.toLocaleString()}`;
+  });
+
+  protected readonly monthlyChartData: Signal<ChartData<'bar'>> = computed(() => {
+    const { monthlyData } = this.data();
+    const quarterLabels = monthlyData.map((d) => {
+      const [year, month] = d.month.split('-');
+      const qi = Math.ceil(Number(month) / 3);
+      return `Q${qi} ${year}`;
+    });
+    return {
+      labels: quarterLabels,
+      datasets: [
+        {
+          data: monthlyData.map((d) => d.value),
+          backgroundColor: lfxColors.blue[500],
+          borderRadius: 4,
+          barPercentage: 0.6,
+        },
+      ],
+    };
+  });
+
+  protected readonly monthlyChartOptions: ChartOptions<'bar'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: true },
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: { display: false },
+        ticks: { color: lfxColors.gray[500], font: { size: 11 } },
+      },
+      y: {
+        display: true,
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: false },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          callback: (value) => {
+            const num = Number(value);
+            if (num >= 1_000) return `${(num / 1_000).toFixed(1)}K`;
+            return String(num);
+          },
+        },
+      },
+    },
+  };
+
+  protected formatEventRevenue(revenue: number): string {
+    if (revenue >= 1_000_000) return `$${(revenue / 1_000_000).toFixed(1)}M`;
+    if (revenue >= 1_000) return `$${(revenue / 1_000).toFixed(1)}K`;
+    return `$${revenue.toLocaleString()}`;
+  }
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
@@ -22,7 +22,10 @@
           <div class="flex items-center gap-2 flex-wrap">
             <h3 class="text-sm font-semibold text-gray-900 leading-snug" data-testid="training-card-name">{{ training().name }}</h3>
             @if (training().level) {
-              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" [ngClass]="levelClasses()" data-testid="training-card-level-badge">
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                [ngClass]="levelClasses()"
+                data-testid="training-card-level-badge">
                 {{ training().level }}
               </span>
             }

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
@@ -107,7 +107,7 @@
               <div data-testid="trainings-ongoing-section">
                 <h2 class="text-base font-semibold text-gray-800 pb-3 mb-4 border-b border-gray-200">Ongoing trainings</h2>
                 <div class="flex flex-col gap-4" data-testid="trainings-ongoing-list">
-                  @for (enrollment of (enrollments() ?? []); track enrollment.id) {
+                  @for (enrollment of enrollments() ?? []; track enrollment.id) {
                     <lfx-training-card [training]="enrollment" variant="ongoing" data-testid="training-card-item" />
                   }
                 </div>
@@ -118,7 +118,7 @@
               <div data-testid="trainings-completed-section">
                 <h2 class="text-base font-semibold text-gray-800 pb-3 mb-4 border-b border-gray-200">Completed trainings</h2>
                 <div class="flex flex-col gap-4" data-testid="trainings-completed-list">
-                  @for (cert of (completedTrainings() ?? []); track cert.id) {
+                  @for (cert of completedTrainings() ?? []; track cert.id) {
                     <lfx-training-card [training]="cert" variant="completed" data-testid="training-completed-item" />
                   }
                 </div>

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -56,6 +56,7 @@ import {
   SocialMediaResponse,
   SocialReachResponse,
   WebActivitiesSummaryResponse,
+  EventGrowthResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
 
@@ -966,6 +967,27 @@ export class AnalyticsService {
             convertedToWorkingGroup: 0,
           },
           monthlyData: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get event growth metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getEventGrowth(foundationSlug: string): Observable<EventGrowthResponse> {
+    return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          totalAttendees: 0,
+          totalEvents: 0,
+          totalRevenue: 0,
+          revenuePerAttendee: 0,
+          attendeeMomChange: 0,
+          revenueMomChange: 0,
+          trend: 'up' as const,
+          monthlyData: [],
+          topEvents: [],
         });
       })
     );

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2160,4 +2160,42 @@ export class AnalyticsController {
       next(error);
     }
   }
+
+  /**
+   * GET /api/analytics/event-growth
+   * Get event growth metrics (total attendees, top events by attendance/revenue)
+   */
+  public async getEventGrowth(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_event_growth');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_event_growth',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_event_growth',
+        });
+      }
+
+      const response = await this.projectService.getEventGrowth(foundationSlug);
+
+      logger.success(req, 'get_event_growth', startTime, {
+        foundation_slug: foundationSlug,
+        total_attendees: response.totalAttendees,
+        total_events: response.totalEvents,
+        top_events: response.topEvents.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_event_growth', startTime, error);
+      next(error);
+    }
+  }
 }

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -148,5 +148,6 @@ router.get('/member-retention', (req, res, next) => analyticsController.getMembe
 router.get('/member-acquisition', (req, res, next) => analyticsController.getMemberAcquisition(req, res, next));
 router.get('/engaged-community', (req, res, next) => analyticsController.getEngagedCommunity(req, res, next));
 router.get('/flywheel-conversion', (req, res, next) => analyticsController.getFlywheelConversion(req, res, next));
+router.get('/event-growth', (req, res, next) => analyticsController.getEventGrowth(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -71,6 +71,8 @@ import {
   EngagedCommunitySizeResponse,
   FlywheelConversionResponse,
   NorthStarMonthlyDataPoint,
+  EventGrowthResponse,
+  EventGrowthTopEvent,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -82,6 +84,13 @@ import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { NatsService } from './nats.service';
 import { SnowflakeService } from './snowflake.service';
+
+/**
+ * Schema prefix for ED dashboard dbt views.
+ * Defaults to production; set SNOWFLAKE_ED_SCHEMA env var to use dev views for testing.
+ * Example: SNOWFLAKE_ED_SCHEMA=ANALYTICS_DEV.DEV_MRAUTELA_PLATINUM_LFX_ONE
+ */
+const ED_SCHEMA = process.env['SNOWFLAKE_ED_SCHEMA'] || 'ANALYTICS.PLATINUM_LFX_ONE';
 
 /**
  * Service for handling project business logic
@@ -2527,6 +2536,116 @@ export class ProjectService {
         },
         monthlyData: [],
       };
+    }
+  }
+
+  /**
+   * Get event growth metrics from Snowflake
+   * Queries ${ED_SCHEMA}.NORTH_STAR_EVENT_GROWTH (single row YTD) and EVENT_GROWTH_TOP_EVENTS
+   */
+  public async getEventGrowth(foundationSlug: string): Promise<EventGrowthResponse> {
+    logger.debug(undefined, 'get_event_growth', 'Fetching event growth from Snowflake', { foundation_slug: foundationSlug });
+
+    const defaultResponse: EventGrowthResponse = {
+      totalAttendees: 0,
+      totalEvents: 0,
+      totalRevenue: 0,
+      revenuePerAttendee: 0,
+      attendeeMomChange: 0,
+      revenueMomChange: 0,
+      trend: 'up',
+      monthlyData: [],
+      topEvents: [],
+    };
+
+    try {
+      const summaryQuery = `
+        SELECT EVENT_COUNT_YTD, ATTENDEE_COUNT_YTD, REGISTRANT_COUNT_YTD,
+               TOTAL_NET_REVENUE_YTD,
+               EVENT_COUNT_YOY_CHANGE_PCT, ATTENDEE_COUNT_YOY_CHANGE_PCT,
+               REVENUE_YOY_CHANGE_PCT
+        FROM ${ED_SCHEMA}.NORTH_STAR_EVENT_GROWTH
+        WHERE FOUNDATION_SLUG = ?
+      `;
+
+      const topEventsQuery = `
+        SELECT QUARTER_START_DATE, EVENT_NAME, EVENT_DATE,
+               ATTENDEE_COUNT, REGISTRANT_COUNT, EVENT_REVENUE, EVENT_RANK
+        FROM ${ED_SCHEMA}.EVENT_GROWTH_TOP_EVENTS
+        WHERE FOUNDATION_SLUG = ?
+        ORDER BY QUARTER_START_DATE DESC, EVENT_RANK
+        LIMIT 10
+      `;
+
+      const [summaryResult, topEventsResult] = await Promise.all([
+        this.snowflakeService.execute<{
+          EVENT_COUNT_YTD: number;
+          ATTENDEE_COUNT_YTD: number;
+          REGISTRANT_COUNT_YTD: number;
+          TOTAL_NET_REVENUE_YTD: number;
+          EVENT_COUNT_YOY_CHANGE_PCT: number;
+          ATTENDEE_COUNT_YOY_CHANGE_PCT: number;
+          REVENUE_YOY_CHANGE_PCT: number;
+        }>(summaryQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          QUARTER_START_DATE: string | Date;
+          EVENT_NAME: string;
+          EVENT_DATE: string;
+          ATTENDEE_COUNT: number;
+          REGISTRANT_COUNT: number;
+          EVENT_REVENUE: number;
+          EVENT_RANK: number;
+        }>(topEventsQuery, [foundationSlug]),
+      ]);
+
+      if (summaryResult.rows.length === 0) {
+        return defaultResponse;
+      }
+
+      const summary = summaryResult.rows[0];
+      const totalAttendees = summary.ATTENDEE_COUNT_YTD ?? 0;
+      const totalEvents = summary.EVENT_COUNT_YTD ?? 0;
+      const totalRevenue = summary.TOTAL_NET_REVENUE_YTD ?? 0;
+      const yoyAttendeeChange = summary.ATTENDEE_COUNT_YOY_CHANGE_PCT ?? 0;
+      const yoyRevenueChange = summary.REVENUE_YOY_CHANGE_PCT ?? 0;
+
+      const topEvents: EventGrowthTopEvent[] = topEventsResult.rows.map((row) => ({
+        name: row.EVENT_NAME ?? '',
+        date: row.EVENT_DATE ?? '',
+        attendees: row.ATTENDEE_COUNT ?? 0,
+        revenue: row.EVENT_REVENUE ?? 0,
+      }));
+
+      // Aggregate attendees by quarter for sparkline
+      const quarterMap = new Map<string, number>();
+      for (const row of topEventsResult.rows) {
+        const raw = row.QUARTER_START_DATE;
+        const q = raw instanceof Date ? raw.toISOString().substring(0, 10) : String(raw ?? '');
+        if (q) {
+          quarterMap.set(q, (quarterMap.get(q) ?? 0) + (row.ATTENDEE_COUNT ?? 0));
+        }
+      }
+      const monthlyData = [...quarterMap.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([quarter, value]) => ({ month: quarter.substring(0, 7), value }));
+
+      return {
+        totalAttendees,
+        totalEvents,
+        totalRevenue,
+        revenuePerAttendee: totalAttendees > 0 ? Number((totalRevenue / totalAttendees).toFixed(2)) : 0,
+        attendeeMomChange: yoyAttendeeChange,
+        revenueMomChange: yoyRevenueChange,
+        trend: yoyAttendeeChange >= 0 ? 'up' : 'down',
+        monthlyData,
+        topEvents,
+      };
+    } catch (error) {
+      logger.warning(undefined, 'get_event_growth', 'Failed to fetch event growth from Snowflake', {
+        foundation_slug: foundationSlug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return defaultResponse;
     }
   }
 }

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2897,3 +2897,29 @@ export interface FlywheelConversionResponse {
   };
   monthlyData: NorthStarMonthlyDataPoint[];
 }
+
+/**
+ * Top event row for Event Growth drill-down
+ */
+export interface EventGrowthTopEvent {
+  name: string;
+  date: string;
+  attendees: number;
+  revenue: number;
+}
+
+/**
+ * API response for Event Growth metric
+ * Total event attendees, event count, revenue, MoM growth, top events
+ */
+export interface EventGrowthResponse {
+  totalAttendees: number;
+  totalEvents: number;
+  totalRevenue: number;
+  revenuePerAttendee: number;
+  attendeeMomChange: number;
+  revenueMomChange: number;
+  trend: 'up' | 'down';
+  monthlyData: NorthStarMonthlyDataPoint[];
+  topEvents: EventGrowthTopEvent[];
+}


### PR DESCRIPTION
## Summary
- Add Event Growth vertical slice for the ED dashboard
- **Shared interfaces**: `EventGrowthResponse`, `EventGrowthTopEvent` in `@lfx-one/shared`
- **Backend**: Snowflake query (`NORTH_STAR_EVENT_GROWTH` + `EVENT_GROWTH_TOP_EVENTS`), controller, route
- **Frontend**: Angular HTTP service method + drawer component with quarterly attendance chart and top events table
- Adds `ED_SCHEMA` constant for configurable Snowflake schema prefix

## Test plan
- [ ] Verify `/api/analytics/event-growth?foundationSlug=tlf` returns valid JSON
- [ ] Verify drawer renders with summary stats, quarterly chart, and top events table
- [ ] Confirm empty state renders gracefully when no data exists
- [ ] Build passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)