### PR TITLE
feat(ed-dashboard): add brand health card (LFXV2-1468)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -1,0 +1,140 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="brand-health-drawer">
+  <!-- Header -->
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full" data-testid="brand-health-drawer-header">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="brand-health-drawer-title">Brand Health</h2>
+        <p class="text-sm text-gray-500">Executive Director · Brand Metric</p>
+      </div>
+      <lfx-button
+        icon="fa-light fa-xmark"
+        [text]="true"
+        [rounded]="true"
+        severity="secondary"
+        ariaLabel="Close panel"
+        (onClick)="onClose()"
+        data-testid="brand-health-drawer-close" />
+    </div>
+  </ng-template>
+
+  <!-- Content -->
+  <div class="flex flex-col gap-6 pb-2" data-testid="brand-health-drawer-content">
+    <!-- Summary Stats -->
+    <div class="flex gap-4" data-testid="brand-health-drawer-stats">
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Total Mentions</span>
+          @if (data().totalMentions > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().totalMentions | number }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Positive Sentiment</span>
+          @if (data().sentiment.positive > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ data().sentiment.positive.toFixed(1) }}%</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">MoM Growth</span>
+          @if (data().sentimentMomChangePp !== 0) {
+            <span
+              class="text-2xl font-semibold"
+              [class.text-green-600]="data().sentimentMomChangePp > 0"
+              [class.text-red-600]="data().sentimentMomChangePp < 0">
+              {{ data().sentimentMomChangePp > 0 ? '+' : '' }}{{ data().sentimentMomChangePp.toFixed(1) }}pp
+            </span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+          }
+        </div>
+      </lfx-card>
+    </div>
+
+    <!-- Mentions Trend -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-health-drawer-mentions-trend">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Mentions Trend</h3>
+        <p class="text-sm text-gray-600">Total brand mentions over the last 6 months (Octolens)</p>
+      </div>
+      @if (data().monthlyMentions.length > 0) {
+        <div class="h-[240px]" data-testid="brand-health-drawer-mentions-chart">
+          <lfx-chart type="line" [data]="mentionsTrendData()" [options]="mentionsTrendOptions" height="100%"></lfx-chart>
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="brand-health-drawer-mentions-empty">
+          Mentions trend data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Sentiment Breakdown -->
+    <div class="flex flex-col gap-4" data-testid="brand-health-drawer-sentiment">
+      <h3 class="text-sm font-semibold text-gray-900">Sentiment Breakdown</h3>
+      @if (data().sentiment.positive + data().sentiment.neutral + data().sentiment.negative > 0) {
+        <div class="flex gap-4">
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Positive</span>
+              <span class="text-2xl font-semibold text-green-600">{{ data().sentiment.positive.toFixed(1) }}%</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Neutral</span>
+              <span class="text-2xl font-semibold text-gray-600">{{ data().sentiment.neutral.toFixed(1) }}%</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Negative</span>
+              <span class="text-2xl font-semibold text-red-600">{{ data().sentiment.negative.toFixed(1) }}%</span>
+            </div>
+          </lfx-card>
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-health-drawer-sentiment-empty">
+          Sentiment data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Top Mentioned Projects -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-health-drawer-top-projects">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Top Mentioned Projects</h3>
+        <p class="text-sm text-gray-600">Projects with the most brand mentions in the last 30 days</p>
+      </div>
+      @if (data().topProjects.length > 0) {
+        <div class="flex flex-col gap-0">
+          @for (project of data().topProjects; track project.name) {
+            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-health-drawer-project-row">
+              <span class="text-sm font-medium text-gray-900">{{ project.name }}</span>
+              <span class="text-sm font-semibold text-gray-900">{{ project.mentions | number }}</span>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-health-drawer-top-projects-empty">
+          Top projects data not yet available
+        </div>
+      }
+    </div>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -1,0 +1,90 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { ChartComponent } from '@components/chart/chart.component';
+import { lfxColors } from '@lfx-one/shared/constants';
+import { hexToRgba } from '@lfx-one/shared/utils';
+import { DrawerModule } from 'primeng/drawer';
+
+import type { ChartData, ChartOptions } from 'chart.js';
+import type { BrandHealthResponse } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-brand-health-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonComponent, CardComponent, ChartComponent, DecimalPipe, DrawerModule],
+  templateUrl: './brand-health-drawer.component.html',
+  styleUrl: './brand-health-drawer.component.scss',
+})
+export class BrandHealthDrawerComponent {
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  public readonly data = input<BrandHealthResponse>({
+    totalMentions: 0,
+    sentiment: { positive: 0, neutral: 0, negative: 0 },
+    sentimentMomChangePp: 0,
+    trend: 'up',
+    monthlyMentions: [],
+    topProjects: [],
+  });
+
+  // === Computed Signals ===
+  protected readonly mentionsTrendData: Signal<ChartData<'line'>> = computed(() => {
+    const { monthlyMentions } = this.data();
+    return {
+      labels: monthlyMentions.map((d) => d.month),
+      datasets: [
+        {
+          data: monthlyMentions.map((d) => d.value),
+          borderColor: lfxColors.blue[500],
+          backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
+          fill: true,
+          tension: 0.4,
+          borderWidth: 2,
+          pointRadius: 4,
+          pointBackgroundColor: lfxColors.blue[500],
+        },
+      ],
+    };
+  });
+
+  protected readonly mentionsTrendOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: true, mode: 'index', intersect: false },
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: { display: false },
+        ticks: { color: lfxColors.gray[500], font: { size: 11 } },
+      },
+      y: {
+        display: true,
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: false },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          callback: (value) => {
+            const num = Number(value);
+            if (num >= 1_000) return `${(num / 1_000).toFixed(1)}K`;
+            return String(num);
+          },
+        },
+      },
+    },
+  };
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
@@ -22,7 +22,10 @@
           <div class="flex items-center gap-2 flex-wrap">
             <h3 class="text-sm font-semibold text-gray-900 leading-snug" data-testid="training-card-name">{{ training().name }}</h3>
             @if (training().level) {
-              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" [ngClass]="levelClasses()" data-testid="training-card-level-badge">
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                [ngClass]="levelClasses()"
+                data-testid="training-card-level-badge">
                 {{ training().level }}
               </span>
             }

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
@@ -107,7 +107,7 @@
               <div data-testid="trainings-ongoing-section">
                 <h2 class="text-base font-semibold text-gray-800 pb-3 mb-4 border-b border-gray-200">Ongoing trainings</h2>
                 <div class="flex flex-col gap-4" data-testid="trainings-ongoing-list">
