### PR TITLE
fix(meetings): add uid and parent_uid to public meeting project

### DIFF
--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -135,7 +135,10 @@ export class PublicMeetingController {
           // Remove public link outside join window
           delete meeting.public_link;
         }
-        res.json({ meeting, project: { name: project.name, slug: project.slug, logo_url: project.logo_url } });
+        res.json({
+          meeting,
+          project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
+        });
         return;
       }
 
@@ -149,7 +152,7 @@ export class PublicMeetingController {
       }
 
       // Send the meeting and project data to the client
-      res.json({ meeting, project: { name: project.name, slug: project.slug, logo_url: project.logo_url } });
+      res.json({ meeting, project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid } });
     } catch (error) {
       // Error handler will log
       next(error);
@@ -250,7 +253,7 @@ export class PublicMeetingController {
 
       res.json({
         meeting: meetingResponse,
-        project: { name: project.name, slug: project.slug, logo_url: project.logo_url },
+        project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
         full_access: fullAccess,
       });
     } catch (error) {

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1004,7 +1004,7 @@ export interface UrlMetadataResponse {
  */
 export interface PublicPastMeetingResponse {
   meeting: PastMeeting;
-  project: { name: string; slug: string; logo_url: string };
+  project: { name: string; slug: string; logo_url: string; uid: string; parent_uid: string };
   full_access: boolean;
 }
 


### PR DESCRIPTION
          - Add uid and parent_uid to stripped project object in all three
            public meeting endpoint responses (public, password-protected, past)
          - Update PublicPastMeetingResponse interface to include new fields
            so frontend can resolve foundation context for navigation

          LFXV2-1469

          Assisted by [Claude Code](https://claude.ai/claude-code)
          
# Overview

This pull request updates the project information returned by the `PublicMeetingController` API endpoints to include `uid` and `parent_uid` fields in addition to the existing project fields. This change ensures that clients receive more comprehensive project data when retrieving meeting information.

API response enhancements:

* All relevant responses from `PublicMeetingController` now include `uid` and `parent_uid` in the `project` object, alongside `name`, `slug`, and `logo_url` (`apps/lfx-one/src/server/controllers/public-meeting.controller.ts`). [[1]](diffhunk://#diff-2e94145afb38178a90de1392aeacf5725dc40fbbad391e805b46b48eb8a13a8bL138-R141) [[2]](diffhunk://#diff-2e94145afb38178a90de1392aeacf5725dc40fbbad391e805b46b48eb8a13a8bL152-R155) [[3]](diffhunk://#diff-2e94145afb38178a90de1392aeacf5725dc40fbbad391e805b46b48eb8a13a8bL253-R256)
* The `PublicPastMeetingResponse` interface in `meeting.interface.ts` is updated to reflect the additional `uid` and `parent_uid` fields in the `project` object (`packages/shared/src/interfaces/meeting.interface.ts`).