### PR TITLE
feat(ed-dashboard): add brand reach card (LFXV2-1468)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
@@ -1,0 +1,129 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="brand-reach-drawer">
+  <!-- Header -->
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full" data-testid="brand-reach-drawer-header">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="brand-reach-drawer-title">Brand Reach</h2>
+        <p class="text-sm text-gray-500">Executive Director · Brand Metric</p>
+      </div>
+      <lfx-button
+        icon="fa-light fa-xmark"
+        [text]="true"
+        [rounded]="true"
+        severity="secondary"
+        ariaLabel="Close panel"
+        (onClick)="onClose()"
+        data-testid="brand-reach-drawer-close" />
+    </div>
+  </ng-template>
+
+  <!-- Content -->
+  <div class="flex flex-col gap-6 pb-2" data-testid="brand-reach-drawer-content">
+    <!-- Summary Stats -->
+    <div class="flex gap-4" data-testid="brand-reach-drawer-stats">
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Social Followers</span>
+          @if (data().totalSocialFollowers > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().totalSocialFollowers | number }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Monthly Sessions</span>
+          @if (data().totalMonthlySessions > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().totalMonthlySessions | number }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Active Platforms</span>
+          @if (data().activePlatforms > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().activePlatforms }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+    </div>
+
+    <!-- Social Followers by Platform -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-social-platforms">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Social Followers by Platform</h3>
+        <p class="text-sm text-gray-600">Follower count across active social channels</p>
+      </div>
+      @if (socialPlatformViews().length > 0) {
+        <div class="flex flex-col gap-0">
+          @for (platform of socialPlatformViews(); track platform.name) {
+            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-reach-drawer-platform-row">
+              <div class="flex items-center gap-3">
+                <i [class]="platform.icon + ' ' + platform.colorClass + ' text-lg w-5 text-center'"></i>
+                <span class="text-sm font-medium text-gray-900">{{ platform.name }}</span>
+              </div>
+              <span class="text-sm font-semibold text-gray-900">{{ platform.followers | number }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-platforms-empty">
+          Social platform data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Website Sessions by Domain -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-website-sessions">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Website Sessions by Domain</h3>
+        <p class="text-sm text-gray-600">Monthly sessions across foundation web properties</p>
+      </div>
+      @if (data().websiteDomains.length > 0) {
+        <div class="flex flex-col gap-0">
+          @for (site of data().websiteDomains; track site.domain) {
+            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-reach-drawer-domain-row">
+              <span class="text-sm font-medium text-gray-900">{{ site.domain }}</span>
+              <span class="text-sm font-semibold text-gray-900">{{ site.sessions | number }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-domains-empty">
+          Website domain data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Daily Sessions Trend -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-daily-trend">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Daily Sessions Trend</h3>
+        <p class="text-sm text-gray-600">Website sessions over the last 30 days</p>
+      </div>
+      @if (data().dailyTrend.length > 0) {
+        <div class="h-[240px]" data-testid="brand-reach-drawer-daily-chart">
+          <lfx-chart type="line" [data]="dailyTrendData()" [options]="dailyTrendOptions" height="100%"></lfx-chart>
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="brand-reach-drawer-daily-empty">
+          Daily trend data not yet available
+        </div>
+      }
+    </div>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
@@ -1,0 +1,111 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { ChartComponent } from '@components/chart/chart.component';
+import { lfxColors, MARKETING_SOCIAL_PLATFORM_MAP } from '@lfx-one/shared/constants';
+import { hexToRgba } from '@lfx-one/shared/utils';
+import { DrawerModule } from 'primeng/drawer';
+
+import type { ChartData, ChartOptions } from 'chart.js';
+import type { BrandReachResponse, BrandReachSocialPlatform } from '@lfx-one/shared/interfaces';
+
+interface SocialPlatformView extends BrandReachSocialPlatform {
+  icon: string;
+  colorClass: string;
+}
+
+@Component({
+  selector: 'lfx-brand-reach-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonComponent, CardComponent, ChartComponent, DecimalPipe, DrawerModule],
+  templateUrl: './brand-reach-drawer.component.html',
+  styleUrl: './brand-reach-drawer.component.scss',
+})
+export class BrandReachDrawerComponent {
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  public readonly data = input<BrandReachResponse>({
+    totalSocialFollowers: 0,
+    totalMonthlySessions: 0,
+    activePlatforms: 0,
+    changePercentage: 0,
+    trend: 'up',
+    socialPlatforms: [],
+    websiteDomains: [],
+    dailyTrend: [],
+  });
+
+  // === Computed Signals ===
+  protected readonly socialPlatformViews: Signal<SocialPlatformView[]> = computed(() =>
+    this.data().socialPlatforms.map((platform) => {
+      const presentation = MARKETING_SOCIAL_PLATFORM_MAP[platform.platformType] ?? MARKETING_SOCIAL_PLATFORM_MAP.other;
+      return {
+        ...platform,
+        icon: presentation.icon,
+        colorClass: presentation.colorClass,
+      };
+    })
+  );
+
+  protected readonly dailyTrendData: Signal<ChartData<'line'>> = computed(() => {
+    const { dailyTrend } = this.data();
+    return {
+      labels: dailyTrend.map((d) => d.day),
+      datasets: [
+        {
+          data: dailyTrend.map((d) => d.sessions),
+          borderColor: lfxColors.blue[500],
+          backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
+          fill: true,
+          tension: 0.4,
+          borderWidth: 2,
+          pointRadius: 0,
+        },
+      ],
+    };
+  });
+
+  protected readonly dailyTrendOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: true, mode: 'index', intersect: false },
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: { display: false },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          maxTicksLimit: 6,
+        },
+      },
+      y: {
+        display: true,
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: false },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          callback: (value) => {
+            const num = Number(value);
+            if (num >= 1_000) return `${(num / 1_000).toFixed(0)}K`;
+            return String(num);
+          },
+        },
+      },
+    },
+  };
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
@@ -22,7 +22,10 @@
           <div class="flex items-center gap-2 flex-wrap">
             <h3 class="text-sm font-semibold text-gray-900 leading-snug" data-testid="training-card-name">{{ training().name }}</h3>
             @if (training().level) {
-              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" [ngClass]="levelClasses()" data-testid="training-card-level-badge">
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                [ngClass]="levelClasses()"
+                data-testid="training-card-level-badge">
                 {{ training().level }}
               </span>
             }

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
@@ -107,7 +107,7 @@
               <div data-testid="trainings-ongoing-section">
                 <h2 class="text-base font-semibold text-gray-800 pb-3 mb-4 border-b border-gray-200">Ongoing trainings</h2>
                 <div class="flex flex-col gap-4" data-testid="trainings-ongoing-list">
