### PR TITLE
feat(training): enrich course logos via TI API

### DIFF
--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -94,6 +94,12 @@ CDP_AUDIENCE=https://lf-staging.crowd.dev/api/
 AI_PROXY_URL=https://litellm.tools.lfx.dev/chat/completions
 AI_API_KEY=your-litellm-ai-api-key
 
+# Thought Industries (TI) API Configuration
+# Used to enrich course logo URLs for training certifications and enrollments.
+# When absent, logo enrichment is skipped and courses fall back to the generic icon.
+# Obtain from the TI admin dashboard (or 1Password — LFX One Dev Environment vault).
+TI_API_KEY=
+
 # LFX Lens (AI Data Assistant) Configuration
 # API endpoint for the LFX Lens workflow agent
 LENS_API_URL=https://lfx-ai.onrender.com

--- a/apps/lfx-one/src/app/modules/trainings/components/certification-card/certification-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/certification-card/certification-card.component.html
@@ -8,7 +8,7 @@
       class="flex-shrink-0 w-14 h-14 flex items-center justify-center overflow-hidden rounded-xl bg-gray-50 border border-gray-100"
       data-testid="cert-card-image-container">
       @if (hasImage()) {
-        <img [src]="cert().imageUrl" [alt]="cert().name" class="w-14 h-14 object-contain" data-testid="cert-card-image" />
+        <img [src]="cert().imageUrl" [alt]="cert().name" class="w-14 h-14 object-cover scale-[1.16] origin-[center_60%]" data-testid="cert-card-image" />
       } @else {
         <i class="fa-light fa-graduation-cap text-2xl text-gray-400" data-testid="cert-card-icon-fallback"></i>
       }
@@ -34,7 +34,8 @@
             <div data-testid="cert-card-actions">
               <lfx-button
                 severity="secondary"
-                styleClass="!text-xs !h-8 !py-0"
+                size="small"
+                styleClass="whitespace-nowrap"
                 label="Download"
                 icon="fa-light fa-arrow-down-to-line"
                 [href]="cert().downloadUrl!"

--- a/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/training-card/training-card.component.html
@@ -8,7 +8,11 @@
       class="flex-shrink-0 w-14 h-14 flex items-center justify-center overflow-hidden rounded-xl bg-gray-50 border border-gray-100"
       data-testid="training-card-image-container">
       @if (hasImage()) {
-        <img [src]="training().imageUrl" [alt]="training().name" class="w-14 h-14 object-contain" data-testid="training-card-image" />
+        <img
+          [src]="training().imageUrl"
+          [alt]="training().name"
+          class="w-14 h-14 object-cover scale-[1.16] origin-[center_60%]"
+          data-testid="training-card-image" />
       } @else {
         <i class="fa-light fa-book-open text-2xl text-gray-400" data-testid="training-card-icon-fallback"></i>
       }
