### PR TITLE
feat(auth): add user impersonation via Auth0 CTE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ Detailed patterns are in `.claude/rules/` and loaded contextually based on file 
 | [Drawer Pattern](docs/architecture/frontend/drawer-pattern.md)                 | Drawer components, lazy loading, chart integration |
 | [Backend Architecture](docs/architecture/backend/README.md)                    | Controller-Service pattern, Express.js server      |
 | [Authentication](docs/architecture/backend/authentication.md)                  | Auth0 setup, selective auth middleware             |
+| [Impersonation](docs/architecture/backend/impersonation.md)                    | User impersonation via Auth0 CTE                   |
 | [SSR Server](docs/architecture/backend/ssr-server.md)                          | Server-side rendering                              |
 | [Logging & Monitoring](docs/architecture/backend/logging-monitoring.md)        | Structured logging with Pino                       |
 | [Error Handling](docs/architecture/backend/error-handling-architecture.md)     | Error classification, middleware                   |

--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -79,6 +79,13 @@ PROFILE_SCOPE="update:current_user_metadata update:current_user_identities"
 # Only override if Auth0 Profile Client has a different callback URL registered
 # PROFILE_REDIRECT_URI=http://localhost:4200/passwordless/callback
 
+# Impersonation — Auth Service client credentials for Management API profile lookup
+# Token exchange goes through NATS (lfx-v2-auth-service); these are only used to
+# fetch the target user's name/picture from Auth0 Management API
+# Only needed if you're testing impersonation; leave blank otherwise
+CTE_CLIENT_ID=your-cte-client-id
+CTE_CLIENT_KEY=your-base64-encoded-private-key
+
 # Social identity connection redirect URI
 # Used for GitHub/LinkedIn identity verification via Auth0 social connections
 # Defaults to ${PCC_BASE_URL}/social/callback if not set

--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -79,12 +79,8 @@ PROFILE_SCOPE="update:current_user_metadata update:current_user_identities"
 # Only override if Auth0 Profile Client has a different callback URL registered
 # PROFILE_REDIRECT_URI=http://localhost:4200/passwordless/callback
 
-# Impersonation — Auth Service client credentials for Management API profile lookup
-# Token exchange goes through NATS (lfx-v2-auth-service); these are only used to
-# fetch the target user's name/picture from Auth0 Management API
-# Only needed if you're testing impersonation; leave blank otherwise
-CTE_CLIENT_ID=your-cte-client-id
-CTE_CLIENT_KEY=your-base64-encoded-private-key
+# Impersonation — no additional env vars needed
+# Token exchange and profile enrichment both go through NATS (lfx-v2-auth-service)
 
 # Social identity connection redirect URI
 # Used for GitHub/LinkedIn identity verification via Auth0 social connections

--- a/apps/lfx-one/src/app/app.component.ts
+++ b/apps/lfx-one/src/app/app.component.ts
@@ -72,6 +72,17 @@ export class AppComponent {
 
       // Set DataDog RUM user context for session tracking
       this.dataDogRumService.setUser(this.auth.user);
+
+      // Hydrate canImpersonate permission from server context
+      if (this.auth?.canImpersonate) {
+        this.userService.canImpersonate.set(true);
+      }
+
+      // Hydrate impersonation state from server context
+      if (this.auth?.impersonating) {
+        this.userService.impersonating.set(true);
+        this.userService.impersonator.set(this.auth.impersonator ?? null);
+      }
     }
   }
 }

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -1,10 +1,33 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<!-- Impersonation Banner -->
+@if (userService.impersonating()) {
+  <div
+    class="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-2 bg-yellow-400 py-2 text-sm font-medium text-black"
+    data-testid="impersonation-banner">
+    <i class="fa-light fa-eye text-sm"></i>
+    <span>Viewing as <strong>{{ userService.user()?.email }}</strong></span>
+    <span class="text-black/60">— by {{ userService.impersonator()?.name }}</span>
+    <button
+      class="ml-4 rounded bg-black/10 px-3 py-1 text-xs font-semibold transition-colors hover:bg-black/20"
+      (click)="stopImpersonation()"
+      data-testid="stop-impersonation-button">
+      Stop Impersonating
+    </button>
+  </div>
+}
+
 <!-- Dev Toolbar (fixed at top) -->
 <lfx-dev-toolbar></lfx-dev-toolbar>
 
-<div class="flex min-h-screen" [ngClass]="{ 'pt-12': showDevToolbar() }">
+<div
+  class="flex min-h-screen"
+  [ngClass]="{
+    'pt-12': showDevToolbar() && !userService.impersonating(),
+    'pt-10': userService.impersonating() && !showDevToolbar(),
+    'pt-[88px]': userService.impersonating() && showDevToolbar(),
+  }">
   <!-- Sidebar - Desktop: lens switcher (64px) + nav panel (280px) = 344px -->
   <div
     class="hidden lg:flex flex-row flex-shrink-0 fixed left-0 bottom-0 z-40"

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -4,7 +4,7 @@
 <!-- Impersonation Banner -->
 @if (userService.impersonating()) {
   <div
-    class="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-2 bg-yellow-400 py-2 text-sm font-medium text-black"
+    class="fixed top-0 left-0 right-0 z-[60] flex items-center justify-center gap-2 bg-yellow-400 py-2 text-sm font-medium text-black"
     data-testid="impersonation-banner">
     <i class="fa-light fa-eye text-sm"></i>
     <span
@@ -21,9 +21,7 @@
 <div
   class="flex min-h-screen"
   [ngClass]="{
-    'pt-12': showDevToolbar() && !userService.impersonating(),
-    'pt-10': userService.impersonating() && !showDevToolbar(),
-    'pt-[88px]': userService.impersonating() && showDevToolbar(),
+    'pt-12': showDevToolbar(),
   }">
   <!-- Sidebar - Desktop: lens switcher (64px) + nav panel (280px) = 344px -->
   <div

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -7,14 +7,11 @@
     class="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-2 bg-yellow-400 py-2 text-sm font-medium text-black"
     data-testid="impersonation-banner">
     <i class="fa-light fa-eye text-sm"></i>
-    <span>Viewing as <strong>{{ userService.user()?.email }}</strong></span>
+    <span
+      >Viewing as <strong>{{ userService.user()?.email }}</strong></span
+    >
     <span class="text-black/60">— by {{ userService.impersonator()?.name }}</span>
