### PR TITLE
feat(ed-dashboard): add revenue impact card

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.html
@@ -1,0 +1,171 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="revenue-impact-drawer">
+  <!-- Header -->
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full" data-testid="revenue-impact-drawer-header">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="revenue-impact-drawer-title">Attribution</h2>
+        <p class="text-sm text-gray-500">Executive Director · Influence Metric</p>
+      </div>
+      <lfx-button
+        icon="fa-light fa-xmark"
+        [text]="true"
+        [rounded]="true"
+        severity="secondary"
+        ariaLabel="Close panel"
+        (onClick)="onClose()"
+        data-testid="revenue-impact-drawer-close" />
+    </div>
+  </ng-template>
+
+  <!-- Content -->
+  <div class="flex flex-col gap-6 pb-2" data-testid="revenue-impact-drawer-content">
+    <!-- SECTION 1: Membership Growth Pipeline -->
+    <div class="flex flex-col gap-4" data-testid="revenue-impact-drawer-pipeline-section">
+      <h3 class="text-sm font-semibold text-gray-900">Membership Growth Pipeline</h3>
+      <div class="flex gap-4" data-testid="revenue-impact-drawer-stats">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Pipeline Influenced</span>
+            @if (data().pipelineInfluenced > 0) {
+              <span class="text-2xl font-semibold text-gray-900">${{ data().pipelineInfluenced / 1000000 | number: '1.1-1' }}M</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Revenue Attributed</span>
+            @if (data().revenueAttributed > 0) {
+              <span class="text-2xl font-semibold text-gray-900">${{ data().revenueAttributed / 1000000 | number: '1.1-1' }}M</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Match Rate</span>
+            @if (data().matchRate > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ data().matchRate.toFixed(1) }}%</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+    </div>
+
+    <!-- Deal Pipeline Breakdown -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="revenue-impact-drawer-engagement">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Deal Pipeline Breakdown</h3>
+        <p class="text-sm text-gray-600">Deal status distribution across the membership pipeline</p>
+      </div>
+      @if (data().engagementTypes.length > 0) {
+        <div class="flex flex-col gap-3">
+          @for (engagement of data().engagementTypes; track engagement.type) {
+            <div class="flex flex-col gap-1" data-testid="revenue-impact-drawer-engagement-row">
+              <div class="flex items-center justify-between">
+                <span class="text-sm font-medium text-gray-900">{{ engagement.type }}</span>
+                <span class="text-sm font-semibold text-gray-900">{{ engagement.percentage.toFixed(1) }}%</span>
+              </div>
+              <div class="w-full h-2 bg-gray-100 rounded-full">
+                <div class="h-2 bg-blue-500 rounded-full" [style.width.%]="engagement.percentage"></div>
+              </div>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="revenue-impact-drawer-engagement-empty">
+          Deal pipeline data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Attribution Model Comparison -->
+    @if (data().attributionModels.linear + data().attributionModels.firstTouch + data().attributionModels.lastTouch > 0) {
+      <div class="flex flex-col gap-4" data-testid="revenue-impact-drawer-attribution">
+        <h3 class="text-sm font-semibold text-gray-900">Attribution Model Comparison</h3>
+        <div class="flex gap-4">
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">First-Touch</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formatRevenue(data().attributionModels.firstTouch) }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Linear</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formatRevenue(data().attributionModels.linear) }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Last-Touch</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formatRevenue(data().attributionModels.lastTouch) }}</span>
+            </div>
+          </lfx-card>
+        </div>
+      </div>
+    }
+
+    <!-- SECTION 2: Paid Media (Marketing Attribution) -->
+    <div class="flex flex-col gap-4" data-testid="revenue-impact-drawer-paid-media">
+      <h3 class="text-sm font-semibold text-gray-900">Paid Media</h3>
+      <div class="flex gap-4">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">ROAS</span>
+            @if (data().paidMedia.roas > 0) {
+              <span class="text-2xl font-semibold text-green-600">{{ data().paidMedia.roas | number: '1.1-1' }}x</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Ad Revenue</span>
+            @if (data().paidMedia.adRevenue > 0) {
+              <span class="text-2xl font-semibold text-gray-900">${{ data().paidMedia.adRevenue | number }}</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+      <div class="flex gap-4">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Impressions</span>
+            @if (data().paidMedia.impressions > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ data().paidMedia.impressions | number }}</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Ad Spend</span>
+            @if (data().paidMedia.adSpend > 0) {
+              <span class="text-2xl font-semibold text-gray-900">${{ data().paidMedia.adSpend | number }}</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">&mdash;</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+    </div>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, input, model } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { DrawerModule } from 'primeng/drawer';
+
+import type { RevenueImpactResponse } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-revenue-impact-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule],
+  templateUrl: './revenue-impact-drawer.component.html',
+  styleUrl: './revenue-impact-drawer.component.scss',
+})
+export class RevenueImpactDrawerComponent {
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  public readonly data = input<RevenueImpactResponse>({
+    pipelineInfluenced: 0,
+    revenueAttributed: 0,
+    matchRate: 0,
+    changePercentage: 0,
+    trend: 'up',
+    attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+    engagementTypes: [],
+    paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0 },
+  });
+
+  protected formatRevenue(value: number): string {
+    if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+    return `$${value.toLocaleString()}`;
+  }
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
@@ -22,7 +22,10 @@
           <div class="flex items-center gap-2 flex-wrap">
             <h3 class="text-sm font-semibold text-gray-900 leading-snug" data-testid="training-card-name">{{ training().name }}</h3>
             @if (training().level) {
-              <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium" [ngClass]="levelClasses()" data-testid="training-card-level-badge">
+              <span
+                class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+                [ngClass]="levelClasses()"
+                data-testid="training-card-level-badge">
                 {{ training().level }}
               </span>
             }

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
@@ -107,7 +107,7 @@
               <div data-testid="trainings-ongoing-section">
                 <h2 class="text-base font-semibold text-gray-800 pb-3 mb-4 border-b border-gray-200">Ongoing trainings</h2>
                 <div class="flex flex-col gap-4" data-testid="trainings-ongoing-list">
-                  @for (enrollment of (enrollments() ?? []); track enrollment.id) {
+                  @for (enrollment of enrollments() ?? []; track enrollment.id) {
                     <lfx-training-card [training]="enrollment" variant="ongoing" data-testid="training-card-item" />
                   }
                 </div>
@@ -118,7 +118,7 @@
               <div data-testid="trainings-completed-section">
                 <h2 class="text-base font-semibold text-gray-800 pb-3 mb-4 border-b border-gray-200">Completed trainings</h2>
                 <div class="flex flex-col gap-4" data-testid="trainings-completed-list">
-                  @for (cert of (completedTrainings() ?? []); track cert.id) {
+                  @for (cert of completedTrainings() ?? []; track cert.id) {
                     <lfx-training-card [training]="cert" variant="completed" data-testid="training-completed-item" />
                   }
                 </div>

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -56,6 +56,7 @@ import {
   SocialMediaResponse,
   SocialReachResponse,
   WebActivitiesSummaryResponse,
+  RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
 
@@ -966,6 +967,26 @@ export class AnalyticsService {
             convertedToWorkingGroup: 0,
           },
           monthlyData: [],
+        });
+      })
+    );
+  }
+
+  /**
+   * Get marketing-attributed revenue metrics (prototype — stub endpoint until dbt view lands)
+   */
+  public getRevenueImpact(foundationSlug: string): Observable<RevenueImpactResponse> {
+    return this.http.get<RevenueImpactResponse>('/api/analytics/revenue-impact', { params: { foundationSlug } }).pipe(
+      catchError(() => {
+        return of({
+          pipelineInfluenced: 0,
+          revenueAttributed: 0,
+          matchRate: 0,
+          changePercentage: 0,
+          trend: 'up' as const,
+          attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+          engagementTypes: [],
+          paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0 },
         });
       })
     );

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2160,4 +2160,42 @@ export class AnalyticsController {
       next(error);
     }
   }
