### PR TITLE
feat(votes): add me lens support for user vote participation

### DIFF
--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -5,10 +5,12 @@
   <!-- Page Header -->
   <div class="flex items-center justify-between mb-8">
     <div>
-      <h1 data-testid="votes-dashboard-title">{{ voteLabelPlural }}</h1>
-      <p class="mt-2 text-gray-500" data-testid="votes-dashboard-description">Make decisions with your project groups.</p>
+      <h1 data-testid="votes-dashboard-title">{{ isMeLens() ? 'My ' + voteLabelPlural : voteLabelPlural }}</h1>
+      <p class="mt-2 text-gray-500" data-testid="votes-dashboard-description">
+        {{ isMeLens() ? voteLabelPlural + ' you have been invited to across all foundations and projects.' : 'Make decisions with your project groups.' }}
+      </p>
     </div>
-    @if (hasPMOAccess()) {
+    @if (!isMeLens() && hasPMOAccess()) {
       <lfx-button
         [label]="'Create ' + voteLabel"
         size="small"
@@ -20,8 +22,30 @@
     }
   </div>
 
-  <!-- Votes Table or Empty State -->
-  @if (!loading() && votes().length === 0) {
+  <!-- Loading State -->
+  @if ((isMeLens() && myVotesLoading()) || (!isMeLens() && loading())) {
+    <div class="flex justify-center items-center min-h-96">
+      <div class="text-center">
+        <i class="fa-light fa-spinner-third fa-spin text-3xl text-blue-600 mb-4"></i>
+        <p class="text-gray-600">Loading {{ voteLabel | lowercase }} details...</p>
+      </div>
+    </div>
+  } @else if (isMeLens() && myVotes().length === 0) {
+    <!-- Me lens empty state -->
+    <lfx-card data-testid="votes-empty-state-card">
+      <div class="p-8 md:p-12">
+        <div class="max-w-2xl mx-auto text-center flex flex-col gap-6">
+          <div class="flex justify-center">
+            <div class="w-20 h-20 rounded-full bg-blue-100 flex items-center justify-center">
+              <i class="fa-light fa-check-to-slot text-4xl text-blue-600"></i>
+            </div>
+          </div>
+          <h2 class="text-xl font-semibold text-gray-900">You don't have any {{ voteLabelPlural | lowercase }} yet</h2>
+        </div>
+      </div>
+    </lfx-card>
+  } @else if (!isMeLens() && !loading() && votes().length === 0) {
+    <!-- Project empty state -->
     <lfx-card data-testid="votes-empty-state-card">
       <div class="p-8 md:p-12">
         <div class="max-w-2xl mx-auto text-center flex flex-col gap-6">
@@ -37,13 +61,13 @@
     </lfx-card>
   } @else {
     <lfx-votes-table
-      [votes]="votes()"
-      [hasPMOAccess]="hasPMOAccess()"
-      [loading]="loading()"
-      [totalRecords]="totalRecords()"
+      [votes]="isMeLens() ? myVotes() : votes()"
+      [hasPMOAccess]="!isMeLens() && hasPMOAccess()"
+      [loading]="isMeLens() ? myVotesLoading() : loading()"
+      [totalRecords]="isMeLens() ? myVotes().length : totalRecords()"
       [rowsPerPage]="rowsPerPage()"
-      [first]="currentFirst()"
-      [lazy]="true"
+      [first]="isMeLens() ? 0 : currentFirst()"
+      [lazy]="!isMeLens()"
       [groupOptions]="groupOptions()"
       (viewVote)="onViewVote($event)"
       (viewResults)="onViewResults($event)"

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -10,9 +10,10 @@ import { CardComponent } from '@components/card/card.component';
 import { VOTE_LABEL } from '@lfx-one/shared';
 import { Committee, PaginatedResponse, ProjectContext, Vote, VoteFilterState } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
+import { LensService } from '@services/lens.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { VoteService } from '@services/vote.service';
-import { BehaviorSubject, catchError, combineLatest, map, of, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, finalize, map, of, switchMap, tap } from 'rxjs';
 
 import { VoteResultsDrawerComponent } from '../components/vote-results-drawer/vote-results-drawer.component';
 import { VotesTableComponent } from '../components/votes-table/votes-table.component';
@@ -27,6 +28,7 @@ export class VotesDashboardComponent {
   // === Services ===
   private readonly voteService = inject(VoteService);
   private readonly committeeService = inject(CommitteeService);
+  private readonly lensService = inject(LensService);
   private readonly projectContextService = inject(ProjectContextService);
 
   // === Constants ===
@@ -47,6 +49,10 @@ export class VotesDashboardComponent {
   protected readonly rowsPerPage = signal<number>(10);
   protected readonly currentFirst = signal<number>(0);
   protected readonly totalRecords = signal<number>(0);
+  protected readonly myVotesLoading = signal<boolean>(true);
+
+  // === Lens ===
+  protected readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
 
   // === Filter State ===
   protected readonly filters = signal<VoteFilterState>({ search: '', status: null, group: null });
@@ -61,6 +67,7 @@ export class VotesDashboardComponent {
   protected readonly groupOptions: Signal<{ label: string; value: string | null }[]> = this.initGroupOptions();
   protected readonly votes: Signal<Vote[]> = this.initVotes();
   protected readonly selectedListVote: Signal<Vote | null> = this.initSelectedListVote();
+  protected readonly myVotes: Signal<Vote[]> = this.initMyVotes();
   protected readonly totalCount: Signal<number> = this.initTotalCount();
 
   protected onViewVote(voteId: string): void {
@@ -123,11 +130,12 @@ export class VotesDashboardComponent {
 
   private initGroupOptions(): Signal<{ label: string; value: string | null }[]> {
     const project$ = toObservable(this.project);
+    const lens$ = toObservable(this.lensService.activeLens);
 
     return toSignal(
-      project$.pipe(
-        switchMap((project) => {
-          if (!project?.uid) {
+      combineLatest([project$, lens$]).pipe(
+        switchMap(([project, lens]) => {
+          if (lens === 'me' || !project?.uid) {
             return of([]);
           }
           return this.committeeService.getCommitteesByProject(project.uid).pipe(catchError(() => of([])));
@@ -148,10 +156,14 @@ export class VotesDashboardComponent {
   private initTotalCount(): Signal<number> {
     const project$ = toObservable(this.project);
     const filters$ = toObservable(this.filters);
+    const lens$ = toObservable(this.lensService.activeLens);
 
     return toSignal(
-      combineLatest([project$, filters$, this.refresh$]).pipe(
-        switchMap(([project]) => {
+      combineLatest([project$, filters$, this.refresh$, lens$]).pipe(
+        switchMap(([project, , , lens]) => {
+          if (lens === 'me') {
+            return of(0);
+          }
           if (!project?.uid) {
             return of(0);
           }
@@ -170,12 +182,13 @@ export class VotesDashboardComponent {
   private initVotes(): Signal<Vote[]> {
     const project$ = toObservable(this.project);
     const filters$ = toObservable(this.filters);
+    const lens$ = toObservable(this.lensService.activeLens);
 
     return toSignal(
-      combineLatest([project$, filters$, this.fetch$]).pipe(
+      combineLatest([project$, filters$, this.fetch$, lens$]).pipe(
         tap(() => this.loading.set(true)),
-        switchMap(([project]) => {
-          if (!project?.uid) {
+        switchMap(([project, , , lens]) => {
+          if (lens === 'me' || !project?.uid) {
             this.loading.set(false);
             return of([]);
           }
@@ -219,7 +232,32 @@ export class VotesDashboardComponent {
     return computed(() => {
       const id = this.selectedVoteId();
       if (!id) return null;
-      return this.votes().find((v) => v.uid === id) || null;
+      const source = this.isMeLens() ? this.myVotes() : this.votes();
+      return source.find((v) => v.uid === id) || null;
     });
+  }
+
+  private initMyVotes(): Signal<Vote[]> {
+    const lens$ = toObservable(this.lensService.activeLens);
+
+    return toSignal(
+      combineLatest([lens$, this.refresh$]).pipe(
+        switchMap(([lens]) => {
+          if (lens !== 'me') {
+            this.myVotesLoading.set(false);
+            return of([] as Vote[]);
+          }
+          this.myVotesLoading.set(true);
+          return this.voteService.getMyVotes().pipe(
+            catchError(() => {
+              this.myVotesLoading.set(false);
+              return of([] as Vote[]);
+            }),
+            finalize(() => this.myVotesLoading.set(false))
+          );
+        })
+      ),
+      { initialValue: [] }
+    );
   }
 }

--- a/apps/lfx-one/src/app/shared/services/vote.service.ts
+++ b/apps/lfx-one/src/app/shared/services/vote.service.ts
@@ -22,6 +22,10 @@ export class VoteService {
     );
   }
 
+  public getMyVotes(): Observable<Vote[]> {
+    return this.http.get<Vote[]>('/api/votes/my-votes');
+  }
+
   public getVotesByProject(projectUid: string, pageSize?: number, orderBy?: string): Observable<Vote[]> {
     let params = new HttpParams().set('parent', `project:${projectUid}`);
 

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -58,6 +58,25 @@ export class VoteController {
   }
 
   /**
+   * GET /votes/my-votes
+   */
+  public async getMyVotes(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_my_votes');
+
+    try {
+      const myVotes = await this.voteService.getMyVotes(req);
+
+      logger.success(req, 'get_my_votes', startTime, {
+        vote_count: myVotes.length,
+      });
+
+      res.json(myVotes);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /votes/:uid
    */
   public async getVoteById(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/routes/votes.route.ts
+++ b/apps/lfx-one/src/server/routes/votes.route.ts
@@ -15,6 +15,9 @@ router.get('/', (req, res, next) => voteController.getVotes(req, res, next));
 // GET /votes/count - get votes count
 router.get('/count', (req, res, next) => voteController.getVotesCount(req, res, next));
 
+// GET /votes/my-votes - get votes the current user has been invited to
+router.get('/my-votes', (req, res, next) => voteController.getMyVotes(req, res, next));
+
 // GET /votes/:uid/results - get vote results
 router.get('/:uid/results', (req, res, next) => voteController.getVoteResults(req, res, next));
 

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -215,20 +215,11 @@ export class SurveyService {
       unique_survey_count: surveyUids.length,
     });
 
-    // Fetch survey details in parallel
+    // Fetch survey details in parallel via the survey microservice
     const surveys = await Promise.all(
       surveyUids.map(async (uid) => {
         try {
-          const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-            type: 'survey',
-            tags: uid,
-          });
-
-          if (!resources || resources.length === 0) {
-            return null;
-          }
-
-          return resources[0].data;
+          return await this.microserviceProxy.proxyRequest<Survey>(req, 'LFX_V2_SERVICE', `/surveys/${uid}`, 'GET');
         } catch (error) {
           logger.warning(req, 'get_my_surveys', 'Failed to fetch survey details, skipping', {
             survey_uid: uid,
@@ -239,6 +230,17 @@ export class SurveyService {
       })
     );
 
-    return surveys.filter((s): s is Survey => s !== null);
+    // Sort: open/sent surveys first, then by cutoff date descending
+    return surveys
+      .filter((s): s is Survey => s !== null)
+      .sort((a, b) => {
+        const openStatuses = new Set(['open', 'sent']);
+        const aOpen = openStatuses.has(a.survey_status) ? 0 : 1;
+        const bOpen = openStatuses.has(b.survey_status) ? 0 : 1;
+        if (aOpen !== bOpen) {
+          return aOpen - bOpen;
+        }
+        return new Date(b.survey_cutoff_date || 0).getTime() - new Date(a.survey_cutoff_date || 0).getTime();
+      });
   }
 }

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -231,16 +231,16 @@ export class SurveyService {
     );
 
     // Sort: open/sent surveys first, then by cutoff date descending
+    const openStatuses = new Set(['open', 'sent']);
     return surveys
       .filter((s): s is Survey => s !== null)
       .sort((a, b) => {
-        const openStatuses = new Set(['open', 'sent']);
         const aOpen = openStatuses.has(a.survey_status) ? 0 : 1;
         const bOpen = openStatuses.has(b.survey_status) ? 0 : 1;
         if (aOpen !== bOpen) {
           return aOpen - bOpen;
         }
-        return new Date(b.survey_cutoff_date || 0).getTime() - new Date(a.survey_cutoff_date || 0).getTime();
+        return new Date(b.survey_cutoff_date).getTime() - new Date(a.survey_cutoff_date).getTime();
       });
   }
 }

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -298,20 +298,11 @@ export class VoteService {
       unique_vote_count: voteUids.length,
     });
 
-    // Fetch vote details in parallel
+    // Fetch vote details in parallel via the voting microservice
     const votes = await Promise.all(
       voteUids.map(async (uid) => {
         try {
-          const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-            type: 'vote',
-            tags: uid,
-          });
-
-          if (!resources || resources.length === 0) {
-            return null;
-          }
-
-          return resources[0].data;
+          return await this.microserviceProxy.proxyRequest<Vote>(req, 'LFX_V2_SERVICE', `/votes/${uid}`, 'GET');
         } catch (error) {
           logger.warning(req, 'get_my_votes', 'Failed to fetch vote details, skipping', {
             vote_uid: uid,
@@ -322,6 +313,16 @@ export class VoteService {
       })
     );
 
-    return votes.filter((v): v is Vote => v !== null);
+    // Sort: active votes first, then by end_time descending
+    return votes
+      .filter((v): v is Vote => v !== null)
+      .sort((a, b) => {
+        const aActive = a.status === 'active' ? 0 : 1;
+        const bActive = b.status === 'active' ? 0 : 1;
+        if (aActive !== bActive) {
+          return aActive - bActive;
+        }
+        return new Date(b.end_time || 0).getTime() - new Date(a.end_time || 0).getTime();
+      });
   }
 }

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -322,7 +322,7 @@ export class VoteService {
         if (aActive !== bActive) {
           return aActive - bActive;
         }
-        return new Date(b.end_time || 0).getTime() - new Date(a.end_time || 0).getTime();
+        return new Date(b.end_time).getTime() - new Date(a.end_time).getTime();
       });
   }
 }

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -14,6 +14,8 @@ import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
+import { fetchAllQueryResources } from '../helpers/query-service.helper';
+import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 
@@ -241,5 +243,85 @@ export class VoteService {
     });
 
     return results;
+  }
+
+  // ============================================
+  // My Votes (Me Lens)
+  // ============================================
+
+  /**
+   * Fetches votes the current user has been invited to.
+   * Queries vote_response records by user_email and username using filters_or.
+   */
+  public async getMyVotes(req: Request): Promise<Vote[]> {
+    const rawUsername = await getUsernameFromAuth(req);
+    const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
+    const email = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+
+    logger.debug(req, 'get_my_votes', 'Fetching votes for current user', {
+      username,
+      has_email: !!email,
+    });
+
+    if (!username && !email) {
+      return [];
+    }
+
+    // Build filters_or array — note: vote_response uses 'user_email' not 'email'
+    const filtersOr: string[] = [];
+    if (email) {
+      filtersOr.push(`user_email:${email}`);
+    }
+    if (username) {
+      filtersOr.push(`username:${username}`);
+    }
+
+    // Query vote_response records using filters_or (OR logic on data fields)
+    const responses = await fetchAllQueryResources<{ vote_uid: string }>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<{ vote_uid: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'vote_response',
+        page_size: 100,
+        filters_or: filtersOr,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+
+    // Extract unique vote UIDs
+    const voteUids = [...new Set(responses.filter((r) => r.vote_uid).map((r) => r.vote_uid))];
+
+    if (voteUids.length === 0) {
+      return [];
+    }
+
+    logger.debug(req, 'get_my_votes', 'Found user vote responses', {
+      response_count: responses.length,
+      unique_vote_count: voteUids.length,
+    });
+
+    // Fetch vote details in parallel
+    const votes = await Promise.all(
+      voteUids.map(async (uid) => {
+        try {
+          const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+            type: 'vote',
+            tags: uid,
+          });
+
+          if (!resources || resources.length === 0) {
+            return null;
+          }
+
+          return resources[0].data;
+        } catch (error) {
+          logger.warning(req, 'get_my_votes', 'Failed to fetch vote details, skipping', {
+            vote_uid: uid,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+          return null;
+        }
+      })
+    );
+
+    return votes.filter((v): v is Vote => v !== null);
   }
 }


### PR DESCRIPTION
## Summary
- Add "me" lens to votes dashboard showing only votes the current user has been invited to
- Query `vote_response` records by both `user_email` and `username` using `filters_or` with full pagination via `fetchAllQueryResources`
- Fetch vote details via direct microservice endpoint (`/votes/{uid}`) instead of query service tag lookup
- Sort results with active/open items first, then by date descending
- Also fixes survey `getMySurveys` to use direct microservice lookup (`/surveys/{uid}`) and adds same sorting

Generated with [Claude Code](https://claude.ai/code)