-                  @for (enrollment of (enrollments() ?? []); track enrollment.id) {
+                  @for (enrollment of enrollments() ?? []; track enrollment.id) {
                     <lfx-training-card [training]="enrollment" variant="ongoing" data-testid="training-card-item" />
                   }
                 </div>
@@ -118,7 +118,7 @@
               <div data-testid="trainings-completed-section">
                 <h2 class="text-base font-semibold text-gray-800 pb-3 mb-4 border-b border-gray-200">Completed trainings</h2>
                 <div class="flex flex-col gap-4" data-testid="trainings-completed-list">
-                  @for (cert of (completedTrainings() ?? []); track cert.id) {
+                  @for (cert of completedTrainings() ?? []; track cert.id) {
                     <lfx-training-card [training]="cert" variant="completed" data-testid="training-completed-item" />
                   }
                 </div>

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -56,6 +56,7 @@ import {
   SocialMediaResponse,
   SocialReachResponse,
   WebActivitiesSummaryResponse,
+  BrandReachResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
 
@@ -966,6 +967,26 @@ export class AnalyticsService {
             convertedToWorkingGroup: 0,
           },
           monthlyData: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get brand reach metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getBrandReach(foundationSlug: string): Observable<BrandReachResponse> {
+    return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          totalSocialFollowers: 0,
+          totalMonthlySessions: 0,
+          activePlatforms: 0,
+          changePercentage: 0,
+          trend: 'up' as const,
+          socialPlatforms: [],
+          websiteDomains: [],
+          dailyTrend: [],
         });
       })
     );

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2160,4 +2160,42 @@ export class AnalyticsController {
       next(error);
     }
   }
