### PR TITLE
feat(dashboards): ed analytics client service

### DIFF
--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -63,6 +63,10 @@ import {
   SocialMediaResponse,
   SocialReachResponse,
   WebActivitiesSummaryResponse,
+  EventGrowthResponse,
+  BrandReachResponse,
+  BrandHealthResponse,
+  RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
 
@@ -829,11 +833,11 @@ export class AnalyticsService {
 
   /**
    * Get email click-through rate data
-   * @param foundationName - Foundation name to filter by (e.g., 'The Linux Foundation')
+   * @param foundationSlug - Foundation slug to filter by
    * @returns Observable of email CTR response
    */
-  public getEmailCtr(foundationName: string): Observable<EmailCtrResponse> {
-    return this.http.get<EmailCtrResponse>('/api/analytics/email-ctr', { params: { foundationName } }).pipe(
+  public getEmailCtr(foundationSlug: string): Observable<EmailCtrResponse> {
+    return this.http.get<EmailCtrResponse>('/api/analytics/email-ctr', { params: { foundationSlug } }).pipe(
       catchError(() => {
         return of({
           currentCtr: 0,
@@ -852,11 +856,11 @@ export class AnalyticsService {
   /**
    * Get social media metrics from Snowflake Platinum tables
    * Queries ANALYTICS.PLATINUM_LFX_ONE.SOCIAL_MEDIA_OVERVIEW and SOCIAL_MEDIA_PLATFORM_BREAKDOWN
-   * @param foundationName - Foundation name used to filter metrics (e.g., 'The Linux Foundation')
+   * @param foundationSlug - Foundation slug used to filter metrics
    * @returns Social media response with followers, platforms, engagement, and trend data
    */
-  public getSocialMedia(foundationName: string): Observable<SocialMediaResponse> {
-    return this.http.get<SocialMediaResponse>('/api/analytics/social-media', { params: { foundationName } }).pipe(
+  public getSocialMedia(foundationSlug: string): Observable<SocialMediaResponse> {
+    return this.http.get<SocialMediaResponse>('/api/analytics/social-media', { params: { foundationSlug } }).pipe(
       catchError(() => {
         return of({
           totalFollowers: 0,
@@ -872,11 +876,11 @@ export class AnalyticsService {
 
   /**
    * Get paid social reach metrics
-   * @param foundationName - Foundation name used to filter metrics (e.g., 'The Linux Foundation')
+   * @param foundationSlug - Foundation slug used to filter metrics
    * @returns Social reach response with ROAS, impressions, and monthly trends
    */
-  public getSocialReach(foundationName: string): Observable<SocialReachResponse> {
-    return this.http.get<SocialReachResponse>('/api/analytics/social-reach', { params: { foundationName } }).pipe(
+  public getSocialReach(foundationSlug: string): Observable<SocialReachResponse> {
+    return this.http.get<SocialReachResponse>('/api/analytics/social-reach', { params: { foundationSlug } }).pipe(
       catchError(() => {
         return of({
           totalReach: 0,
@@ -971,6 +975,20 @@ export class AnalyticsService {
             convertedToNewsletter: 0,
             convertedToCommunity: 0,
             convertedToWorkingGroup: 0,
+            convertedToTraining: 0,
+            convertedToCode: 0,
+            convertedToWeb: 0,
+          },
+          reengagement: {
+            totalReengaged: 0,
+            reengagementRate: 0,
+            reengagementMomChange: 0,
+            reengagedToNewsletter: 0,
+            reengagedToCommunity: 0,
+            reengagedToWorkingGroup: 0,
+            reengagedToTraining: 0,
+            reengagedToCode: 0,
+            reengagedToWeb: 0,
           },
           reengagement: {
             totalReengaged: 0,
@@ -1149,5 +1167,33 @@ export class AnalyticsService {
         });
       })
     );
+  }
+
+  /**
+   * Get event growth metrics. Errors propagate to the caller so the UI can show an error state.
+   */
+  public getEventGrowth(foundationSlug: string): Observable<EventGrowthResponse> {
+    return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } });
+  }
+
+  /**
+   * Get brand reach metrics. Errors propagate to the caller so the UI can show an error state.
+   */
+  public getBrandReach(foundationSlug: string): Observable<BrandReachResponse> {
+    return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: { foundationSlug } });
+  }
+
+  /**
+   * Get brand health metrics. Errors propagate to the caller so the UI can show an error state.
+   */
+  public getBrandHealth(foundationSlug: string): Observable<BrandHealthResponse> {
+    return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params: { foundationSlug } });
+  }
+
+  /**
+   * Get marketing-attributed revenue metrics. Errors propagate to the caller so the UI can show an error state.
+   */
+  public getRevenueImpact(foundationSlug: string): Observable<RevenueImpactResponse> {
+    return this.http.get<RevenueImpactResponse>('/api/analytics/revenue-impact', { params: { foundationSlug } });
   }
 }

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1158,6 +1158,11 @@ export class AnalyticsService {
     );
   }
 
+  /**
+   * Get event growth metrics for the ED dashboard.
+   * @param foundationSlug Foundation slug used to filter Snowflake queries
+   * @returns Observable emitting event growth totals, YoY changes, and monthly trend (or zeroed defaults on error)
+   */
   public getEventGrowth(foundationSlug: string): Observable<EventGrowthResponse> {
     return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } }).pipe(
       catchError(() =>
@@ -1178,6 +1183,11 @@ export class AnalyticsService {
     );
   }
 
+  /**
+   * Get brand reach metrics for the ED dashboard (social followers + web sessions).
+   * @param foundationSlug Foundation slug used to filter Snowflake queries
+   * @returns Observable emitting reach totals, platform breakdowns, and weekly trend (or zeroed defaults on error)
+   */
   public getBrandReach(foundationSlug: string): Observable<BrandReachResponse> {
     return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: { foundationSlug } }).pipe(
       catchError(() =>
@@ -1195,6 +1205,11 @@ export class AnalyticsService {
     );
   }
 
+  /**
+   * Get brand health metrics for the ED dashboard (mention volume + sentiment breakdown).
+   * @param foundationSlug Foundation slug used to filter Snowflake queries
+   * @returns Observable emitting mention totals, sentiment percentages, and monthly history (or zeroed defaults on error)
+   */
   public getBrandHealth(foundationSlug: string): Observable<BrandHealthResponse> {
     return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params: { foundationSlug } }).pipe(
       catchError(() =>
@@ -1210,6 +1225,11 @@ export class AnalyticsService {
     );
   }
 
+  /**
+   * Get revenue impact metrics for the ED dashboard (attribution + paid media + event registration).
+   * @param foundationSlug Foundation slug used to filter Snowflake queries
+   * @returns Observable emitting pipeline/revenue totals, attribution breakdowns, and event registration data (or zeroed defaults on error)
+   */
   public getRevenueImpact(foundationSlug: string): Observable<RevenueImpactResponse> {
     return this.http.get<RevenueImpactResponse>('/api/analytics/revenue-impact', { params: { foundationSlug } }).pipe(
       catchError(() =>

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -990,17 +990,6 @@ export class AnalyticsService {
             reengagedToCode: 0,
             reengagedToWeb: 0,
           },
-          reengagement: {
-            totalReengaged: 0,
-            reengagementRate: 0,
-            reengagementMomChange: 0,
-            reengagedToNewsletter: 0,
-            reengagedToCommunity: 0,
-            reengagedToWorkingGroup: 0,
-            reengagedToTraining: 0,
-            reengagedToCode: 0,
-            reengagedToWeb: 0,
-          },
           monthlyData: [],
         });
       })
@@ -1169,31 +1158,75 @@ export class AnalyticsService {
     );
   }
 
-  /**
-   * Get event growth metrics. Errors propagate to the caller so the UI can show an error state.
-   */
   public getEventGrowth(foundationSlug: string): Observable<EventGrowthResponse> {
-    return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } });
+    return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } }).pipe(
+      catchError(() =>
+        of({
+          totalAttendees: 0,
+          totalRegistrants: 0,
+          totalEvents: 0,
+          totalRevenue: 0,
+          revenuePerAttendee: 0,
+          attendeeYoyChange: 0,
+          registrantYoyChange: 0,
+          revenueYoyChange: 0,
+          trend: 'up' as const,
+          monthlyData: [],
+          topEvents: [],
+        })
+      )
+    );
   }
 
-  /**
-   * Get brand reach metrics. Errors propagate to the caller so the UI can show an error state.
-   */
   public getBrandReach(foundationSlug: string): Observable<BrandReachResponse> {
-    return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: { foundationSlug } });
+    return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: { foundationSlug } }).pipe(
+      catchError(() =>
+        of({
+          totalSocialFollowers: 0,
+          totalMonthlySessions: 0,
+          activePlatforms: 0,
+          changePercentage: 0,
+          trend: 'up' as const,
+          socialPlatforms: [],
+          websiteDomains: [],
+          weeklyTrend: [],
+        })
+      )
+    );
   }
 
-  /**
-   * Get brand health metrics. Errors propagate to the caller so the UI can show an error state.
-   */
   public getBrandHealth(foundationSlug: string): Observable<BrandHealthResponse> {
-    return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params: { foundationSlug } });
+    return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params: { foundationSlug } }).pipe(
+      catchError(() =>
+        of({
+          totalMentions: 0,
+          sentiment: { positive: 0, neutral: 0, negative: 0 },
+          sentimentMomChangePp: 0,
+          trend: 'up' as const,
+          monthlyMentions: [],
+          topProjects: [],
+        })
+      )
+    );
   }
 