-                  @for (enrollment of (enrollments() ?? []); track enrollment.id) {
+                  @for (enrollment of enrollments() ?? []; track enrollment.id) {
                     <lfx-training-card [training]="enrollment" variant="ongoing" data-testid="training-card-item" />
                   }
                 </div>
@@ -118,7 +118,7 @@
               <div data-testid="trainings-completed-section">
                 <h2 class="text-base font-semibold text-gray-800 pb-3 mb-4 border-b border-gray-200">Completed trainings</h2>
                 <div class="flex flex-col gap-4" data-testid="trainings-completed-list">
-                  @for (cert of (completedTrainings() ?? []); track cert.id) {
+                  @for (cert of completedTrainings() ?? []; track cert.id) {
                     <lfx-training-card [training]="cert" variant="completed" data-testid="training-completed-item" />
                   }
                 </div>

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -56,6 +56,7 @@ import {
   SocialMediaResponse,
   SocialReachResponse,
   WebActivitiesSummaryResponse,
+  BrandHealthResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
 
@@ -966,6 +967,24 @@ export class AnalyticsService {
             convertedToWorkingGroup: 0,
           },
           monthlyData: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get brand health metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getBrandHealth(foundationSlug: string): Observable<BrandHealthResponse> {
+    return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          totalMentions: 0,
+          sentiment: { positive: 0, neutral: 0, negative: 0 },
+          sentimentMomChangePp: 0,
+          trend: 'up' as const,
+          monthlyMentions: [],
+          topProjects: [],
         });
       })
     );

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2160,4 +2160,42 @@ export class AnalyticsController {
       next(error);
     }
   }