+
+  /**
+   * GET /api/analytics/revenue-impact
+   * Get marketing-attributed revenue metrics by engagement type
+   */
+  public async getRevenueImpact(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_revenue_impact');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_revenue_impact',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_revenue_impact',
+        });
+      }
+
+      const response = await this.projectService.getRevenueImpact(foundationSlug);
+
+      logger.success(req, 'get_revenue_impact', startTime, {
+        foundation_slug: foundationSlug,
+        pipeline_influenced: response.pipelineInfluenced,
+        revenue_attributed: response.revenueAttributed,
+        engagement_types: response.engagementTypes.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      logger.error(req, 'get_revenue_impact', startTime, error);
+      next(error);
+    }
+  }
 }

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -148,5 +148,6 @@ router.get('/member-retention', (req, res, next) => analyticsController.getMembe
 router.get('/member-acquisition', (req, res, next) => analyticsController.getMemberAcquisition(req, res, next));
 router.get('/engaged-community', (req, res, next) => analyticsController.getEngagedCommunity(req, res, next));
 router.get('/flywheel-conversion', (req, res, next) => analyticsController.getFlywheelConversion(req, res, next));
+router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -71,6 +71,7 @@ import {
   EngagedCommunitySizeResponse,
   FlywheelConversionResponse,
   NorthStarMonthlyDataPoint,
+  RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -82,6 +83,13 @@ import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { NatsService } from './nats.service';
 import { SnowflakeService } from './snowflake.service';
+
+/**
+ * Schema prefix for ED dashboard dbt views.
+ * Defaults to production; set SNOWFLAKE_ED_SCHEMA env var to use dev views for testing.
+ * Example: SNOWFLAKE_ED_SCHEMA=ANALYTICS_DEV.DEV_MRAUTELA_PLATINUM_LFX_ONE
+ */
+const ED_SCHEMA = process.env['SNOWFLAKE_ED_SCHEMA'] || 'ANALYTICS.PLATINUM_LFX_ONE';
 
 /**
  * Service for handling project business logic
@@ -2527,6 +2535,119 @@ export class ProjectService {
         },
         monthlyData: [],
       };
+    }
+  }
+
+  /**
+   * Get marketing-attributed revenue metrics from Snowflake
+   * Queries ${ED_SCHEMA}.PIPELINE_SUMMARY and PAID_ADS_ATTRIBUTION
+   */
+  public async getRevenueImpact(foundationSlug: string): Promise<RevenueImpactResponse> {
+    logger.debug(undefined, 'get_revenue_impact', 'Fetching revenue impact from Snowflake', { foundation_slug: foundationSlug });
+
+    const defaultResponse: RevenueImpactResponse = {
+      pipelineInfluenced: 0,
+      revenueAttributed: 0,
+      matchRate: 0,
+      changePercentage: 0,
+      trend: 'up',
+      attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+      engagementTypes: [],
+      paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0 },
+    };
+
+    try {
+      const pipelineQuery = `
+        SELECT TOTAL_PIPELINE_YTD, WON_REVENUE_YTD, LOST_REVENUE_YTD, OPEN_PIPELINE_YTD,
+               TOTAL_DEALS_YTD, WON_DEALS_YTD, LOST_DEALS_YTD, OPEN_DEALS_YTD,
+               AVG_WON_DEAL_SIZE_YTD, CONVERSION_RATE_YTD,
+               WON_REVENUE_PRIOR_YEAR, WON_REVENUE_YOY_CHANGE_PCT
+        FROM ${ED_SCHEMA}.PIPELINE_SUMMARY
+        WHERE FOUNDATION_SLUG = ?
+      `;
+
+      const paidAdsQuery = `
+        SELECT TOTAL_SPEND_YTD, TOTAL_IMPRESSIONS_YTD, TOTAL_CLICKS_YTD,
+               LINEAR_ROAS_YTD, AVG_CPC_YTD, CTR_YTD, CONVERSION_RATE_YTD,
+               FIRST_TOUCH_REVENUE_YTD, LAST_TOUCH_REVENUE_YTD,
+               LINEAR_REVENUE_YTD, TIME_DECAY_REVENUE_YTD,
+               SPEND_YOY_CHANGE_PCT, IMPRESSIONS_YOY_CHANGE_PCT
+        FROM ${ED_SCHEMA}.PAID_ADS_ATTRIBUTION
+        WHERE FOUNDATION_SLUG = ?
+      `;
+
+      const [pipelineResult, adsResult] = await Promise.all([
+        this.snowflakeService.execute<{
+          TOTAL_PIPELINE_YTD: number;
+          WON_REVENUE_YTD: number;
+          LOST_REVENUE_YTD: number;
+          OPEN_PIPELINE_YTD: number;
+          TOTAL_DEALS_YTD: number;
+          WON_DEALS_YTD: number;
+          LOST_DEALS_YTD: number;
+          OPEN_DEALS_YTD: number;
+          AVG_WON_DEAL_SIZE_YTD: number;
+          CONVERSION_RATE_YTD: number;
+          WON_REVENUE_PRIOR_YEAR: number;
+          WON_REVENUE_YOY_CHANGE_PCT: number;
+        }>(pipelineQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          TOTAL_SPEND_YTD: number;
+          TOTAL_IMPRESSIONS_YTD: number;
+          TOTAL_CLICKS_YTD: number;
+          LINEAR_ROAS_YTD: number;
+          AVG_CPC_YTD: number;
+          CTR_YTD: number;
+          CONVERSION_RATE_YTD: number;
+          FIRST_TOUCH_REVENUE_YTD: number;
+          LAST_TOUCH_REVENUE_YTD: number;
+          LINEAR_REVENUE_YTD: number;
+          TIME_DECAY_REVENUE_YTD: number;
+          SPEND_YOY_CHANGE_PCT: number;
+          IMPRESSIONS_YOY_CHANGE_PCT: number;
+        }>(paidAdsQuery, [foundationSlug]),
+      ]);
+
+      const pipeline = pipelineResult.rows.length > 0 ? pipelineResult.rows[0] : null;
+      const ads = adsResult.rows.length > 0 ? adsResult.rows[0] : null;
+
+      const pipelineInfluenced = pipeline?.TOTAL_PIPELINE_YTD ?? 0;
+      const wonRevenue = pipeline?.WON_REVENUE_YTD ?? 0;
+      const changePercentage = pipeline?.WON_REVENUE_YOY_CHANGE_PCT ?? 0;
+      const matchRate = pipeline?.CONVERSION_RATE_YTD ?? 0;
+      const totalDeals = pipeline?.TOTAL_DEALS_YTD ?? 0;
+
+      return {
+        pipelineInfluenced,
+        revenueAttributed: wonRevenue,
+        matchRate,
+        changePercentage,
+        trend: changePercentage >= 0 ? 'up' : 'down',
+        attributionModels: {
+          linear: ads?.LINEAR_REVENUE_YTD ?? 0,
+          firstTouch: ads?.FIRST_TOUCH_REVENUE_YTD ?? 0,
+          lastTouch: ads?.LAST_TOUCH_REVENUE_YTD ?? 0,
+        },
+        engagementTypes: pipeline
+          ? [
+              { type: 'Won', percentage: totalDeals > 0 ? Number(((pipeline.WON_DEALS_YTD / totalDeals) * 100).toFixed(1)) : 0 },
+              { type: 'Lost', percentage: totalDeals > 0 ? Number(((pipeline.LOST_DEALS_YTD / totalDeals) * 100).toFixed(1)) : 0 },
+              { type: 'Open', percentage: totalDeals > 0 ? Number(((pipeline.OPEN_DEALS_YTD / totalDeals) * 100).toFixed(1)) : 0 },
+            ]
+          : [],
+        paidMedia: {
+          roas: ads?.LINEAR_ROAS_YTD ?? 0,
+          impressions: ads?.TOTAL_IMPRESSIONS_YTD ?? 0,
+          adSpend: ads?.TOTAL_SPEND_YTD ?? 0,
+          adRevenue: (ads?.LINEAR_ROAS_YTD ?? 0) * (ads?.TOTAL_SPEND_YTD ?? 0),
+        },
+      };
+    } catch (error) {
+      logger.warning(undefined, 'get_revenue_impact', 'Failed to fetch revenue impact from Snowflake', {
+        foundation_slug: foundationSlug,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return defaultResponse;
     }
   }
 }

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2897,3 +2897,45 @@ export interface FlywheelConversionResponse {
   };
   monthlyData: NorthStarMonthlyDataPoint[];
 }
+
+/**
+ * Engagement-type attribution row for Revenue Impact drill-down
+ */
+export interface RevenueImpactEngagementType {
+  type: string;
+  percentage: number;
+}
+
+/**
+ * Attribution model comparison for Revenue Impact drill-down
+ */
+export interface RevenueImpactAttributionModels {
+  linear: number;
+  firstTouch: number;
+  lastTouch: number;
+}
+
+/**
+ * Paid media metrics for Revenue Impact drill-down
+ */
+export interface RevenueImpactPaidMedia {
+  roas: number;
+  impressions: number;
+  adSpend: number;
+  adRevenue: number;
+}
+
+/**
+ * API response for Revenue Impact (Marketing Attribution) metric
+ * Pipeline, revenue, attribution models, engagement channels, paid media
+ */
+export interface RevenueImpactResponse {
+  pipelineInfluenced: number;
+  revenueAttributed: number;
+  matchRate: number;
+  changePercentage: number;
+  trend: 'up' | 'down';
+  attributionModels: RevenueImpactAttributionModels;
+  engagementTypes: RevenueImpactEngagementType[];
+  paidMedia: RevenueImpactPaidMedia;
+}


### PR DESCRIPTION
## Summary
- Add `RevenueImpactResponse` interface to shared package with pipeline, attribution, and paid media types
- Add Snowflake queries for `PIPELINE_SUMMARY` and `PAID_ADS_ATTRIBUTION` views in `project.service.ts`
- Add backend controller method, route (`/revenue-impact`), and frontend HTTP service method
- Create revenue impact drawer component with pipeline stats, deal breakdown, attribution model comparison, and paid media metrics

## JIRA
LFXV2-1468

## Test plan
- [ ] Verify `GET /api/analytics/revenue-impact?foundationSlug=tlf` returns expected shape
- [ ] Open revenue impact drawer and verify pipeline stats render
- [ ] Verify deal pipeline breakdown progress bars display correctly
- [ ] Verify attribution model comparison cards show formatted revenue
- [ ] Verify paid media section shows ROAS, ad revenue, impressions, ad spend
- [ ] Verify em-dash fallback renders when values are 0
- [ ] Verify drawer close button works

🤖 Generated with [Claude Code](https://claude.ai/code)