+
+  /**
+   * GET /api/analytics/brand-reach
+   * Get brand reach metrics (total digital reach across social + owned sites)
+   */
+  public async getBrandReach(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_brand_reach');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_brand_reach',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_brand_reach',
+        });
+      }
+
+      const response = await this.projectService.getBrandReach(foundationSlug);
+
+      logger.success(req, 'get_brand_reach', startTime, {
+        foundation_slug: foundationSlug,
+        total_social_followers: response.totalSocialFollowers,
+        total_monthly_sessions: response.totalMonthlySessions,
+        social_platforms: response.socialPlatforms.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_brand_reach', startTime, error);
+      next(error);
+    }
+  }
 }

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -148,5 +148,6 @@ router.get('/member-retention', (req, res, next) => analyticsController.getMembe
 router.get('/member-acquisition', (req, res, next) => analyticsController.getMemberAcquisition(req, res, next));
 router.get('/engaged-community', (req, res, next) => analyticsController.getEngagedCommunity(req, res, next));
 router.get('/flywheel-conversion', (req, res, next) => analyticsController.getFlywheelConversion(req, res, next));
+router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -71,6 +71,8 @@ import {
   EngagedCommunitySizeResponse,
   FlywheelConversionResponse,
   NorthStarMonthlyDataPoint,
+  BrandReachResponse,
+  BrandReachPlatformType,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -82,6 +84,13 @@ import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { NatsService } from './nats.service';
 import { SnowflakeService } from './snowflake.service';
+
+/**
+ * Schema prefix for ED dashboard dbt views.
+ * Defaults to production; set SNOWFLAKE_ED_SCHEMA env var to use dev views for testing.
+ * Example: SNOWFLAKE_ED_SCHEMA=ANALYTICS_DEV.DEV_MRAUTELA_PLATINUM_LFX_ONE
+ */
+const ED_SCHEMA = process.env['SNOWFLAKE_ED_SCHEMA'] || 'ANALYTICS.PLATINUM_LFX_ONE';
 
 /**
  * Service for handling project business logic
@@ -2527,6 +2536,120 @@ export class ProjectService {
         },
         monthlyData: [],
       };
+    }
+  }
+
+  /**
+   * Get brand reach metrics from Snowflake
+   * Combines SOCIAL_MEDIA_OVERVIEW (followers) and WEB_ACTIVITIES_SUMMARY (sessions)
+   */
+  public async getBrandReach(foundationSlug: string): Promise<BrandReachResponse> {
+    logger.debug(undefined, 'get_brand_reach', 'Fetching brand reach from Snowflake', { foundation_slug: foundationSlug });
+
+    const defaultResponse: BrandReachResponse = {
+      totalSocialFollowers: 0,
+      totalMonthlySessions: 0,
+      activePlatforms: 0,
+      changePercentage: 0,
+      trend: 'up',
+      socialPlatforms: [],
+      websiteDomains: [],
+      dailyTrend: [],
+    };
+
+    try {
+      const webQuery = `
+        SELECT LF_SUB_DOMAIN_CLASSIFICATION,
+               SUM(TOTAL_SESSIONS_LAST_30_DAYS) AS TOTAL_SESSIONS
+        FROM ${ED_SCHEMA}.WEB_ACTIVITIES_SUMMARY
+        WHERE FOUNDATION_SLUG = ?
+        GROUP BY LF_SUB_DOMAIN_CLASSIFICATION
+        ORDER BY TOTAL_SESSIONS DESC
+      `;
+
+      const dailyQuery = `
+        SELECT ACTIVITY_DATE, SUM(DAILY_SESSIONS) AS DAILY_SESSIONS
+        FROM ${ED_SCHEMA}.WEB_ACTIVITIES_BY_PROJECT
+        WHERE FOUNDATION_SLUG = ?
+          AND ACTIVITY_DATE >= DATEADD('DAY', -30, CURRENT_DATE())
+        GROUP BY ACTIVITY_DATE
+        ORDER BY ACTIVITY_DATE ASC
+      `;
+
+      const [webResult, dailyResult] = await Promise.all([
+        this.snowflakeService.execute<{ LF_SUB_DOMAIN_CLASSIFICATION: string; TOTAL_SESSIONS: number }>(webQuery, [foundationSlug]),
+        this.snowflakeService.execute<{ ACTIVITY_DATE: string; DAILY_SESSIONS: number }>(dailyQuery, [foundationSlug]),
+      ]);
+
+      let totalSocialFollowers = 0;
+      let socialPlatforms: BrandReachResponse['socialPlatforms'] = [];
+      try {
+        const [socialResult, socialPlatformResult] = await Promise.all([
+          this.snowflakeService.execute<{ TOTAL_FOLLOWERS: number; PLATFORMS_ACTIVE: number }>(
+            `SELECT TOTAL_FOLLOWERS, PLATFORMS_ACTIVE
+             FROM ${ED_SCHEMA}.SOCIAL_MEDIA_OVERVIEW WHERE FOUNDATION_SLUG = ?`,
+            [foundationSlug]
+          ),
+          this.snowflakeService.execute<{ PLATFORM_NAME: string; FOLLOWERS: number }>(
+            `SELECT PLATFORM_NAME, FOLLOWERS
+             FROM ${ED_SCHEMA}.SOCIAL_MEDIA_PLATFORM_BREAKDOWN WHERE FOUNDATION_SLUG = ?
+             ORDER BY FOLLOWERS DESC`,
+            [foundationSlug]
+          ),
+        ]);
+
+        totalSocialFollowers = socialResult.rows.length > 0 ? (socialResult.rows[0].TOTAL_FOLLOWERS ?? 0) : 0;
+
+        const platformMap: Record<string, BrandReachPlatformType> = {
+          LinkedIn: 'linkedin',
+          Twitter: 'twitter',
+          'Twitter/X': 'twitter',
+          YouTube: 'youtube',
+          Facebook: 'facebook',
+          Mastodon: 'mastodon',
+        };
+        socialPlatforms = socialPlatformResult.rows.map((row) => ({
+          name: row.PLATFORM_NAME ?? 'Other',
+          platformType: platformMap[row.PLATFORM_NAME] || ('other' as BrandReachPlatformType),
+          followers: row.FOLLOWERS ?? 0,
+        }));
+      } catch (socialError) {
+        logger.debug(undefined, 'get_brand_reach', 'Social media query failed, returning web-only data', {
+          error: socialError instanceof Error ? socialError.message : 'Unknown error',
+        });
+      }
+
+      const websiteDomains = webResult.rows.map((row) => ({
+        domain: row.LF_SUB_DOMAIN_CLASSIFICATION || 'Other',
+        sessions: row.TOTAL_SESSIONS ?? 0,
+      }));
+
+      const totalMonthlySessions = websiteDomains.reduce((sum, d) => sum + d.sessions, 0);
+
+      const dailyTrend = dailyResult.rows.map((row) => {
+        const date = new Date(row.ACTIVITY_DATE);
+        return {
+          day: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+          sessions: row.DAILY_SESSIONS ?? 0,
+        };
+      });
+
+      return {
+        totalSocialFollowers,
+        totalMonthlySessions,
+        activePlatforms: socialPlatforms.length,
+        changePercentage: 0,
+        trend: 'up',
+        socialPlatforms,
+        websiteDomains,
+        dailyTrend,
+      };
+    } catch (error) {
+      logger.warning(undefined, 'get_brand_reach', 'Failed to fetch brand reach from Snowflake', {
+        foundation_slug: foundationSlug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return defaultResponse;
     }
   }
 }

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DashboardDrawerType, MarketingActionType } from '../interfaces';
+import { BrandReachPlatformType, DashboardDrawerType, MarketingActionType } from '../interfaces';
 import { hexToRgba } from '../utils';
 import { EMPTY_CHART_DATA, NO_TOOLTIP_CHART_OPTIONS } from './chart-options.constants';
 import { lfxColors } from './colors.constants';
@@ -27,6 +27,19 @@ export const MARKETING_ACTION_ICON_MAP: Record<MarketingActionType, string> = {
   optimize: 'fa-light fa-bullseye-pointer',
   investigate: 'fa-light fa-magnifying-glass-chart',
   monitor: 'fa-light fa-circle-info',
+};
+
+/**
+ * Maps social platform types to Font Awesome icon + Tailwind color classes.
+ * Keeps presentation out of Brand Reach data interfaces.
+ */
+export const MARKETING_SOCIAL_PLATFORM_MAP: Record<BrandReachPlatformType, { icon: string; colorClass: string }> = {
+  linkedin: { icon: 'fa-brands fa-linkedin', colorClass: 'text-blue-700' },
+  twitter: { icon: 'fa-brands fa-x-twitter', colorClass: 'text-gray-900' },
+  youtube: { icon: 'fa-brands fa-youtube', colorClass: 'text-red-600' },
+  facebook: { icon: 'fa-brands fa-facebook', colorClass: 'text-blue-600' },
+  mastodon: { icon: 'fa-brands fa-mastodon', colorClass: 'text-purple-600' },
+  other: { icon: 'fa-light fa-hashtag', colorClass: 'text-gray-500' },
 };
 
 // ============================================

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2897,3 +2897,50 @@ export interface FlywheelConversionResponse {
   };
   monthlyData: NorthStarMonthlyDataPoint[];
 }
+
+/**
+ * Social platform identifier — maps to a presentation icon + color in the component layer
+ * New platforms must be added to MARKETING_SOCIAL_PLATFORM_MAP in the component constants
+ */
+export type BrandReachPlatformType = 'linkedin' | 'twitter' | 'youtube' | 'facebook' | 'mastodon' | 'other';
+
+/**
+ * Social platform row for Brand Reach drill-down
+ * Icon + color mapping is handled in the component, not the data layer
+ */
+export interface BrandReachSocialPlatform {
+  name: string;
+  platformType: BrandReachPlatformType;
+  followers: number;
+}
+
+/**
+ * Website domain row for Brand Reach drill-down
+ */
+export interface BrandReachWebsiteDomain {
+  domain: string;
+  sessions: number;
+}
+
+/**
+ * Daily sessions data point for Brand Reach drill-down
+ */
+export interface BrandReachDailyDataPoint {
+  day: string;
+  sessions: number;
+}
+
+/**
+ * API response for Brand Reach metric
+ * Digital reach across social platforms and owned websites
+ */
+export interface BrandReachResponse {
+  totalSocialFollowers: number;
+  totalMonthlySessions: number;
+  activePlatforms: number;
+  changePercentage: number;
+  trend: 'up' | 'down';
+  socialPlatforms: BrandReachSocialPlatform[];
+  websiteDomains: BrandReachWebsiteDomain[];
+  dailyTrend: BrandReachDailyDataPoint[];
+}


### PR DESCRIPTION
## Summary
- Add Brand Reach vertical slice for the ED dashboard
- **Shared interfaces**: `BrandReachResponse`, `BrandReachSocialPlatform`, `BrandReachWebsiteDomain`, `BrandReachDailyDataPoint`, `BrandReachPlatformType`
- **Shared constants**: `MARKETING_SOCIAL_PLATFORM_MAP` for platform icon/color mapping
- **Backend**: Snowflake queries combining `WEB_ACTIVITIES_SUMMARY`, `WEB_ACTIVITIES_BY_PROJECT`, `SOCIAL_MEDIA_OVERVIEW`, `SOCIAL_MEDIA_PLATFORM_BREAKDOWN`
- **Frontend**: Angular HTTP service method + drawer component with social followers list, website sessions by domain, and daily sessions trend chart

## Test plan
- [ ] Verify `/api/analytics/brand-reach?foundationSlug=tlf` returns valid JSON
- [ ] Verify drawer renders social platform rows with correct icons
- [ ] Verify website sessions list and daily trend line chart render
- [ ] Confirm empty states render gracefully
- [ ] Build passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)