@@ -35,12 +39,11 @@
 
         @if (isOngoing()) {
           <div class="flex-shrink-0" data-testid="training-card-continue-action">
-            <!-- TODO: replace !important overrides with a size="sm" input on ButtonComponent (LFXV2-TODO) -->
             <lfx-button
-              severity="secondary"
-              styleClass="!text-xs !h-8 !py-0"
+              severity="primary"
+              size="small"
+              styleClass="whitespace-nowrap"
               label="Continue Learning"
-              icon="fa-light fa-arrow-right"
               [href]="continueLearningUrl()"
               target="_blank"
               rel="noopener noreferrer"
@@ -49,10 +52,10 @@
           </div>
         } @else if (downloadUrl()) {
           <div class="flex-shrink-0" data-testid="training-card-actions">
-            <!-- TODO: replace !important overrides with a size="sm" input on ButtonComponent (LFXV2-TODO) -->
             <lfx-button
               severity="secondary"
-              styleClass="!text-xs !h-8 !py-0"
+              size="small"
+              styleClass="whitespace-nowrap"
               label="Download Certificate"
               icon="fa-light fa-arrow-down-to-line"
               [href]="downloadUrl()!"

--- a/apps/lfx-one/src/server/services/ti.service.ts
+++ b/apps/lfx-one/src/server/services/ti.service.ts
@@ -11,7 +11,7 @@ const TI_API_URL = 'https://linux.thoughtindustries.com/incoming/v2/content';
 const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
 interface TiCacheEntry {
-  url: string;
+  url: string | null; // null = confirmed TI miss; still cached to avoid re-fetching
   expiresAt: number;
 }
 
@@ -82,7 +82,10 @@ export class TiService {
     for (const id of courseIds) {
       const cached = this.cache.get(id);
       if (cached && cached.expiresAt > now) {
-        result.set(id, cached.url);
+        if (cached.url) {
+          result.set(id, cached.url);
+        }
+        // null entry = confirmed TI miss, skip without re-fetching
       } else {
         uncachedIds.push(id);
       }
@@ -90,6 +93,13 @@ export class TiService {
 
     if (uncachedIds.length === 0) {
       logger.debug(req, 'ti_cache_hit', 'All course logos served from cache', { count: courseIds.length });
+      return result;
+    }
+
+    if (!this.apiKey) {
+      logger.debug(req, 'ti_get_logos', 'TI_API_KEY not configured — skipping fetch, returning cached results only', {
+        uncached_count: uncachedIds.length,
+      });
       return result;
     }
 
@@ -113,7 +123,8 @@ export class TiService {
 
       if (response.status === 429) {
         const resetHeader = response.headers.get('x-ratelimit-reset');
-        const resetTime = resetHeader ? new Date(parseInt(resetHeader, 10) * 1000).toISOString() : 'unknown';
+        const resetTimestamp = resetHeader ? parseInt(resetHeader, 10) : NaN;
+        const resetTime = Number.isFinite(resetTimestamp) ? new Date(resetTimestamp * 1000).toISOString() : 'unknown';
         logger.warning(req, 'ti_get_logos', 'TI API rate limit hit — returning cached results only', {
           uncached_count: uncachedIds.length,
           rate_limit_resets_at: resetTime,
@@ -133,11 +144,20 @@ export class TiService {
 
       const data = (await response.json()) as TiContentResponse;
       const items = data.contentItems || [];
+      const foundIds = new Set<string>();
 
       for (const item of items) {
         if (item.id && item.asset) {
+          foundIds.add(item.id);
           this.cache.set(item.id, { url: item.asset, expiresAt: now + CACHE_TTL_MS });
           result.set(item.id, item.asset);
+        }
+      }
+
+      // Cache negative results so unmatched IDs aren't re-fetched until TTL expires
+      for (const id of uncachedIds) {
+        if (!foundIds.has(id)) {
+          this.cache.set(id, { url: null, expiresAt: now + CACHE_TTL_MS });
         }
       }
 

--- a/apps/lfx-one/src/server/services/ti.service.ts
+++ b/apps/lfx-one/src/server/services/ti.service.ts
@@ -3,26 +3,13 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
+import { TiCacheEntry, TiContentItem, TiContentResponse } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
 import { logger } from './logger.service';
 
 const TI_API_URL = 'https://linux.thoughtindustries.com/incoming/v2/content';
 const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
-
-interface TiCacheEntry {
-  url: string | null; // null = confirmed TI miss; still cached to avoid re-fetching
-  expiresAt: number;
-}
-
-interface TiContentItem {
-  id: string;
-  asset: string;
-}
-
-interface TiContentResponse {
-  contentItems: TiContentItem[];
-}
 
 /**
  * Service for fetching logo URLs from the Thought Industries (TI) API.

--- a/apps/lfx-one/src/server/services/ti.service.ts
+++ b/apps/lfx-one/src/server/services/ti.service.ts
@@ -30,8 +30,8 @@ interface TiContentResponse {
  * TI serves full card images (wide banners with geometric frames) as LOGO_URL in Snowflake.
  * The `asset` field in the TI API response contains the clean logo URL without the frame.
  *
- * Uses singleton pattern and in-memory cache (1hr TTL) to minimize API calls.
- * Rate limit: 250 requests per ~15-minute window.
+ * Uses singleton pattern and in-memory cache (30-day TTL) to minimize API calls.
+ * Rate limit: ~250 requests per 15-minute window, shared with LF Education production flows.
  */
 export class TiService {
   private static instance: TiService | null = null;

--- a/apps/lfx-one/src/server/services/ti.service.ts
+++ b/apps/lfx-one/src/server/services/ti.service.ts
@@ -1,0 +1,160 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { Request } from 'express';
+
+import { logger } from './logger.service';
+
+const TI_API_URL = 'https://linux.thoughtindustries.com/incoming/v2/content';
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+interface TiCacheEntry {
+  url: string;
+  expiresAt: number;
+}
+
+interface TiContentItem {
+  id: string;
+  asset: string;
+}
+
+interface TiContentResponse {
+  contentItems: TiContentItem[];
+}
+
+/**
+ * Service for fetching logo URLs from the Thought Industries (TI) API.
+ *
+ * TI serves full card images (wide banners with geometric frames) as LOGO_URL in Snowflake.
+ * The `asset` field in the TI API response contains the clean logo URL without the frame.
+ *
+ * Uses singleton pattern and in-memory cache (1hr TTL) to minimize API calls.
+ * Rate limit: 250 requests per ~15-minute window.
+ */
+export class TiService {
+  private static instance: TiService | null = null;
+
+  private readonly apiKey: string;
+  private readonly cache: Map<string, TiCacheEntry> = new Map();
+
+  private constructor() {
+    this.apiKey = process.env['TI_API_KEY'] || '';
+  }
+
+  /**
+   * Get the singleton instance of TiService
+   */
+  public static getInstance(): TiService {
+    if (!TiService.instance) {
+      TiService.instance = new TiService();
+    }
+    return TiService.instance;
+  }
+
+  /**
+   * Reset the singleton instance (primarily for testing)
+   */
+  public static resetInstance(): void {
+    TiService.instance = null;
+  }
+
+  /**
+   * Fetch logo asset URLs for the given course IDs from the TI API.
+   *
+   * Returns a Map<courseId, assetUrl>. On any error (including rate limits),
+   * returns whatever is available from the cache — never throws.
+   *
+   * @param req - Express request for logging context
+   * @param courseIds - Array of TI course UUIDs (_id field in TI API)
+   */
+  public async getLogoUrls(req: Request | undefined, courseIds: string[]): Promise<Map<string, string>> {
+    if (courseIds.length === 0) {
+      return new Map();
+    }
+
+    // Split into cached and uncached IDs
+    const now = Date.now();
+    const result = new Map<string, string>();
+    const uncachedIds: string[] = [];
+
+    for (const id of courseIds) {
+      const cached = this.cache.get(id);
+      if (cached && cached.expiresAt > now) {
+        result.set(id, cached.url);
+      } else {
+        uncachedIds.push(id);
+      }
+    }
+
+    if (uncachedIds.length === 0) {
+      logger.debug(req, 'ti_cache_hit', 'All course logos served from cache', { count: courseIds.length });
+      return result;
+    }
+
+    logger.debug(req, 'ti_get_logos', 'Fetching course logos from TI API', {
+      total: courseIds.length,
+      cached: courseIds.length - uncachedIds.length,
+      uncached: uncachedIds.length,
+    });
+
+    try {
+      const query = `(${uncachedIds.map((id) => `_id:${id}`).join(' OR ')})`;
+      const url = `${TI_API_URL}?query=${encodeURIComponent(query)}`;
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+        },
+        signal: AbortSignal.timeout(10000),
+      });
+
+      if (response.status === 429) {
+        const resetHeader = response.headers.get('x-ratelimit-reset');
+        const resetTime = resetHeader ? new Date(parseInt(resetHeader, 10) * 1000).toISOString() : 'unknown';
+        logger.warning(req, 'ti_get_logos', 'TI API rate limit hit — returning cached results only', {
+          uncached_count: uncachedIds.length,
+          rate_limit_resets_at: resetTime,
+        });
+        // Return whatever we have from cache — already populated in result
+        return result;
+      }
+
+      if (!response.ok) {
+        logger.warning(req, 'ti_get_logos', 'TI API returned non-OK response — returning cached results only', {
+          status: response.status,
+          status_text: response.statusText,
+          uncached_count: uncachedIds.length,
+        });
+        return result;
+      }
+
+      const data = (await response.json()) as TiContentResponse;
+      const items = data.contentItems || [];
+
+      for (const item of items) {
+        if (item.id && item.asset) {
+          this.cache.set(item.id, { url: item.asset, expiresAt: now + CACHE_TTL_MS });
+          result.set(item.id, item.asset);
+        }
+      }
+
+      logger.debug(req, 'ti_get_logos', 'Fetched course logos from TI API', {
+        requested: uncachedIds.length,
+        returned: items.length,
+        total_result: result.size,
+      });
+    } catch (error) {
+      logger.warning(req, 'ti_get_logos', 'Failed to fetch course logos from TI API — returning cached results only', {
+        uncached_count: uncachedIds.length,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    return result;
+  }
+}
+
+export const tiService = TiService.getInstance();

--- a/apps/lfx-one/src/server/services/training.service.ts
+++ b/apps/lfx-one/src/server/services/training.service.ts
@@ -9,10 +9,11 @@ import { Request } from 'express';
 
 import { logger } from './logger.service';
 import { SnowflakeService } from './snowflake.service';
+import { tiService } from './ti.service';
 
 const CERTIFICATES_BASE_QUERY = `
   SELECT _KEY, IDENTIFIER, COURSE_NAME, COURSE_GROUP_DESCRIPTION,
-         LOGO_URL, PROJECT_NAME, ISSUED_TS, EXPIRATION_DATE, DOWNLOAD_URL, LEVEL
+         LOGO_URL, PROJECT_NAME, ISSUED_TS, EXPIRATION_DATE, DOWNLOAD_URL, LEVEL, COURSE_ID
   FROM ANALYTICS.PLATINUM_LFX_ONE.USER_CERTIFICATES
   WHERE USER_NAME = ?`;
 
@@ -27,7 +28,7 @@ const CERTIFICATES_UNFILTERED_QUERY = `${CERTIFICATES_BASE_QUERY}
 
 const ENROLLMENTS_QUERY = `
   SELECT ENROLLMENT_ID, ENROLLMENT_TS, COURSE_NAME, COURSE_GROUP_DESCRIPTION,
-         LOGO_URL, PROJECT_NAME, LEVEL, COURSE_SLUG
+         LOGO_URL, PROJECT_NAME, LEVEL, COURSE_SLUG, COURSE_ID
   FROM ANALYTICS.PLATINUM_LFX_ONE.USER_COURSE_ENROLLMENTS
   WHERE USER_NAME = ? AND PRODUCT_TYPE = ?
   ORDER BY ENROLLMENT_TS DESC
@@ -61,7 +62,24 @@ export class TrainingService {
 
     logger.debug(req, 'get_certifications', 'Fetched certifications', { count: result.rows.length });
 
-    return result.rows.map((row) => this.mapRowToCertification(row));
+    const certifications = result.rows.map((row) => this.mapRowToCertification(row));
+
+    // Enrich with clean logo URLs from TI API (replaces Snowflake card banner images)
+    const courseIds = result.rows.map((row) => row.COURSE_ID).filter((id): id is string => Boolean(id));
+    if (courseIds.length > 0) {
+      const logoMap = await tiService.getLogoUrls(req, courseIds);
+      if (logoMap.size > 0) {
+        logger.info(req, 'get_certifications', 'Enriched certifications with TI logo URLs', { enriched: logoMap.size });
+        for (let i = 0; i < certifications.length; i++) {
+          const courseId = result.rows[i].COURSE_ID;
+          if (courseId && logoMap.has(courseId)) {
+            certifications[i] = { ...certifications[i], imageUrl: logoMap.get(courseId)! };
+          }
+        }
+      }
+    }
+
+    return certifications;
   }
 
   public async getEnrollments(req: Request, username: string): Promise<TrainingEnrollment[]> {
@@ -81,7 +99,24 @@ export class TrainingService {
 
     logger.debug(req, 'get_enrollments', 'Fetched enrollments', { count: result.rows.length });
 
-    return result.rows.map((row) => this.mapRowToEnrollment(row));
+    const enrollments = result.rows.map((row) => this.mapRowToEnrollment(row));
+
+    // Enrich with clean logo URLs from TI API (replaces Snowflake card banner images)
+    const courseIds = result.rows.map((row) => row.COURSE_ID).filter((id): id is string => Boolean(id));
+    if (courseIds.length > 0) {
+      const logoMap = await tiService.getLogoUrls(req, courseIds);
+      if (logoMap.size > 0) {
+        logger.info(req, 'get_enrollments', 'Enriched enrollments with TI logo URLs', { enriched: logoMap.size });
+        for (let i = 0; i < enrollments.length; i++) {
+          const courseId = result.rows[i].COURSE_ID;
+          if (courseId && logoMap.has(courseId)) {
+            enrollments[i] = { ...enrollments[i], imageUrl: logoMap.get(courseId)! };
+          }
+        }
+      }
+    }
+
+    return enrollments;
   }
 
   private mapRowToCertification(row: CertificateRow): Certification {

--- a/apps/lfx-one/src/server/services/training.service.ts
+++ b/apps/lfx-one/src/server/services/training.service.ts
@@ -65,7 +65,7 @@ export class TrainingService {
     const certifications = result.rows.map((row) => this.mapRowToCertification(row));
     const courseIds = result.rows.map((row) => row.COURSE_ID);
 
-    return this.enrichWithTiLogos(req, 'get_certifications', certifications, courseIds);
+    return this.enrichWithTiLogos(req, certifications, courseIds);
   }
 
   public async getEnrollments(req: Request, username: string): Promise<TrainingEnrollment[]> {
@@ -88,7 +88,7 @@ export class TrainingService {
     const enrollments = result.rows.map((row) => this.mapRowToEnrollment(row));
     const courseIds = result.rows.map((row) => row.COURSE_ID);
 
-    return this.enrichWithTiLogos(req, 'get_enrollments', enrollments, courseIds);
+    return this.enrichWithTiLogos(req, enrollments, courseIds);
   }
 
   // ─── Private Enrichment Methods ────────────────────────────────────────────
@@ -99,7 +99,6 @@ export class TrainingService {
    */
   private async enrichWithTiLogos<T extends { imageUrl: string }>(
     req: Request,
-    operation: string,
     items: T[],
     courseIds: (string | null)[],
   ): Promise<T[]> {
@@ -109,7 +108,7 @@ export class TrainingService {
     const logoMap = await tiService.getLogoUrls(req, validIds);
     if (logoMap.size === 0) return items;
 
-    logger.info(req, operation, 'Enriched with TI logo URLs', { enriched: logoMap.size });
+    logger.info(req, 'enrich_ti_logos', 'Enriched with TI logo URLs', { enriched: logoMap.size });
 
     return items.map((item, i) => {
       const courseId = courseIds[i];

--- a/apps/lfx-one/src/server/services/training.service.ts
+++ b/apps/lfx-one/src/server/services/training.service.ts
@@ -63,23 +63,9 @@ export class TrainingService {
     logger.debug(req, 'get_certifications', 'Fetched certifications', { count: result.rows.length });
 
     const certifications = result.rows.map((row) => this.mapRowToCertification(row));
+    const courseIds = result.rows.map((row) => row.COURSE_ID);
 
-    // Enrich with clean logo URLs from TI API (replaces Snowflake card banner images)
-    const courseIds = result.rows.map((row) => row.COURSE_ID).filter((id): id is string => Boolean(id));
-    if (courseIds.length > 0) {
-      const logoMap = await tiService.getLogoUrls(req, courseIds);
-      if (logoMap.size > 0) {
-        logger.info(req, 'get_certifications', 'Enriched certifications with TI logo URLs', { enriched: logoMap.size });
-        for (let i = 0; i < certifications.length; i++) {
-          const courseId = result.rows[i].COURSE_ID;
-          if (courseId && logoMap.has(courseId)) {
-            certifications[i] = { ...certifications[i], imageUrl: logoMap.get(courseId)! };
-          }
-        }
-      }
-    }
-
-    return certifications;
+    return this.enrichWithTiLogos(req, 'get_certifications', certifications, courseIds);
   }
 
   public async getEnrollments(req: Request, username: string): Promise<TrainingEnrollment[]> {
@@ -100,23 +86,35 @@ export class TrainingService {
     logger.debug(req, 'get_enrollments', 'Fetched enrollments', { count: result.rows.length });
 
     const enrollments = result.rows.map((row) => this.mapRowToEnrollment(row));
+    const courseIds = result.rows.map((row) => row.COURSE_ID);
 
-    // Enrich with clean logo URLs from TI API (replaces Snowflake card banner images)
-    const courseIds = result.rows.map((row) => row.COURSE_ID).filter((id): id is string => Boolean(id));
-    if (courseIds.length > 0) {
-      const logoMap = await tiService.getLogoUrls(req, courseIds);
-      if (logoMap.size > 0) {
-        logger.info(req, 'get_enrollments', 'Enriched enrollments with TI logo URLs', { enriched: logoMap.size });
-        for (let i = 0; i < enrollments.length; i++) {
-          const courseId = result.rows[i].COURSE_ID;
-          if (courseId && logoMap.has(courseId)) {
-            enrollments[i] = { ...enrollments[i], imageUrl: logoMap.get(courseId)! };
-          }
-        }
-      }
-    }
+    return this.enrichWithTiLogos(req, 'get_enrollments', enrollments, courseIds);
+  }
 
-    return enrollments;
+  // ─── Private Enrichment Methods ────────────────────────────────────────────
+
+  /**
+   * Enriches items with logo URLs fetched from the TI API.
+   * Course IDs that are null or have no TI match are left with their existing imageUrl.
+   */
+  private async enrichWithTiLogos<T extends { imageUrl: string }>(
+    req: Request,
+    operation: string,
+    items: T[],
+    courseIds: (string | null)[],
+  ): Promise<T[]> {
+    const validIds = courseIds.filter((id): id is string => Boolean(id));
+    if (validIds.length === 0) return items;
+
+    const logoMap = await tiService.getLogoUrls(req, validIds);
+    if (logoMap.size === 0) return items;
+
+    logger.info(req, operation, 'Enriched with TI logo URLs', { enriched: logoMap.size });
+
+    return items.map((item, i) => {
+      const courseId = courseIds[i];
+      return courseId && logoMap.has(courseId) ? { ...item, imageUrl: logoMap.get(courseId)! } : item;
+    });
   }
 
   private mapRowToCertification(row: CertificateRow): Certification {

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ of conduct, development process, and how to submit pull requests.
 
    **Optional variables** (not needed for basic development):
    - `AI_PROXY_URL` / `AI_API_KEY` — For AI-powered features (meeting agenda generation)
+   - `TI_API_KEY` — For enriching course logo URLs via the Thought Industries API (training module); falls back to generic icons when absent
    - `TEST_USERNAME` / `TEST_PASSWORD` — For automated E2E testing
 
 #### Install and Run

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -110,5 +110,8 @@ export * from './my-event.interface';
 // Training interfaces
 export * from './training.interface';
 
+// TI (Thought Industries) interfaces
+export * from './ti.interface';
+
 // My Documents interfaces
 export * from './my-document.interface';

--- a/packages/shared/src/interfaces/ti.interface.ts
+++ b/packages/shared/src/interfaces/ti.interface.ts
@@ -1,0 +1,16 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export interface TiCacheEntry {
+  url: string | null; // null = confirmed TI miss; still cached to avoid re-fetching
+  expiresAt: number;
+}
+
+export interface TiContentItem {
+  id: string;
+  asset: string;
+}
+
+export interface TiContentResponse {
+  contentItems: TiContentItem[];
+}

--- a/packages/shared/src/interfaces/training.interface.ts
+++ b/packages/shared/src/interfaces/training.interface.ts
@@ -48,6 +48,7 @@ export interface CertificateRow {
   EXPIRATION_DATE: string | null;
   DOWNLOAD_URL: string | null;
   LEVEL: string;
+  COURSE_ID: string | null;
 }
 
 /**
@@ -62,6 +63,7 @@ export interface EnrollmentRow {
   PROJECT_NAME: string | null;
   LEVEL: string | null;
   COURSE_SLUG: string | null;
+  COURSE_ID: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `TiService` — a singleton that batches all course IDs into a **single** TI API request (`/incoming/v2/content`) per page load and caches results for **30 days** in memory
- Enriches `imageUrl` on certifications and enrollments after fetching from Snowflake, since `LOGO_URL` in Snowflake is always `null`
- Falls back to the generic icon (book / graduation cap) when TI returns nothing — no change to UX for courses without a logo
- Handles 429 rate-limit responses gracefully: logs the reset time, returns whatever is already in cache, never throws
- Caches negative TI results (course IDs with no match) for 30 days to avoid re-fetching on every request
- Skips TI fetch entirely when `TI_API_KEY` is not configured — avoids 401s and log noise
- Fixes `Continue Learning` and `Download` button styling on training cards — uses `size="small"` instead of `!important` overrides (TODO comment removed), and `Continue Learning` changed to `severity="primary"` per design

## Actual Implementation

<img width="1438" height="952" alt="Screenshot 2026-04-14 at 12 09 31 PM" src="https://github.com/user-attachments/assets/d924ec27-904f-4ce3-8cbb-6f9acf427c8b" />

## Why the CSS crop?

TI's `asset` field returns full card banners — the logo sits inside a styled geometric frame. The CSS crop (`object-cover scale-[1.16] origin-[center_60%]`) zooms into the center of the image to show just the logo without the frame.

Example of the dominant format (~98.9% of enrollments) — framed banner:

![LFS268 framed banner](https://d36ai2hkxl16us.cloudfront.net/thoughtindustries/image/upload/v1/course-uploads/e0df7fbf-a057-42af-8a1f-590912be5460/lff2eihc1z2f-LFS268.png)

Two edge cases exist where the crop produces suboptimal results:

- **Internal courses** (LFT/LFX prefix) — use a plain icon format with no frame; the crop zooms incorrectly. These are internal LF courses not displayed publicly. ~0.12% of enrollments.

  ![LFT127 plain icon](https://d36ai2hkxl16us.cloudfront.net/thoughtindustries/image/upload/v1/course-uploads/e0df7fbf-a057-42af-8a1f-590912be5460/bu7ap2kg7vvp-LFT127.png)

- **Microlearning courses** (MLV/MLI/MLM/MLC prefix) — use a full-bleed illustration; the crop shows a random slice. ~1% of enrollments, growing weekly.

  ![Microcourse illustration](https://media.thoughtindustries.com/thoughtindustries/image/upload/v1/course-uploads/e0df7fbf-a057-42af-8a1f-590912be5460/60owbdpcn9p2-PyroSVI_WhatYourLossCurveIsTellingYou.png)

These edge cases are known and accepted for now. A follow-up will address them properly once the long-term Snowflake pipeline (DL-943) is in place.

## Before this can be merged

- [ ] **`TI_API_KEY` environment variable must be configured** in staging and production environments (ArgoCD / Kubernetes secrets). The key is the Bearer token for `https://linux.thoughtindustries.com/incoming/v2/content`. Without it, TI calls are skipped and logos fall back to the generic icon silently — no errors.
- [ ] Smoke-test on staging: visit `/me/training` and verify certification and enrollment logos load correctly

## Rate limit protection

The TI API is shared with LF Education production flows (~250 req / 15-min window). The 30-day in-memory cache means a cold-started server pod makes **one batch request** on first load, then serves all subsequent requests from cache. Unmatched course IDs are also cached (as misses) so they don't trigger repeat fetches. Worst-case across 3 pods × 6 restarts/month = ~18 requests/month to TI.

## Long-term plan

A JIRA ticket ([DL-943](https://linuxfoundation.atlassian.net/browse/DL-943)) has been filed to feed `COURSE_ID → asset_url` into Snowflake via Fivetran. Once that data is available, `TiService` can be deleted entirely and the Snowflake query can return the logo URL directly — eliminating all runtime TI API calls.

## Test plan

- [ ] Visit `/me/training` → Certifications tab — logos should appear (not generic icons)
- [ ] Visit `/me/training` → Enrolled Trainings tab — logos should appear
- [ ] Check server logs on first load: `ti_get_logos` fetch logged
- [ ] Reload page: `ti_cache_hit` logged, no second TI API call
- [ ] Courses without a TI match still show generic icon fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DL-943]: https://linuxfoundation.atlassian.net/browse/DL-943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
