### PR TITLE
feat(ui): add foundation and project filters to me lens dashboards

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -72,6 +72,52 @@
       </div>
     }
 
+    <!-- Search & Filters (Me lens only) -->
+    @if (isMeLens()) {
+      <div class="bg-white rounded-lg border border-gray-200 p-4 mb-6">
+        <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
+          <div class="flex-1">
+            <lfx-input-text
+              [form]="searchForm"
+              control="search"
+              [placeholder]="'Search ' + committeeLabel.plural.toLowerCase() + '...'"
+              icon="fa-light fa-search"
+              styleClass="w-full"
+              size="small"
+              data-testid="committee-me-search-input"></lfx-input-text>
+          </div>
+          @if (showFoundationFilter()) {
+            <div class="w-full sm:w-48">
+              <lfx-select
+                [form]="searchForm"
+                control="foundationFilter"
+                size="small"
+                [options]="foundationOptions()"
+                placeholder="All Foundations"
+                [showClear]="true"
+                styleClass="w-full"
+                (onChange)="onFoundationFilterChange($event.value)"
+                data-testid="committee-foundation-filter"></lfx-select>
+            </div>
+          }
+          @if (showProjectFilter() && projectOptions().length > 0) {
+            <div class="w-full sm:w-48">
+              <lfx-select
+                [form]="searchForm"
+                control="projectFilter"
+                size="small"
+                [options]="projectOptions()"
+                placeholder="All Projects"
+                [showClear]="true"
+                styleClass="w-full"
+                (onChange)="onProjectFilterChange($event.value)"
+                data-testid="committee-project-filter"></lfx-select>
+            </div>
+          }
+        </div>
+      </div>
+    }
+
     <!-- My Groups Section -->
     @if (myCommitteesLoading()) {
       <div>
@@ -104,89 +150,100 @@
       <div>
         <div class="flex items-center gap-2 mb-4">
           <h2 class="text-lg font-semibold text-gray-900">My {{ committeeLabel.plural }}</h2>
-          <span class="text-xs font-medium text-gray-500 bg-gray-100 rounded-full px-2 py-0.5">{{ myCommittees().length }}</span>
+          <span class="text-xs font-medium text-gray-500 bg-gray-100 rounded-full px-2 py-0.5">{{ filteredMyCommittees().length }}</span>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          @for (committee of myCommittees(); track committee.uid) {
-            <div
-              class="block cursor-pointer"
-              tabindex="0"
-              role="link"
-              [attr.aria-label]="'Open ' + (committee.display_name || committee.name)"
-              (click)="onCommitteeClick(committee)"
-              (keydown.enter)="onCommitteeClick(committee)">
-              <lfx-card styleClass="hover:shadow-md transition-shadow cursor-pointer h-full">
-                <div class="flex flex-col h-full">
-                  <!-- Header: Name + Role Badge -->
-                  <div class="flex items-start justify-between gap-2 mb-3">
-                    <div class="min-w-0 flex-1">
-                      <h3 class="text-sm font-semibold text-gray-900 truncate">{{ committee.display_name || committee.name }}</h3>
-                      <div class="flex items-center gap-2 mt-1">
-                        <span class="text-sm text-gray-500">{{ committee.category }}</span>
-                        @if (!committee.public) {
-                          <i class="fa-light fa-lock w-3 h-3 text-gray-400"></i>
-                        }
-                      </div>
-                    </div>
-                    <!-- Role Badge -->
-                    <span
-                      class="inline-flex items-center text-xs font-medium rounded-full px-2.5 py-1 flex-shrink-0"
-                      [ngClass]="committee.my_role | roleBadgeClass">
-                      {{ committee.my_role }}
-                    </span>
-                  </div>
-
-                  <!-- Meta Row: Members + Voting + Channels -->
-                  <div class="flex items-center gap-4 mt-auto pt-3 border-t border-gray-100">
-                    <div class="flex items-center gap-1.5 text-sm text-gray-500">
-                      <i class="fa-light fa-users w-3.5 h-3.5"></i>
-                      <span>{{ committee.total_members || 0 }} members</span>
-                    </div>
-                    @if (committee.enable_voting) {
-                      <div class="flex items-center gap-1.5 text-xs text-emerald-600">
-                        <i class="fa-light fa-check-to-slot w-3.5 h-3.5"></i>
-                        <span>Voting</span>
-                      </div>
-                    }
-                    <!-- Channels: mailing_list and chat_channel are plain strings from upstream -->
-                    @if (committee.mailing_list) {
-                      <a
-                        [href]="'mailto:' + committee.mailing_list"
-                        (click)="$event.stopPropagation()"
-                        class="flex items-center gap-1 text-sm text-gray-500 hover:text-blue-600 no-underline"
-                        [pTooltip]="committee.mailing_list"
-                        tooltipPosition="top"
-                        aria-label="Mailing list">
-                        <i class="fa-light fa-envelope w-3.5 h-3.5" aria-hidden="true"></i>
-                      </a>
-                    } @else {
-                      <span class="flex items-center gap-1 text-gray-300 cursor-default" pTooltip="No mailing list" tooltipPosition="top">
-                        <i class="fa-light fa-envelope w-3.5 h-3.5"></i>
-                      </span>
-                    }
-                    @if (committee.chat_channel) {
-                      <a
-                        [href]="committee.chat_channel"
-                        target="_blank"
-                        rel="noopener"
-                        (click)="$event.stopPropagation()"
-                        class="flex items-center gap-1 text-sm text-gray-500 hover:text-blue-600 no-underline"
-                        [pTooltip]="committee.chat_channel | platformLabel"
-                        tooltipPosition="top"
-                        [attr.aria-label]="committee.chat_channel | platformLabel">
-                        <i [class]="(committee.chat_channel | platformIcon) + ' w-3.5 h-3.5'" aria-hidden="true"></i>
-                      </a>
-                    } @else {
-                      <span class="flex items-center gap-1 text-gray-300 cursor-default" pTooltip="No chat channel" tooltipPosition="top">
-                        <i class="fa-light fa-comment w-3.5 h-3.5"></i>
-                      </span>
-                    }
-                  </div>
-                </div>
-              </lfx-card>
+        @if (filteredMyCommittees().length === 0) {
+          <lfx-card>
+            <div class="flex items-center justify-center p-8">
+              <div class="text-center">
+                <i class="fa-light fa-eyes text-2xl text-gray-400 mb-2"></i>
+                <p class="text-sm text-gray-500">No {{ committeeLabel.plural.toLowerCase() }} found matching your filters</p>
+              </div>
             </div>
-          }
-        </div>
+          </lfx-card>
+        } @else {
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            @for (committee of filteredMyCommittees(); track committee.uid) {
+              <div
+                class="block cursor-pointer"
+                tabindex="0"
+                role="link"
+                [attr.aria-label]="'Open ' + (committee.display_name || committee.name)"
+                (click)="onCommitteeClick(committee)"
+                (keydown.enter)="onCommitteeClick(committee)">
+                <lfx-card styleClass="hover:shadow-md transition-shadow cursor-pointer h-full">
+                  <div class="flex flex-col h-full">
+                    <!-- Header: Name + Role Badge -->
+                    <div class="flex items-start justify-between gap-2 mb-3">
+                      <div class="min-w-0 flex-1">
+                        <h3 class="text-sm font-semibold text-gray-900 truncate">{{ committee.display_name || committee.name }}</h3>
+                        <div class="flex items-center gap-2 mt-1">
+                          <span class="text-sm text-gray-500">{{ committee.category }}</span>
+                          @if (!committee.public) {
+                            <i class="fa-light fa-lock w-3 h-3 text-gray-400"></i>
+                          }
+                        </div>
+                      </div>
+                      <!-- Role Badge -->
+                      <span
+                        class="inline-flex items-center text-xs font-medium rounded-full px-2.5 py-1 flex-shrink-0"
+                        [ngClass]="committee.my_role | roleBadgeClass">
+                        {{ committee.my_role }}
+                      </span>
+                    </div>
+
+                    <!-- Meta Row: Members + Voting + Channels -->
+                    <div class="flex items-center gap-4 mt-auto pt-3 border-t border-gray-100">
+                      <div class="flex items-center gap-1.5 text-sm text-gray-500">
+                        <i class="fa-light fa-users w-3.5 h-3.5"></i>
+                        <span>{{ committee.total_members || 0 }} members</span>
+                      </div>
+                      @if (committee.enable_voting) {
+                        <div class="flex items-center gap-1.5 text-xs text-emerald-600">
+                          <i class="fa-light fa-check-to-slot w-3.5 h-3.5"></i>
+                          <span>Voting</span>
+                        </div>
+                      }
+                      <!-- Channels: mailing_list and chat_channel are plain strings from upstream -->
+                      @if (committee.mailing_list) {
+                        <a
+                          [href]="'mailto:' + committee.mailing_list"
+                          (click)="$event.stopPropagation()"
+                          class="flex items-center gap-1 text-sm text-gray-500 hover:text-blue-600 no-underline"
+                          [pTooltip]="committee.mailing_list"
+                          tooltipPosition="top"
+                          aria-label="Mailing list">
+                          <i class="fa-light fa-envelope w-3.5 h-3.5" aria-hidden="true"></i>
+                        </a>
+                      } @else {
+                        <span class="flex items-center gap-1 text-gray-300 cursor-default" pTooltip="No mailing list" tooltipPosition="top">
+                          <i class="fa-light fa-envelope w-3.5 h-3.5"></i>
+                        </span>
+                      }
+                      @if (committee.chat_channel) {
+                        <a
+                          [href]="committee.chat_channel"
+                          target="_blank"
+                          rel="noopener"
+                          (click)="$event.stopPropagation()"
+                          class="flex items-center gap-1 text-sm text-gray-500 hover:text-blue-600 no-underline"
+                          [pTooltip]="committee.chat_channel | platformLabel"
+                          tooltipPosition="top"
+                          [attr.aria-label]="committee.chat_channel | platformLabel">
+                          <i [class]="(committee.chat_channel | platformIcon) + ' w-3.5 h-3.5'" aria-hidden="true"></i>
+                        </a>
+                      } @else {
+                        <span class="flex items-center gap-1 text-gray-300 cursor-default" pTooltip="No chat channel" tooltipPosition="top">
+                          <i class="fa-light fa-comment w-3.5 h-3.5"></i>
+                        </span>
+                      }
+                    </div>
+                  </div>
+                </lfx-card>
+              </div>
+            }
+          </div>
+        }
       </div>
     } @else if (isMeLens()) {
       <lfx-card>

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -4,10 +4,12 @@
 import { DecimalPipe, NgClass } from '@angular/common';
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { SelectComponent } from '@components/select/select.component';
 import { COMMITTEE_LABEL } from '@lfx-one/shared/constants';
 import { Committee, MyCommittee, ProjectContext } from '@lfx-one/shared/interfaces';
 import { RoleBadgeClassPipe } from '@pipes/role-badge-class.pipe';
@@ -31,9 +33,12 @@ import { CommitteeTableComponent } from '../components/committee-table/committee
   imports: [
     DecimalPipe,
     NgClass,
+    ReactiveFormsModule,
     ButtonComponent,
     CardComponent,
     CommitteeTableComponent,
+    InputTextComponent,
+    SelectComponent,
     RoleBadgeClassPipe,
     PlatformIconPipe,
     PlatformLabelPipe,
@@ -60,14 +65,16 @@ export class CommitteeDashboardComponent {
   public committeesLoading = signal<boolean>(true);
   public myCommitteesLoading = signal<boolean>(true);
   public refresh = signal(0);
+  public foundationFilter = signal<string | null>(null);
+  public projectFilter = signal<string | null>(null);
 
   // ── Forms ─────────────────────────────────────────────────────────────────
   public searchForm: FormGroup;
-
   // ── Computed / Read-only Signals ──────────────────────────────────────────
   public project: Signal<ProjectContext | null>;
   public committees: Signal<Committee[]>;
   public myCommittees: Signal<MyCommittee[]>;
+  public filteredMyCommittees: Signal<MyCommittee[]>;
   public myCommitteeUids: Signal<Set<string>>;
   public categories: Signal<{ label: string; value: string | null }[]>;
   public votingStatusOptions: Signal<{ label: string; value: string | null }[]>;
@@ -82,8 +89,14 @@ export class CommitteeDashboardComponent {
   public foundationCreateCommitteeFlag: Signal<boolean>;
   public canCreateGroup: Signal<boolean>;
 
+  // Foundation and project filter options (separate dropdowns)
+  public foundationOptions: Signal<{ label: string; value: string }[]> = this.initializeFoundationOptions();
+  public projectOptions: Signal<{ label: string; value: string }[]> = this.initializeProjectOptions();
+
   // Lens
   public readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+  public showFoundationFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
+  public showProjectFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
 
   // Statistics
   public totalCommittees: Signal<number>;
@@ -135,6 +148,7 @@ export class CommitteeDashboardComponent {
     this.categories = this.initializeCategories();
     this.votingStatusOptions = this.initializeVotingStatusOptions();
     this.filteredCommittees = this.initializeFilteredCommittees();
+    this.filteredMyCommittees = this.initializeFilteredMyCommittees();
 
     // Initialize statistics
     this.totalCommittees = computed(() => this.committees().length);
@@ -171,21 +185,34 @@ export class CommitteeDashboardComponent {
     this.router.navigate(['/groups', committee.uid]);
   }
 
+  public onFoundationFilterChange(value: string | null): void {
+    this.foundationFilter.set(value);
+    this.projectFilter.set(null);
+    this.searchForm.get('projectFilter')?.setValue(null, { emitEvent: false });
+  }
+
+  public onProjectFilterChange(value: string | null): void {
+    this.projectFilter.set(value);
+  }
+
   private initializeMyCommittees(): Signal<MyCommittee[]> {
     const project$ = toObservable(this.project);
     const refresh$ = toObservable(this.refresh);
     const lens$ = toObservable(this.lensService.activeLens);
+    const projectFilter$ = toObservable(this.projectFilter);
+    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([project$, refresh$, lens$]).pipe(
-        switchMap(([project, , lens]) => {
+      combineLatest([project$, refresh$, lens$, projectFilter$, foundationFilter$]).pipe(
+        switchMap(([project, , lens, projectFilter, foundationFilter]) => {
           this.myCommitteesLoading.set(true);
           if (lens !== 'me' && !project?.uid) {
             this.myCommitteesLoading.set(false);
             return of([] as MyCommittee[]);
           }
-          const projectUid = lens === 'me' ? undefined : project!.uid;
-          return this.committeeService.getMyCommittees(projectUid).pipe(
+          const projectUid = lens === 'me' ? (projectFilter ?? undefined) : project!.uid;
+          const foundationUid = lens === 'me' ? (foundationFilter ?? undefined) : undefined;
+          return this.committeeService.getMyCommittees(projectUid, foundationUid).pipe(
             catchError((error) => {
               console.error('Failed to load my committees:', error);
               this.myCommitteesLoading.set(false);
@@ -204,6 +231,8 @@ export class CommitteeDashboardComponent {
       search: new FormControl<string>(''),
       category: new FormControl<string | null>(null),
       votingStatus: new FormControl<string | null>(null),
+      foundationFilter: new FormControl<string | null>(null),
+      projectFilter: new FormControl<string | null>(null),
     });
   }
 
@@ -287,6 +316,25 @@ export class CommitteeDashboardComponent {
     });
   }
 
+  private initializeFoundationOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() => {
+      const projects = this.personaService.detectedProjects();
+      return projects.filter((p) => p.isFoundation).map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+    });
+  }
+
+  private initializeProjectOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() => {
+      const projects = this.personaService.detectedProjects();
+      const foundation = this.foundationFilter();
+      let candidates = projects.filter((p) => !p.isFoundation);
+      if (foundation) {
+        candidates = candidates.filter((p) => p.parentProjectUid === foundation);
+      }
+      return candidates.map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+    });
+  }
+
   private initializeFilteredCommittees(): Signal<Committee[]> {
     return computed(() => {
       let filtered = this.committees();
@@ -319,6 +367,23 @@ export class CommitteeDashboardComponent {
       }
 
       return filtered;
+    });
+  }
+
+  private initializeFilteredMyCommittees(): Signal<MyCommittee[]> {
+    return computed(() => {
+      const committees = this.myCommittees();
+      const searchTerm = this.searchTerm()?.toLowerCase() || '';
+      if (!searchTerm) {
+        return committees;
+      }
+      return committees.filter(
+        (committee) =>
+          committee.name.toLowerCase().includes(searchTerm) ||
+          committee.display_name?.toLowerCase().includes(searchTerm) ||
+          committee.description?.toLowerCase().includes(searchTerm) ||
+          committee.category?.toLowerCase().includes(searchTerm)
+      );
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
@@ -17,6 +17,39 @@
           data-testid="mailing-list-search-input"></lfx-input-text>
       </div>
 
+      <!-- Foundation Filter Dropdown (Me lens only) -->
+      @if (showFoundationFilter()) {
+        <div class="w-full sm:w-48">
+          <lfx-select
+            [form]="searchForm()"
+            control="foundationFilter"
+            size="small"
+            [options]="foundationOptions()"
+            placeholder="All Foundations"
+            [showClear]="true"
+            styleClass="w-full"
+            (onChange)="foundationFilterChange.emit($event.value)"
+            data-testid="mailing-list-foundation-filter">
+          </lfx-select>
+        </div>
+      }
+      <!-- Project Filter Dropdown (Me lens only, cascading from foundation) -->
+      @if (showProjectFilter() && projectOptions().length > 0) {
+        <div class="w-full sm:w-48">
+          <lfx-select
+            [form]="searchForm()"
+            control="projectFilter"
+            size="small"
+            [options]="projectOptions()"
+            placeholder="All Projects"
+            [showClear]="true"
+            styleClass="w-full"
+            (onChange)="projectFilterChange.emit($event.value)"
+            data-testid="mailing-list-project-filter">
+          </lfx-select>
+        </div>
+      }
+
       <!-- Committee Filter Dropdown -->
       <div class="w-full sm:w-48">
         <lfx-select
@@ -47,6 +80,7 @@
 
   <lfx-table
     [value]="mailingLists()"
+    [loading]="loading()"
     [paginator]="mailingLists().length > 10"
     [rows]="10"
     [rowsPerPageOptions]="[10, 25, 50]"

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts
@@ -54,6 +54,11 @@ export class MailingListTableComponent {
   public searchForm = input.required<FormGroup>();
   public committeeFilterOptions = input.required<FilterOption[]>();
   public statusFilterOptions = input.required<FilterOption[]>();
+  public foundationOptions = input<{ label: string; value: string }[]>([]);
+  public projectOptions = input<{ label: string; value: string }[]>([]);
+  public showFoundationFilter = input<boolean>(false);
+  public showProjectFilter = input<boolean>(false);
+  public loading = input<boolean>(false);
 
   // Constants
   protected readonly maxVisibleGroups = MAILING_LIST_MAX_VISIBLE_GROUPS;
@@ -65,6 +70,8 @@ export class MailingListTableComponent {
   // Outputs
   public readonly refresh = output<void>();
   public readonly rowClick = output<GroupsIOMailingList>();
+  public readonly foundationFilterChange = output<string | null>();
+  public readonly projectFilterChange = output<string | null>();
 
   // Event Handlers
   protected onRowSelect(event: { data: GroupsIOMailingList }): void {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
-  @if ((isMeLens() && myMailingListsLoading()) || (!isMeLens() && (mailingListsLoading() || !servicesLoaded()))) {
+  @if (!isMeLens() && (mailingListsLoading() || !servicesLoaded())) {
     <div class="flex justify-center items-center min-h-96">
       <div class="text-center">
         <i class="fa-light fa-spinner-third fa-spin text-3xl text-blue-600 mb-4"></i>
@@ -64,19 +64,7 @@
 
     <!-- Content Area -->
     <div class="min-h-[400px]">
-      @if (isMeLens() && myMailingLists().length === 0) {
-        <!-- Me lens empty state -->
-        <lfx-card>
-          <div class="flex items-center justify-center p-16">
-            <div class="text-center max-w-md">
-              <div class="text-gray-400 mb-4">
-                <i class="fa-light fa-envelope text-[2rem] mb-4"></i>
-                <h3 class="text-gray-600 mt-2">You are not subscribed to any {{ mailingListLabelPlural.toLowerCase() }} yet.</h3>
-              </div>
-            </div>
-          </div>
-        </lfx-card>
-      } @else if (!isMeLens() && mailingLists().length === 0 && project()?.uid) {
+      @if (!isMeLens() && mailingLists().length === 0 && project()?.uid) {
         <!-- Empty state: No mailing lists exist -->
         <lfx-card>
           <div class="flex items-center justify-center p-16">
@@ -88,27 +76,21 @@
             </div>
           </div>
         </lfx-card>
-      } @else if (filteredMailingLists().length === 0) {
-        <!-- Empty state: Filters returned no results -->
-        <lfx-card>
-          <div class="flex items-center justify-center p-16">
-            <div class="text-center max-w-md">
-              <div class="text-gray-400 mb-4">
-                <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
-              </div>
-              <h3 class="text-xl font-semibold text-gray-900 mt-4">No {{ mailingListLabelPlural.toLowerCase() }} Found</h3>
-              <p class="text-gray-600 mt-2">Try adjusting your search or filter criteria</p>
-            </div>
-          </div>
-        </lfx-card>
       } @else {
         <lfx-mailing-list-table
           [mailingLists]="filteredMailingLists()"
+          [loading]="isMeLens() && myMailingListsLoading()"
           [isMaintainer]="isMaintainer()"
           [mailingListLabel]="mailingListLabel"
           [searchForm]="searchForm"
           [committeeFilterOptions]="committeeOptions()"
           [statusFilterOptions]="statusOptions()"
+          [foundationOptions]="foundationOptions()"
+          [projectOptions]="projectOptions()"
+          [showFoundationFilter]="showFoundationFilter()"
+          [showProjectFilter]="showProjectFilter()"
+          (foundationFilterChange)="onFoundationFilterChange($event)"
+          (projectFilterChange)="onProjectFilterChange($event)"
           (refresh)="refreshMailingLists()"
           (rowClick)="onMailingListClick($event)">
         </lfx-mailing-list-table>

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -1,9 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, signal, Signal } from '@angular/core';
+import { Component, computed, inject, signal, Signal, WritableSignal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -21,7 +21,7 @@ import { MailingListTableComponent } from '../components/mailing-list-table/mail
 
 @Component({
   selector: 'lfx-mailing-list-dashboard',
-  imports: [ButtonComponent, CardComponent, MailingListTableComponent],
+  imports: [ButtonComponent, CardComponent, MailingListTableComponent, ReactiveFormsModule],
   templateUrl: './mailing-list-dashboard.component.html',
   styleUrl: './mailing-list-dashboard.component.scss',
 })
@@ -54,7 +54,15 @@ export class MailingListDashboardComponent {
 
   // Lens
   public readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+  public showFoundationFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
+  public showProjectFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
   public myMailingListsLoading = signal<boolean>(true);
+
+  // Foundation + Project filter (Me lens only)
+  public foundationFilter: WritableSignal<string | null> = signal<string | null>(null);
+  public projectFilter: WritableSignal<string | null> = signal<string | null>(null);
+  public foundationOptions: Signal<{ label: string; value: string }[]> = this.initializeFoundationOptions();
+  public projectOptions: Signal<{ label: string; value: string }[]> = this.initializeProjectOptions();
 
   // Complex computed/toSignal signals
   public readonly project: Signal<ProjectContext | null> = this.initProject();
@@ -103,12 +111,31 @@ export class MailingListDashboardComponent {
     this.router.navigate(['/mailing-lists', mailingList.uid]);
   }
 
+  /**
+   * Handle foundation filter change
+   */
+  public onFoundationFilterChange(value: string | null): void {
+    this.foundationFilter.set(value);
+    // Reset project filter when foundation changes
+    this.projectFilter.set(null);
+    this.searchForm.get('projectFilter')?.setValue(null);
+  }
+
+  /**
+   * Handle project filter change
+   */
+  public onProjectFilterChange(value: string | null): void {
+    this.projectFilter.set(value);
+  }
+
   // Private initializer functions
   private initializeSearchForm(): FormGroup {
     return new FormGroup({
       search: new FormControl<string>(''),
       committee: new FormControl<string | null>(null),
       status: new FormControl<string | null>(null),
+      foundationFilter: new FormControl<string | null>(null),
+      projectFilter: new FormControl<string | null>(null),
     });
   }
 
@@ -302,18 +329,39 @@ export class MailingListDashboardComponent {
     return computed(() => this.servicesLoaded() && this.availableServices().length === 0);
   }
 
+  private initializeFoundationOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() => {
+      const projects = this.personaService.detectedProjects();
+      return projects.filter((p) => p.isFoundation).map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+    });
+  }
+
+  private initializeProjectOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() => {
+      const projects = this.personaService.detectedProjects();
+      const foundation = this.foundationFilter();
+      let candidates = projects.filter((p) => !p.isFoundation);
+      if (foundation) {
+        candidates = candidates.filter((p) => p.parentProjectUid === foundation);
+      }
+      return candidates.map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+    });
+  }
+
   private initMyMailingLists(): Signal<MyMailingList[]> {
     const lens$ = toObservable(this.lensService.activeLens);
+    const projectFilter$ = toObservable(this.projectFilter);
+    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([lens$, this.refresh]).pipe(
-        switchMap(([lens]) => {
+      combineLatest([lens$, this.refresh, projectFilter$, foundationFilter$]).pipe(
+        switchMap(([lens, , projectFilter, foundationFilter]) => {
           if (lens !== 'me') {
             this.myMailingListsLoading.set(false);
             return of([] as MyMailingList[]);
           }
           this.myMailingListsLoading.set(true);
-          return this.mailingListService.getMyMailingLists().pipe(
+          return this.mailingListService.getMyMailingLists(projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
             catchError(() => {
               this.myMailingListsLoading.set(false);
               return of([] as MyMailingList[]);

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.html
@@ -14,6 +14,38 @@
       data-testid="meetings-search-input"></lfx-input-text>
   </div>
 
+  <!-- Foundation Filter Dropdown -->
+  @if (showFoundationFilter()) {
+    <div class="w-full sm:w-48">
+      <lfx-select
+        [form]="searchForm"
+        control="foundationFilter"
+        size="small"
+        [options]="foundationOptions()"
+        placeholder="All Foundations"
+        [showClear]="true"
+        styleClass="w-full"
+        (onChange)="onFoundationFilterChange($event.value)"
+        data-testid="foundation-filter-dropdown"></lfx-select>
+    </div>
+  }
+
+  <!-- Project Filter Dropdown -->
+  @if (showProjectFilter() && projectOptions().length > 0) {
+    <div class="w-full sm:w-48">
+      <lfx-select
+        [form]="searchForm"
+        control="projectFilter"
+        size="small"
+        [options]="projectOptions()"
+        placeholder="All Projects"
+        [showClear]="true"
+        styleClass="w-full"
+        (onChange)="onProjectFilterChange($event.value)"
+        data-testid="project-filter-dropdown"></lfx-select>
+    </div>
+  }
+
   <!-- Meeting Type Filter Dropdown -->
   <div class="w-full sm:w-64">
     <lfx-select

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.ts
@@ -15,8 +15,14 @@ import { SelectComponent } from '@components/select/select.component';
 })
 export class MeetingsTopBarComponent implements OnInit {
   public meetingTypeOptions = input.required<{ label: string; value: string | null }[]>();
+  public foundationOptions = input<{ label: string; value: string }[]>([]);
+  public projectOptions = input<{ label: string; value: string }[]>([]);
+  public showFoundationFilter = input<boolean>(false);
+  public showProjectFilter = input<boolean>(false);
   public readonly initialTimeFilter = input<'upcoming' | 'past'>('upcoming');
   public readonly meetingTypeChange = output<string | null>();
+  public readonly foundationFilterChange = output<string | null>();
+  public readonly projectFilterChange = output<string | null>();
   public readonly searchQueryChange = output<string>();
   public readonly timeFilterChange = output<'upcoming' | 'past'>();
 
@@ -34,6 +40,8 @@ export class MeetingsTopBarComponent implements OnInit {
     this.searchForm = new FormGroup({
       search: new FormControl(''),
       meetingType: new FormControl<string | null>(null),
+      foundationFilter: new FormControl<string | null>(null),
+      projectFilter: new FormControl<string | null>(null),
       timeFilter: new FormControl<'upcoming' | 'past'>('upcoming'),
     });
 
@@ -52,6 +60,8 @@ export class MeetingsTopBarComponent implements OnInit {
       .subscribe((value) => {
         if (value) {
           this.timeFilterChange.emit(value);
+          this.searchForm.get('foundationFilter')?.setValue(null, { emitEvent: false });
+          this.searchForm.get('projectFilter')?.setValue(null, { emitEvent: false });
         }
       });
   }
@@ -65,6 +75,17 @@ export class MeetingsTopBarComponent implements OnInit {
 
   public onMeetingTypeChange(value: string | null): void {
     this.meetingTypeChange.emit(value);
+  }
+
+  public onFoundationFilterChange(value: string | null): void {
+    this.foundationFilterChange.emit(value);
+    // Reset project filter when foundation changes
+    this.searchForm.get('projectFilter')?.setValue(null, { emitEvent: false });
+    this.projectFilterChange.emit(null);
+  }
+
+  public onProjectFilterChange(value: string | null): void {
+    this.projectFilterChange.emit(value);
   }
 
   public onTimeFilterChange(value: 'upcoming' | 'past'): void {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -25,8 +25,14 @@
       @if (upcomingMeetings() || pastMeetings()) {
         <lfx-meetings-top-bar
           [meetingTypeOptions]="meetingTypeOptions()"
+          [foundationOptions]="foundationOptions()"
+          [projectOptions]="projectOptions()"
+          [showFoundationFilter]="showFoundationFilter()"
+          [showProjectFilter]="showProjectFilter()"
           [initialTimeFilter]="timeFilter()"
           (meetingTypeChange)="onMeetingTypeChange($event)"
+          (foundationFilterChange)="onFoundationFilterChange($event)"
+          (projectFilterChange)="onProjectFilterChange($event)"
           (searchQueryChange)="searchQuery.set($event)"
           (timeFilterChange)="onTimeFilterChange($event)" />
       }

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -65,6 +65,12 @@ export class MeetingsDashboardComponent {
   public timeFilter: WritableSignal<'upcoming' | 'past'>;
   public meetingTypeFilter: WritableSignal<string | null>;
   public meetingTypeOptions: Signal<{ label: string; value: string | null }[]>;
+  public foundationFilter: WritableSignal<string | null>;
+  public projectFilter: WritableSignal<string | null>;
+  public showFoundationFilter: Signal<boolean>;
+  public showProjectFilter: Signal<boolean>;
+  public foundationOptions: Signal<{ label: string; value: string }[]>;
+  public projectOptions: Signal<{ label: string; value: string }[]>;
   public project: Signal<ProjectContext | null>;
   public isMaintainer: Signal<boolean>;
   public isFoundationContext: Signal<boolean>;
@@ -109,6 +115,12 @@ export class MeetingsDashboardComponent {
     const initialTimeFilter = this.route.snapshot.queryParamMap.get('time') === 'past' ? 'past' : 'upcoming';
     this.timeFilter = signal<'upcoming' | 'past'>(initialTimeFilter);
     this.meetingTypeFilter = signal<string | null>(null);
+    this.foundationFilter = signal<string | null>(null);
+    this.projectFilter = signal<string | null>(null);
+    this.foundationOptions = this.initializeFoundationOptions();
+    this.projectOptions = this.initializeProjectOptions();
+    this.showFoundationFilter = computed(() => this.activeLens() === 'me' && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
+    this.showProjectFilter = computed(() => this.activeLens() === 'me' && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
     this.hasMore = computed(() => this.activeLens() !== 'me' && (this.timeFilter() === 'past' ? !!this.pastPageToken() : !!this.upcomingPageToken()));
 
     // Initialize meeting type options
@@ -137,8 +149,19 @@ export class MeetingsDashboardComponent {
     this.meetingTypeFilter.set(value);
   }
 
+  public onFoundationFilterChange(value: string | null): void {
+    this.foundationFilter.set(value);
+    this.projectFilter.set(null);
+  }
+
+  public onProjectFilterChange(value: string | null): void {
+    this.projectFilter.set(value);
+  }
+
   public onTimeFilterChange(value: 'upcoming' | 'past'): void {
     this.timeFilter.set(value);
+    this.foundationFilter.set(null);
+    this.projectFilter.set(null);
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { time: value === 'past' ? 'past' : null },
@@ -319,15 +342,17 @@ export class MeetingsDashboardComponent {
 
   private initializeRawUserMeetings(): Signal<Meeting[]> {
     const lens$ = toObservable(this.activeLens);
+    const projectFilter$ = toObservable(this.projectFilter);
+    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([lens$, this.refresh$]).pipe(
-        switchMap(([lens]) => {
+      combineLatest([lens$, this.refresh$, projectFilter$, foundationFilter$]).pipe(
+        switchMap(([lens, , projectFilter, foundationFilter]) => {
           if (lens !== 'me') {
             return of([] as Meeting[]);
           }
           this.meetingsLoading.set(true);
-          return this.userService.getUserMeetings(100).pipe(
+          return this.userService.getUserMeetings(100, projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
             tap(() => this.meetingsLoading.set(false)),
             catchError(() => {
               this.meetingsLoading.set(false);
@@ -342,15 +367,17 @@ export class MeetingsDashboardComponent {
 
   private initializeRawUserPastMeetings(): Signal<PastMeeting[]> {
     const lens$ = toObservable(this.activeLens);
+    const projectFilter$ = toObservable(this.projectFilter);
+    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([lens$, this.refresh$]).pipe(
-        switchMap(([lens]) => {
+      combineLatest([lens$, this.refresh$, projectFilter$, foundationFilter$]).pipe(
+        switchMap(([lens, , projectFilter, foundationFilter]) => {
           if (lens !== 'me') {
             return of([] as PastMeeting[]);
           }
           this.pastMeetingsLoading.set(true);
-          return this.userService.getUserPastMeetings(100).pipe(
+          return this.userService.getUserPastMeetings(100, projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
             tap(() => this.pastMeetingsLoading.set(false)),
             catchError(() => {
               this.pastMeetingsLoading.set(false);
@@ -408,6 +435,30 @@ export class MeetingsDashboardComponent {
       filtered = filtered.filter((m) => m.meeting_type === meetingType);
     }
     return filtered;
+  }
+
+  private initializeFoundationOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() => {
+      const projects = this.personaService.detectedProjects();
+      return projects.filter((p) => p.isFoundation).map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+    });
+  }
+
+  private initializeProjectOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() => {
+      const projects = this.personaService.detectedProjects();
+      const foundation = this.foundationFilter();
+
+      // Filter to non-foundation projects
+      let candidates = projects.filter((p) => !p.isFoundation);
+
+      // If a foundation is selected, show only its children
+      if (foundation) {
+        candidates = candidates.filter((p) => p.parentProjectUid === foundation);
+      }
+
+      return candidates.map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+    });
   }
 
   private buildMeetingTypeFilters(meetingType: string | null): string[] | undefined {

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -15,6 +15,36 @@
           data-testid="surveys-search-input"></lfx-input-text>
       </div>
 
+      @if (showFoundationFilter()) {
+        <div class="w-full sm:w-48">
+          <lfx-select
+            [form]="searchForm"
+            control="foundationFilter"
+            size="small"
+            [options]="foundationOptions()"
+            placeholder="All Foundations"
+            [showClear]="true"
+            styleClass="w-full"
+            (onChange)="onFoundationFilterChange($event.value)"
+            data-testid="surveys-foundation-filter"></lfx-select>
+        </div>
+      }
+
+      @if (showProjectFilter() && projectOptions().length > 0) {
+        <div class="w-full sm:w-48">
+          <lfx-select
+            [form]="searchForm"
+            control="projectFilter"
+            size="small"
+            [options]="projectOptions()"
+            placeholder="All Projects"
+            [showClear]="true"
+            styleClass="w-full"
+            (onChange)="projectFilterChange.emit($event.value)"
+            data-testid="surveys-project-filter"></lfx-select>
+        </div>
+      }
+
       <div class="w-full sm:w-auto sm:shrink-0">
         <lfx-select
           [form]="searchForm"

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -53,11 +53,17 @@ export class SurveysTableComponent {
   public readonly surveys = input.required<Survey[]>();
   public readonly hasPMOAccess = input<boolean>(false);
   public readonly loading = input<boolean>(false);
+  public readonly foundationOptions = input<{ label: string; value: string }[]>([]);
+  public readonly projectOptions = input<{ label: string; value: string }[]>([]);
+  public readonly showFoundationFilter = input<boolean>(false);
+  public readonly showProjectFilter = input<boolean>(false);
 
   // === Outputs ===
   public readonly viewResults = output<string>();
   public readonly refresh = output<void>();
   public readonly rowClick = output<Survey>();
+  public readonly foundationFilterChange = output<string | null>();
+  public readonly projectFilterChange = output<string | null>();
 
   // === Writable Signals ===
   protected readonly isDeleting = signal(false);
@@ -68,6 +74,8 @@ export class SurveysTableComponent {
     status: new FormControl<string | null>(null),
     group: new FormControl<string | null>(null),
     surveyType: new FormControl<string | null>(null),
+    foundationFilter: new FormControl<string | null>(null),
+    projectFilter: new FormControl<string | null>(null),
   });
 
   // === Writable Signals ===
@@ -83,6 +91,13 @@ export class SurveysTableComponent {
   protected readonly filteredSurveys: Signal<Survey[]> = this.initFilteredSurveys();
 
   // === Protected Methods ===
+  protected onFoundationFilterChange(value: string | null): void {
+    this.foundationFilterChange.emit(value);
+    // Reset project filter when foundation changes
+    this.searchForm.get('projectFilter')?.setValue(null, { emitEvent: false });
+    this.projectFilterChange.emit(null);
+  }
+
   protected onStatusChange(value: string | null): void {
     this.statusFilter.set(value);
   }

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
@@ -26,28 +26,14 @@
     }
   </div>
 
-  <!-- Loading State -->
-  @if ((isMeLens() && mySurveysLoading()) || (!isMeLens() && loading())) {
+  <!-- Loading State (non-Me lens only) -->
+  @if (!isMeLens() && loading()) {
     <div class="flex justify-center items-center min-h-96">
       <div class="text-center">
         <i class="fa-light fa-spinner-third fa-spin text-3xl text-violet-600 mb-4"></i>
         <p class="text-gray-600">Loading {{ surveyLabel | lowercase }} details...</p>
       </div>
     </div>
-  } @else if (isMeLens() && mySurveys().length === 0) {
-    <!-- Me lens empty state -->
-    <lfx-card data-testid="surveys-empty-state-card">
-      <div class="p-8 md:p-12">
-        <div class="max-w-2xl mx-auto text-center flex flex-col gap-6">
-          <div class="flex justify-center">
-            <div class="w-20 h-20 rounded-full bg-violet-100 flex items-center justify-center">
-              <i class="fa-light fa-clipboard-list text-4xl text-violet-600"></i>
-            </div>
-          </div>
-          <h2 class="text-xl font-semibold text-gray-900">You don't have any {{ surveyLabelPlural | lowercase }} yet</h2>
-        </div>
-      </div>
-    </lfx-card>
   } @else if (!isMeLens() && surveys().length === 0) {
     <!-- Project empty state -->
     <lfx-card data-testid="surveys-empty-state-card">
@@ -68,6 +54,12 @@
       [surveys]="isMeLens() ? mySurveys() : surveys()"
       [hasPMOAccess]="!isMeLens() && hasPMOAccess()"
       [loading]="isMeLens() ? mySurveysLoading() : loading()"
+      [foundationOptions]="foundationOptions()"
+      [projectOptions]="projectOptions()"
+      [showFoundationFilter]="showFoundationFilter()"
+      [showProjectFilter]="showProjectFilter()"
+      (foundationFilterChange)="onFoundationFilterChange($event)"
+      (projectFilterChange)="onProjectFilterChange($event)"
       (viewResults)="onViewResults($event)"
       (rowClick)="onRowClick($event)"
       (refresh)="refreshSurveys()"

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
@@ -10,6 +10,7 @@ import { CardComponent } from '@components/card/card.component';
 import { SURVEY_LABEL } from '@lfx-one/shared';
 import { ProjectContext, Survey } from '@lfx-one/shared/interfaces';
 import { LensService } from '@services/lens.service';
+import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { SurveyService } from '@services/survey.service';
 import { BehaviorSubject, catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
@@ -28,6 +29,7 @@ export class SurveysDashboardComponent {
   private readonly surveyService = inject(SurveyService);
   private readonly lensService = inject(LensService);
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly personaService = inject(PersonaService);
 
   // === Constants ===
   protected readonly surveyLabel = SURVEY_LABEL.singular;
@@ -42,15 +44,21 @@ export class SurveysDashboardComponent {
   protected readonly resultsDrawerVisible = signal<boolean>(false);
   protected readonly selectedSurveyId = signal<string | null>(null);
   protected readonly mySurveysLoading = signal<boolean>(true);
+  protected readonly foundationFilter = signal<string | null>(null);
+  protected readonly projectFilter = signal<string | null>(null);
 
   // === Lens ===
   protected readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+  public showFoundationFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
+  public showProjectFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
 
   // === Computed / toSignal Signals ===
   protected readonly project: Signal<ProjectContext | null> = this.initProject();
   protected readonly surveys: Signal<Survey[]> = this.initSurveys();
   protected readonly selectedListSurvey: Signal<Survey | null> = this.initSelectedListSurvey();
   protected readonly mySurveys: Signal<Survey[]> = this.initMySurveys();
+  protected readonly foundationOptions: Signal<{ label: string; value: string }[]> = this.initializeFoundationOptions();
+  protected readonly projectOptions: Signal<{ label: string; value: string }[]> = this.initializeProjectOptions();
 
   protected onViewResults(surveyId: string): void {
     this.selectedSurveyId.set(surveyId);
@@ -59,6 +67,15 @@ export class SurveysDashboardComponent {
 
   protected onRowClick(survey: Survey): void {
     this.onViewResults(survey.uid);
+  }
+
+  protected onFoundationFilterChange(value: string | null): void {
+    this.foundationFilter.set(value);
+    this.projectFilter.set(null);
+  }
+
+  protected onProjectFilterChange(value: string | null): void {
+    this.projectFilter.set(value);
   }
 
   protected refreshSurveys(): void {
@@ -120,16 +137,18 @@ export class SurveysDashboardComponent {
 
   private initMySurveys(): Signal<Survey[]> {
     const lens$ = toObservable(this.lensService.activeLens);
+    const projectFilter$ = toObservable(this.projectFilter);
+    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([lens$, this.refresh$]).pipe(
-        switchMap(([lens]) => {
+      combineLatest([lens$, this.refresh$, projectFilter$, foundationFilter$]).pipe(
+        switchMap(([lens, , projectFilter, foundationFilter]) => {
           if (lens !== 'me') {
             this.mySurveysLoading.set(false);
             return of([] as Survey[]);
           }
           this.mySurveysLoading.set(true);
-          return this.surveyService.getMySurveys().pipe(
+          return this.surveyService.getMySurveys(projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
             catchError(() => {
               this.mySurveysLoading.set(false);
               return of([] as Survey[]);
@@ -140,5 +159,29 @@ export class SurveysDashboardComponent {
       ),
       { initialValue: [] }
     );
+  }
+
+  private initializeFoundationOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() => {
+      const projects = this.personaService.detectedProjects();
+      return projects.filter((p) => p.isFoundation).map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+    });
+  }
+
+  private initializeProjectOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() => {
+      const projects = this.personaService.detectedProjects();
+      const foundation = this.foundationFilter();
+
+      // Filter to non-foundation projects
+      let candidates = projects.filter((p) => !p.isFoundation);
+
+      // If a foundation is selected, show only its children
+      if (foundation) {
+        candidates = candidates.filter((p) => p.parentProjectUid === foundation);
+      }
+
+      return candidates.map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -15,6 +15,41 @@
           data-testid="votes-search-input"></lfx-input-text>
       </div>
 
+      @if (showFoundationFilter()) {
+        <div class="w-full sm:w-56">
+          <lfx-select
+            [form]="searchForm"
+            control="foundationFilter"
+            size="small"
+            [options]="foundationOptions()"
+            placeholder="All Foundations"
+            [showClear]="true"
+            [filter]="true"
+            filterPlaceholder="Search foundations..."
+            styleClass="w-full"
+            (onChange)="foundationFilterChange.emit($event.value)"
+            data-testid="votes-foundation-filter">
+          </lfx-select>
+        </div>
+      }
+      @if (showProjectFilter() && projectOptions().length > 0) {
+        <div class="w-full sm:w-56">
+          <lfx-select
+            [form]="searchForm"
+            control="projectFilter"
+            size="small"
+            [options]="projectOptions()"
+            placeholder="All Projects"
+            [showClear]="true"
+            [filter]="true"
+            filterPlaceholder="Search projects..."
+            styleClass="w-full"
+            (onChange)="projectFilterChange.emit($event.value)"
+            data-testid="votes-project-filter">
+          </lfx-select>
+        </div>
+      }
+
       <div class="w-full sm:w-auto sm:shrink-0">
         <lfx-select
           [form]="searchForm"

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -27,7 +27,7 @@
             [filter]="true"
             filterPlaceholder="Search foundations..."
             styleClass="w-full"
-            (onChange)="foundationFilterChange.emit($event.value)"
+            (onChange)="onFoundationFilterChange($event.value)"
             data-testid="votes-foundation-filter">
           </lfx-select>
         </div>

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -107,6 +107,12 @@ export class VotesTableComponent implements OnInit {
     this.viewResults.emit(voteId);
   }
 
+  protected onFoundationFilterChange(value: string | null): void {
+    this.foundationFilterChange.emit(value);
+    this.searchForm.get('projectFilter')?.setValue(null, { emitEvent: false });
+    this.projectFilterChange.emit(null);
+  }
+
   protected onPageChange(event: { first: number; rows: number }): void {
     this.pageChange.emit({ first: event.first, rows: event.rows });
   }

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -64,6 +64,10 @@ export class VotesTableComponent implements OnInit {
   public readonly first = input<number>(0);
   public readonly lazy = input<boolean>(false);
   public readonly groupOptions = input<{ label: string; value: string | null }[]>([{ label: 'All Groups', value: null }]);
+  public readonly foundationOptions = input<{ label: string; value: string }[]>([]);
+  public readonly projectOptions = input<{ label: string; value: string }[]>([]);
+  public readonly showFoundationFilter = input<boolean>(false);
+  public readonly showProjectFilter = input<boolean>(false);
 
   // === Outputs ===
   public readonly viewVote = output<string>();
@@ -71,6 +75,8 @@ export class VotesTableComponent implements OnInit {
   public readonly refresh = output<void>();
   public readonly pageChange = output<{ first: number; rows: number }>();
   public readonly filtersChange = output<VoteFilterState>();
+  public readonly foundationFilterChange = output<string | null>();
+  public readonly projectFilterChange = output<string | null>();
 
   // === Writable Signals ===
   protected readonly isDeleting = signal(false);
@@ -80,6 +86,8 @@ export class VotesTableComponent implements OnInit {
     search: new FormControl<string>(''),
     status: new FormControl<PollStatus | null>(null),
     group: new FormControl<string | null>(null),
+    foundationFilter: new FormControl<string | null>(null),
+    projectFilter: new FormControl<string | null>(null),
   });
 
   // === Computed Signals ===

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -22,28 +22,14 @@
     }
   </div>
 
-  <!-- Loading State -->
-  @if ((isMeLens() && myVotesLoading()) || (!isMeLens() && loading())) {
+  <!-- Loading State (non-Me lens only) -->
+  @if (!isMeLens() && loading()) {
     <div class="flex justify-center items-center min-h-96">
       <div class="text-center">
         <i class="fa-light fa-spinner-third fa-spin text-3xl text-blue-600 mb-4"></i>
         <p class="text-gray-600">Loading {{ voteLabel | lowercase }} details...</p>
       </div>
     </div>
-  } @else if (isMeLens() && myVotes().length === 0) {
-    <!-- Me lens empty state -->
-    <lfx-card data-testid="votes-empty-state-card">
-      <div class="p-8 md:p-12">
-        <div class="max-w-2xl mx-auto text-center flex flex-col gap-6">
-          <div class="flex justify-center">
-            <div class="w-20 h-20 rounded-full bg-blue-100 flex items-center justify-center">
-              <i class="fa-light fa-check-to-slot text-4xl text-blue-600"></i>
-            </div>
-          </div>
-          <h2 class="text-xl font-semibold text-gray-900">You don't have any {{ voteLabelPlural | lowercase }} yet</h2>
-        </div>
-      </div>
-    </lfx-card>
   } @else if (!isMeLens() && !loading() && votes().length === 0) {
     <!-- Project empty state -->
     <lfx-card data-testid="votes-empty-state-card">
@@ -69,6 +55,12 @@
       [first]="isMeLens() ? 0 : currentFirst()"
       [lazy]="!isMeLens()"
       [groupOptions]="groupOptions()"
+      [foundationOptions]="foundationOptions()"
+      [projectOptions]="projectOptions()"
+      [showFoundationFilter]="showFoundationFilter()"
+      [showProjectFilter]="showProjectFilter()"
+      (foundationFilterChange)="onFoundationFilterChange($event)"
+      (projectFilterChange)="onProjectFilterChange($event)"
       (viewVote)="onViewVote($event)"
       (viewResults)="onViewResults($event)"
       (refresh)="refreshVotes()"

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -11,6 +11,7 @@ import { VOTE_LABEL } from '@lfx-one/shared';
 import { Committee, PaginatedResponse, ProjectContext, Vote, VoteFilterState } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
+import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { VoteService } from '@services/vote.service';
 import { BehaviorSubject, catchError, combineLatest, finalize, map, of, switchMap, tap } from 'rxjs';
@@ -29,6 +30,7 @@ export class VotesDashboardComponent {
   private readonly voteService = inject(VoteService);
   private readonly committeeService = inject(CommitteeService);
   private readonly lensService = inject(LensService);
+  private readonly personaService = inject(PersonaService);
   private readonly projectContextService = inject(ProjectContextService);
 
   // === Constants ===
@@ -50,9 +52,13 @@ export class VotesDashboardComponent {
   protected readonly currentFirst = signal<number>(0);
   protected readonly totalRecords = signal<number>(0);
   protected readonly myVotesLoading = signal<boolean>(true);
+  protected readonly foundationFilter = signal<string | null>(null);
+  protected readonly projectFilter = signal<string | null>(null);
 
   // === Lens ===
   protected readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+  public showFoundationFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
+  public showProjectFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
 
   // === Filter State ===
   protected readonly filters = signal<VoteFilterState>({ search: '', status: null, group: null });
@@ -69,6 +75,8 @@ export class VotesDashboardComponent {
   protected readonly selectedListVote: Signal<Vote | null> = this.initSelectedListVote();
   protected readonly myVotes: Signal<Vote[]> = this.initMyVotes();
   protected readonly totalCount: Signal<number> = this.initTotalCount();
+  protected readonly foundationOptions: Signal<{ label: string; value: string }[]> = this.initializeFoundationOptions();
+  protected readonly projectOptions: Signal<{ label: string; value: string }[]> = this.initializeProjectOptions();
 
   protected onViewVote(voteId: string): void {
     this.selectedVoteId.set(voteId);
@@ -99,6 +107,15 @@ export class VotesDashboardComponent {
 
     this.currentFirst.set(event.first);
     this.fetch$.next();
+  }
+
+  protected onFoundationFilterChange(value: string | null): void {
+    this.foundationFilter.set(value);
+    this.projectFilter.set(null);
+  }
+
+  protected onProjectFilterChange(value: string | null): void {
+    this.projectFilter.set(value);
   }
 
   protected onFiltersChange(state: VoteFilterState): void {
@@ -239,16 +256,18 @@ export class VotesDashboardComponent {
 
   private initMyVotes(): Signal<Vote[]> {
     const lens$ = toObservable(this.lensService.activeLens);
+    const projectFilter$ = toObservable(this.projectFilter);
+    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([lens$, this.refresh$]).pipe(
-        switchMap(([lens]) => {
+      combineLatest([lens$, this.refresh$, projectFilter$, foundationFilter$]).pipe(
+        switchMap(([lens, , projectFilter, foundationFilter]) => {
           if (lens !== 'me') {
             this.myVotesLoading.set(false);
             return of([] as Vote[]);
           }
           this.myVotesLoading.set(true);
-          return this.voteService.getMyVotes().pipe(
+          return this.voteService.getMyVotes(projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
             catchError(() => {
               this.myVotesLoading.set(false);
               return of([] as Vote[]);
@@ -259,5 +278,26 @@ export class VotesDashboardComponent {
       ),
       { initialValue: [] }
     );
+  }
+
+  private initializeFoundationOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() => {
+      return this.personaService
+        .detectedProjects()
+        .filter((p) => p.isFoundation)
+        .map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+    });
+  }
+
+  private initializeProjectOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() => {
+      const projects = this.personaService.detectedProjects();
+      const foundation = this.foundationFilter();
+      let candidates = projects.filter((p) => !p.isFoundation);
+      if (foundation) {
+        candidates = candidates.filter((p) => p.parentProjectUid === foundation);
+      }
+      return candidates.map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+    });
   }
 }

--- a/apps/lfx-one/src/app/shared/components/select/select.component.html
+++ b/apps/lfx-one/src/app/shared/components/select/select.component.html
@@ -55,5 +55,16 @@
     [variant]="variant()"
     [checkmark]="checkmark()"
     [loading]="loading()"
-    (onChange)="handleChange($event)"></p-select>
+    (onChange)="handleChange($event)">
+    @if (itemTemplate()) {
+      <ng-template let-option #item>
+        <ng-container *ngTemplateOutlet="itemTemplate()!; context: { $implicit: option }"></ng-container>
+      </ng-template>
+    }
+    @if (selectedItemTemplate()) {
+      <ng-template let-option #selectedItem>
+        <ng-container *ngTemplateOutlet="selectedItemTemplate()!; context: { $implicit: option }"></ng-container>
+      </ng-template>
+    }
+  </p-select>
 </ng-container>

--- a/apps/lfx-one/src/app/shared/components/select/select.component.ts
+++ b/apps/lfx-one/src/app/shared/components/select/select.component.ts
@@ -1,13 +1,14 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, input, model, output } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
+import { Component, contentChild, input, model, output, TemplateRef } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { SelectModule } from 'primeng/select';
 
 @Component({
   selector: 'lfx-select',
-  imports: [SelectModule, ReactiveFormsModule],
+  imports: [SelectModule, ReactiveFormsModule, NgTemplateOutlet],
   templateUrl: './select.component.html',
   styleUrl: './select.component.scss',
 })
@@ -82,6 +83,10 @@ export class SelectComponent {
   public readonly tooltipPositionStyle = input<string>('absolute');
   public readonly tooltipStyleClass = input<string | undefined>(undefined);
   public readonly autofocusFilter = input<boolean>(true);
+
+  // Templates
+  public readonly itemTemplate = contentChild<TemplateRef<any>>('item');
+  public readonly selectedItemTemplate = contentChild<TemplateRef<any>>('selectedItem');
 
   // Events
   public readonly onChange = output<any>();

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -139,7 +139,7 @@ export class CommitteeService {
       params = params.set('project_uid', projectUid);
     }
     if (foundationUid) {
-      params = params.set('foundationUid', foundationUid);
+      params = params.set('foundation_uid', foundationUid);
     }
     return this.http.get<MyCommittee[]>('/api/committees/my-committees', { params }).pipe(catchError(() => of([])));
   }

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -132,11 +132,14 @@ export class CommitteeService {
 
   // ── My Committees ─────────────────────────────────────────────────────────
 
-  /** Get committees for the current user, optionally scoped to a project */
-  public getMyCommittees(projectUid?: string): Observable<MyCommittee[]> {
+  /** Get committees for the current user, optionally scoped to a project or foundation */
+  public getMyCommittees(projectUid?: string, foundationUid?: string): Observable<MyCommittee[]> {
     let params = new HttpParams();
     if (projectUid) {
       params = params.set('project_uid', projectUid);
+    }
+    if (foundationUid) {
+      params = params.set('foundationUid', foundationUid);
     }
     return this.http.get<MyCommittee[]>('/api/committees/my-committees', { params }).pipe(catchError(() => of([])));
   }

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
@@ -41,10 +41,13 @@ export class MailingListService {
     return this.http.get<GroupsIOMailingList[]>(this.baseUrl);
   }
 
-  public getMyMailingLists(projectUid?: string): Observable<MyMailingList[]> {
+  public getMyMailingLists(projectUid?: string, foundationUid?: string): Observable<MyMailingList[]> {
     let params = new HttpParams();
     if (projectUid) {
       params = params.set('project_uid', projectUid);
+    }
+    if (foundationUid) {
+      params = params.set('foundationUid', foundationUid);
     }
     return this.http.get<MyMailingList[]>(`${this.baseUrl}/my-mailing-lists`, { params });
   }

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
@@ -14,7 +14,7 @@ import {
   QueryServiceCountResponse,
   UpdateMailingListMemberRequest,
 } from '@lfx-one/shared/interfaces';
-import { map, Observable } from 'rxjs';
+import { catchError, map, Observable, of } from 'rxjs';
 
 /**
  * Service for managing mailing list data
@@ -47,9 +47,9 @@ export class MailingListService {
       params = params.set('project_uid', projectUid);
     }
     if (foundationUid) {
-      params = params.set('foundationUid', foundationUid);
+      params = params.set('foundation_uid', foundationUid);
     }
-    return this.http.get<MyMailingList[]>(`${this.baseUrl}/my-mailing-lists`, { params });
+    return this.http.get<MyMailingList[]>(`${this.baseUrl}/my-mailing-lists`, { params }).pipe(catchError(() => of([])));
   }
 
   public getMailingList(uid: string): Observable<GroupsIOMailingList> {

--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -63,7 +63,7 @@ export class PersonaService {
     this.multiProject = signal<boolean>(stored?.multiProject ?? false);
     this.multiFoundation = signal<boolean>(stored?.multiFoundation ?? false);
     this.personaProjects = signal<Partial<Record<PersonaType, PersonaProject[]>>>({});
-    this.detectedProjects = signal<EnrichedPersonaProject[]>([]);
+    this.detectedProjects = signal<EnrichedPersonaProject[]>(stored?.projects ?? []);
     this.isBoardScoped = computed(() => isBoardScopedPersona(this.currentPersona()));
     this.hasBoardRole = this.initHasBoardRole();
     this.hasProjectRole = this.initHasProjectRole();
@@ -99,7 +99,7 @@ export class PersonaService {
     if (organizations !== undefined) {
       this.lastKnownOrganizations.set(organizations);
     }
-    this.persistToCookie({ primary, all, multiProject, multiFoundation, organizations: this.lastKnownOrganizations() });
+    this.persistToCookie({ primary, all, multiProject, multiFoundation, organizations: this.lastKnownOrganizations(), projects: this.detectedProjects() });
   }
 
   /**
@@ -139,6 +139,7 @@ export class PersonaService {
             multiProject: this.multiProject(),
             multiFoundation: this.multiFoundation(),
             organizations: response.organizations,
+            projects: this.detectedProjects(),
           });
         }
 

--- a/apps/lfx-one/src/app/shared/services/survey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/survey.service.ts
@@ -4,7 +4,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { CreateSurveyRequest, Survey } from '@lfx-one/shared/interfaces';
-import { catchError, Observable, take, throwError } from 'rxjs';
+import { catchError, Observable, of, take, throwError } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -51,9 +51,9 @@ export class SurveyService {
       params = params.set('project_uid', projectUid);
     }
     if (foundationUid) {
-      params = params.set('foundationUid', foundationUid);
+      params = params.set('foundation_uid', foundationUid);
     }
-    return this.http.get<Survey[]>('/api/surveys/my-surveys', { params });
+    return this.http.get<Survey[]>('/api/surveys/my-surveys', { params }).pipe(catchError(() => of([])));
   }
 
   public getSurvey(surveyUid: string, projectId?: string): Observable<Survey> {

--- a/apps/lfx-one/src/app/shared/services/survey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/survey.service.ts
@@ -45,8 +45,15 @@ export class SurveyService {
     return this.getSurveys(params);
   }
 
-  public getMySurveys(): Observable<Survey[]> {
-    return this.http.get<Survey[]>('/api/surveys/my-surveys');
+  public getMySurveys(projectUid?: string, foundationUid?: string): Observable<Survey[]> {
+    let params = new HttpParams();
+    if (projectUid) {
+      params = params.set('project_uid', projectUid);
+    }
+    if (foundationUid) {
+      params = params.set('foundationUid', foundationUid);
+    }
+    return this.http.get<Survey[]>('/api/surveys/my-surveys', { params });
   }
 
   public getSurvey(surveyUid: string, projectId?: string): Observable<Survey> {

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -143,10 +143,16 @@ export class UserService {
    * Returns meetings the user is registered for across all projects
    * @param limit - Optional limit on number of meetings to return
    */
-  public getUserMeetings(limit?: number): Observable<Meeting[]> {
+  public getUserMeetings(limit?: number, projectUid?: string, foundationUid?: string): Observable<Meeting[]> {
     const params: Record<string, string> = {};
     if (limit !== undefined) {
       params['limit'] = limit.toString();
+    }
+    if (projectUid) {
+      params['projectUid'] = projectUid;
+    }
+    if (foundationUid) {
+      params['foundationUid'] = foundationUid;
     }
     return this.http.get<Meeting[]>('/api/user/meetings', { params }).pipe(
       catchError((error) => {
@@ -160,10 +166,16 @@ export class UserService {
    * Gets past meetings for the current authenticated user
    * @param limit - Optional limit on number of past meetings to return
    */
-  public getUserPastMeetings(limit?: number): Observable<PastMeeting[]> {
+  public getUserPastMeetings(limit?: number, projectUid?: string, foundationUid?: string): Observable<PastMeeting[]> {
     const params: Record<string, string> = {};
     if (limit !== undefined) {
       params['limit'] = limit.toString();
+    }
+    if (projectUid) {
+      params['projectUid'] = projectUid;
+    }
+    if (foundationUid) {
+      params['foundationUid'] = foundationUid;
     }
     return this.http.get<PastMeeting[]>('/api/user/past-meetings', { params }).pipe(
       catchError((error) => {

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -152,7 +152,7 @@ export class UserService {
       params['projectUid'] = projectUid;
     }
     if (foundationUid) {
-      params['foundationUid'] = foundationUid;
+      params['foundation_uid'] = foundationUid;
     }
     return this.http.get<Meeting[]>('/api/user/meetings', { params }).pipe(
       catchError((error) => {
@@ -175,7 +175,7 @@ export class UserService {
       params['projectUid'] = projectUid;
     }
     if (foundationUid) {
-      params['foundationUid'] = foundationUid;
+      params['foundation_uid'] = foundationUid;
     }
     return this.http.get<PastMeeting[]>('/api/user/past-meetings', { params }).pipe(
       catchError((error) => {

--- a/apps/lfx-one/src/app/shared/services/vote.service.ts
+++ b/apps/lfx-one/src/app/shared/services/vote.service.ts
@@ -28,9 +28,9 @@ export class VoteService {
       params = params.set('project_uid', projectUid);
     }
     if (foundationUid) {
-      params = params.set('foundationUid', foundationUid);
+      params = params.set('foundation_uid', foundationUid);
     }
-    return this.http.get<Vote[]>('/api/votes/my-votes', { params });
+    return this.http.get<Vote[]>('/api/votes/my-votes', { params }).pipe(catchError(() => of([])));
   }
 
   public getVotesByProject(projectUid: string, pageSize?: number, orderBy?: string): Observable<Vote[]> {

--- a/apps/lfx-one/src/app/shared/services/vote.service.ts
+++ b/apps/lfx-one/src/app/shared/services/vote.service.ts
@@ -22,8 +22,15 @@ export class VoteService {
     );
   }
 
-  public getMyVotes(): Observable<Vote[]> {
-    return this.http.get<Vote[]>('/api/votes/my-votes');
+  public getMyVotes(projectUid?: string, foundationUid?: string): Observable<Vote[]> {
+    let params = new HttpParams();
+    if (projectUid) {
+      params = params.set('project_uid', projectUid);
+    }
+    if (foundationUid) {
+      params = params.set('foundationUid', foundationUid);
+    }
+    return this.http.get<Vote[]>('/api/votes/my-votes', { params });
   }
 
   public getVotesByProject(projectUid: string, pageSize?: number, orderBy?: string): Observable<Vote[]> {

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -72,10 +72,11 @@ export class CommitteeController {
    */
   public async getMyCommittees(req: Request, res: Response, next: NextFunction): Promise<void> {
     const projectUid = req.query['project_uid'] as string | undefined;
-    const startTime = logger.startOperation(req, 'get_my_committees', { project_uid: projectUid });
+    const foundationUid = req.query['foundationUid'] as string | undefined;
+    const startTime = logger.startOperation(req, 'get_my_committees', { project_uid: projectUid, foundation_uid: foundationUid });
 
     try {
-      const myCommittees = await this.committeeService.getMyCommittees(req, projectUid);
+      const myCommittees = await this.committeeService.getMyCommittees(req, projectUid, foundationUid);
 
       logger.success(req, 'get_my_committees', startTime, {
         committee_count: myCommittees.length,

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -72,7 +72,7 @@ export class CommitteeController {
    */
   public async getMyCommittees(req: Request, res: Response, next: NextFunction): Promise<void> {
     const projectUid = req.query['project_uid'] as string | undefined;
-    const foundationUid = req.query['foundationUid'] as string | undefined;
+    const foundationUid = req.query['foundation_uid'] as string | undefined;
     const startTime = logger.startOperation(req, 'get_my_committees', { project_uid: projectUid, foundation_uid: foundationUid });
 
     try {

--- a/apps/lfx-one/src/server/controllers/mailing-list.controller.ts
+++ b/apps/lfx-one/src/server/controllers/mailing-list.controller.ts
@@ -242,10 +242,11 @@ export class MailingListController {
    */
   public async getMyMailingLists(req: Request, res: Response, next: NextFunction): Promise<void> {
     const projectUid = req.query['project_uid'] as string | undefined;
-    const startTime = logger.startOperation(req, 'get_my_mailing_lists', { project_uid: projectUid });
+    const foundationUid = req.query['foundationUid'] as string | undefined;
+    const startTime = logger.startOperation(req, 'get_my_mailing_lists', { project_uid: projectUid, foundation_uid: foundationUid });
 
     try {
-      const myMailingLists = await this.mailingListService.getMyMailingLists(req, projectUid);
+      const myMailingLists = await this.mailingListService.getMyMailingLists(req, projectUid, foundationUid);
 
       logger.success(req, 'get_my_mailing_lists', startTime, {
         mailing_list_count: myMailingLists.length,

--- a/apps/lfx-one/src/server/controllers/mailing-list.controller.ts
+++ b/apps/lfx-one/src/server/controllers/mailing-list.controller.ts
@@ -242,7 +242,7 @@ export class MailingListController {
    */
   public async getMyMailingLists(req: Request, res: Response, next: NextFunction): Promise<void> {
     const projectUid = req.query['project_uid'] as string | undefined;
-    const foundationUid = req.query['foundationUid'] as string | undefined;
+    const foundationUid = req.query['foundation_uid'] as string | undefined;
     const startTime = logger.startOperation(req, 'get_my_mailing_lists', { project_uid: projectUid, foundation_uid: foundationUid });
 
     try {

--- a/apps/lfx-one/src/server/controllers/survey.controller.ts
+++ b/apps/lfx-one/src/server/controllers/survey.controller.ts
@@ -70,13 +70,20 @@ export class SurveyController {
    * GET /surveys/my-surveys
    */
   public async getMySurveys(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const startTime = logger.startOperation(req, 'get_my_surveys');
+    const projectUid = req.query['project_uid'] as string | undefined;
+    const foundationUid = req.query['foundationUid'] as string | undefined;
+    const startTime = logger.startOperation(req, 'get_my_surveys', {
+      project_uid: projectUid,
+      foundation_uid: foundationUid,
+    });
 
     try {
-      const mySurveys = await this.surveyService.getMySurveys(req);
+      const mySurveys = await this.surveyService.getMySurveys(req, projectUid, foundationUid);
 
       logger.success(req, 'get_my_surveys', startTime, {
         survey_count: mySurveys.length,
+        project_uid: projectUid,
+        foundation_uid: foundationUid,
       });
 
       res.json(mySurveys);

--- a/apps/lfx-one/src/server/controllers/survey.controller.ts
+++ b/apps/lfx-one/src/server/controllers/survey.controller.ts
@@ -71,7 +71,7 @@ export class SurveyController {
    */
   public async getMySurveys(req: Request, res: Response, next: NextFunction): Promise<void> {
     const projectUid = req.query['project_uid'] as string | undefined;
-    const foundationUid = req.query['foundationUid'] as string | undefined;
+    const foundationUid = req.query['foundation_uid'] as string | undefined;
     const startTime = logger.startOperation(req, 'get_my_surveys', {
       project_uid: projectUid,
       foundation_uid: foundationUid,

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -101,13 +101,13 @@ export class UserController {
   public async getUserMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_user_meetings', {
       project_uid: req.query['projectUid'],
-      foundation_uid: req.query['foundationUid'],
+      foundation_uid: req.query['foundation_uid'],
       limit: req.query['limit'],
     });
 
     try {
       const projectUid = req.query['projectUid'] as string | undefined;
-      const foundationUid = req.query['foundationUid'] as string | undefined;
+      const foundationUid = req.query['foundation_uid'] as string | undefined;
 
       // Extract user email from OIDC (lowercased for consistent tag matching)
       const userEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
@@ -165,13 +165,13 @@ export class UserController {
   public async getUserPastMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_user_past_meetings', {
       project_uid: req.query['projectUid'],
-      foundation_uid: req.query['foundationUid'],
+      foundation_uid: req.query['foundation_uid'],
       limit: req.query['limit'],
     });
 
     try {
       const projectUid = req.query['projectUid'] as string | undefined;
-      const foundationUid = req.query['foundationUid'] as string | undefined;
+      const foundationUid = req.query['foundation_uid'] as string | undefined;
 
       // Extract user email from OIDC (lowercased for consistent tag matching)
       const userEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -101,11 +101,13 @@ export class UserController {
   public async getUserMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_user_meetings', {
       project_uid: req.query['projectUid'],
+      foundation_uid: req.query['foundationUid'],
       limit: req.query['limit'],
     });
 
     try {
       const projectUid = req.query['projectUid'] as string | undefined;
+      const foundationUid = req.query['foundationUid'] as string | undefined;
 
       // Extract user email from OIDC (lowercased for consistent tag matching)
       const userEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
@@ -139,10 +141,11 @@ export class UserController {
       }
 
       // Get user's meetings from service
-      const meetings = await this.userService.getUserMeetings(req, userEmail, projectUid, limit);
+      const meetings = await this.userService.getUserMeetings(req, userEmail, projectUid, limit, foundationUid);
 
       logger.success(req, 'get_user_meetings', startTime, {
         project_uid: projectUid,
+        foundation_uid: foundationUid,
         meeting_count: meetings.length,
         limit,
       });
@@ -162,11 +165,13 @@ export class UserController {
   public async getUserPastMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_user_past_meetings', {
       project_uid: req.query['projectUid'],
+      foundation_uid: req.query['foundationUid'],
       limit: req.query['limit'],
     });
 
     try {
       const projectUid = req.query['projectUid'] as string | undefined;
+      const foundationUid = req.query['foundationUid'] as string | undefined;
 
       // Extract user email from OIDC (lowercased for consistent tag matching)
       const userEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
@@ -200,10 +205,11 @@ export class UserController {
       }
 
       // Get user's past meetings from service
-      const pastMeetings = await this.userService.getUserPastMeetings(req, userEmail, projectUid, limit);
+      const pastMeetings = await this.userService.getUserPastMeetings(req, userEmail, projectUid, limit, foundationUid);
 
       logger.success(req, 'get_user_past_meetings', startTime, {
         project_uid: projectUid,
+        foundation_uid: foundationUid,
         past_meeting_count: pastMeetings.length,
         limit,
       });

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -61,13 +61,20 @@ export class VoteController {
    * GET /votes/my-votes
    */
   public async getMyVotes(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const startTime = logger.startOperation(req, 'get_my_votes');
+    const projectUid = req.query['project_uid'] as string | undefined;
+    const foundationUid = req.query['foundationUid'] as string | undefined;
+    const startTime = logger.startOperation(req, 'get_my_votes', {
+      project_uid: projectUid,
+      foundation_uid: foundationUid,
+    });
 
     try {
-      const myVotes = await this.voteService.getMyVotes(req);
+      const myVotes = await this.voteService.getMyVotes(req, projectUid, foundationUid);
 
       logger.success(req, 'get_my_votes', startTime, {
         vote_count: myVotes.length,
+        project_uid: projectUid,
+        foundation_uid: foundationUid,
       });
 
       res.json(myVotes);

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -62,7 +62,7 @@ export class VoteController {
    */
   public async getMyVotes(req: Request, res: Response, next: NextFunction): Promise<void> {
     const projectUid = req.query['project_uid'] as string | undefined;
-    const foundationUid = req.query['foundationUid'] as string | undefined;
+    const foundationUid = req.query['foundation_uid'] as string | undefined;
     const startTime = logger.startOperation(req, 'get_my_votes', {
       project_uid: projectUid,
       foundation_uid: foundationUid,

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -528,6 +528,7 @@ export class CommitteeService {
     if (projectUid) {
       return result.filter((c) => c.project_uid === projectUid);
     } else if (foundationUid) {
+      logger.debug(req, 'get_my_committees', 'Filtering by foundation', { foundation_uid: foundationUid });
       const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
       const uidSet = new Set(uids);
       return result.filter((c) => uidSet.has(c.project_uid));

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -25,6 +25,7 @@ import { logger } from '../services/logger.service';
 import { AccessCheckService } from './access-check.service';
 import { ETagService } from './etag.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
+import { ProjectService } from './project.service';
 
 /** Upstream response shape for committee folders */
 interface CommitteeFolder {
@@ -58,11 +59,13 @@ export class CommitteeService {
   private accessCheckService: AccessCheckService;
   private etagService: ETagService;
   private microserviceProxy: MicroserviceProxyService;
+  private projectService: ProjectService;
 
   public constructor() {
     this.accessCheckService = new AccessCheckService();
     this.microserviceProxy = new MicroserviceProxyService();
     this.etagService = new ETagService();
+    this.projectService = new ProjectService();
   }
 
   /**
@@ -457,17 +460,22 @@ export class CommitteeService {
 
   // ── My Committees ─────────────────────────────────────────────────────────
 
-  public async getMyCommittees(req: Request, projectUid?: string): Promise<MyCommittee[]> {
+  public async getMyCommittees(req: Request, projectUid?: string, foundationUid?: string): Promise<MyCommittee[]> {
     const username = await getUsernameFromAuth(req);
     if (!username) {
       return [];
     }
 
     // Fetch all committee_member records for the current user
+    const tagsAll = [`username:${username}`];
+    if (projectUid) {
+      tagsAll.push(`project_uid:${projectUid}`);
+    }
+
     const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
       v: '1',
       type: 'committee_member',
-      tags_all: [`username:${username}`],
+      tags_all: tagsAll,
     });
 
     const memberships = resources.map((r) => r.data);
@@ -519,6 +527,10 @@ export class CommitteeService {
     // Filter by project_uid server-side if provided
     if (projectUid) {
       return result.filter((c) => c.project_uid === projectUid);
+    } else if (foundationUid) {
+      const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
+      const uidSet = new Set(uids);
+      return result.filter((c) => uidSet.has(c.project_uid));
     }
 
     return result;

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -24,6 +24,7 @@ import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { AccessCheckService } from './access-check.service';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
+import { ProjectService } from './project.service';
 
 /**
  * Service for handling mailing list business logic
@@ -32,10 +33,12 @@ import { MicroserviceProxyService } from './microservice-proxy.service';
 export class MailingListService {
   private accessCheckService: AccessCheckService;
   private microserviceProxy: MicroserviceProxyService;
+  private projectService: ProjectService;
 
   public constructor() {
     this.accessCheckService = new AccessCheckService();
     this.microserviceProxy = new MicroserviceProxyService();
+    this.projectService = new ProjectService();
   }
 
   // ============================================
@@ -340,7 +343,7 @@ export class MailingListService {
    * Fetches mailing lists the current user is a member of.
    * Queries by both email and username to ensure complete coverage.
    */
-  public async getMyMailingLists(req: Request, projectUid?: string): Promise<MyMailingList[]> {
+  public async getMyMailingLists(req: Request, projectUid?: string, foundationUid?: string): Promise<MyMailingList[]> {
     // Get user identity from auth context
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
@@ -366,7 +369,7 @@ export class MailingListService {
             v: '1',
             type: 'groupsio_member',
             page_size: 100,
-            tags_all: [`email:${email}`],
+            tags_all: projectUid ? [`email:${email}`, `project_uid:${projectUid}`] : [`email:${email}`],
             ...(pageToken && { page_token: pageToken }),
           })
         )
@@ -380,7 +383,7 @@ export class MailingListService {
             v: '1',
             type: 'groupsio_member',
             page_size: 100,
-            tags_all: [`username:${username}`],
+            tags_all: projectUid ? [`username:${username}`, `project_uid:${projectUid}`] : [`username:${username}`],
             ...(pageToken && { page_token: pageToken }),
           })
         )
@@ -459,8 +462,15 @@ export class MailingListService {
 
     const filtered = mailingLists.filter((ml): ml is MyMailingList => ml !== null);
 
-    // Filter by project_uid server-side if provided
-    const result = projectUid ? filtered.filter((ml) => ml.project_uid === projectUid) : filtered;
+    // Filter by project_uid or foundation_uid server-side if provided
+    let result = filtered;
+    if (projectUid) {
+      result = filtered.filter((ml) => ml.project_uid === projectUid);
+    } else if (foundationUid) {
+      const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
+      const uidSet = new Set(uids);
+      result = filtered.filter((ml) => uidSet.has(ml.project_uid));
+    }
 
     // Enrich with service data for correct email display in UI
     return (await this.enrichWithServices(req, result)) as MyMailingList[];

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -462,7 +462,7 @@ export class MailingListService {
 
     const filtered = mailingLists.filter((ml): ml is MyMailingList => ml !== null);
 
-    // Filter by project_uid or foundation_uid server-side if provided
+    // Post-fetch filtering by project_uid or foundation_uid
     let result = filtered;
     if (projectUid) {
       result = filtered.filter((ml) => ml.project_uid === projectUid);

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -467,6 +467,7 @@ export class MailingListService {
     if (projectUid) {
       result = filtered.filter((ml) => ml.project_uid === projectUid);
     } else if (foundationUid) {
+      logger.debug(req, 'get_my_mailing_lists', 'Filtering by foundation', { foundation_uid: foundationUid });
       const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
       const uidSet = new Set(uids);
       result = filtered.filter((ml) => uidSet.has(ml.project_uid));

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -329,6 +329,56 @@ export class PersonaDetectionService {
       })
     );
 
+    const enriched = results.filter((r): r is PromiseFulfilledResult<EnrichedPersonaProject> => r.status === 'fulfilled').map((r) => r.value);
+
+    // Fetch missing parent foundations so the UI can group child projects properly
+    const missingParents = await this.fetchMissingParentProjects(req, enriched);
+    if (missingParents.length > 0) {
+      enriched.push(...missingParents);
+    }
+
+    return enriched;
+  }
+
+  /**
+   * Fetch parent projects that aren't in the detected list but are referenced by child projects.
+   * This ensures the UI can group child projects under their foundation in the filter dropdown.
+   */
+  private async fetchMissingParentProjects(req: Request, enrichedProjects: EnrichedPersonaProject[]): Promise<EnrichedPersonaProject[]> {
+    const knownUids = new Set(enrichedProjects.map((p) => p.projectUid));
+    const missingParentUids = new Set<string>();
+
+    for (const project of enrichedProjects) {
+      if (project.parentProjectUid && !knownUids.has(project.parentProjectUid)) {
+        missingParentUids.add(project.parentProjectUid);
+      }
+    }
+
+    if (missingParentUids.size === 0) {
+      return [];
+    }
+
+    logger.debug(req, 'fetch_missing_parent_projects', 'Fetching missing parent projects for grouping', {
+      missing_parent_uids: [...missingParentUids],
+    });
+
+    const results = await Promise.allSettled(
+      [...missingParentUids].map(async (parentUid) => {
+        const projectData = await this.projectService.getProjectById(req, parentUid, false);
+        return {
+          projectUid: parentUid,
+          projectSlug: projectData?.slug || '',
+          projectName: projectData?.name || null,
+          parentProjectUid: projectData?.parent_uid || null,
+          isFoundation: this.computeIsFoundation(projectData),
+          logoUrl: projectData?.logo_url || null,
+          description: projectData?.description || null,
+          detections: [],
+          personas: [],
+        } as EnrichedPersonaProject;
+      })
+    );
+
     return results.filter((r): r is PromiseFulfilledResult<EnrichedPersonaProject> => r.status === 'fulfilled').map((r) => r.value);
   }
 

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -162,17 +162,19 @@ export class PersonaDetectionService {
     // Enrich projects with names in parallel
     const enrichedProjects = await this.enrichProjectsWithNames(req, detectionResponse);
 
-    // Build persona-centric mapping
+    // Build persona-centric mapping (before adding synthetic parents — they have no personas)
     const personaProjects = this.buildPersonaProjectsMap(enrichedProjects);
 
     // Collect all unique personas sorted by priority
     const personas = this.collectUniquePersonas(enrichedProjects);
 
-    // Compute multi-access flags from enriched projects
-    const uniqueProjectUids = new Set(enrichedProjects.map((p) => p.projectUid));
+    // Compute multi-access flags from detected projects only (before synthetic parents are added)
+    // Synthetic parent projects are for UI grouping only — they shouldn't inflate access counts
+    const detectedOnly = enrichedProjects.filter((p) => p.detections.length > 0);
+    const uniqueProjectUids = new Set(detectedOnly.map((p) => p.projectUid));
     const multiProject = uniqueProjectUids.size > 1;
 
-    const foundationUids = new Set(enrichedProjects.map((p) => (p.isFoundation ? p.projectUid : p.parentProjectUid || p.projectUid)));
+    const foundationUids = new Set(detectedOnly.map((p) => (p.isFoundation ? p.projectUid : p.parentProjectUid || p.projectUid)));
     const multiFoundation = foundationUids.size > 1;
 
     logger.debug(req, 'get_personas', 'Persona detection complete', {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2529,4 +2529,34 @@ export class ProjectService {
       };
     }
   }
+
+  /**
+   * Get all project UIDs under a foundation (foundation UID + child project UIDs).
+   * Queries the query service for projects with parent_uid matching the foundation.
+   * @param req - Express request object
+   * @param foundationUid - The foundation UID to resolve children for
+   * @returns Array of UIDs including the foundation itself and all child projects
+   */
+  public async getFoundationProjectUids(req: Request, foundationUid: string): Promise<string[]> {
+    const uids = [foundationUid];
+    try {
+      const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<{ uid: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        v: '1',
+        type: 'project',
+        parent: `project:${foundationUid}`,
+        page_size: 200,
+      });
+      for (const r of resources) {
+        if (r.data?.uid) {
+          uids.push(r.data.uid);
+        }
+      }
+    } catch {
+      // If child lookup fails, just filter by foundation UID alone
+      logger.warning(req, 'get_foundation_project_uids', 'Failed to resolve child projects, using foundation UID only', {
+        foundation_uid: foundationUid,
+      });
+    }
+    return uids;
+  }
 }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2538,6 +2538,7 @@ export class ProjectService {
    * @returns Array of UIDs including the foundation itself and all child projects
    */
   public async getFoundationProjectUids(req: Request, foundationUid: string): Promise<string[]> {
+    logger.debug(req, 'get_foundation_project_uids', 'Resolving child projects for foundation', { foundation_uid: foundationUid });
     const uids = [foundationUid];
     try {
       const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<{ uid: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
@@ -2557,6 +2558,7 @@ export class ProjectService {
         foundation_uid: foundationUid,
       });
     }
+    logger.debug(req, 'get_foundation_project_uids', 'Resolved foundation project UIDs', { foundation_uid: foundationUid, count: uids.length });
     return uids;
   }
 }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2552,10 +2552,11 @@ export class ProjectService {
           uids.push(r.data.uid);
         }
       }
-    } catch {
+    } catch (error) {
       // If child lookup fails, just filter by foundation UID alone
       logger.warning(req, 'get_foundation_project_uids', 'Failed to resolve child projects, using foundation UID only', {
         foundation_uid: foundationUid,
+        error: error instanceof Error ? error.message : String(error),
       });
     }
     logger.debug(req, 'get_foundation_project_uids', 'Resolved foundation project UIDs', { foundation_uid: foundationUid, count: uids.length });

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -250,6 +250,7 @@ export class SurveyService {
     if (projectUid) {
       return sorted.filter((s) => s.committees?.some((c) => c.project_uid === projectUid));
     } else if (foundationUid) {
+      logger.debug(req, 'get_my_surveys', 'Filtering by foundation', { foundation_uid: foundationUid });
       const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
       const uidSet = new Set(uids);
       return sorted.filter((s) => s.committees?.some((c) => uidSet.has(c.project_uid)));

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -169,7 +169,7 @@ export class SurveyService {
    * Fetches surveys the current user has responded to.
    * Queries survey_response records by email and username using filters_or.
    */
-  public async getMySurveys(req: Request): Promise<Survey[]> {
+  public async getMySurveys(req: Request, projectUid?: string, foundationUid?: string): Promise<Survey[]> {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
     const email = (req.oidc?.user?.['email'] as string)?.toLowerCase();
@@ -177,6 +177,8 @@ export class SurveyService {
     logger.debug(req, 'get_my_surveys', 'Fetching surveys for current user', {
       username,
       has_email: !!email,
+      project_uid: projectUid,
+      foundation_uid: foundationUid,
     });
 
     if (!username && !email) {
@@ -199,6 +201,7 @@ export class SurveyService {
         type: 'survey_response',
         page_size: 100,
         filters_or: filtersOr,
+        ...(projectUid && { tags: `project_uid:${projectUid}` }),
         ...(pageToken && { page_token: pageToken }),
       })
     );
@@ -232,7 +235,7 @@ export class SurveyService {
 
     // Sort: open/sent surveys first, then by cutoff date descending
     const openStatuses = new Set(['open', 'sent']);
-    return surveys
+    const sorted = surveys
       .filter((s): s is Survey => s !== null)
       .sort((a, b) => {
         const aOpen = openStatuses.has(a.survey_status) ? 0 : 1;
@@ -242,5 +245,16 @@ export class SurveyService {
         }
         return new Date(b.survey_cutoff_date).getTime() - new Date(a.survey_cutoff_date).getTime();
       });
+
+    // Post-fetch safety net: filter by project_uid or foundation_uid if provided
+    if (projectUid) {
+      return sorted.filter((s) => s.committees?.some((c) => c.project_uid === projectUid));
+    } else if (foundationUid) {
+      const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
+      const uidSet = new Set(uids);
+      return sorted.filter((s) => s.committees?.some((c) => uidSet.has(c.project_uid)));
+    }
+
+    return sorted;
   }
 }

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -472,7 +472,7 @@ export class UserService {
    * @param limit - Optional limit on number of meetings to return
    * @returns Array of Meeting objects the user is registered for
    */
-  public async getUserMeetings(req: Request, email: string, projectUid?: string, limit?: number): Promise<Meeting[]> {
+  public async getUserMeetings(req: Request, email: string, projectUid?: string, limit?: number, foundationUid?: string): Promise<Meeting[]> {
     const meetingIds = await this.getUserRegisteredMeetingIds(req, email);
 
     logger.debug(req, 'get_user_meetings', 'Found registered meeting IDs for user', { meeting_count: meetingIds.size });
@@ -481,7 +481,13 @@ export class UserService {
       return [];
     }
 
-    return this.fetchByIdFilterAndLimit<Meeting>(req, meetingIds, '/itx/meetings', 'get_user_meetings', projectUid, limit);
+    let foundationProjectUids: Set<string> | undefined;
+    if (foundationUid) {
+      const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
+      foundationProjectUids = new Set(uids);
+    }
+
+    return this.fetchByIdFilterAndLimit<Meeting>(req, meetingIds, '/itx/meetings', 'get_user_meetings', projectUid, limit, foundationProjectUids);
   }
 
   /**
@@ -494,7 +500,7 @@ export class UserService {
    * @param limit - Optional limit on number of past meetings to return
    * @returns Array of PastMeeting objects the user participated in
    */
-  public async getUserPastMeetings(req: Request, email: string, projectUid?: string, limit?: number): Promise<PastMeeting[]> {
+  public async getUserPastMeetings(req: Request, email: string, projectUid?: string, limit?: number, foundationUid?: string): Promise<PastMeeting[]> {
     // Step 1: Get past meeting participant records for this user via query service
     const normalizedEmail = email.toLowerCase();
     const participantParams: Record<string, any> = {
@@ -525,8 +531,22 @@ export class UserService {
       return [];
     }
 
+    let foundationProjectUids: Set<string> | undefined;
+    if (foundationUid) {
+      const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
+      foundationProjectUids = new Set(uids);
+    }
+
     // Step 2: Fetch each past meeting and filter/limit
-    return this.fetchByIdFilterAndLimit<PastMeeting>(req, pastMeetingIds, '/itx/past_meetings', 'get_user_past_meetings', projectUid, limit);
+    return this.fetchByIdFilterAndLimit<PastMeeting>(
+      req,
+      pastMeetingIds,
+      '/itx/past_meetings',
+      'get_user_past_meetings',
+      projectUid,
+      limit,
+      foundationProjectUids
+    );
   }
 
   /**
@@ -539,7 +559,8 @@ export class UserService {
     endpoint: string,
     operation: string,
     projectUid?: string,
-    limit?: number
+    limit?: number,
+    projectUids?: Set<string>
   ): Promise<T[]> {
     const results: T[] = [];
 
@@ -563,12 +584,18 @@ export class UserService {
       }
     }
 
-    let filtered = projectUid ? results.filter((r) => r.project_uid === projectUid) : results;
+    let filtered = results;
+    if (projectUid) {
+      filtered = filtered.filter((r) => r.project_uid === projectUid);
+    } else if (projectUids && projectUids.size > 0) {
+      filtered = filtered.filter((r) => r.project_uid !== undefined && projectUids.has(r.project_uid));
+    }
 
     logger.debug(req, operation, 'Filtered results', {
       total_fetched: results.length,
       filtered: filtered.length,
       project_uid: projectUid ?? 'all',
+      foundation_filter: projectUids ? projectUids.size : 0,
     });
 
     if (limit !== undefined && limit > 0) {

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -18,15 +18,18 @@ import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
+import { ProjectService } from './project.service';
 
 /**
  * Service for handling vote/poll business logic with microservice proxy
  */
 export class VoteService {
   private microserviceProxy: MicroserviceProxyService;
+  private projectService: ProjectService;
 
   public constructor() {
     this.microserviceProxy = new MicroserviceProxyService();
+    this.projectService = new ProjectService();
   }
 
   /**
@@ -253,7 +256,7 @@ export class VoteService {
    * Fetches votes the current user has been invited to.
    * Queries vote_response records by user_email and username using filters_or.
    */
-  public async getMyVotes(req: Request): Promise<Vote[]> {
+  public async getMyVotes(req: Request, projectUid?: string, foundationUid?: string): Promise<Vote[]> {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
     const email = (req.oidc?.user?.['email'] as string)?.toLowerCase();
@@ -282,6 +285,7 @@ export class VoteService {
         type: 'vote_response',
         page_size: 100,
         filters_or: filtersOr,
+        ...(projectUid && { tags: `project_uid:${projectUid}` }),
         ...(pageToken && { page_token: pageToken }),
       })
     );
@@ -314,7 +318,7 @@ export class VoteService {
     );
 
     // Sort: active votes first, then by end_time descending
-    return votes
+    const sorted = votes
       .filter((v): v is Vote => v !== null)
       .sort((a, b) => {
         const aActive = a.status === 'active' ? 0 : 1;
@@ -324,5 +328,16 @@ export class VoteService {
         }
         return new Date(b.end_time).getTime() - new Date(a.end_time).getTime();
       });
+
+    // Post-fetch safety net: filter by project_uid or foundation_uid if provided
+    if (projectUid) {
+      return sorted.filter((v) => v.project_uid === projectUid);
+    } else if (foundationUid) {
+      const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
+      const uidSet = new Set(uids);
+      return sorted.filter((v) => uidSet.has(v.project_uid));
+    }
+
+    return sorted;
   }
 }

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -333,6 +333,7 @@ export class VoteService {
     if (projectUid) {
       return sorted.filter((v) => v.project_uid === projectUid);
     } else if (foundationUid) {
+      logger.debug(req, 'get_my_votes', 'Filtering by foundation', { foundation_uid: foundationUid });
       const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
       const uidSet = new Set(uids);
       return sorted.filter((v) => uidSet.has(v.project_uid));

--- a/packages/shared/src/interfaces/persona.interface.ts
+++ b/packages/shared/src/interfaces/persona.interface.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { Account } from './account.interface';
+import type { EnrichedPersonaProject } from './persona-detection.interface';
 
 /**
  * Available persona types for UI customization
@@ -43,6 +44,8 @@ export interface PersistedPersonaState {
   multiFoundation?: boolean;
   /** User's organizations from board member detections */
   organizations?: Account[];
+  /** Enriched projects from persona detection — fallback when API is unavailable */
+  projects?: EnrichedPersonaProject[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add foundation and project filter dropdowns to all Me lens dashboards (meetings, committees, mailing lists, votes, surveys) allowing users to narrow results by foundation or specific project
- Foundation dropdown visible for board-scoped personas, project dropdown for project-scoped personas, both shown when user has dual roles
- Foundation filter resolves child project UIDs server-side via `ProjectService.getFoundationProjectUids()` using query service parent references
- Project filter uses server-side `tags`/`tags_all` where supported with post-fetch safety net
- Persona detection service fetches missing parent foundation projects for proper UI grouping
- `detectedProjects` persisted in persona cookie for fallback when API unavailable
- `lfx-select` wrapper extended with `#item` and `#selectedItem` template projection
- Me lens empty states restructured so filter bars remain visible when filters return empty results
- Search added to committees Me lens filter bar

Generated with [Claude Code](https://claude.ai/code)