-    <button
-      class="ml-4 rounded bg-black/10 px-3 py-1 text-xs font-semibold transition-colors hover:bg-black/20"
-      (click)="stopImpersonation()"
-      data-testid="stop-impersonation-button">
-      Stop Impersonating
-    </button>
+    <lfx-button label="Stop Impersonating" severity="contrast" size="small" (onClick)="stopImpersonation()" data-testid="stop-impersonation-button" />
   </div>
 }
 

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -11,10 +11,12 @@ import { ALL_LENSES, COMMITTEE_LABEL, DOCUMENT_LABEL, MAILING_LIST_LABEL, SURVEY
 import { Lens, SidebarMenuItem } from '@lfx-one/shared/interfaces';
 import { AppService } from '@services/app.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
+import { ImpersonationService } from '@services/impersonation.service';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
+import { UserService } from '@services/user.service';
 import { DrawerModule } from 'primeng/drawer';
-import { filter } from 'rxjs';
+import { filter, take } from 'rxjs';
 
 import { DevToolbarComponent } from '../dev-toolbar/dev-toolbar.component';
 
@@ -32,6 +34,8 @@ export class MainLayoutComponent {
   private readonly featureFlagService = inject(FeatureFlagService);
   private readonly personaService = inject(PersonaService);
   private readonly lensService = inject(LensService);
+  private readonly impersonationService = inject(ImpersonationService);
+  public readonly userService = inject(UserService);
 
   // Expose mobile sidebar state from service (writable for two-way binding with p-drawer)
   protected readonly showMobileSidebar = this.appService.showMobileSidebar;
@@ -358,6 +362,12 @@ export class MainLayoutComponent {
     if (!visible) {
       this.appService.closeMobileSidebar();
     }
+  }
+
+  public stopImpersonation(): void {
+    this.impersonationService.stopImpersonation().pipe(take(1)).subscribe(() => {
+      window.location.reload();
+    });
   }
 
   /**

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -18,11 +18,12 @@ import { UserService } from '@services/user.service';
 import { DrawerModule } from 'primeng/drawer';
 import { filter, take } from 'rxjs';
 
+import { ButtonComponent } from '@components/button/button.component';
 import { DevToolbarComponent } from '../dev-toolbar/dev-toolbar.component';
 
 @Component({
   selector: 'lfx-main-layout',
-  imports: [NgClass, RouterModule, SidebarComponent, DrawerModule, DevToolbarComponent, LensSwitcherComponent],
+  imports: [NgClass, RouterModule, SidebarComponent, DrawerModule, DevToolbarComponent, LensSwitcherComponent, ButtonComponent],
   templateUrl: './main-layout.component.html',
   styleUrl: './main-layout.component.scss',
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -35,7 +36,7 @@ export class MainLayoutComponent {
   private readonly personaService = inject(PersonaService);
   private readonly lensService = inject(LensService);
   private readonly impersonationService = inject(ImpersonationService);
-  public readonly userService = inject(UserService);
+  protected readonly userService = inject(UserService);
 
   // Expose mobile sidebar state from service (writable for two-way binding with p-drawer)
   protected readonly showMobileSidebar = this.appService.showMobileSidebar;
@@ -364,10 +365,13 @@ export class MainLayoutComponent {
     }
   }
 
-  public stopImpersonation(): void {
-    this.impersonationService.stopImpersonation().pipe(take(1)).subscribe(() => {
-      window.location.reload();
-    });
+  protected stopImpersonation(): void {
+    this.impersonationService
+      .stopImpersonation()
+      .pipe(take(1))
+      .subscribe(() => {
+        window.location.reload();
+      });
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
@@ -3,8 +3,8 @@
 
 <div class="relative flex flex-col gap-4">
   @if (loading()) {
-    <div class="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-white/80">
-      <div class="flex items-center gap-2 text-sm text-gray-600">
+    <div class="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-white/80" aria-busy="true">
+      <div class="flex items-center gap-2 text-sm text-gray-600" role="status" aria-live="polite">
         <i class="fa-light fa-spinner-third fa-spin"></i>
         <span>Starting impersonation...</span>
       </div>
@@ -22,7 +22,7 @@
       dataTest="impersonation-target-input" />
   </div>
   @if (error()) {
-    <p class="text-sm text-red-600" data-testid="impersonation-error">{{ error() }}</p>
+    <p class="text-sm text-red-600" role="alert" data-testid="impersonation-error">{{ error() }}</p>
   }
   <div class="flex justify-end gap-2">
     <lfx-button

--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
@@ -25,7 +25,14 @@
     <p class="text-sm text-red-600" data-testid="impersonation-error">{{ error() }}</p>
   }
   <div class="flex justify-end gap-2">
-    <lfx-button size="small" label="Cancel" severity="secondary" [outlined]="true" [disabled]="loading()" (onClick)="cancel()" />
+    <lfx-button
+      size="small"
+      label="Cancel"
+      severity="secondary"
+      [outlined]="true"
+      [disabled]="loading()"
+      (onClick)="cancel()"
+      data-testid="impersonation-cancel-button" />
     <lfx-button
       size="small"
       label="Start Impersonation"

--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
@@ -1,0 +1,48 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="relative flex flex-col gap-4">
+  @if (loading()) {
+    <div class="absolute inset-0 z-10 flex items-center justify-center rounded-lg bg-white/80">
+      <div class="flex items-center gap-2 text-sm text-gray-600">
+        <i class="fa-light fa-spinner-third fa-spin"></i>
+        <span>Starting impersonation...</span>
+      </div>
+    </div>
+  }
+  <p class="text-sm text-gray-600">Enter the email or username of the user you want to view the app as.</p>
+  <div class="flex flex-col gap-1">
+    <label for="targetUser" class="text-sm font-medium text-gray-700">Email or Username</label>
+    <input
+      id="targetUser"
+      type="text"
+      class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
+      placeholder="e.g. jdoe or jdoe@example.com"
+      [formControl]="targetUserControl"
+      (keydown.enter)="submit()"
+      data-testid="impersonation-target-input" />
+  </div>
+  @if (error()) {
+    <p class="text-sm text-red-600" data-testid="impersonation-error">{{ error() }}</p>
+  }
+  <div class="flex justify-end gap-2">
+    <button
+      type="button"
+      class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
+      (click)="cancel()"
+      [disabled]="loading()">
+      Cancel
+    </button>
+    <button
+      type="button"
+      class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+      (click)="submit()"
+      [disabled]="targetUserControl.invalid || loading()"
+      data-testid="impersonation-submit-button">
+      @if (loading()) {
+        <i class="fa-light fa-spinner-third fa-spin mr-1"></i>
+      }
+      Start Impersonation
+    </button>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
@@ -11,38 +11,27 @@
     </div>
   }
   <p class="text-sm text-gray-600">Enter the email or username of the user you want to view the app as.</p>
-  <div class="flex flex-col gap-1">
+  <div class="flex flex-col gap-1" (keydown.enter)="submit()">
     <label for="targetUser" class="text-sm font-medium text-gray-700">Email or Username</label>
-    <input
-      id="targetUser"
-      type="text"
-      class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none disabled:bg-gray-50 disabled:text-gray-400"
+    <lfx-input-text
+      size="small"
+      [form]="targetUserForm"
+      control="targetUser"
       placeholder="e.g. jdoe or jdoe@example.com"
-      [formControl]="targetUserControl"
-      (keydown.enter)="submit()"
-      data-testid="impersonation-target-input" />
+      id="targetUser"
+      dataTest="impersonation-target-input" />
   </div>
   @if (error()) {
     <p class="text-sm text-red-600" data-testid="impersonation-error">{{ error() }}</p>
   }
   <div class="flex justify-end gap-2">
-    <button
-      type="button"
-      class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50"
-      (click)="cancel()"
-      [disabled]="loading()">
-      Cancel
-    </button>
-    <button
-      type="button"
-      class="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
-      (click)="submit()"
-      [disabled]="targetUserControl.invalid || loading()"
-      data-testid="impersonation-submit-button">
-      @if (loading()) {
-        <i class="fa-light fa-spinner-third fa-spin mr-1"></i>
-      }
-      Start Impersonation
-    </button>
+    <lfx-button size="small" label="Cancel" severity="secondary" [outlined]="true" [disabled]="loading()" (onClick)="cancel()" />
+    <lfx-button
+      size="small"
+      label="Start Impersonation"
+      [loading]="loading()"
+      [disabled]="targetUserForm.controls.targetUser.invalid || loading()"
+      (onClick)="submit()"
+      data-testid="impersonation-submit-button" />
   </div>
 </div>

--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.ts
@@ -2,31 +2,35 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, inject, signal } from '@angular/core';
-import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
 import { ImpersonationService } from '@services/impersonation.service';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
 import { take } from 'rxjs';
 
 @Component({
   selector: 'lfx-impersonation-dialog',
-  imports: [ReactiveFormsModule],
+  imports: [InputTextComponent, ButtonComponent],
   templateUrl: './impersonation-dialog.component.html',
 })
 export class ImpersonationDialogComponent {
   private readonly impersonationService = inject(ImpersonationService);
   private readonly dialogRef = inject(DynamicDialogRef);
 
-  public targetUserControl = new FormControl('', { nonNullable: true, validators: [Validators.required] });
-  public loading = signal(false);
-  public error = signal('');
+  protected targetUserForm = new FormGroup({
+    targetUser: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+  });
+  protected loading = signal(false);
+  protected error = signal('');
 
   public submit(): void {
-    const target = this.targetUserControl.value.trim();
+    const target = this.targetUserForm.controls.targetUser.value.trim();
     if (!target) return;
 
     this.loading.set(true);
     this.error.set('');
-    this.targetUserControl.disable();
+    this.targetUserForm.controls.targetUser.disable();
 
     this.impersonationService
       .startImpersonation(target)
@@ -38,7 +42,7 @@ export class ImpersonationDialogComponent {
         },
         error: (err) => {
           this.loading.set(false);
-          this.targetUserControl.enable();
+          this.targetUserForm.controls.targetUser.enable();
           this.error.set(err.error?.error || 'Failed to start impersonation');
         },
       });

--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.ts
@@ -1,0 +1,50 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, inject, signal } from '@angular/core';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import { ImpersonationService } from '@services/impersonation.service';
+import { DynamicDialogRef } from 'primeng/dynamicdialog';
+import { take } from 'rxjs';
+
+@Component({
+  selector: 'lfx-impersonation-dialog',
+  imports: [ReactiveFormsModule],
+  templateUrl: './impersonation-dialog.component.html',
+})
+export class ImpersonationDialogComponent {
+  private readonly impersonationService = inject(ImpersonationService);
+  private readonly dialogRef = inject(DynamicDialogRef);
+
+  public targetUserControl = new FormControl('', { nonNullable: true, validators: [Validators.required] });
+  public loading = signal(false);
+  public error = signal('');
+
+  public submit(): void {
+    const target = this.targetUserControl.value.trim();
+    if (!target) return;
+
+    this.loading.set(true);
+    this.error.set('');
+    this.targetUserControl.disable();
+
+    this.impersonationService
+      .startImpersonation(target)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.dialogRef.close(true);
+          window.location.reload();
+        },
+        error: (err) => {
+          this.loading.set(false);
+          this.targetUserControl.enable();
+          this.error.set(err.error?.error || 'Failed to start impersonation');
+        },
+      });
+  }
+
+  public cancel(): void {
+    this.dialogRef.close(false);
+  }
+}

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -114,16 +114,18 @@
 
       <!-- Impersonation Button (only for authorized users) -->
       @if (canImpersonate() && !isImpersonating()) {
-        <lfx-button
-          icon="fa-light fa-user-secret text-blue-200/70 hover:text-white"
-          severity="secondary"
-          [text]="true"
-          [rounded]="true"
-          tooltip="Impersonate User"
+        <button
+          type="button"
+          (click)="openImpersonationDialog()"
+          data-testid="lens-impersonate-button"
+          aria-label="Impersonate user"
+          pTooltip="Impersonate User"
           tooltipPosition="right"
-          ariaLabel="Impersonate user"
-          (onClick)="openImpersonationDialog()"
-          data-testid="lens-impersonate-button" />
+          class="group flex flex-col items-center gap-1 w-full transition-colors text-blue-200/70 hover:text-white">
+          <div class="flex items-center justify-center w-10 h-10 rounded-xl transition-colors group-hover:bg-white/10">
+            <i class="fa-light fa-user-secret text-xl"></i>
+          </div>
+        </button>
       }
 
       <!-- Divider -->

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -18,13 +18,13 @@
     <!-- Mobile account actions -->
     <div class="ml-auto flex items-center gap-2">
       @if (canImpersonate() && !isImpersonating()) {
-        <button
-          type="button"
-          (click)="openImpersonationDialog()"
-          data-testid="lens-mobile-impersonate"
-          class="flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:bg-gray-100 transition-colors">
-          <i class="fa-light fa-user-secret text-sm"></i>
-        </button>
+        <lfx-button
+          icon="fa-light fa-user-secret"
+          [text]="true"
+          [rounded]="true"
+          ariaLabel="Impersonate user"
+          (onClick)="openImpersonationDialog()"
+          data-testid="lens-mobile-impersonate" />
       }
       <a
         [routerLink]="['/profile']"
@@ -114,18 +114,16 @@
 
       <!-- Impersonation Button (only for authorized users) -->
       @if (canImpersonate() && !isImpersonating()) {
-        <button
-          type="button"
-          (click)="openImpersonationDialog()"
-          data-testid="lens-impersonate-button"
-          aria-label="Impersonate user"
-          pTooltip="Impersonate User"
+        <lfx-button
+          icon="fa-light fa-user-secret text-blue-200/70 hover:text-white"
+          severity="secondary"
+          [text]="true"
+          [rounded]="true"
+          tooltip="Impersonate User"
           tooltipPosition="right"
-          class="group flex flex-col items-center gap-1 w-full transition-colors text-blue-200/70 hover:text-white">
-          <div class="flex items-center justify-center w-10 h-10 rounded-xl transition-colors group-hover:bg-white/10">
-            <i class="fa-light fa-user-secret text-xl"></i>
-          </div>
-        </button>
+          ariaLabel="Impersonate user"
+          (onClick)="openImpersonationDialog()"
+          data-testid="lens-impersonate-button" />
       }
 
       <!-- Divider -->
@@ -194,5 +192,4 @@
       </div>
     </ng-template>
   </p-popover>
-
 }

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -17,6 +17,15 @@
 
     <!-- Mobile account actions -->
     <div class="ml-auto flex items-center gap-2">
+      @if (canImpersonate() && !isImpersonating()) {
+        <button
+          type="button"
+          (click)="openImpersonationDialog()"
+          data-testid="lens-mobile-impersonate"
+          class="flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:bg-gray-100 transition-colors">
+          <i class="fa-light fa-user-secret text-sm"></i>
+        </button>
+      }
       <a
         [routerLink]="['/profile']"
         data-testid="lens-mobile-profile"
@@ -103,6 +112,22 @@
         </div>
       </a>
 
+      <!-- Impersonation Button (only for authorized users) -->
+      @if (canImpersonate() && !isImpersonating()) {
+        <button
+          type="button"
+          (click)="openImpersonationDialog()"
+          data-testid="lens-impersonate-button"
+          aria-label="Impersonate user"
+          pTooltip="Impersonate User"
+          tooltipPosition="right"
+          class="group flex flex-col items-center gap-1 w-full transition-colors text-blue-200/70 hover:text-white">
+          <div class="flex items-center justify-center w-10 h-10 rounded-xl transition-colors group-hover:bg-white/10">
+            <i class="fa-light fa-user-secret text-xl"></i>
+          </div>
+        </button>
+      }
+
       <!-- Divider -->
       <hr class="w-6 border-white/20" />
 
@@ -169,4 +194,5 @@
       </div>
     </ng-template>
   </p-popover>
+
 }

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
@@ -5,6 +5,7 @@ import { NgClass } from '@angular/common';
 import { Component, inject, input, viewChild } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
+import { ButtonComponent } from '@components/button/button.component';
 import { ImpersonationDialogComponent } from '@components/impersonation-dialog/impersonation-dialog.component';
 import { environment } from '@environments/environment';
 import { LENS_DEFAULT_ROUTES } from '@lfx-one/shared/constants';
@@ -17,7 +18,7 @@ import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   selector: 'lfx-lens-switcher',
-  imports: [NgClass, RouterLink, TooltipModule, PopoverModule, AvatarComponent],
+  imports: [NgClass, RouterLink, TooltipModule, PopoverModule, AvatarComponent, ButtonComponent],
   providers: [DialogService],
   templateUrl: './lens-switcher.component.html',
   styleUrl: './lens-switcher.component.scss',

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
@@ -5,17 +5,20 @@ import { NgClass } from '@angular/common';
 import { Component, inject, input, viewChild } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
+import { ImpersonationDialogComponent } from '@components/impersonation-dialog/impersonation-dialog.component';
 import { environment } from '@environments/environment';
 import { LENS_DEFAULT_ROUTES } from '@lfx-one/shared/constants';
 import { Lens } from '@lfx-one/shared/interfaces';
 import { LensService } from '@services/lens.service';
 import { UserService } from '@services/user.service';
+import { DialogService } from 'primeng/dynamicdialog';
 import { Popover, PopoverModule } from 'primeng/popover';
 import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   selector: 'lfx-lens-switcher',
   imports: [NgClass, RouterLink, TooltipModule, PopoverModule, AvatarComponent],
+  providers: [DialogService],
   templateUrl: './lens-switcher.component.html',
   styleUrl: './lens-switcher.component.scss',
 })
@@ -23,6 +26,7 @@ export class LensSwitcherComponent {
   private readonly lensService = inject(LensService);
   private readonly router = inject(Router);
   private readonly userService = inject(UserService);
+  private readonly dialogService = inject(DialogService);
 
   public readonly mobile = input<boolean>(false);
 
@@ -33,6 +37,8 @@ export class LensSwitcherComponent {
   protected readonly userMenu = viewChild<Popover>('userMenu');
 
   protected readonly userInitials = this.userService.userInitials;
+  protected readonly canImpersonate = this.userService.canImpersonate;
+  protected readonly isImpersonating = this.userService.impersonating;
 
   protected setLens(lens: Lens): void {
     this.userMenu()?.hide();
@@ -48,5 +54,15 @@ export class LensSwitcherComponent {
     this.userMenu()?.hide();
     this.lensService.setLens('me');
     this.router.navigate(['/profile']);
+  }
+
+  protected openImpersonationDialog(): void {
+    this.dialogService.open(ImpersonationDialogComponent, {
+      header: 'Impersonate User',
+      width: '400px',
+      modal: true,
+      draggable: false,
+      resizable: false,
+    });
   }
 }

--- a/apps/lfx-one/src/app/shared/services/impersonation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/impersonation.service.ts
@@ -4,7 +4,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { ImpersonationStartResponse, ImpersonationStatusResponse } from '@lfx-one/shared/interfaces';
-import { catchError, Observable, of, take } from 'rxjs';
+import { catchError, Observable, of } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -13,11 +13,11 @@ export class ImpersonationService {
   private readonly http = inject(HttpClient);
 
   public startImpersonation(targetUser: string): Observable<ImpersonationStartResponse> {
-    return this.http.post<ImpersonationStartResponse>('/api/impersonate', { targetUser }).pipe(take(1));
+    return this.http.post<ImpersonationStartResponse>('/api/impersonate', { targetUser });
   }
 
   public stopImpersonation(): Observable<{ impersonating: false }> {
-    return this.http.post<{ impersonating: false }>('/api/impersonate/stop', {}).pipe(take(1));
+    return this.http.post<{ impersonating: false }>('/api/impersonate/stop', {});
   }
 
   public getStatus(): Observable<ImpersonationStatusResponse> {

--- a/apps/lfx-one/src/app/shared/services/impersonation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/impersonation.service.ts
@@ -21,8 +21,8 @@ export class ImpersonationService {
   }
 
   public getStatus(): Observable<ImpersonationStatusResponse> {
-    return this.http.get<ImpersonationStatusResponse>('/api/impersonate/status').pipe(
-      catchError(() => of({ impersonating: false } as ImpersonationStatusResponse))
-    );
+    return this.http
+      .get<ImpersonationStatusResponse>('/api/impersonate/status')
+      .pipe(catchError(() => of({ impersonating: false } as ImpersonationStatusResponse)));
   }
 }

--- a/apps/lfx-one/src/app/shared/services/impersonation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/impersonation.service.ts
@@ -1,0 +1,28 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { ImpersonationStartResponse, ImpersonationStatusResponse } from '@lfx-one/shared/interfaces';
+import { catchError, Observable, of, take } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ImpersonationService {
+  private readonly http = inject(HttpClient);
+
+  public startImpersonation(targetUser: string): Observable<ImpersonationStartResponse> {
+    return this.http.post<ImpersonationStartResponse>('/api/impersonate', { targetUser }).pipe(take(1));
+  }
+
+  public stopImpersonation(): Observable<{ impersonating: false }> {
+    return this.http.post<{ impersonating: false }>('/api/impersonate/stop', {}).pipe(take(1));
+  }
+
+  public getStatus(): Observable<ImpersonationStatusResponse> {
+    return this.http.get<ImpersonationStatusResponse>('/api/impersonate/status').pipe(
+      catchError(() => of({ impersonating: false } as ImpersonationStatusResponse))
+    );
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -14,6 +14,7 @@ import {
   EmailManagementData,
   EmailPreferences,
   EnrichedIdentity,
+  Impersonator,
   Meeting,
   PastMeeting,
   ProfileAuthStatus,
@@ -39,6 +40,9 @@ export class UserService {
 
   public authenticated: WritableSignal<boolean> = signal<boolean>(false);
   public user: WritableSignal<User | null> = signal<User | null>(null);
+  public impersonating: WritableSignal<boolean> = signal<boolean>(false);
+  public impersonator: WritableSignal<Impersonator | null> = signal<Impersonator | null>(null);
+  public canImpersonate: WritableSignal<boolean> = signal<boolean>(false);
   public readonly userInitials: Signal<string> = this.initUserInitials();
 
   // Create a new user with permissions

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -8,7 +8,7 @@ import { logger } from '../services/logger.service';
 import { OrganizationService } from '../services/organization.service';
 import { ProjectService } from '../services/project.service';
 import { UserService } from '../services/user.service';
-import { getUsernameFromAuth } from '../utils/auth-helper';
+import { getEffectiveEmail, getUsernameFromAuth } from '../utils/auth-helper';
 
 /** Allowed pattern for foundationSlug: lowercase alphanumeric and hyphens only */
 const SLUG_PATTERN = /^[a-z0-9-]+$/;
@@ -39,7 +39,7 @@ export class AnalyticsController {
     const startTime = logger.startOperation(req, 'get_active_weeks_streak');
 
     try {
-      const userEmail = req.oidc?.user?.['email'];
+      const userEmail = getEffectiveEmail(req);
 
       if (!userEmail) {
         throw new AuthenticationError('User email not found in authentication context', {
@@ -69,7 +69,7 @@ export class AnalyticsController {
     const startTime = logger.startOperation(req, 'get_pull_requests_merged');
 
     try {
-      const userEmail = req.oidc?.user?.['email'];
+      const userEmail = getEffectiveEmail(req);
 
       if (!userEmail) {
         throw new AuthenticationError('User email not found in authentication context', {
@@ -99,7 +99,7 @@ export class AnalyticsController {
     const startTime = logger.startOperation(req, 'get_code_commits');
 
     try {
-      const userEmail = req.oidc?.user?.['email'];
+      const userEmail = getEffectiveEmail(req);
 
       if (!userEmail) {
         throw new AuthenticationError('User email not found in authentication context', {

--- a/apps/lfx-one/src/server/controllers/copilot.controller.ts
+++ b/apps/lfx-one/src/server/controllers/copilot.controller.ts
@@ -7,6 +7,7 @@ import { NextFunction, Request, Response } from 'express';
 import { ServiceValidationError } from '../errors';
 import { CopilotService } from '../services/copilot.service';
 import { logger } from '../services/logger.service';
+import { getEffectiveSub } from '../utils/auth-helper';
 
 export class CopilotController {
   private readonly copilotService = new CopilotService();
@@ -28,7 +29,7 @@ export class CopilotController {
     const validSessionId = typeof sessionId === 'string' && sessionId.trim() ? sessionId.trim() : undefined;
     const validContext = context && typeof context === 'object' && !Array.isArray(context) ? context : undefined;
 
-    const userId = (req.oidc?.user?.['sub'] as string) || 'anonymous';
+    const userId = getEffectiveSub(req) || 'anonymous';
 
     const startTime = logger.startOperation(req, 'copilot_chat', {
       has_session: !!validSessionId,

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -241,11 +241,10 @@ export class EventsController {
         });
       }
 
-      const userName =
-        (req.appSession?.['impersonationUser']?.name as string) ||
-        (req.appSession?.['impersonationUser']?.username as string) ||
-        (req.oidc?.user?.['name'] as string) ||
-        userEmail;
+      const impersonationUser = req.appSession?.['impersonationUser'];
+      const userName = impersonationUser
+        ? (impersonationUser.name as string) || (impersonationUser.username as string) || userEmail
+        : (req.oidc?.user?.['name'] as string) || userEmail;
 
       const pdfBuffer = await this.certificateService.generateCertificate(req, {
         eventId,

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -18,7 +18,7 @@ import {
 import { EventSortOrder, EventStatusFilter, GetEventOrganizationsOptions, GetEventsOptions } from '@lfx-one/shared/interfaces';
 import { EventsService } from '../services/events.service';
 import { PersonaDetectionService } from '../services/persona-detection.service';
-import { getEffectiveEmail } from '../utils/auth-helper';
+import { getEffectiveEmail, getEffectiveName } from '../utils/auth-helper';
 
 export class EventsController {
   private readonly eventsService = new EventsService();
@@ -241,10 +241,7 @@ export class EventsController {
         });
       }
 
-      const impersonationUser = req.appSession?.['impersonationUser'];
-      const userName = impersonationUser
-        ? (impersonationUser.name as string) || (impersonationUser.username as string) || userEmail
-        : (req.oidc?.user?.['name'] as string) || userEmail;
+      const userName = getEffectiveName(req) || userEmail;
 
       const pdfBuffer = await this.certificateService.generateCertificate(req, {
         eventId,

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -18,6 +18,7 @@ import {
 import { EventSortOrder, EventStatusFilter, GetEventOrganizationsOptions, GetEventsOptions } from '@lfx-one/shared/interfaces';
 import { EventsService } from '../services/events.service';
 import { PersonaDetectionService } from '../services/persona-detection.service';
+import { getEffectiveEmail } from '../utils/auth-helper';
 
 export class EventsController {
   private readonly eventsService = new EventsService();
@@ -35,7 +36,7 @@ export class EventsController {
     });
 
     try {
-      const userEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+      const userEmail = getEffectiveEmail(req);
 
       if (!userEmail) {
         throw new AuthenticationError('User authentication required', {
@@ -173,7 +174,7 @@ export class EventsController {
     });
 
     try {
-      const userEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+      const userEmail = getEffectiveEmail(req);
 
       if (!userEmail) {
         throw new AuthenticationError('User authentication required', {
@@ -224,7 +225,7 @@ export class EventsController {
     const startTime = logger.startOperation(req, 'get_certificate', { event_id: eventId });
 
     try {
-      const userEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+      const userEmail = getEffectiveEmail(req);
 
       if (!userEmail) {
         throw new AuthenticationError('User authentication required', {
@@ -240,7 +241,7 @@ export class EventsController {
         });
       }
 
-      const userName = (req.oidc?.user?.['name'] as string) || userEmail;
+      const userName = (req.appSession?.['impersonationUser']?.username as string) || (req.oidc?.user?.['name'] as string) || userEmail;
 
       const pdfBuffer = await this.certificateService.generateCertificate(req, {
         eventId,

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -241,7 +241,11 @@ export class EventsController {
         });
       }
 
-      const userName = (req.appSession?.['impersonationUser']?.username as string) || (req.oidc?.user?.['name'] as string) || userEmail;
+      const userName =
+        (req.appSession?.['impersonationUser']?.name as string) ||
+        (req.appSession?.['impersonationUser']?.username as string) ||
+        (req.oidc?.user?.['name'] as string) ||
+        userEmail;
 
       const pdfBuffer = await this.certificateService.generateCertificate(req, {
         eventId,

--- a/apps/lfx-one/src/server/controllers/impersonation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/impersonation.controller.ts
@@ -3,6 +3,7 @@
 
 import { NextFunction, Request, Response } from 'express';
 
+import { AuthorizationError, MicroserviceError, ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
 import { ImpersonationService } from '../services/impersonation.service';
 
@@ -16,19 +17,40 @@ export class ImpersonationController {
 
     try {
       if (!this.impersonationService.isConfigured()) {
-        res.status(501).json({ error: 'Impersonation is not configured' });
+        next(
+          new MicroserviceError('Impersonation is not configured', 501, 'IMPERSONATION_NOT_CONFIGURED', {
+            operation: 'start_impersonation',
+            service: 'impersonation',
+          })
+        );
+        return;
+      }
+
+      if (req.appSession?.['impersonationToken']) {
+        next(
+          new MicroserviceError('Already impersonating a user. Stop the current session first.', 409, 'ALREADY_IMPERSONATING', {
+            operation: 'start_impersonation',
+            service: 'impersonation',
+          })
+        );
         return;
       }
 
       const targetUser = req.body?.targetUser;
       if (!targetUser || typeof targetUser !== 'string' || targetUser.trim() === '') {
-        res.status(400).json({ error: 'targetUser is required and must be a non-empty string' });
+        next(
+          ServiceValidationError.forField('targetUser', 'targetUser is required and must be a non-empty string', {
+            operation: 'start_impersonation',
+            service: 'impersonation',
+          })
+        );
         return;
       }
 
-      const tokenPayload = this.impersonationService.decodeJwtPayload(req.bearerToken || '');
+      const realToken = req.oidc?.accessToken?.access_token || '';
+      const tokenPayload = this.impersonationService.decodeJwtPayload(realToken);
       if (!tokenPayload || tokenPayload['http://lfx.dev/claims/can_impersonate'] !== true) {
-        res.status(403).json({ error: 'Insufficient permissions to impersonate users' });
+        next(new AuthorizationError('Insufficient permissions to impersonate users', { operation: 'start_impersonation', service: 'impersonation' }));
         return;
       }
 

--- a/apps/lfx-one/src/server/controllers/impersonation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/impersonation.controller.ts
@@ -1,0 +1,91 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NextFunction, Request, Response } from 'express';
+
+import { logger } from '../services/logger.service';
+import { ImpersonationService } from '../services/impersonation.service';
+
+export class ImpersonationController {
+  private impersonationService: ImpersonationService = new ImpersonationService();
+
+  public async startImpersonation(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'start_impersonation', {
+      target_user: req.body?.targetUser,
+    });
+
+    try {
+      if (!this.impersonationService.isConfigured()) {
+        res.status(501).json({ error: 'Impersonation is not configured' });
+        return;
+      }
+
+      const targetUser = req.body?.targetUser;
+      if (!targetUser || typeof targetUser !== 'string' || targetUser.trim() === '') {
+        res.status(400).json({ error: 'targetUser is required and must be a non-empty string' });
+        return;
+      }
+
+      const tokenPayload = this.impersonationService.decodeJwtPayload(req.bearerToken || '');
+      if (!tokenPayload || tokenPayload['http://lfx.dev/claims/can_impersonate'] !== true) {
+        res.status(403).json({ error: 'Insufficient permissions to impersonate users' });
+        return;
+      }
+
+      const tokenResponse = await this.impersonationService.exchangeToken(req, targetUser.trim());
+      const targetClaims = this.impersonationService.decodeJwtPayload(tokenResponse.access_token);
+
+      if (!targetClaims) {
+        throw new Error('Failed to decode target user claims from CTE response');
+      }
+
+      const profile = await this.impersonationService.fetchTargetUserProfile(req, targetClaims['sub']);
+      this.impersonationService.startImpersonation(req, tokenResponse, targetClaims, profile);
+
+      logger.success(req, 'start_impersonation', startTime, {
+        target_sub: targetClaims['sub'],
+      });
+
+      res.json({
+        impersonating: true,
+        targetUser: {
+          sub: targetClaims['sub'] || '',
+          email: targetClaims['http://lfx.dev/claims/email'] || '',
+          username: targetClaims['http://lfx.dev/claims/username'] || '',
+        },
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async stopImpersonation(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'stop_impersonation');
+
+    try {
+      this.impersonationService.stopImpersonation(req);
+
+      logger.success(req, 'stop_impersonation', startTime);
+
+      res.json({ impersonating: false });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  public async getImpersonationStatus(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_impersonation_status');
+
+    try {
+      const status = this.impersonationService.getImpersonationStatus(req);
+
+      logger.success(req, 'get_impersonation_status', startTime, {
+        impersonating: status.impersonating,
+      });
+
+      res.json(status);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/controllers/impersonation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/impersonation.controller.ts
@@ -6,9 +6,10 @@ import { NextFunction, Request, Response } from 'express';
 import { AuthorizationError, MicroserviceError, ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
 import { ImpersonationService } from '../services/impersonation.service';
+import { decodeJwtPayload } from '../utils/auth-helper';
 
 export class ImpersonationController {
-  private impersonationService: ImpersonationService = new ImpersonationService();
+  private readonly impersonationService: ImpersonationService = new ImpersonationService();
 
   public async startImpersonation(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'start_impersonation', {
@@ -16,16 +17,6 @@ export class ImpersonationController {
     });
 
     try {
-      if (!this.impersonationService.isConfigured()) {
-        next(
-          new MicroserviceError('Impersonation is not configured', 501, 'IMPERSONATION_NOT_CONFIGURED', {
-            operation: 'start_impersonation',
-            service: 'impersonation',
-          })
-        );
-        return;
-      }
-
       if (req.appSession?.['impersonationToken']) {
         next(
           new MicroserviceError('Already impersonating a user. Stop the current session first.', 409, 'ALREADY_IMPERSONATING', {
@@ -48,14 +39,14 @@ export class ImpersonationController {
       }
 
       const realToken = req.oidc?.accessToken?.access_token || '';
-      const tokenPayload = this.impersonationService.decodeJwtPayload(realToken);
+      const tokenPayload = decodeJwtPayload(realToken);
       if (!tokenPayload || tokenPayload['http://lfx.dev/claims/can_impersonate'] !== true) {
         next(new AuthorizationError('Insufficient permissions to impersonate users', { operation: 'start_impersonation', service: 'impersonation' }));
         return;
       }
 
       const tokenResponse = await this.impersonationService.exchangeToken(req, targetUser.trim());
-      const targetClaims = this.impersonationService.decodeJwtPayload(tokenResponse.access_token);
+      const targetClaims = decodeJwtPayload(tokenResponse.access_token);
 
       if (!targetClaims) {
         throw new Error('Failed to decode target user claims from CTE response');

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -30,7 +30,7 @@ import { CommitteeService } from '../services/committee.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
 import { NatsService } from '../services/nats.service';
-import { getUsernameFromAuth, usernameMatches } from '../utils/auth-helper';
+import { getEffectiveEmail, getUsernameFromAuth, usernameMatches } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
 
 /**
@@ -72,7 +72,7 @@ export class MeetingController {
         return;
       }
 
-      const userEmail = (req.oidc.user?.['email'] as string)?.toLowerCase() || '';
+      const userEmail = getEffectiveEmail(req) || '';
       const username = await getUsernameFromAuth(req);
       const registrantsByMeeting = await Promise.all(
         meetings.map(async (m) => {
@@ -193,7 +193,7 @@ export class MeetingController {
         title: meeting.title,
       });
 
-      const userEmail = (req.oidc.user?.['email'] as string) || '';
+      const userEmail = getEffectiveEmail(req) || '';
 
       // Run registrant counts and invited status check in parallel
       const [registrants, meetingWithInvitedStatus] = await Promise.all([
@@ -487,7 +487,7 @@ export class MeetingController {
       // }
 
       // Step 5: Check if current user is a registrant (access control)
-      const userEmail = req.oidc?.user?.['email'] as string | undefined;
+      const userEmail = getEffectiveEmail(req) ?? undefined;
 
       logger.debug(req, 'get_my_meeting_registrants', 'Checking user authentication', {
         meeting_id: uid,

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -8,6 +8,7 @@ import { NextFunction, Request, Response } from 'express';
 import { ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
 import { ProjectService } from '../services/project.service';
+import { getEffectiveEmail } from '../utils/auth-helper';
 
 /**
  * Controller for handling project HTTP requests
@@ -370,8 +371,8 @@ export class ProjectController {
     const startTime = logger.startOperation(req, 'get_pending_action_surveys');
 
     try {
-      // Extract user email from OIDC
-      const userEmail = req.oidc?.user?.['email'];
+      // Extract user email from auth context (impersonation-aware)
+      const userEmail = getEffectiveEmail(req);
       if (!userEmail) {
         const validationError = ServiceValidationError.forField('email', 'User email not found in authentication context', {
           operation: 'get_pending_action_surveys',

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -265,7 +265,8 @@ export class PublicMeetingController {
   public async postMeetingJoinUrl(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { id } = req.params;
     const { password } = req.query;
-    const email: string = req.body.email ?? getEffectiveEmail(req) ?? '';
+    const bodyEmail = typeof req.body.email === 'string' ? req.body.email.trim() : '';
+    const email: string = bodyEmail || getEffectiveEmail(req) || '';
     const startTime = logger.startOperation(req, 'post_meeting_link', {
       meeting_id: id,
     });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -13,6 +13,7 @@ import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
+import { getEffectiveEmail } from '../utils/auth-helper';
 import { ProjectService } from '../services/project.service';
 import { generateM2MToken } from '../utils/m2m-token.util';
 import { validatePassword } from '../utils/security.util';
@@ -63,7 +64,7 @@ export class PublicMeetingController {
       const [project, meetingWithInvited] = await Promise.all([
         this.projectService.getProjectById(req, meeting.project_uid, false),
         isAuthenticated
-          ? addInvitedStatusToMeeting(req, meeting, (req.oidc.user?.['email'] as string) || '', m2mToken)
+          ? addInvitedStatusToMeeting(req, meeting, getEffectiveEmail(req) || '', m2mToken)
           : Promise.resolve(Object.assign(meeting, { invited: false })),
       ]);
       meeting = meetingWithInvited;
@@ -261,7 +262,7 @@ export class PublicMeetingController {
   public async postMeetingJoinUrl(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { id } = req.params;
     const { password } = req.query;
-    const email: string = req.body.email ?? req.oidc.user?.['email'] ?? '';
+    const email: string = req.body.email ?? getEffectiveEmail(req) ?? '';
     const startTime = logger.startOperation(req, 'post_meeting_link', {
       meeting_id: id,
     });

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -7,6 +7,7 @@ import { NextFunction, Request, Response } from 'express';
 import { ServiceValidationError } from '../errors';
 import { logger } from '../services/logger.service';
 import { UserService } from '../services/user.service';
+import { getEffectiveEmail } from '../utils/auth-helper';
 
 /**
  * Controller for handling user-related HTTP requests
@@ -24,8 +25,8 @@ export class UserController {
     });
 
     try {
-      // Extract user email from OIDC
-      const userEmail = req.oidc?.user?.['email'];
+      // Extract user email from auth context (impersonation-aware)
+      const userEmail = getEffectiveEmail(req);
       if (!userEmail) {
         const validationError = ServiceValidationError.forField('email', 'User email not found in authentication context', {
           operation: 'get_pending_actions',
@@ -109,8 +110,8 @@ export class UserController {
       const projectUid = req.query['projectUid'] as string | undefined;
       const foundationUid = req.query['foundation_uid'] as string | undefined;
 
-      // Extract user email from OIDC (lowercased for consistent tag matching)
-      const userEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+      // Extract user email from auth context (impersonation-aware, already lowercased)
+      const userEmail = getEffectiveEmail(req);
       if (!userEmail) {
         const validationError = ServiceValidationError.forField('email', 'User email not found in authentication context', {
           operation: 'get_user_meetings',
@@ -173,8 +174,8 @@ export class UserController {
       const projectUid = req.query['projectUid'] as string | undefined;
       const foundationUid = req.query['foundation_uid'] as string | undefined;
 
-      // Extract user email from OIDC (lowercased for consistent tag matching)
-      const userEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+      // Extract user email from auth context (impersonation-aware, already lowercased)
+      const userEmail = getEffectiveEmail(req);
       if (!userEmail) {
         const validationError = ServiceValidationError.forField('email', 'User email not found in authentication context', {
           operation: 'get_user_past_meetings',

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -142,8 +142,8 @@ export async function checkPastMeetingAccess(req: Request, meeting: PastMeeting,
 
   logger.debug(req, 'check_past_meeting_access', 'Membership check complete', {
     past_meeting_id: meeting.id,
-    email,
-    username,
+    has_email: !!email,
+    has_username: !!username,
     is_registrant: isRegistrant,
     is_participant: isParticipant,
     is_committee_member: isCommitteeMember,

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -8,7 +8,7 @@ import { Request } from 'express';
 import { CommitteeService } from '../services/committee.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
-import { getUsernameFromAuth } from '../utils/auth-helper';
+import { getEffectiveEmail, getUsernameFromAuth } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
 
 const meetingService = new MeetingService();
@@ -110,7 +110,7 @@ export async function checkPastMeetingAccess(req: Request, meeting: PastMeeting,
     return false;
   }
 
-  const email = (req.oidc.user?.['email'] as string) || '';
+  const email = getEffectiveEmail(req) || '';
   const username = await getUsernameFromAuth(req);
 
   logger.debug(req, 'check_past_meeting_access', 'Running membership checks', {

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -125,10 +125,10 @@ async function extractBearerToken(req: Request, isOptionalRoute: boolean = false
         } else {
           req.bearerToken = impersonationToken;
 
-          logger.info(req, 'impersonation_request', 'Request under impersonation', {
+          logger.debug(req, 'impersonation_request', 'Request under impersonation', {
             path: req.path,
-            impersonator: req.appSession?.['impersonator']?.email,
-            target: req.appSession?.['impersonationUser']?.email,
+            impersonator_sub: req.appSession?.['impersonator']?.sub,
+            target_sub: req.appSession?.['impersonationUser']?.sub,
           });
           return { success: true, needsLogout: false };
         }

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -6,6 +6,7 @@ import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError } from '../errors';
 import { logger } from '../services/logger.service';
+import { clearImpersonationSession } from '../utils/auth-helper';
 
 // OIDC middleware already provides req.oidc with authentication context
 
@@ -116,12 +117,7 @@ async function extractBearerToken(req: Request, isOptionalRoute: boolean = false
           logger.warning(req, 'impersonation_token_malformed', 'Impersonation token has invalid JWT format, clearing session', {
             path: req.path,
           });
-          if (req.appSession) {
-            delete req.appSession['impersonationToken'];
-            delete req.appSession['impersonationExpiresAt'];
-            delete req.appSession['impersonationUser'];
-            delete req.appSession['impersonator'];
-          }
+          clearImpersonationSession(req);
         } else {
           req.bearerToken = impersonationToken;
 
@@ -141,12 +137,7 @@ async function extractBearerToken(req: Request, isOptionalRoute: boolean = false
           impersonator: req.appSession?.['impersonator']?.email,
           target: req.appSession?.['impersonationUser']?.email,
         });
-        if (req.appSession) {
-          delete req.appSession['impersonationToken'];
-          delete req.appSession['impersonationExpiresAt'];
-          delete req.appSession['impersonationUser'];
-          delete req.appSession['impersonator'];
-        }
+        clearImpersonationSession(req);
       }
 
       // Check if token exists and is expired

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -109,14 +109,29 @@ async function extractBearerToken(req: Request, isOptionalRoute: boolean = false
       const impersonationExpiresAt = req.appSession?.['impersonationExpiresAt'];
 
       if (impersonationToken && typeof impersonationToken === 'string' && impersonationExpiresAt && Date.now() < impersonationExpiresAt) {
-        req.bearerToken = impersonationToken;
+        // Validate JWT format before using
+        const tokenParts = impersonationToken.split('.');
+        if (tokenParts.length !== 3) {
+          // Malformed token — clean up and fall through to normal extraction
+          logger.warning(req, 'impersonation_token_malformed', 'Impersonation token has invalid JWT format, clearing session', {
+            path: req.path,
+          });
+          if (req.appSession) {
+            delete req.appSession['impersonationToken'];
+            delete req.appSession['impersonationExpiresAt'];
+            delete req.appSession['impersonationUser'];
+            delete req.appSession['impersonator'];
+          }
+        } else {
+          req.bearerToken = impersonationToken;
 
-        logger.info(req, 'impersonation_request', 'Request under impersonation', {
-          path: req.path,
-          impersonator: req.appSession?.['impersonator']?.email,
-          target: req.appSession?.['impersonationUser']?.email,
-        });
-        return { success: true, needsLogout: false };
+          logger.info(req, 'impersonation_request', 'Request under impersonation', {
+            path: req.path,
+            impersonator: req.appSession?.['impersonator']?.email,
+            target: req.appSession?.['impersonationUser']?.email,
+          });
+          return { success: true, needsLogout: false };
+        }
       }
 
       // If impersonation token is expired, clear it and fall through to normal extraction

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -6,7 +6,7 @@ import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError } from '../errors';
 import { logger } from '../services/logger.service';
-import { clearImpersonationSession } from '../utils/auth-helper';
+import { clearImpersonationSession, decodeJwtPayload } from '../utils/auth-helper';
 
 // OIDC middleware already provides req.oidc with authentication context
 
@@ -110,9 +110,8 @@ async function extractBearerToken(req: Request, isOptionalRoute: boolean = false
       const impersonationExpiresAt = req.appSession?.['impersonationExpiresAt'];
 
       if (impersonationToken && typeof impersonationToken === 'string' && impersonationExpiresAt && Date.now() < impersonationExpiresAt) {
-        // Validate JWT format before using
-        const tokenParts = impersonationToken.split('.');
-        if (tokenParts.length !== 3) {
+        // Validate JWT payload is decodable before using
+        if (!decodeJwtPayload(impersonationToken)) {
           // Malformed token — clean up and fall through to normal extraction
           logger.warning(req, 'impersonation_token_malformed', 'Impersonation token has invalid JWT format, clearing session', {
             path: req.path,

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -104,6 +104,36 @@ async function extractBearerToken(req: Request, isOptionalRoute: boolean = false
 
   try {
     if (req.oidc?.isAuthenticated()) {
+      // Check for active impersonation token first
+      const impersonationToken = req.appSession?.['impersonationToken'];
+      const impersonationExpiresAt = req.appSession?.['impersonationExpiresAt'];
+
+      if (impersonationToken && typeof impersonationToken === 'string' && impersonationExpiresAt && Date.now() < impersonationExpiresAt) {
+        req.bearerToken = impersonationToken;
+
+        logger.info(req, 'impersonation_request', 'Request under impersonation', {
+          path: req.path,
+          impersonator: req.appSession?.['impersonator']?.email,
+          target: req.appSession?.['impersonationUser']?.email,
+        });
+        return { success: true, needsLogout: false };
+      }
+
+      // If impersonation token is expired, clear it and fall through to normal extraction
+      if (impersonationToken && impersonationExpiresAt && Date.now() >= impersonationExpiresAt) {
+        logger.warning(req, 'impersonation_token_expired', 'Impersonation token expired, clearing session', {
+          path: req.path,
+          impersonator: req.appSession?.['impersonator']?.email,
+          target: req.appSession?.['impersonationUser']?.email,
+        });
+        if (req.appSession) {
+          delete req.appSession['impersonationToken'];
+          delete req.appSession['impersonationExpiresAt'];
+          delete req.appSession['impersonationUser'];
+          delete req.appSession['impersonator'];
+        }
+      }
+
       // Check if token exists and is expired
       if (req.oidc.accessToken?.isExpired()) {
         try {

--- a/apps/lfx-one/src/server/routes/impersonation.route.ts
+++ b/apps/lfx-one/src/server/routes/impersonation.route.ts
@@ -1,0 +1,16 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { ImpersonationController } from '../controllers/impersonation.controller';
+
+const router = Router();
+
+const impersonationController = new ImpersonationController();
+
+router.post('/', (req, res, next) => impersonationController.startImpersonation(req, res, next));
+router.post('/stop', (req, res, next) => impersonationController.stopImpersonation(req, res, next));
+router.get('/status', (req, res, next) => impersonationController.getImpersonationStatus(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -23,6 +23,7 @@ import committeesRouter from './routes/committees.route';
 import copilotRouter from './routes/copilot.route';
 import documentsRouter from './routes/documents.route';
 import eventsRouter from './routes/events.route';
+import impersonationRouter from './routes/impersonation.route';
 import mailingListsRouter from './routes/mailing-lists.route';
 import meetingsRouter from './routes/meetings.route';
 import organizationsRouter from './routes/organizations.route';
@@ -194,6 +195,7 @@ app.use('/api/surveys', surveysRouter);
 app.use('/api/copilot', copilotRouter);
 app.use('/api/documents', documentsRouter);
 app.use('/api/events', eventsRouter);
+app.use('/api/impersonate', impersonationRouter);
 app.use('/api/training', trainingRouter);
 
 // Add API error handler middleware
@@ -246,6 +248,41 @@ app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
     auth.persona = personaResult.persona;
     auth.personas = personaResult.personas;
     auth.organizations = personaResult.organizations ?? [];
+  }
+
+  // Check if user can impersonate (from access token custom claim)
+  if (req.oidc?.accessToken?.access_token) {
+    try {
+      const parts = req.oidc.accessToken.access_token.split('.');
+      if (parts.length === 3) {
+        const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+        auth.canImpersonate = payload['http://lfx.dev/claims/can_impersonate'] === true;
+      }
+    } catch {
+      // JWT decode failed — canImpersonate stays false
+    }
+  }
+
+  // Override user identity when impersonating
+  if (req.appSession?.['impersonationToken'] && req.appSession?.['impersonationUser']) {
+    const impersonationExpiresAt = req.appSession['impersonationExpiresAt'];
+    if (impersonationExpiresAt && Date.now() < impersonationExpiresAt) {
+      const targetClaims = JSON.parse(Buffer.from(req.appSession['impersonationToken'].split('.')[1], 'base64url').toString());
+
+      const impersonationUser = req.appSession['impersonationUser'];
+      auth.user = {
+        ...auth.user,
+        sub: targetClaims.sub,
+        email: targetClaims['http://lfx.dev/claims/email'] || '',
+        username: targetClaims['http://lfx.dev/claims/username'] || '',
+        'https://sso.linuxfoundation.org/claims/username': targetClaims['http://lfx.dev/claims/username'] || '',
+        name: impersonationUser?.name || targetClaims['http://lfx.dev/claims/username'] || '',
+        nickname: targetClaims['http://lfx.dev/claims/username'] || '',
+        picture: impersonationUser?.picture || auth.user?.picture || '',
+      } as User;
+      auth.impersonating = true;
+      auth.impersonator = req.appSession['impersonator'];
+    }
   }
 
   // Build runtime config from environment variables

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -40,6 +40,7 @@ import userRouter from './routes/user.route';
 import votesRouter from './routes/votes.route';
 import { reqSerializer, resSerializer, serverLogger } from './server-logger';
 import { logger } from './services/logger.service';
+import { clearImpersonationSession, decodeJwtPayload } from './utils/auth-helper';
 import { resolvePersonaForSsr } from './utils/persona-helper';
 
 if (process.env['NODE_ENV'] !== 'production') {
@@ -253,9 +254,8 @@ app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
   // Check if user can impersonate (from access token custom claim)
   if (req.oidc?.accessToken?.access_token) {
     try {
-      const parts = req.oidc.accessToken.access_token.split('.');
-      if (parts.length === 3) {
-        const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+      const payload = decodeJwtPayload(req.oidc.accessToken.access_token);
+      if (payload) {
         auth.canImpersonate = payload['http://lfx.dev/claims/can_impersonate'] === true;
       }
     } catch {
@@ -268,13 +268,12 @@ app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
     const impersonationExpiresAt = req.appSession['impersonationExpiresAt'];
     if (impersonationExpiresAt && Date.now() < impersonationExpiresAt) {
       try {
-        const tokenParts = req.appSession['impersonationToken'].split('.');
-        if (tokenParts.length !== 3) throw new Error('Invalid token format');
-        const targetClaims = JSON.parse(Buffer.from(tokenParts[1], 'base64url').toString());
+        const targetClaims = decodeJwtPayload(req.appSession['impersonationToken']);
+        if (!targetClaims) throw new Error('Invalid token format');
 
         const impersonationUser = req.appSession['impersonationUser'];
-        auth.user = {
-          ...auth.user,
+        if (!auth.user) throw new Error('No authenticated user for impersonation override');
+        Object.assign(auth.user, {
           sub: targetClaims.sub,
           email: targetClaims['http://lfx.dev/claims/email'] || '',
           username: targetClaims['http://lfx.dev/claims/username'] || '',
@@ -282,14 +281,11 @@ app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
           name: impersonationUser?.name || targetClaims['http://lfx.dev/claims/username'] || '',
           nickname: targetClaims['http://lfx.dev/claims/username'] || '',
           picture: impersonationUser?.picture || auth.user?.picture || '',
-        } as User;
+        });
         auth.impersonating = true;
         auth.impersonator = req.appSession['impersonator'];
       } catch {
-        delete req.appSession['impersonationToken'];
-        delete req.appSession['impersonationExpiresAt'];
-        delete req.appSession['impersonationUser'];
-        delete req.appSession['impersonator'];
+        clearImpersonationSession(req);
       }
     }
   }

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -267,21 +267,30 @@ app.use('/**', async (req: Request, res: Response, next: NextFunction) => {
   if (req.appSession?.['impersonationToken'] && req.appSession?.['impersonationUser']) {
     const impersonationExpiresAt = req.appSession['impersonationExpiresAt'];
     if (impersonationExpiresAt && Date.now() < impersonationExpiresAt) {
-      const targetClaims = JSON.parse(Buffer.from(req.appSession['impersonationToken'].split('.')[1], 'base64url').toString());
+      try {
+        const tokenParts = req.appSession['impersonationToken'].split('.');
+        if (tokenParts.length !== 3) throw new Error('Invalid token format');
+        const targetClaims = JSON.parse(Buffer.from(tokenParts[1], 'base64url').toString());
 
-      const impersonationUser = req.appSession['impersonationUser'];
-      auth.user = {
-        ...auth.user,
-        sub: targetClaims.sub,
-        email: targetClaims['http://lfx.dev/claims/email'] || '',
-        username: targetClaims['http://lfx.dev/claims/username'] || '',
-        'https://sso.linuxfoundation.org/claims/username': targetClaims['http://lfx.dev/claims/username'] || '',
-        name: impersonationUser?.name || targetClaims['http://lfx.dev/claims/username'] || '',
-        nickname: targetClaims['http://lfx.dev/claims/username'] || '',
-        picture: impersonationUser?.picture || auth.user?.picture || '',
-      } as User;
-      auth.impersonating = true;
-      auth.impersonator = req.appSession['impersonator'];
+        const impersonationUser = req.appSession['impersonationUser'];
+        auth.user = {
+          ...auth.user,
+          sub: targetClaims.sub,
+          email: targetClaims['http://lfx.dev/claims/email'] || '',
+          username: targetClaims['http://lfx.dev/claims/username'] || '',
+          'https://sso.linuxfoundation.org/claims/username': targetClaims['http://lfx.dev/claims/username'] || '',
+          name: impersonationUser?.name || targetClaims['http://lfx.dev/claims/username'] || '',
+          nickname: targetClaims['http://lfx.dev/claims/username'] || '',
+          picture: impersonationUser?.picture || auth.user?.picture || '',
+        } as User;
+        auth.impersonating = true;
+        auth.impersonator = req.appSession['impersonator'];
+      } catch {
+        delete req.appSession['impersonationToken'];
+        delete req.appSession['impersonationExpiresAt'];
+        delete req.appSession['impersonationUser'];
+        delete req.appSession['impersonator'];
+      }
     }
   }
 

--- a/apps/lfx-one/src/server/services/document.service.ts
+++ b/apps/lfx-one/src/server/services/document.service.ts
@@ -17,6 +17,7 @@ import {
 import { Request } from 'express';
 
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
+import { getEffectiveEmail } from '../utils/auth-helper';
 import { CommitteeService } from './committee.service';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -304,7 +305,7 @@ export class DocumentService {
   private async fetchRawMeetingAttachments(req: Request): Promise<MeetingAttachment[]> {
     logger.debug(req, 'get_my_documents', 'Fetching user meeting registrations for attachments');
 
-    const email = (req.oidc?.user?.['email'] as string | undefined)?.toLowerCase();
+    const email = getEffectiveEmail(req) ?? undefined;
 
     // Delegate registrant lookup to UserService which handles email+username dual lookup
     // with M2M tokens (required because registrant queries search across all participants

--- a/apps/lfx-one/src/server/services/impersonation.service.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.ts
@@ -38,11 +38,9 @@ export class ImpersonationService {
     });
 
     try {
-      const response = await this.natsService.request(
-        NatsSubjects.IMPERSONATION_TOKEN_EXCHANGE,
-        codec.encode(payload),
-        { timeout: NATS_CONFIG.REQUEST_TIMEOUT }
-      );
+      const response = await this.natsService.request(NatsSubjects.IMPERSONATION_TOKEN_EXCHANGE, codec.encode(payload), {
+        timeout: NATS_CONFIG.REQUEST_TIMEOUT,
+      });
 
       const responseText = codec.decode(response.data);
       const result = JSON.parse(responseText);
@@ -64,12 +62,23 @@ export class ImpersonationService {
         });
       }
 
-      logger.debug(req, 'cte_token_exchange', 'CTE token exchange successful', { target_user: targetUser });
+      // Derive expires_in from the JWT exp claim
+      let expiresIn = 86400;
+      try {
+        const payload = this.decodeJwtPayload(accessToken);
+        if (payload?.['exp']) {
+          expiresIn = Math.max(payload['exp'] - Math.floor(Date.now() / 1000), 0);
+        }
+      } catch {
+        // Fall back to 24h default
+      }
+
+      logger.debug(req, 'cte_token_exchange', 'CTE token exchange successful', { target_user: targetUser, expires_in: expiresIn });
 
       return {
         access_token: accessToken,
         token_type: 'Bearer',
-        expires_in: 86400,
+        expires_in: expiresIn,
       };
     } catch (error) {
       if (error instanceof MicroserviceError) {
@@ -138,7 +147,12 @@ export class ImpersonationService {
     }
   }
 
-  public startImpersonation(req: Request, tokenResponse: M2MTokenResponse, targetClaims: Record<string, any>, profile?: { name?: string; picture?: string }): void {
+  public startImpersonation(
+    req: Request,
+    tokenResponse: M2MTokenResponse,
+    targetClaims: Record<string, any>,
+    profile?: { name?: string; picture?: string }
+  ): void {
     if (!req.appSession) {
       req.appSession = {};
     }
@@ -222,12 +236,15 @@ export class ImpersonationService {
   }
 
   public decodeJwtPayload(token: string): Record<string, any> | null {
-    const parts = token.split('.');
-    if (parts.length !== 3) {
+    try {
+      const parts = token.split('.');
+      if (parts.length !== 3) {
+        return null;
+      }
+      return JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+    } catch {
       return null;
     }
-
-    return JSON.parse(Buffer.from(parts[1], 'base64url').toString());
   }
 
   private buildClientAssertion(tokenEndpoint: string): string {

--- a/apps/lfx-one/src/server/services/impersonation.service.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.ts
@@ -1,0 +1,264 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NATS_CONFIG } from '@lfx-one/shared/constants';
+import { NatsSubjects } from '@lfx-one/shared/enums';
+import { ImpersonationStatusResponse, ImpersonationUser, Impersonator, M2MTokenResponse } from '@lfx-one/shared/interfaces';
+import crypto from 'crypto';
+import { Request } from 'express';
+
+import { MicroserviceError } from '../errors';
+import { logger } from './logger.service';
+import { NatsService } from './nats.service';
+
+export class ImpersonationService {
+  private readonly clientId: string;
+  private readonly clientKeyBase64: string;
+  private readonly issuerBaseUrl: string;
+  private readonly natsService: NatsService;
+
+  public constructor() {
+    this.clientId = process.env['CTE_CLIENT_ID'] || '';
+    this.clientKeyBase64 = process.env['CTE_CLIENT_KEY'] || '';
+    this.issuerBaseUrl = (process.env['PCC_AUTH0_ISSUER_BASE_URL'] || '').replace(/\/+$/, '');
+    this.natsService = new NatsService();
+  }
+
+  public isConfigured(): boolean {
+    return !!this.clientId && !!this.clientKeyBase64;
+  }
+
+  public async exchangeToken(req: Request, targetUser: string): Promise<M2MTokenResponse> {
+    logger.debug(req, 'cte_token_exchange', 'Starting CTE token exchange via NATS', { target_user: targetUser });
+
+    const codec = this.natsService.getCodec();
+    const payload = JSON.stringify({
+      subject_token: req.bearerToken || '',
+      target_user: targetUser,
+    });
+
+    try {
+      const response = await this.natsService.request(
+        NatsSubjects.IMPERSONATION_TOKEN_EXCHANGE,
+        codec.encode(payload),
+        { timeout: NATS_CONFIG.REQUEST_TIMEOUT }
+      );
+
+      const responseText = codec.decode(response.data);
+      const result = JSON.parse(responseText);
+
+      if (!result.success) {
+        const errorMessage = result.error || 'Impersonation token exchange failed';
+        throw new MicroserviceError(errorMessage, 400, 'CTE_EXCHANGE_FAILED', {
+          operation: 'cte_token_exchange',
+          service: 'auth-service',
+          errorBody: { target_user: targetUser },
+        });
+      }
+
+      const accessToken = result.data?.access_token;
+      if (!accessToken) {
+        throw new MicroserviceError('No access token in impersonation response', 500, 'CTE_NO_TOKEN', {
+          operation: 'cte_token_exchange',
+          service: 'auth-service',
+        });
+      }
+
+      logger.debug(req, 'cte_token_exchange', 'CTE token exchange successful', { target_user: targetUser });
+
+      return {
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: 86400,
+      };
+    } catch (error) {
+      if (error instanceof MicroserviceError) {
+        throw error;
+      }
+
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      throw new MicroserviceError(`Impersonation token exchange failed: ${errorMessage}`, 502, 'CTE_NATS_ERROR', {
+        operation: 'cte_token_exchange',
+        service: 'auth-service',
+        errorBody: { target_user: targetUser },
+      });
+    }
+  }
+
+  public async fetchTargetUserProfile(req: Request, userId: string): Promise<{ name?: string; picture?: string }> {
+    try {
+      const mgmtAudience = `${this.issuerBaseUrl}/api/v2/`;
+      const tokenEndpoint = `${this.issuerBaseUrl}/oauth/token`;
+      const clientAssertion = this.buildClientAssertion(tokenEndpoint);
+
+      const tokenResponse = await fetch(tokenEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'client_credentials',
+          client_id: this.clientId,
+          client_assertion: clientAssertion,
+          client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+          audience: mgmtAudience,
+        }).toString(),
+      });
+
+      if (!tokenResponse.ok) {
+        logger.warning(req, 'fetch_target_user_profile', 'Failed to get management API token', {
+          status: tokenResponse.status,
+        });
+        return {};
+      }
+
+      const { access_token: mgmtToken } = await tokenResponse.json();
+
+      const response = await fetch(`${this.issuerBaseUrl}/api/v2/users/${encodeURIComponent(userId)}?fields=name,picture,given_name,family_name`, {
+        headers: { Authorization: `Bearer ${mgmtToken}` },
+      });
+
+      if (!response.ok) {
+        logger.warning(req, 'fetch_target_user_profile', 'Failed to fetch target user profile', {
+          status: response.status,
+          user_id: userId,
+        });
+        return {};
+      }
+
+      const profile = await response.json();
+      return {
+        name: profile.name || profile.given_name || undefined,
+        picture: profile.picture || undefined,
+      };
+    } catch (error) {
+      logger.warning(req, 'fetch_target_user_profile', 'Error fetching target user profile', {
+        user_id: userId,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return {};
+    }
+  }
+
+  public startImpersonation(req: Request, tokenResponse: M2MTokenResponse, targetClaims: Record<string, any>, profile?: { name?: string; picture?: string }): void {
+    if (!req.appSession) {
+      req.appSession = {};
+    }
+
+    const targetUser: ImpersonationUser = {
+      sub: targetClaims['sub'] || '',
+      email: targetClaims['http://lfx.dev/claims/email'] || '',
+      username: targetClaims['http://lfx.dev/claims/username'] || '',
+      name: profile?.name,
+      picture: profile?.picture,
+    };
+
+    const oidcUser = req.oidc?.user;
+    const impersonator: Impersonator = {
+      sub: oidcUser?.['sub'] || '',
+      email: oidcUser?.['email'] || '',
+      name: oidcUser?.['name'] || '',
+    };
+
+    req.appSession['impersonationToken'] = tokenResponse.access_token;
+    req.appSession['impersonationExpiresAt'] = Date.now() + (tokenResponse.expires_in - 300) * 1000;
+    req.appSession['impersonationUser'] = targetUser;
+    req.appSession['impersonator'] = impersonator;
+
+    logger.info(req, 'impersonation_granted', 'Impersonation session started', {
+      impersonator_sub: impersonator.sub,
+      impersonator_email: impersonator.email,
+      target_sub: targetUser.sub,
+      target_email: targetUser.email,
+    });
+  }
+
+  public stopImpersonation(req: Request): void {
+    if (!req.appSession) {
+      return;
+    }
+
+    const impersonator = req.appSession['impersonator'];
+    const targetUser = req.appSession['impersonationUser'];
+
+    delete req.appSession['impersonationToken'];
+    delete req.appSession['impersonationExpiresAt'];
+    delete req.appSession['impersonationUser'];
+    delete req.appSession['impersonator'];
+
+    logger.info(req, 'impersonation_stopped', 'Impersonation session ended', {
+      impersonator_sub: impersonator?.sub,
+      impersonator_email: impersonator?.email,
+      target_sub: targetUser?.sub,
+      target_email: targetUser?.email,
+    });
+  }
+
+  public getImpersonationToken(req: Request): string | null {
+    const token = req.appSession?.['impersonationToken'];
+    if (!token || typeof token !== 'string') {
+      return null;
+    }
+
+    const expiresAt = req.appSession?.['impersonationExpiresAt'];
+    if (!expiresAt || Date.now() >= expiresAt) {
+      logger.debug(req, 'impersonation_token_expired', 'Impersonation token expired, clearing session');
+      this.clearImpersonationSession(req);
+      return null;
+    }
+
+    return token;
+  }
+
+  public getImpersonationStatus(req: Request): ImpersonationStatusResponse {
+    const token = this.getImpersonationToken(req);
+    if (!token) {
+      return { impersonating: false };
+    }
+
+    return {
+      impersonating: true,
+      targetUser: req.appSession?.['impersonationUser'],
+      impersonator: req.appSession?.['impersonator'],
+    };
+  }
+
+  public decodeJwtPayload(token: string): Record<string, any> | null {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return null;
+    }
+
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+  }
+
+  private buildClientAssertion(tokenEndpoint: string): string {
+    const keyPem = Buffer.from(this.clientKeyBase64, 'base64').toString('utf-8');
+
+    const header = { alg: 'RS256', typ: 'JWT' };
+    const now = Math.floor(Date.now() / 1000);
+    const payload = {
+      iss: this.clientId,
+      sub: this.clientId,
+      aud: tokenEndpoint,
+      iat: now,
+      exp: now + 120,
+      jti: crypto.randomUUID(),
+    };
+
+    const encode = (obj: object): string => Buffer.from(JSON.stringify(obj)).toString('base64url');
+    const signingInput = `${encode(header)}.${encode(payload)}`;
+    const signature = crypto.sign('RSA-SHA256', Buffer.from(signingInput), keyPem);
+
+    return `${signingInput}.${signature.toString('base64url')}`;
+  }
+
+  private clearImpersonationSession(req: Request): void {
+    if (!req.appSession) {
+      return;
+    }
+
+    delete req.appSession['impersonationToken'];
+    delete req.appSession['impersonationExpiresAt'];
+    delete req.appSession['impersonationUser'];
+    delete req.appSession['impersonator'];
+  }
+}

--- a/apps/lfx-one/src/server/services/impersonation.service.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.ts
@@ -3,29 +3,19 @@
 
 import { NATS_CONFIG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
-import { ImpersonationStatusResponse, ImpersonationUser, Impersonator, M2MTokenResponse } from '@lfx-one/shared/interfaces';
-import crypto from 'crypto';
+import { ImpersonationStatusResponse, ImpersonationUser, Impersonator, LfxAccessTokenClaims, M2MTokenResponse } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
 import { MicroserviceError } from '../errors';
+import { clearImpersonationSession, decodeJwtPayload } from '../utils/auth-helper';
 import { logger } from './logger.service';
 import { NatsService } from './nats.service';
 
 export class ImpersonationService {
-  private readonly clientId: string;
-  private readonly clientKeyBase64: string;
-  private readonly issuerBaseUrl: string;
   private readonly natsService: NatsService;
 
   public constructor() {
-    this.clientId = process.env['CTE_CLIENT_ID'] || '';
-    this.clientKeyBase64 = process.env['CTE_CLIENT_KEY'] || '';
-    this.issuerBaseUrl = (process.env['PCC_AUTH0_ISSUER_BASE_URL'] || '').replace(/\/+$/, '');
     this.natsService = new NatsService();
-  }
-
-  public isConfigured(): boolean {
-    return !!this.clientId && !!this.clientKeyBase64;
   }
 
   public async exchangeToken(req: Request, targetUser: string): Promise<M2MTokenResponse> {
@@ -65,7 +55,7 @@ export class ImpersonationService {
       // Derive expires_in from the JWT exp claim
       let expiresIn = 86400;
       try {
-        const payload = this.decodeJwtPayload(accessToken);
+        const payload = decodeJwtPayload(accessToken);
         if (payload?.['exp']) {
           expiresIn = Math.max(payload['exp'] - Math.floor(Date.now() / 1000), 0);
         }
@@ -96,73 +86,30 @@ export class ImpersonationService {
 
   public async fetchTargetUserProfile(req: Request, userId: string): Promise<{ name?: string; picture?: string }> {
     try {
-      const mgmtAudience = `${this.issuerBaseUrl}/api/v2/`;
-      const tokenEndpoint = `${this.issuerBaseUrl}/oauth/token`;
-      const clientAssertion = this.buildClientAssertion(tokenEndpoint);
+      logger.debug(req, 'fetch_target_user_profile', 'Fetching target user metadata via NATS', { user_id: userId });
 
-      const tokenController = new AbortController();
-      const tokenTimeout = setTimeout(() => tokenController.abort(), 10000);
-      let tokenResponse: Response;
-      try {
-        tokenResponse = await fetch(tokenEndpoint, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: new URLSearchParams({
-            grant_type: 'client_credentials',
-            client_id: this.clientId,
-            client_assertion: clientAssertion,
-            client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
-            audience: mgmtAudience,
-          }).toString(),
-          signal: tokenController.signal,
-        });
-      } finally {
-        clearTimeout(tokenTimeout);
-      }
+      const codec = this.natsService.getCodec();
+      const response = await this.natsService.request(NatsSubjects.USER_METADATA_READ, codec.encode(userId), {
+        timeout: NATS_CONFIG.REQUEST_TIMEOUT,
+      });
 
-      if (!tokenResponse.ok) {
-        logger.warning(req, 'fetch_target_user_profile', 'Failed to get management API token', {
-          status: tokenResponse.status,
-        });
-        return {};
-      }
+      const responseText = codec.decode(response.data);
+      const result = JSON.parse(responseText);
 
-      const { access_token: mgmtToken } = await tokenResponse.json();
-
-      const profileController = new AbortController();
-      const profileTimeout = setTimeout(() => profileController.abort(), 5000);
-      let response: Response;
-      try {
-        response = await fetch(`${this.issuerBaseUrl}/api/v2/users/${encodeURIComponent(userId)}?fields=name,picture,given_name,family_name`, {
-          headers: { Authorization: `Bearer ${mgmtToken}` },
-          signal: profileController.signal,
-        });
-      } catch (abortError) {
-        clearTimeout(profileTimeout);
-        logger.warning(req, 'fetch_target_user_profile', 'Profile lookup timed out, continuing without profile data', {
+      if (!result.success || !result.data) {
+        logger.warning(req, 'fetch_target_user_profile', 'User metadata lookup returned no data', {
           user_id: userId,
-          error: abortError instanceof Error ? abortError.message : 'Unknown error',
-        });
-        return {};
-      } finally {
-        clearTimeout(profileTimeout);
-      }
-
-      if (!response.ok) {
-        logger.warning(req, 'fetch_target_user_profile', 'Failed to fetch target user profile', {
-          status: response.status,
-          user_id: userId,
+          error: result.error,
         });
         return {};
       }
 
-      const profile = await response.json();
       return {
-        name: profile.name || profile.given_name || undefined,
-        picture: profile.picture || undefined,
+        name: result.data.name || result.data.given_name || undefined,
+        picture: result.data.picture || undefined,
       };
     } catch (error) {
-      logger.warning(req, 'fetch_target_user_profile', 'Error fetching target user profile', {
+      logger.warning(req, 'fetch_target_user_profile', 'Error fetching target user metadata via NATS', {
         user_id: userId,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
@@ -173,7 +120,7 @@ export class ImpersonationService {
   public startImpersonation(
     req: Request,
     tokenResponse: M2MTokenResponse,
-    targetClaims: Record<string, any>,
+    targetClaims: LfxAccessTokenClaims,
     profile?: { name?: string; picture?: string }
   ): void {
     if (!req.appSession) {
@@ -217,10 +164,7 @@ export class ImpersonationService {
     const impersonator = req.appSession['impersonator'];
     const targetUser = req.appSession['impersonationUser'];
 
-    delete req.appSession['impersonationToken'];
-    delete req.appSession['impersonationExpiresAt'];
-    delete req.appSession['impersonationUser'];
-    delete req.appSession['impersonator'];
+    clearImpersonationSession(req);
 
     logger.info(req, 'impersonation_stopped', 'Impersonation session ended', {
       impersonator_sub: impersonator?.sub,
@@ -239,7 +183,7 @@ export class ImpersonationService {
     const expiresAt = req.appSession?.['impersonationExpiresAt'];
     if (!expiresAt || Date.now() >= expiresAt) {
       logger.debug(req, 'impersonation_token_expired', 'Impersonation token expired, clearing session');
-      this.clearImpersonationSession(req);
+      clearImpersonationSession(req);
       return null;
     }
 
@@ -257,49 +201,5 @@ export class ImpersonationService {
       targetUser: req.appSession?.['impersonationUser'],
       impersonator: req.appSession?.['impersonator'],
     };
-  }
-
-  public decodeJwtPayload(token: string): Record<string, any> | null {
-    try {
-      const parts = token.split('.');
-      if (parts.length !== 3) {
-        return null;
-      }
-      return JSON.parse(Buffer.from(parts[1], 'base64url').toString());
-    } catch {
-      return null;
-    }
-  }
-
-  private buildClientAssertion(tokenEndpoint: string): string {
-    const keyPem = Buffer.from(this.clientKeyBase64, 'base64').toString('utf-8');
-
-    const header = { alg: 'RS256', typ: 'JWT' };
-    const now = Math.floor(Date.now() / 1000);
-    const payload = {
-      iss: this.clientId,
-      sub: this.clientId,
-      aud: tokenEndpoint,
-      iat: now,
-      exp: now + 120,
-      jti: crypto.randomUUID(),
-    };
-
-    const encode = (obj: object): string => Buffer.from(JSON.stringify(obj)).toString('base64url');
-    const signingInput = `${encode(header)}.${encode(payload)}`;
-    const signature = crypto.sign('RSA-SHA256', Buffer.from(signingInput), keyPem);
-
-    return `${signingInput}.${signature.toString('base64url')}`;
-  }
-
-  private clearImpersonationSession(req: Request): void {
-    if (!req.appSession) {
-      return;
-    }
-
-    delete req.appSession['impersonationToken'];
-    delete req.appSession['impersonationExpiresAt'];
-    delete req.appSession['impersonationUser'];
-    delete req.appSession['impersonator'];
   }
 }

--- a/apps/lfx-one/src/server/services/impersonation.service.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.ts
@@ -100,17 +100,25 @@ export class ImpersonationService {
       const tokenEndpoint = `${this.issuerBaseUrl}/oauth/token`;
       const clientAssertion = this.buildClientAssertion(tokenEndpoint);
 
-      const tokenResponse = await fetch(tokenEndpoint, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({
-          grant_type: 'client_credentials',
-          client_id: this.clientId,
-          client_assertion: clientAssertion,
-          client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
-          audience: mgmtAudience,
-        }).toString(),
-      });
+      const tokenController = new AbortController();
+      const tokenTimeout = setTimeout(() => tokenController.abort(), 10000);
+      let tokenResponse: Response;
+      try {
+        tokenResponse = await fetch(tokenEndpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'client_credentials',
+            client_id: this.clientId,
+            client_assertion: clientAssertion,
+            client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+            audience: mgmtAudience,
+          }).toString(),
+          signal: tokenController.signal,
+        });
+      } finally {
+        clearTimeout(tokenTimeout);
+      }
 
       if (!tokenResponse.ok) {
         logger.warning(req, 'fetch_target_user_profile', 'Failed to get management API token', {
@@ -121,9 +129,24 @@ export class ImpersonationService {
 
       const { access_token: mgmtToken } = await tokenResponse.json();
 
-      const response = await fetch(`${this.issuerBaseUrl}/api/v2/users/${encodeURIComponent(userId)}?fields=name,picture,given_name,family_name`, {
-        headers: { Authorization: `Bearer ${mgmtToken}` },
-      });
+      const profileController = new AbortController();
+      const profileTimeout = setTimeout(() => profileController.abort(), 5000);
+      let response: Response;
+      try {
+        response = await fetch(`${this.issuerBaseUrl}/api/v2/users/${encodeURIComponent(userId)}?fields=name,picture,given_name,family_name`, {
+          headers: { Authorization: `Bearer ${mgmtToken}` },
+          signal: profileController.signal,
+        });
+      } catch (abortError) {
+        clearTimeout(profileTimeout);
+        logger.warning(req, 'fetch_target_user_profile', 'Profile lookup timed out, continuing without profile data', {
+          user_id: userId,
+          error: abortError instanceof Error ? abortError.message : 'Unknown error',
+        });
+        return {};
+      } finally {
+        clearTimeout(profileTimeout);
+      }
 
       if (!response.ok) {
         logger.warning(req, 'fetch_target_user_profile', 'Failed to fetch target user profile', {
@@ -173,7 +196,8 @@ export class ImpersonationService {
     };
 
     req.appSession['impersonationToken'] = tokenResponse.access_token;
-    req.appSession['impersonationExpiresAt'] = Date.now() + (tokenResponse.expires_in - 300) * 1000;
+    const safetyBufferSeconds = tokenResponse.expires_in > 300 ? 300 : 0;
+    req.appSession['impersonationExpiresAt'] = Date.now() + (tokenResponse.expires_in - safetyBufferSeconds) * 1000;
     req.appSession['impersonationUser'] = targetUser;
     req.appSession['impersonator'] = impersonator;
 

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -18,7 +18,7 @@ import { MailingListMemberDeliveryMode, MailingListMemberModStatus } from '@lfx-
 import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
-import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
+import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { pollEndpoint, pollUntilIndexed } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { AccessCheckService } from './access-check.service';
@@ -347,7 +347,7 @@ export class MailingListService {
     // Get user identity from auth context
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
-    const email = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+    const email = getEffectiveEmail(req);
 
     logger.debug(req, 'get_my_mailing_lists', 'Fetching mailing lists for current user', {
       username,

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -37,7 +37,7 @@ import { Request } from 'express';
 import { ResourceNotFoundError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
-import { getUsernameFromAuth, stripAuthPrefix, usernameMatches } from '../utils/auth-helper';
+import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix, usernameMatches } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
 import { CommitteeService } from './committee.service';
 import { logger } from './logger.service';
@@ -780,8 +780,7 @@ export class MeetingService {
     });
 
     // Resolve registrant_id — try email first, fall back to username
-    const rawEmail = req.oidc?.user?.['email'] as string | undefined;
-    const email = rawEmail?.toLowerCase();
+    const email = getEffectiveEmail(req) ?? undefined;
     let registrants: MeetingRegistrant[] = [];
 
     if (email) {

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -14,6 +14,7 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
+import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
 import { logger } from './logger.service';
 import { NatsService } from './nats.service';
 import { ProjectService } from './project.service';
@@ -79,8 +80,8 @@ export class PersonaDetectionService {
    * Returns an empty array on error so callers degrade gracefully.
    */
   public async getAffiliatedProjectSlugs(req: Request): Promise<string[]> {
-    const username = req.oidc?.user?.['nickname'] || '';
-    const email = ((req.oidc?.user?.['email'] as string) || '').toLowerCase();
+    const username = getEffectiveUsername(req) || '';
+    const email = getEffectiveEmail(req) || '';
     const cacheKey = username || email;
 
     // No stable identifier — bypass cache to prevent cross-user data leaks.
@@ -118,8 +119,8 @@ export class PersonaDetectionService {
    * and maps detections to persona types
    */
   public async getPersonas(req: Request): Promise<PersonaApiResponse> {
-    const username = req.oidc?.user?.['nickname'] || '';
-    const email = (req.oidc?.user?.['email'] as string) || '';
+    const username = getEffectiveUsername(req) || '';
+    const email = getEffectiveEmail(req) || '';
 
     logger.debug(req, 'get_personas', 'Fetching personas from detection service', {
       username,

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -7,7 +7,7 @@ import { Request } from 'express';
 import { ResourceNotFoundError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
-import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
+import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { ETagService } from './etag.service';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -172,7 +172,7 @@ export class SurveyService {
   public async getMySurveys(req: Request, projectUid?: string, foundationUid?: string): Promise<Survey[]> {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
-    const email = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+    const email = getEffectiveEmail(req);
 
     logger.debug(req, 'get_my_surveys', 'Fetching surveys for current user', {
       username,

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -30,7 +30,7 @@ import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
-import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
+import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
 import { logger } from './logger.service';
 import { MeetingService } from './meeting.service';
@@ -558,7 +558,7 @@ export class UserService {
    * @returns Array of unique meeting_and_occurrence_id strings
    */
   public async getPastMeetingOccurrenceIds(req: Request): Promise<string[]> {
-    const email = (req.oidc?.user?.['email'] as string | undefined)?.toLowerCase();
+    const email = getEffectiveEmail(req) ?? undefined;
     const username = await getUsernameFromAuth(req);
 
     if (!email && !username) {

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -15,7 +15,7 @@ import { Request } from 'express';
 import { ResourceNotFoundError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
-import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
+import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { ProjectService } from './project.service';
@@ -259,7 +259,7 @@ export class VoteService {
   public async getMyVotes(req: Request, projectUid?: string, foundationUid?: string): Promise<Vote[]> {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
-    const email = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+    const email = getEffectiveEmail(req);
 
     logger.debug(req, 'get_my_votes', 'Fetching votes for current user', {
       username,

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -3,6 +3,8 @@
 
 import { Request } from 'express';
 
+import { LfxAccessTokenClaims } from '@lfx-one/shared/interfaces';
+
 /**
  * Strips the auth provider prefix (e.g. "auth0|") from a username/sub claim.
  * Returns the raw username if no prefix is present.
@@ -72,4 +74,45 @@ export function getEffectiveSub(req: Request): string | null {
     return req.appSession['impersonationUser'].sub as string;
   }
   return (req.oidc?.user?.['sub'] as string) || null;
+}
+
+/**
+ * Gets the effective name for the current request context.
+ * During impersonation, returns the target user's name from the impersonation session.
+ * Otherwise returns the OIDC session user's name.
+ */
+export function getEffectiveName(req: Request): string | null {
+  if (req.appSession?.['impersonationUser']) {
+    return (req.appSession['impersonationUser'].name as string) || (req.appSession['impersonationUser'].username as string) || null;
+  }
+  return (req.oidc?.user?.['name'] as string) || null;
+}
+
+/**
+ * Decodes the payload from a JWT token without verifying the signature.
+ * Returns null if the token is malformed or cannot be decoded.
+ */
+export function decodeJwtPayload(token: string): LfxAccessTokenClaims | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+      return null;
+    }
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clears all impersonation-related data from the request session.
+ */
+export function clearImpersonationSession(req: Request): void {
+  if (!req.appSession) {
+    return;
+  }
+  delete req.appSession['impersonationToken'];
+  delete req.appSession['impersonationExpiresAt'];
+  delete req.appSession['impersonationUser'];
+  delete req.appSession['impersonator'];
 }

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -27,7 +27,7 @@ export async function getUsernameFromAuth(req: Request): Promise<string | null> 
   }
 
   // Fall back to OIDC claims for non-authelia tokens
-  return req.oidc?.user?.['sub'] || null;
+  return getEffectiveSub(req);
 }
 
 /**
@@ -36,4 +36,40 @@ export async function getUsernameFromAuth(req: Request): Promise<string | null> 
  */
 export function usernameMatches(authUsername: string, storedUsername: string): boolean {
   return stripAuthPrefix(authUsername) === stripAuthPrefix(storedUsername);
+}
+
+/**
+ * Gets the effective email for the current request context.
+ * During impersonation, returns the target user's email from the impersonation session.
+ * Otherwise returns the OIDC session user's email.
+ */
+export function getEffectiveEmail(req: Request): string | null {
+  if (req.appSession?.['impersonationUser']?.email) {
+    return (req.appSession['impersonationUser'].email as string).toLowerCase();
+  }
+  return (req.oidc?.user?.['email'] as string)?.toLowerCase() || null;
+}
+
+/**
+ * Gets the effective username for the current request context.
+ * During impersonation, returns the target user's username from the impersonation session.
+ * Otherwise returns the OIDC session user's username/nickname.
+ */
+export function getEffectiveUsername(req: Request): string | null {
+  if (req.appSession?.['impersonationUser']?.username) {
+    return req.appSession['impersonationUser'].username as string;
+  }
+  return (req.oidc?.user?.['nickname'] as string) || (req.oidc?.user?.['username'] as string) || null;
+}
+
+/**
+ * Gets the effective sub (user ID) for the current request context.
+ * During impersonation, returns the target user's sub from the impersonation session.
+ * Otherwise returns the OIDC session user's sub.
+ */
+export function getEffectiveSub(req: Request): string | null {
+  if (req.appSession?.['impersonationUser']?.sub) {
+    return req.appSession['impersonationUser'].sub as string;
+  }
+  return (req.oidc?.user?.['sub'] as string) || null;
 }

--- a/docs/architecture/backend/impersonation.md
+++ b/docs/architecture/backend/impersonation.md
@@ -1,0 +1,278 @@
+# User Impersonation
+
+## Overview
+
+User impersonation allows authorized LF staff to view the application as another user. This is a debugging and support tool — the impersonator sees the target user's dashboard, meetings, committees, and other data as if they were logged in as that user.
+
+Impersonation uses Auth0's Custom Token Exchange (CTE) feature (RFC 8693) to obtain an access token with the target user's identity while keeping the impersonator's OIDC session intact.
+
+**JIRA:** [LFXV2-1463](https://linuxfoundation.atlassian.net/browse/LFXV2-1463)
+
+## Architecture
+
+### Auth0 Infrastructure
+
+The Auth0 side is managed in the `auth0-terraform` repo:
+
+- **CTE Action** (`lfx_impersonation_token_exchange.js`) — validates the requestor, looks up the target user via Management API, and calls `api.authentication.setUserById()` to issue a new token
+- **`can_impersonate` claim** — added to LFX v2 access tokens via `custom_claims.js` for users matching an email allow-list
+- **Token Exchange Profile** — maps the LFX v2 API `subject_token_type` to the impersonation CTE action
+- **Auth Service Client** — the "LFX V2 Auth Service" client has `token_exchange` enabled with `allow_any_profile_of_type: ["custom_authentication"]`
+
+### Authorization
+
+Only users whose email matches the allow-list regex in the Auth0 action receive the `can_impersonate` claim. The allow-list is maintained in `src/includes/impersonation.js` in the `auth0-terraform` repo.
+
+### Token Exchange Flow
+
+```text
+┌──────────┐     ┌──────────────┐     ┌──────────────┐     ┌───────────┐     ┌─────────┐
+│ Frontend  │     │ Express (us) │     │ Auth Service │     │   Auth0   │     │ Upstream│
+│ (Angular) │     │              │     │   (NATS)     │     │   CTE     │     │  µsvc   │
+└────┬─────┘     └──────┬───────┘     └──────┬───────┘     └─────┬─────┘     └────┬────┘
+     │                  │                    │                   │                 │
+     │ POST /api/impersonate                 │                   │                 │
+     │  { targetUser: "jdoe" }               │                   │                 │
+     │─────────────────>│                    │                   │                 │
+     │                  │                    │                   │                 │
+     │           Server checks:              │                   │                 │
+     │            - can_impersonate claim     │                   │                 │
+     │            - service configured       │                   │                 │
+     │                  │                    │                   │                 │
+     │                  │ NATS request       │                   │                 │
+     │                  │  subject_token=    │                   │                 │
+     │                  │   <user's JWT>     │                   │                 │
+     │                  │  target_user=jdoe  │                   │                 │
+     │                  │───────────────────>│                   │                 │
+     │                  │                    │                   │                 │
+     │                  │                    │ POST /oauth/token  │                 │
+     │                  │                    │  grant_type=       │                 │
+     │                  │                    │   token-exchange   │                 │
+     │                  │                    │──────────────────>│                 │
+     │                  │                    │                   │                 │
+     │                  │                    │  { access_token }  │                 │
+     │                  │                    │<──────────────────│                 │
+     │                  │                    │                   │                 │
+     │                  │  { access_token }   │                   │                 │
+     │                  │<───────────────────│                   │                 │
+     │                  │                   │                 │
+     │           Store in appSession:       │                 │
+     │            impersonationToken        │                 │
+     │            impersonationUser         │                 │
+     │            impersonator              │                 │
+     │                  │                   │                 │
+     │  200 OK          │                   │                 │
+     │<─────────────────│                   │                 │
+     │                  │                   │                 │
+     │  Page reload     │                   │                 │
+     │─────────────────>│                   │                 │
+     │                  │                   │                 │
+     │           Auth middleware:           │                 │
+     │            req.bearerToken =         │                 │
+     │             impersonation token      │                 │
+     │                  │                   │                 │
+     │                  │ Bearer <target>   │                 │
+     │                  │──────────────────────────────────>│
+     │                  │                   │              │
+     │                  │          target user's data      │
+     │                  │<─────────────────────────────────│
+     │  Response        │                   │                 │
+     │<─────────────────│                   │                 │
+```
+
+### Token Exchange via NATS
+
+The CTE is performed by the **lfx-v2-auth-service** via NATS request-reply on subject `lfx.auth-service.impersonation.token_exchange`. The auth service handles all Auth0 client authentication (private key JWT, RFC 7523) internally — the UI server only sends the subject token and target user.
+
+```typescript
+// NATS request payload
+{ subject_token: "<user's LFX v2 JWT>", target_user: "jdoe@example.com" }
+
+// NATS response (success)
+{ success: true, data: { access_token: "<target user's JWT>" } }
+
+// NATS response (failure)
+{ success: false, error: "target_user_not_found: Target user 'jdoe' not found" }
+```
+
+The `CTE_CLIENT_ID` and `CTE_CLIENT_KEY` env vars are still used for the Management API profile lookup (fetching target user's name and picture), but not for the token exchange itself.
+
+## Implementation Layers
+
+### 1. Shared Interfaces
+
+**`packages/shared/src/interfaces/impersonation.interface.ts`**
+
+- `ImpersonationUser` — target user identity (`sub`, `email`, `username`, `name?`, `picture?`)
+- `Impersonator` — real user identity (`sub`, `email`, `name`)
+- `ImpersonationStartRequest`, `ImpersonationStartResponse`, `ImpersonationStatusResponse`
+
+**`packages/shared/src/interfaces/auth.interface.ts`** — `AuthContext` has additional fields:
+
+- `canImpersonate?: boolean` — whether the user has the `can_impersonate` claim
+- `impersonating?: boolean` — whether an impersonation session is active
+- `impersonator?: Impersonator` — the real user's identity during impersonation
+
+### 2. Backend Service
+
+**`apps/lfx-one/src/server/services/impersonation.service.ts`**
+
+| Method                                                    | Purpose                                                        |
+| --------------------------------------------------------- | -------------------------------------------------------------- |
+| `exchangeToken(req, targetUser)`                          | Performs CTE call to Auth0 `/oauth/token`                      |
+| `fetchTargetUserProfile(req, userId)`                     | Fetches target user's name/picture from Management API         |
+| `startImpersonation(req, tokenResponse, claims, profile)` | Stores impersonation state in `appSession`                     |
+| `stopImpersonation(req)`                                  | Clears impersonation state from `appSession`                   |
+| `getImpersonationToken(req)`                              | Returns active impersonation token or null (clears if expired) |
+| `getImpersonationStatus(req)`                             | Returns current impersonation status                           |
+
+### 3. API Endpoints
+
+**`apps/lfx-one/src/server/routes/impersonation.route.ts`** — mounted at `/api/impersonate`
+
+| Endpoint                  | Method | Purpose                                                           |
+| ------------------------- | ------ | ----------------------------------------------------------------- |
+| `/api/impersonate`        | POST   | Start impersonation (body: `{ targetUser: "email-or-username" }`) |
+| `/api/impersonate/stop`   | POST   | Stop impersonation, clear session                                 |
+| `/api/impersonate/status` | GET    | Check current impersonation state                                 |
+
+### 4. Auth Middleware Override
+
+**`apps/lfx-one/src/server/middleware/auth.middleware.ts`**
+
+In `extractBearerToken()`, the impersonation token is checked **before** the normal OIDC token extraction:
+
+```typescript
+if (impersonationToken && !expired) {
+  req.bearerToken = impersonationToken; // All upstream calls use target's identity
+  return { success: true, needsLogout: false };
+}
+// ... normal OIDC token extraction follows
+```
+
+This is the single choke point — every controller and service uses `req.bearerToken` for upstream API calls, so all microservices automatically see the target user's identity.
+
+### 5. Identity Helpers
+
+**`apps/lfx-one/src/server/utils/auth-helper.ts`**
+
+Many controllers and services read the user's email/username from `req.oidc.user` for server-side filtering (e.g., "get my meetings"). During impersonation, `req.oidc.user` is still the real user. Three helpers resolve the correct identity:
+
+| Helper                      | Returns                                       |
+| --------------------------- | --------------------------------------------- |
+| `getEffectiveEmail(req)`    | Impersonated email or OIDC email (lowercased) |
+| `getEffectiveUsername(req)` | Impersonated username or OIDC nickname        |
+| `getEffectiveSub(req)`      | Impersonated sub or OIDC sub                  |
+
+These check `req.appSession['impersonationUser']` first, falling back to `req.oidc.user`. All controllers/services that filter by user identity use these helpers (meetings, events, committees, votes, surveys, mailing lists, documents, analytics, persona detection).
+
+**Exception:** The profile controller always uses `req.oidc.user` directly because profile operations (change password, update metadata, link identities) must act on the real user's account.
+
+### 6. SSR Handler
+
+**`apps/lfx-one/src/server/server.ts`**
+
+During SSR, the handler:
+
+1. Populates `auth.canImpersonate` by decoding the `can_impersonate` claim from the access token
+2. When impersonation is active, overrides `auth.user` with the target user's claims (sub, email, username, name, picture)
+3. Sets `auth.impersonating = true` and `auth.impersonator` with the real user's identity
+
+Persona detection (`resolvePersonaForSsr`) runs after the override, so it resolves the target user's persona.
+
+### 7. Frontend
+
+**Components:**
+
+- **Impersonation banner** (`main-layout.component.html`) — fixed yellow bar at the top showing who is being impersonated and a "Stop" button
+- **Impersonation trigger** (`lens-switcher.component.html`) — user-secret icon in the sidebar footer (visible only when `canImpersonate` is true), opens a dialog to enter a target email/username
+
+**Services:**
+
+- `ImpersonationService` — frontend HTTP client for start/stop/status endpoints
+- `UserService` — signals: `canImpersonate`, `impersonating`, `impersonator`
+
+**Hydration:** `AppComponent` reads impersonation state from `AuthContext` via `TransferState` and populates `UserService` signals.
+
+## Session Storage
+
+All impersonation state is stored in the `express-openid-connect` session cookie (encrypted, chunked):
+
+```text
+┌─────────────────────────────────────────────────────┐
+│  req.appSession (encrypted cookie)                  │
+│                                                     │
+│  Primary OIDC Session (managed by library):         │
+│    access_token, refresh_token, id_token            │
+│                                                     │
+│  Impersonation (manually stored):                   │
+│    impersonationToken      — target user's JWT      │
+│    impersonationExpiresAt  — expiry timestamp       │
+│    impersonationUser       — { sub, email, ...}     │
+│    impersonator            — { sub, email, name }   │
+└─────────────────────────────────────────────────────┘
+```
+
+This is cookie-based (no server-side session store), so it works across replicas without sticky sessions.
+
+## Environment Variables
+
+```bash
+# Auth Service client credentials (for Management API profile lookup)
+# Client ID of the "LFX V2 Auth Service" Auth0 client
+CTE_CLIENT_ID=your-cte-client-id
+# Base64-encoded RSA private key for private_key_jwt auth
+CTE_CLIENT_KEY=your-base64-encoded-private-key
+```
+
+The private key is stored in the `auth-secrets` k8s secret in the `auth-service` namespace (`client_private_key` field).
+
+The token exchange itself goes through NATS to the auth service — no additional credentials needed beyond `NATS_URL`.
+
+## Token Expiry
+
+When the impersonation token expires, the auth middleware clears the session and falls through to the real user's token. The user is silently returned to their own identity. To re-impersonate, they must initiate a new session.
+
+## Audit Trail
+
+Every request made under impersonation is logged at INFO level:
+
+```text
+impersonation_request: Request under impersonation
+  impersonator: adesilva@linuxfoundation.org
+  target: jdoe@example.com
+  path: /api/user/meetings
+```
+
+Impersonation start/stop events are also logged:
+
+```text
+impersonation_granted: Impersonation session started
+  impersonator_sub: auth0|asitha
+  target_sub: auth0|jdoe
+
+impersonation_stopped: Impersonation session ended
+```
+
+## Limitations
+
+1. **Profile operations are not impersonated** — the profile controller always operates on the real user's account. Viewing another user's profile page during impersonation shows the real user's profile data, not the target's.
+
+2. **Write operations use the target's identity** — creating meetings, committees, or votes while impersonating will attribute them to the target user (via the bearer token). The `created_by_name` field on committees is an exception (uses the real user's name).
+
+3. **Local dev (Authelia) not supported** — CTE is an Auth0-specific feature. Impersonation won't work with the Authelia dev auth provider. The impersonation button is hidden when `CTE_CLIENT_KEY` is not configured.
+
+4. **Target user must exist in LFID connection** — the Auth0 CTE action looks up users in the `Username-Password-Authentication` connection only. Social-only or enterprise SSO users cannot be impersonated.
+
+5. **Persona cookie stale during impersonation** — if the real user has a cached persona cookie, the first page load after starting impersonation may briefly show the wrong persona until the cookie is refreshed via NATS.
+
+6. **No impersonation of impersonators** — if user A impersonates user B, user B's `can_impersonate` claim is not evaluated. Nested impersonation is not supported.
+
+## Future Work
+
+- **Read-only profile viewing** — allow impersonators to view (but not modify) the target user's profile page
+- **Impersonation audit dashboard** — a dedicated UI for reviewing impersonation logs
+- **Session duration controls** — configurable max impersonation duration, auto-expiry notifications
+- **Impersonation notifications** — optionally notify the target user when they are being impersonated
+- **Allow-list management UI** — manage authorized impersonators without Terraform changes
+- **Authelia dev support** — mock impersonation flow for local development

--- a/docs/architecture/backend/impersonation.md
+++ b/docs/architecture/backend/impersonation.md
@@ -117,14 +117,14 @@ Profile enrichment (fetching the target user's name and picture) also uses NATS 
 
 **`apps/lfx-one/src/server/services/impersonation.service.ts`**
 
-| Method                                                    | Purpose                                                        |
-| --------------------------------------------------------- | -------------------------------------------------------------- |
-| `exchangeToken(req, targetUser)`                          | Performs CTE call to Auth0 `/oauth/token`                      |
-| `fetchTargetUserProfile(req, userId)`                     | Fetches target user's name/picture from Management API         |
-| `startImpersonation(req, tokenResponse, claims, profile)` | Stores impersonation state in `appSession`                     |
-| `stopImpersonation(req)`                                  | Clears impersonation state from `appSession`                   |
-| `getImpersonationToken(req)`                              | Returns active impersonation token or null (clears if expired) |
-| `getImpersonationStatus(req)`                             | Returns current impersonation status                           |
+| Method                                                    | Purpose                                                          |
+| --------------------------------------------------------- | ---------------------------------------------------------------- |
+| `exchangeToken(req, targetUser)`                          | Performs CTE via NATS to `lfx-v2-auth-service`                   |
+| `fetchTargetUserProfile(req, userId)`                     | Fetches target user's name/picture via NATS `user_metadata.read` |
+| `startImpersonation(req, tokenResponse, claims, profile)` | Stores impersonation state in `appSession`                       |
+| `stopImpersonation(req)`                                  | Clears impersonation state from `appSession`                     |
+| `getImpersonationToken(req)`                              | Returns active impersonation token or null (clears if expired)   |
+| `getImpersonationStatus(req)`                             | Returns current impersonation status                             |
 
 ### 3. API Endpoints
 

--- a/docs/architecture/backend/impersonation.md
+++ b/docs/architecture/backend/impersonation.md
@@ -95,7 +95,7 @@ The CTE is performed by the **lfx-v2-auth-service** via NATS request-reply on su
 { success: false, error: "target_user_not_found: Target user 'jdoe' not found" }
 ```
 
-The `CTE_CLIENT_ID` and `CTE_CLIENT_KEY` env vars are still used for the Management API profile lookup (fetching target user's name and picture), but not for the token exchange itself.
+Profile enrichment (fetching the target user's name and picture) also uses NATS via the `lfx.auth-service.user_metadata.read` subject — no direct Auth0 Management API calls are made from the UI server.
 
 ## Implementation Layers
 
@@ -217,17 +217,7 @@ This is cookie-based (no server-side session store), so it works across replicas
 
 ## Environment Variables
 
-```bash
-# Auth Service client credentials (for Management API profile lookup)
-# Client ID of the "LFX V2 Auth Service" Auth0 client
-CTE_CLIENT_ID=your-cte-client-id
-# Base64-encoded RSA private key for private_key_jwt auth
-CTE_CLIENT_KEY=your-base64-encoded-private-key
-```
-
-The private key is stored in the `auth-secrets` k8s secret in the `auth-service` namespace (`client_private_key` field).
-
-The token exchange itself goes through NATS to the auth service — no additional credentials needed beyond `NATS_URL`.
+No impersonation-specific environment variables are required. Both the token exchange and profile enrichment use NATS to communicate with the auth service. The only requirement is `NATS_URL`.
 
 ## Token Expiry
 
@@ -235,16 +225,16 @@ When the impersonation token expires, the auth middleware clears the session and
 
 ## Audit Trail
 
-Every request made under impersonation is logged at INFO level:
+Every request made under impersonation is logged at DEBUG level with opaque identifiers:
 
 ```text
 impersonation_request: Request under impersonation
-  impersonator: adesilva@linuxfoundation.org
-  target: jdoe@example.com
+  impersonator_sub: auth0|asitha
+  target_sub: auth0|jdoe
   path: /api/user/meetings
 ```
 
-Impersonation start/stop events are also logged:
+Impersonation start/stop events are logged at INFO level:
 
 ```text
 impersonation_granted: Impersonation session started
@@ -260,7 +250,7 @@ impersonation_stopped: Impersonation session ended
 
 2. **Write operations use the target's identity** — creating meetings, committees, or votes while impersonating will attribute them to the target user (via the bearer token). The `created_by_name` field on committees is an exception (uses the real user's name).
 
-3. **Local dev (Authelia) not supported** — CTE is an Auth0-specific feature. Impersonation won't work with the Authelia dev auth provider. The impersonation button is hidden when `CTE_CLIENT_KEY` is not configured.
+3. **Local dev (Authelia) not supported** — CTE is an Auth0-specific feature. Impersonation won't work with the Authelia dev auth provider.
 
 4. **Target user must exist in LFID connection** — the Auth0 CTE action looks up users in the `Username-Password-Authentication` connection only. Social-only or enterprise SSO users cannot be impersonated.
 

--- a/packages/shared/src/enums/nats.enum.ts
+++ b/packages/shared/src/enums/nats.enum.ts
@@ -19,4 +19,5 @@ export enum NatsSubjects {
   USER_IDENTITY_LIST = 'lfx.auth-service.user_identity.list',
   LOOKUP_V1_MAPPING = 'lfx.lookup_v1_mapping',
   PERSONAS_GET = 'lfx.personas-api.get',
+  IMPERSONATION_TOKEN_EXCHANGE = 'lfx.auth-service.impersonation.token_exchange',
 }

--- a/packages/shared/src/interfaces/auth.interface.ts
+++ b/packages/shared/src/interfaces/auth.interface.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { Account } from './account.interface';
+import type { Impersonator } from './impersonation.interface';
 import type { PersonaType } from './persona.interface';
 
 /**
@@ -60,6 +61,12 @@ export interface AuthContext {
   personas?: PersonaType[];
   /** User's affiliated organizations from committee memberships */
   organizations?: Account[];
+  /** Whether the user has permission to impersonate other users */
+  canImpersonate?: boolean;
+  /** Whether the current session is impersonating another user */
+  impersonating?: boolean;
+  /** Information about the admin performing impersonation */
+  impersonator?: Impersonator;
 }
 
 /**

--- a/packages/shared/src/interfaces/impersonation.interface.ts
+++ b/packages/shared/src/interfaces/impersonation.interface.ts
@@ -2,6 +2,20 @@
 // SPDX-License-Identifier: MIT
 
 /**
+ * Decoded claims from an LFX access token (JWT payload).
+ */
+export interface LfxAccessTokenClaims {
+  sub: string;
+  'http://lfx.dev/claims/email'?: string;
+  'http://lfx.dev/claims/username'?: string;
+  'http://lfx.dev/claims/can_impersonate'?: boolean;
+  exp?: number;
+  aud?: string | string[];
+  iss?: string;
+  [key: string]: unknown;
+}
+
+/**
  * Target user information during impersonation
  */
 export interface ImpersonationUser {

--- a/packages/shared/src/interfaces/impersonation.interface.ts
+++ b/packages/shared/src/interfaces/impersonation.interface.ts
@@ -1,0 +1,46 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Target user information during impersonation
+ */
+export interface ImpersonationUser {
+  sub: string;
+  email: string;
+  username: string;
+  name?: string;
+  picture?: string;
+}
+
+/**
+ * Information about the admin performing impersonation
+ */
+export interface Impersonator {
+  sub: string;
+  email: string;
+  name: string;
+}
+
+/**
+ * Request body for starting impersonation
+ */
+export interface ImpersonationStartRequest {
+  targetUser: string;
+}
+
+/**
+ * Response for impersonation status check
+ */
+export interface ImpersonationStatusResponse {
+  impersonating: boolean;
+  targetUser?: ImpersonationUser;
+  impersonator?: Impersonator;
+}
+
+/**
+ * Response after successfully starting impersonation
+ */
+export interface ImpersonationStartResponse {
+  impersonating: boolean;
+  targetUser: ImpersonationUser;
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -112,3 +112,6 @@ export * from './training.interface';
 
 // My Documents interfaces
 export * from './my-document.interface';
+
+// Impersonation interfaces
+export * from './impersonation.interface';


### PR DESCRIPTION
## Summary

- Adds user impersonation allowing authorized LF staff to view the application as another user for debugging and support
- Uses Auth0 Custom Token Exchange (RFC 8693) via NATS request to `lfx-v2-auth-service` for token exchange
- Profile enrichment (name, picture) via NATS `user_metadata.read` — no direct Auth0 Management API calls
- Impersonation-aware identity helpers (`getEffectiveEmail`/`getEffectiveUsername`/`getEffectiveSub`/`getEffectiveName`) replace direct `req.oidc.user` reads across all controllers and services
- Shared utilities (`decodeJwtPayload`, `clearImpersonationSession`) extracted to `auth-helper.ts`
- Typed JWT claims via `LfxAccessTokenClaims` interface
- Frontend: impersonation dialog in lens switcher (gated by `can_impersonate` claim), yellow banner during active impersonation
- Architecture documentation at `docs/architecture/backend/impersonation.md`

## Dependencies

- [auth0-terraform #272](https://github.com/linuxfoundation/auth0-terraform/pull/272) — CTE action + `can_impersonate` claim (merged)
- [lfx-v2-auth-service #39](https://github.com/linuxfoundation/lfx-v2-auth-service/pull/39) — NATS impersonation token exchange handler (merged)

## Environment Variables

No impersonation-specific environment variables required. Both token exchange and profile enrichment use NATS (`NATS_URL`).

## JIRA

[LFXV2-1463](https://linuxfoundation.atlassian.net/browse/LFXV2-1463)

---

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-1463]: https://linuxfoundation.atlassian.net/browse/LFXV2-1463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