-  /**
-   * Get marketing-attributed revenue metrics. Errors propagate to the caller so the UI can show an error state.
-   */
   public getRevenueImpact(foundationSlug: string): Observable<RevenueImpactResponse> {
-    return this.http.get<RevenueImpactResponse>('/api/analytics/revenue-impact', { params: { foundationSlug } });
+    return this.http.get<RevenueImpactResponse>('/api/analytics/revenue-impact', { params: { foundationSlug } }).pipe(
+      catchError(() =>
+        of({
+          pipelineInfluenced: 0,
+          revenueAttributed: 0,
+          matchRate: 0,
+          changePercentage: 0,
+          trend: 'up' as const,
+          attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+          engagementTypes: [],
+          paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0, monthlyTrend: [] },
+          attributionChannels: [],
+          projectBreakdown: [],
+          eventRegistrationAttribution: { channelBreakdown: [], monthlyTrend: [] },
+        })
+      )
+    );
   }
 }


### PR DESCRIPTION
## Summary

Split **2 of 4** from #452. Wires the Angular analytics service to the 8 new \`/api/analytics/*\` endpoints added in #455.

Pure client plumbing — no UI consumers yet. Those ship in:
- PR 3 — overview + 8 existing drawer edits
- PR 4 — 4 new drawers

## Stack

1. #455 — backend + shared types (base)
2. **This PR** — client service
3. PR 3 — overview + existing drawer refresh
4. PR 4 — 4 new drawers

## Test plan

- [x] \`yarn build\` passes
- [x] \`yarn lint\` clean
- [x] License header check passes

Part of LFXV2-1468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)