+
+  /**
+   * GET /api/analytics/brand-health
+   * Get brand health metrics (share of voice, sentiment, press mentions)
+   */
+  public async getBrandHealth(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_brand_health');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_brand_health',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_brand_health',
+        });
+      }
+
+      const response = await this.projectService.getBrandHealth(foundationSlug);
+
+      logger.success(req, 'get_brand_health', startTime, {
+        foundation_slug: foundationSlug,
+        total_mentions: response.totalMentions,
+        positive_sentiment: response.sentiment.positive,
+        top_projects: response.topProjects.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_brand_health', startTime, error);
+      next(error);
+    }
+  }
 }

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -148,5 +148,6 @@ router.get('/member-retention', (req, res, next) => analyticsController.getMembe
 router.get('/member-acquisition', (req, res, next) => analyticsController.getMemberAcquisition(req, res, next));
 router.get('/engaged-community', (req, res, next) => analyticsController.getEngagedCommunity(req, res, next));
 router.get('/flywheel-conversion', (req, res, next) => analyticsController.getFlywheelConversion(req, res, next));
+router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -71,6 +71,8 @@ import {
   EngagedCommunitySizeResponse,
   FlywheelConversionResponse,
   NorthStarMonthlyDataPoint,
+  BrandHealthResponse,
+  BrandHealthTopProject,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -82,6 +84,13 @@ import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { NatsService } from './nats.service';
 import { SnowflakeService } from './snowflake.service';
+
+/**
+ * Schema prefix for ED dashboard dbt views.
+ * Defaults to production; set SNOWFLAKE_ED_SCHEMA env var to use dev views for testing.
+ * Example: SNOWFLAKE_ED_SCHEMA=ANALYTICS_DEV.DEV_MRAUTELA_PLATINUM_LFX_ONE
+ */
+const ED_SCHEMA = process.env['SNOWFLAKE_ED_SCHEMA'] || 'ANALYTICS.PLATINUM_LFX_ONE';
 
 /**
  * Service for handling project business logic
@@ -2527,6 +2536,119 @@ export class ProjectService {
         },
         monthlyData: [],
       };
+    }
+  }
+
+  /**
+   * Get brand health metrics from Snowflake (Share of Voice)
+   * Queries ${ED_SCHEMA}.SHARE_OF_VOICE, SHARE_OF_VOICE_MONTHLY_TREND, SHARE_OF_VOICE_TOP_PROJECTS
+   */
+  public async getBrandHealth(foundationSlug: string): Promise<BrandHealthResponse> {
+    logger.debug(undefined, 'get_brand_health', 'Fetching brand health (Share of Voice) from Snowflake', { foundation_slug: foundationSlug });
+
+    const defaultResponse: BrandHealthResponse = {
+      totalMentions: 0,
+      sentiment: { positive: 0, neutral: 0, negative: 0 },
+      sentimentMomChangePp: 0,
+      trend: 'up',
+      monthlyMentions: [],
+      topProjects: [],
+    };
+
+    try {
+      const sovSummaryQuery = `
+        SELECT SUM(TOTAL_MENTIONS_30D) AS TOTAL_MENTIONS,
+               SUM(POSITIVE_MENTIONS_30D) AS POSITIVE,
+               SUM(NEGATIVE_MENTIONS_30D) AS NEGATIVE,
+               SUM(NEUTRAL_MENTIONS_30D) AS NEUTRAL,
+               CASE WHEN SUM(TOTAL_MENTIONS_30D) > 0
+                   THEN ROUND(SUM(POSITIVE_MENTIONS_30D)::FLOAT / SUM(TOTAL_MENTIONS_30D)::FLOAT * 100, 2)
+                   ELSE 0
+               END AS POSITIVE_PCT,
+               CASE WHEN SUM(TOTAL_MENTIONS_30D) > 0
+                   THEN ROUND(SUM(NEGATIVE_MENTIONS_30D)::FLOAT / SUM(TOTAL_MENTIONS_30D)::FLOAT * 100, 2)
+                   ELSE 0
+               END AS NEGATIVE_PCT
+        FROM ${ED_SCHEMA}.SHARE_OF_VOICE
+        WHERE FOUNDATION_SLUG = ?
+      `;
+
+      const monthlyTrendQuery = `
+        SELECT MONTH_START_DATE, MENTION_COUNT, MOM_CHANGE_PCT
+        FROM ${ED_SCHEMA}.SHARE_OF_VOICE_MONTHLY_TREND
+        WHERE FOUNDATION_SLUG = ?
+        ORDER BY MONTH_START_DATE DESC
+        LIMIT 12
+      `;
+
+      const topProjectsQuery = `
+        SELECT PROJECT_NAME, MENTION_COUNT_30D, PROJECT_RANK
+        FROM ${ED_SCHEMA}.SHARE_OF_VOICE_TOP_PROJECTS
+        WHERE FOUNDATION_SLUG = ?
+        ORDER BY PROJECT_RANK
+        LIMIT 5
+      `;
+
+      const [summaryResult, trendResult, projectsResult] = await Promise.all([
+        this.snowflakeService.execute<{
+          TOTAL_MENTIONS: number;
+          POSITIVE: number;
+          NEGATIVE: number;
+          NEUTRAL: number;
+          POSITIVE_PCT: number;
+          NEGATIVE_PCT: number;
+        }>(sovSummaryQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          MONTH_START_DATE: string;
+          MENTION_COUNT: number;
+          MOM_CHANGE_PCT: number;
+        }>(monthlyTrendQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          PROJECT_NAME: string;
+          MENTION_COUNT_30D: number;
+          PROJECT_RANK: number;
+        }>(topProjectsQuery, [foundationSlug]),
+      ]);
+
+      if (summaryResult.rows.length === 0) {
+        return defaultResponse;
+      }
+
+      const summary = summaryResult.rows[0];
+      const totalMentions = summary.TOTAL_MENTIONS ?? 0;
+      const positivePct = summary.POSITIVE_PCT ?? 0;
+      const negativePct = summary.NEGATIVE_PCT ?? 0;
+      const neutralPct = Number(Math.max(0, 100 - positivePct - negativePct).toFixed(1));
+
+      const sentimentMomChangePp = trendResult.rows.length > 0 ? (trendResult.rows[0].MOM_CHANGE_PCT ?? 0) : 0;
+
+      const monthlyMentions: NorthStarMonthlyDataPoint[] = [...trendResult.rows].reverse().map((row) => {
+        const date = new Date(row.MONTH_START_DATE);
+        return {
+          month: date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' }),
+          value: row.MENTION_COUNT ?? 0,
+        };
+      });
+
+      const topProjects: BrandHealthTopProject[] = projectsResult.rows.map((row) => ({
+        name: row.PROJECT_NAME ?? '',
+        mentions: row.MENTION_COUNT_30D ?? 0,
+      }));
+
+      return {
+        totalMentions,
+        sentiment: { positive: positivePct, neutral: neutralPct, negative: negativePct },
+        sentimentMomChangePp,
+        trend: sentimentMomChangePp >= 0 ? 'up' : 'down',
+        monthlyMentions,
+        topProjects,
+      };
+    } catch (error) {
+      logger.warning(undefined, 'get_brand_health', 'Failed to fetch brand health from Snowflake', {
+        foundation_slug: foundationSlug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return defaultResponse;
     }
   }
 }

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2897,3 +2897,34 @@ export interface FlywheelConversionResponse {
   };
   monthlyData: NorthStarMonthlyDataPoint[];
 }
+
+/**
+ * Top project row for Brand Health drill-down
+ */
+export interface BrandHealthTopProject {
+  name: string;
+  mentions: number;
+}
+
+/**
+ * Sentiment breakdown for Brand Health drill-down
+ * Percentages out of 100
+ */
+export interface BrandHealthSentimentBreakdown {
+  positive: number;
+  neutral: number;
+  negative: number;
+}
+
+/**
+ * API response for Brand Health metric
+ * Total mentions, sentiment breakdown, monthly mentions trend, top projects
+ */
+export interface BrandHealthResponse {
+  totalMentions: number;
+  sentiment: BrandHealthSentimentBreakdown;
+  sentimentMomChangePp: number;
+  trend: 'up' | 'down';
+  monthlyMentions: NorthStarMonthlyDataPoint[];
+  topProjects: BrandHealthTopProject[];
+}


### PR DESCRIPTION
## Summary
- Add Brand Health vertical slice for the ED dashboard
- **Shared interfaces**: `BrandHealthResponse`, `BrandHealthSentimentBreakdown`, `BrandHealthTopProject`
- **Backend**: Snowflake queries for `SHARE_OF_VOICE`, `SHARE_OF_VOICE_MONTHLY_TREND`, `SHARE_OF_VOICE_TOP_PROJECTS`
- **Frontend**: Angular HTTP service method + drawer component with mentions trend chart, sentiment breakdown cards, and top mentioned projects list

## Test plan
- [ ] Verify `/api/analytics/brand-health?foundationSlug=tlf` returns valid JSON
- [ ] Verify drawer renders mentions trend chart and sentiment percentages
- [ ] Verify top projects list renders with mention counts
- [ ] Confirm empty states render gracefully
- [ ] Build passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)