### PR TITLE
feat(dashboards): wire marketing overview and drawers to live data

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -8,7 +8,7 @@ import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { lfxColors } from '@lfx-one/shared/constants';
-import { formatNumber, hexToRgba } from '@lfx-one/shared/utils';
+import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -70,14 +70,15 @@ export class BrandHealthDrawerComponent {
   protected readonly mentionsTrendData: Signal<ChartData<'line'>> = this.initMentionsTrendData();
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
   protected readonly formattedSentimentMom: Signal<string> = computed(() => {
     const v = this.data().sentimentMomChangePp;

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { MARKETING_SOCIAL_PLATFORM_MAP } from '@lfx-one/shared/constants';
-import { formatNumber } from '@lfx-one/shared/utils';
+import { formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -49,14 +49,15 @@ export class BrandReachDrawerComponent {
 
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
   protected onClose(): void {
     this.visible.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -44,7 +44,7 @@
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Current CTR</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ drawerData().currentCtr.toFixed(2) }}%</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ drawerData().currentCtr.toFixed(1) }}%</span>
           </div>
         </lfx-card>
         <lfx-card styleClass="flex-1">
@@ -53,7 +53,7 @@
             @if (drawerData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage }}%
+                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
                 </span>
                 <i class="text-sm" [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>
@@ -64,29 +64,28 @@
         </lfx-card>
       </div>
 
-      <!-- Recommended Actions -->
-      @if (recommendedActions().length > 0) {
-        <div class="flex flex-col gap-3" data-testid="email-ctr-drawer-actions">
+      <!-- FIRST FOLD: Needs Your Attention -->
+      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+        <div class="flex flex-col gap-4 p-4 bg-red-50 border border-red-200 rounded-lg" data-testid="email-ctr-drawer-attention">
           <div class="flex items-center gap-2">
-            <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900">
-              <i class="fa-light fa-lightbulb text-amber-500"></i>
-              Recommended Actions
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-red-800">
+              <i class="fa-light fa-triangle-exclamation text-red-500"></i>
+              Needs Your Attention
             </h3>
           </div>
-          @for (action of recommendedActions(); track action.title) {
-            <div class="flex items-start gap-3 p-4 border border-gray-200 rounded-lg">
-              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-gray-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-gray-600'"></i>
+
+          @for (action of attentionActions(); track action.title) {
+            <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
+              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
+                <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center justify-between gap-2">
                   <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
                   @if (action.priority === 'high') {
                     <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-                  } @else if (action.priority === 'medium') {
-                    <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
                   } @else {
-                    <lfx-tag value="Low Priority" severity="info" [rounded]="true" />
+                    <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
@@ -94,28 +93,46 @@
               </div>
             </div>
           }
+
+          @for (insight of attentionInsights(); track insight.text) {
+            <div class="flex items-center gap-2 text-sm px-1">
+              <i class="fa-light fa-triangle-exclamation text-red-500"></i>
+              <span class="text-red-800">{{ insight.text }}</span>
+            </div>
+          }
         </div>
       }
 
-      <!-- Key Insights -->
-      @if (keyInsights().length > 0) {
-        <div class="flex flex-col gap-3 p-4 bg-gray-50 rounded-lg" data-testid="email-ctr-drawer-insights">
+      <!-- SECOND FOLD: Performing Well -->
+      @if (performingActions().length > 0 || performingInsights().length > 0) {
+        <div class="flex flex-col gap-4 p-4 bg-green-50 border border-green-200 rounded-lg" data-testid="email-ctr-drawer-performing">
           <div class="flex items-center gap-2">
-            <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900">
-              <i class="fa-light fa-triangle-exclamation text-amber-500"></i>
-              Key Insights
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-green-800">
+              <i class="fa-light fa-check-circle text-green-500"></i>
+              Performing Well
             </h3>
           </div>
-          @for (insight of keyInsights(); track insight.text) {
-            <div class="flex items-center gap-2 text-sm">
+
+          @for (action of performingActions(); track action.title) {
+            <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
+              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
+                <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+              </div>
+              <div class="flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
+              </div>
+            </div>
+          }
+
+          @for (insight of performingInsights(); track insight.text) {
+            <div class="flex items-center gap-2 text-sm px-1">
               @if (insight.type === 'driver') {
-                <i class="fa-light fa-bullseye text-gray-500"></i>
-              } @else if (insight.type === 'warning') {
-                <i class="fa-light fa-triangle-exclamation text-amber-500"></i>
+                <i class="fa-light fa-bullseye text-green-500"></i>
               } @else {
                 <i class="fa-light fa-circle-info text-blue-500"></i>
               }
-              <span class="text-gray-700">{{ insight.text }}</span>
+              <span class="text-green-800">{{ insight.text }}</span>
             </div>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -77,7 +77,7 @@
           @for (action of attentionActions(); track action.title) {
             <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
               <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
+                <i [class]="(action.actionType | marketingActionIcon) + ' text-red-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center justify-between gap-2">
@@ -116,7 +116,7 @@
           @for (action of performingActions(); track action.title) {
             <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
               <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+                <i [class]="(action.actionType | marketingActionIcon) + ' text-green-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -44,7 +44,7 @@
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Current CTR</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ drawerData().currentCtr.toFixed(1) }}%</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ drawerData().currentCtr | number: '1.1-1' }}%</span>
           </div>
         </lfx-card>
         <lfx-card styleClass="flex-1">
@@ -53,7 +53,7 @@
             @if (drawerData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
+                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage | number: '1.1-1' }}%
                 </span>
                 <i class="text-sm" [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -47,6 +47,14 @@ export class EmailCtrDrawerComponent {
   protected readonly drawerData: Signal<EmailCtrResponse> = this.initDrawerData();
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
+    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
+  );
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
+    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
+  );
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
   protected readonly campaignChartData: Signal<ChartData<'bar'>> = this.initCampaignChartData();
   protected readonly reachVsOpensChartData: Signal<ChartData<'bar'>> = this.initReachVsOpensChartData();
@@ -179,15 +187,15 @@ export class EmailCtrDrawerComponent {
     };
 
     const visible$ = toObservable(this.visible);
-    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.name || ''));
+    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.slug || ''));
 
     return toSignal(
       combineLatest([visible$, foundation$]).pipe(
-        filter(([isVisible, name]) => isVisible && !!name),
-        map(([, name]) => name),
+        filter(([isVisible, slug]) => isVisible && !!slug),
+        map(([, slug]) => slug),
         tap(() => this.drawerLoading.set(true)),
-        switchMap((foundationName) =>
-          this.analyticsService.getEmailCtr(foundationName).pipe(
+        switchMap((foundationSlug) =>
+          this.analyticsService.getEmailCtr(foundationSlug).pipe(
             tap(() => this.drawerLoading.set(false)),
             catchError(() => {
               this.drawerLoading.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -7,27 +7,23 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import {
-  createBarChartOptions,
-  createHorizontalBarChartOptions,
-  DASHBOARD_TOOLTIP_CONFIG,
-  lfxColors,
-  MARKETING_ACTION_ICON_MAP,
-} from '@lfx-one/shared/constants';
+import { createBarChartOptions, createHorizontalBarChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { MessageService } from 'primeng/api';
 import { catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
 
 import type { ChartData, ChartOptions } from 'chart.js';
-import type { EmailCtrResponse, MarketingActionType, MarketingKeyInsight, MarketingRecommendedAction } from '@lfx-one/shared/interfaces';
+import type { EmailCtrResponse, MarketingKeyInsight, MarketingRecommendedAction } from '@lfx-one/shared/interfaces';
+import { splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 
 @Component({
   selector: 'lfx-email-ctr-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TagComponent],
+  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TagComponent, MarketingActionIconPipe],
   templateUrl: './email-ctr-drawer.component.html',
   styleUrl: './email-ctr-drawer.component.scss',
 })
@@ -47,14 +43,15 @@ export class EmailCtrDrawerComponent {
   protected readonly drawerData: Signal<EmailCtrResponse> = this.initDrawerData();
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
   protected readonly campaignChartData: Signal<ChartData<'bar'>> = this.initCampaignChartData();
   protected readonly reachVsOpensChartData: Signal<ChartData<'bar'>> = this.initReachVsOpensChartData();
@@ -167,10 +164,6 @@ export class EmailCtrDrawerComponent {
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
-  }
-
-  protected actionIcon(type: MarketingActionType): string {
-    return MARKETING_ACTION_ICON_MAP[type];
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DecimalPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
@@ -23,7 +24,7 @@ import { splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/
 @Component({
   selector: 'lfx-email-ctr-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TagComponent, MarketingActionIconPipe],
+  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule, ChartComponent, SkeletonModule, TagComponent, MarketingActionIconPipe],
   templateUrl: './email-ctr-drawer.component.html',
   styleUrl: './email-ctr-drawer.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -42,7 +42,7 @@
           @if (data().changePercentage !== 0) {
             <div class="flex items-center gap-2">
               <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage.toFixed(1) }}%
+                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage | number: '1.1-1' }}%
               </span>
               <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -157,7 +157,7 @@
     </div>
 
     <!-- Weekly Sessions Trend -->
-    @if (brandReachData().dailyTrend.length > 0) {
+    @if (brandReachData().weeklyTrend.length > 0) {
       <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="engaged-community-drawer-daily-trend">
         <div class="flex flex-col gap-1">
           <h3 class="text-sm font-semibold text-gray-900">Weekly Sessions Trend</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -66,7 +66,7 @@
         @for (action of attentionActions(); track action.title) {
           <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
             <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
-              <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
+              <i [class]="(action.actionType | marketingActionIcon) + ' text-red-600'"></i>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center justify-between gap-2">
@@ -105,7 +105,7 @@
         @for (action of performingActions(); track action.title) {
           <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
             <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
-              <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+              <i [class]="(action.actionType | marketingActionIcon) + ' text-green-600'"></i>
             </div>
             <div class="flex-1 min-w-0">
               <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -42,7 +42,7 @@
           @if (data().changePercentage !== 0) {
             <div class="flex items-center gap-2">
               <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage }}%
+                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage.toFixed(1) }}%
               </span>
               <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>
@@ -155,5 +155,18 @@
         <lfx-chart type="bar" [data]="breakdownChartData()" [options]="breakdownChartOptions" height="100%"></lfx-chart>
       </div>
     </div>
+
+    <!-- Weekly Sessions Trend -->
+    @if (brandReachData().dailyTrend.length > 0) {
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="engaged-community-drawer-daily-trend">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">Weekly Sessions Trend</h3>
+          <p class="text-sm text-gray-600">Website sessions over the last 6 months (weekly)</p>
+        </div>
+        <div class="h-[240px]" data-testid="engaged-community-drawer-daily-chart">
+          <lfx-chart type="line" [data]="dailyTrendData()" [options]="dailyTrendOptions" height="100%"></lfx-chart>
+        </div>
+      </div>
+    }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -6,29 +6,18 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import {
-  createHorizontalBarChartOptions,
-  createLineChartOptions,
-  DASHBOARD_TOOLTIP_CONFIG,
-  lfxColors,
-  MARKETING_ACTION_ICON_MAP,
-} from '@lfx-one/shared/constants';
-import { formatNumber, hexToRgba } from '@lfx-one/shared/utils';
+import { createHorizontalBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { ChartData, ChartOptions } from 'chart.js';
-import type {
-  BrandReachResponse,
-  EngagedCommunitySizeResponse,
-  MarketingActionType,
-  MarketingRecommendedAction,
-  MarketingKeyInsight,
-} from '@lfx-one/shared/interfaces';
+import type { BrandReachResponse, EngagedCommunitySizeResponse, MarketingKeyInsight, MarketingRecommendedAction } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-engaged-community-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, TagComponent],
+  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, TagComponent, MarketingActionIconPipe],
   templateUrl: './engaged-community-drawer.component.html',
   styleUrl: './engaged-community-drawer.component.scss',
 })
@@ -58,14 +47,15 @@ export class EngagedCommunityDrawerComponent {
   protected readonly formattedTotalMembers: Signal<string> = computed(() => formatNumber(this.data().totalMembers));
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly trendChartData: Signal<ChartData<'line'>> = this.initTrendChartData();
   protected readonly breakdownChartData: Signal<ChartData<'bar'>> = this.initBreakdownChartData();
   protected readonly dailyTrendData: Signal<ChartData<'line'>> = this.initDailyTrendData();
@@ -177,10 +167,6 @@ export class EngagedCommunityDrawerComponent {
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
-  }
-
-  protected actionIcon(type: MarketingActionType): string {
-    return MARKETING_ACTION_ICON_MAP[type];
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -52,7 +52,7 @@ export class EngagedCommunityDrawerComponent {
     trend: 'up',
     socialPlatforms: [],
     websiteDomains: [],
-    dailyTrend: [],
+    weeklyTrend: [],
   });
   // === Computed Signals ===
   protected readonly formattedTotalMembers: Signal<string> = computed(() => formatNumber(this.data().totalMembers));
@@ -261,9 +261,9 @@ export class EngagedCommunityDrawerComponent {
       }
 
       // Weekly sessions — drawer renders 6-month weekly chart, compare recent 4 weeks vs prior 4
-      if (brand.dailyTrend.length >= 8) {
-        const recent4 = brand.dailyTrend.slice(-4).reduce((s, d) => s + d.sessions, 0);
-        const prior4 = brand.dailyTrend.slice(-8, -4).reduce((s, d) => s + d.sessions, 0);
+      if (brand.weeklyTrend.length >= 8) {
+        const recent4 = brand.weeklyTrend.slice(-4).reduce((s, d) => s + d.sessions, 0);
+        const prior4 = brand.weeklyTrend.slice(-8, -4).reduce((s, d) => s + d.sessions, 0);
         if (prior4 === 0 && recent4 > 0) {
           insights.push({
             text: `Weekly sessions started growing from a zero baseline (${formatNumber(recent4)} last 4 weeks)`,
@@ -309,12 +309,12 @@ export class EngagedCommunityDrawerComponent {
 
   private initDailyTrendData(): Signal<ChartData<'line'>> {
     return computed(() => {
-      const { dailyTrend } = this.brandReachData();
+      const { weeklyTrend } = this.brandReachData();
       return {
-        labels: dailyTrend.map((d) => d.day),
+        labels: weeklyTrend.map((d) => d.week),
         datasets: [
           {
-            data: dailyTrend.map((d) => d.sessions),
+            data: weeklyTrend.map((d) => d.sessions),
             borderColor: lfxColors.blue[500],
             backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
             fill: true,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -17,7 +17,13 @@ import { formatNumber, hexToRgba } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { ChartData, ChartOptions } from 'chart.js';
-import type { EngagedCommunitySizeResponse, MarketingActionType, MarketingRecommendedAction, MarketingKeyInsight } from '@lfx-one/shared/interfaces';
+import type {
+  BrandReachResponse,
+  EngagedCommunitySizeResponse,
+  MarketingActionType,
+  MarketingRecommendedAction,
+  MarketingKeyInsight,
+} from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-engaged-community-drawer',
@@ -38,6 +44,16 @@ export class EngagedCommunityDrawerComponent {
     breakdown: { newsletterSubscribers: 0, communityMembers: 0, workingGroupMembers: 0, certifiedIndividuals: 0 },
     monthlyData: [],
   });
+  public readonly brandReachData = input<BrandReachResponse>({
+    totalSocialFollowers: 0,
+    totalMonthlySessions: 0,
+    activePlatforms: 0,
+    changePercentage: 0,
+    trend: 'up',
+    socialPlatforms: [],
+    websiteDomains: [],
+    dailyTrend: [],
+  });
   // === Computed Signals ===
   protected readonly formattedTotalMembers: Signal<string> = computed(() => formatNumber(this.data().totalMembers));
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
@@ -52,6 +68,7 @@ export class EngagedCommunityDrawerComponent {
   );
   protected readonly trendChartData: Signal<ChartData<'line'>> = this.initTrendChartData();
   protected readonly breakdownChartData: Signal<ChartData<'bar'>> = this.initBreakdownChartData();
+  protected readonly dailyTrendData: Signal<ChartData<'line'>> = this.initDailyTrendData();
 
   protected readonly trendChartOptions: ChartOptions<'line'> = createLineChartOptions({
     plugins: {
@@ -121,6 +138,40 @@ export class EngagedCommunityDrawerComponent {
     },
   });
 
+  protected readonly dailyTrendOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: { enabled: true, mode: 'index', intersect: false },
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: { display: false },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          maxTicksLimit: 6,
+        },
+      },
+      y: {
+        display: true,
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: false },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          callback: (value) => {
+            const num = Number(value);
+            if (num >= 1_000) return `${(num / 1_000).toFixed(0)}K`;
+            return String(num);
+          },
+        },
+      },
+    },
+  };
+
   protected readonly formatNumber = formatNumber;
 
   // === Protected Methods ===
@@ -142,36 +193,29 @@ export class EngagedCommunityDrawerComponent {
         return actions;
       }
 
-      // Check if working groups are underrepresented
-      if (totalMembers > 0 && breakdown.workingGroupMembers < totalMembers * 0.1) {
-        actions.push({
-          title: 'Increase working group participation',
-          description: `Working group members are only ${((breakdown.workingGroupMembers / totalMembers) * 100).toFixed(0)}% of total — improve outreach to convert community members into active participants`,
-          priority: 'high',
-          dueLabel: 'This quarter',
-          actionType: 'engagement',
-        });
-      }
-
-      // Check for declining community
-      if (changePercentage < -5) {
+      // MoM drop — actionable when large
+      if (changePercentage <= -5) {
         actions.push({
           title: 'Address community decline',
-          description: `Community size dropped ${Math.abs(changePercentage)}% — review engagement programs and onboarding flow`,
+          description: `Engaged community dropped ${Math.abs(changePercentage).toFixed(1)}% vs last month — review engagement programs and onboarding flow`,
           priority: 'high',
           dueLabel: 'This month',
           actionType: 'decline',
         });
       }
 
-      if (actions.length === 0) {
-        actions.push({
-          title: 'Continue community growth strategy',
-          description: `${formatNumber(totalMembers)} engaged members${changePercentage > 0 ? ` — growing ${changePercentage}%` : ''}`,
-          priority: 'low',
-          dueLabel: 'Ongoing',
-          actionType: 'growth',
-        });
+      // Working group is the deepest engagement signal — flag floor
+      if (totalMembers > 0) {
+        const wgShare = (breakdown.workingGroupMembers / totalMembers) * 100;
+        if (wgShare < 10) {
+          actions.push({
+            title: 'Grow working group participation',
+            description: `Working groups hold only ${wgShare.toFixed(0)}% of engaged members (${formatNumber(breakdown.workingGroupMembers)}) — convert passive community members into active contributors`,
+            priority: 'medium',
+            dueLabel: 'This quarter',
+            actionType: 'engagement',
+          });
+        }
       }
 
       return actions;
@@ -181,41 +225,60 @@ export class EngagedCommunityDrawerComponent {
   private initKeyInsights(): Signal<MarketingKeyInsight[]> {
     return computed(() => {
       const { totalMembers, changePercentage, breakdown, monthlyData } = this.data();
+      const brand = this.brandReachData();
       const insights: MarketingKeyInsight[] = [];
 
       if (totalMembers === 0 && monthlyData.length === 0) {
         return insights;
       }
 
-      // Growth trend
-      if (changePercentage > 5) {
-        insights.push({ text: `Community grew ${changePercentage}% month-over-month`, type: 'driver' });
-      } else if (changePercentage < -5) {
-        insights.push({ text: `Community declined ${Math.abs(changePercentage)}% month-over-month`, type: 'warning' });
-      } else if (changePercentage !== 0) {
-        insights.push({ text: `Community ${changePercentage > 0 ? 'up' : 'down'} ${Math.abs(changePercentage)}% — relatively stable`, type: 'info' });
+      // MoM headline
+      if (changePercentage >= 5) {
+        insights.push({ text: `Engaged community grew ${changePercentage.toFixed(1)}% MoM to ${formatNumber(totalMembers)}`, type: 'driver' });
+      } else if (changePercentage <= -2) {
+        insights.push({ text: `Engaged community declined ${Math.abs(changePercentage).toFixed(1)}% MoM`, type: 'warning' });
       }
 
-      // Largest segment
+      // 3-month consistent growth
+      if (monthlyData.length >= 3) {
+        const recent3 = monthlyData.slice(-3);
+        const isGrowing = recent3[0].value < recent3[1].value && recent3[1].value < recent3[2].value;
+        if (isGrowing) {
+          insights.push({ text: 'Engaged community growing for 3 consecutive months', type: 'driver' });
+        }
+      }
+
+      // Segment composition — keep in sync with initBreakdownChartData (Community / Working Groups / Certified)
       if (totalMembers > 0) {
         const segments = [
           { name: 'Community members', value: breakdown.communityMembers },
           { name: 'Working group members', value: breakdown.workingGroupMembers },
           { name: 'Certified individuals', value: breakdown.certifiedIndividuals },
         ].sort((a, b) => b.value - a.value);
-        const topShare = (segments[0].value / totalMembers) * 100;
-        insights.push({ text: `${segments[0].name} are the largest segment at ${topShare.toFixed(0)}% of total`, type: 'info' });
+        const top = segments[0];
+        const topShare = (top.value / totalMembers) * 100;
+        insights.push({ text: `${top.name} are the largest segment (${formatNumber(top.value)}, ${topShare.toFixed(0)}%)`, type: 'info' });
       }
 
-      // Monthly trend consistency
-      if (monthlyData.length >= 3) {
-        const recent3 = monthlyData.slice(-3);
-        const isGrowing = recent3[0].value < recent3[1].value && recent3[1].value < recent3[2].value;
-        const isShrinking = recent3[0].value > recent3[1].value && recent3[1].value > recent3[2].value;
-        if (isGrowing) {
-          insights.push({ text: 'Community growing for 3 consecutive months', type: 'driver' });
-        } else if (isShrinking) {
-          insights.push({ text: 'Community declining for 3 consecutive months', type: 'warning' });
+      // Weekly sessions — drawer renders 6-month weekly chart, compare recent 4 weeks vs prior 4
+      if (brand.dailyTrend.length >= 8) {
+        const recent4 = brand.dailyTrend.slice(-4).reduce((s, d) => s + d.sessions, 0);
+        const prior4 = brand.dailyTrend.slice(-8, -4).reduce((s, d) => s + d.sessions, 0);
+        if (prior4 === 0 && recent4 > 0) {
+          insights.push({
+            text: `Weekly sessions started growing from a zero baseline (${formatNumber(recent4)} last 4 weeks)`,
+            type: 'driver',
+          });
+        } else if (prior4 > 0) {
+          const monthDelta = ((recent4 - prior4) / prior4) * 100;
+          if (monthDelta >= 10) {
+            insights.push({ text: `Weekly sessions up ${monthDelta.toFixed(0)}% vs prior month (${formatNumber(recent4)} last 4 weeks)`, type: 'driver' });
+          } else if (monthDelta <= -10) {
+            insights.push({
+              text: `Weekly sessions down ${Math.abs(monthDelta).toFixed(0)}% vs prior month — investigate content or promotion changes`,
+              type: 'warning',
+            });
+          }
         }
       }
 
@@ -238,6 +301,26 @@ export class EngagedCommunityDrawerComponent {
             borderWidth: 2,
             pointRadius: 3,
             pointBackgroundColor: lfxColors.blue[500],
+          },
+        ],
+      };
+    });
+  }
+
+  private initDailyTrendData(): Signal<ChartData<'line'>> {
+    return computed(() => {
+      const { dailyTrend } = this.brandReachData();
+      return {
+        labels: dailyTrend.map((d) => d.day),
+        datasets: [
+          {
+            data: dailyTrend.map((d) => d.sessions),
+            borderColor: lfxColors.blue[500],
+            backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
+            fill: true,
+            tension: 0.4,
+            borderWidth: 2,
+            pointRadius: 0,
           },
         ],
       };

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DecimalPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -17,7 +18,7 @@ import type { BrandReachResponse, EngagedCommunitySizeResponse, MarketingKeyInsi
 @Component({
   selector: 'lfx-engaged-community-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, TagComponent, MarketingActionIconPipe],
+  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule, ChartComponent, TagComponent, MarketingActionIconPipe],
   templateUrl: './engaged-community-drawer.component.html',
   styleUrl: './engaged-community-drawer.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
@@ -8,7 +8,7 @@ import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { lfxColors } from '@lfx-one/shared/constants';
-import { formatNumber } from '@lfx-one/shared/utils';
+import { formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 
 import { DrawerModule } from 'primeng/drawer';
@@ -89,14 +89,15 @@ export class EventGrowthDrawerComponent {
   protected readonly monthlyChartData: Signal<ChartData<'bar'>> = this.initMonthlyChartData();
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
   protected onClose(): void {
     this.visible.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -33,13 +33,13 @@
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Re-engagement Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ reengagement().reengagementRate.toFixed(1) }}%</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ reengagement().reengagementRate | number: '1.1-1' }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Conversion Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().conversionRate.toFixed(1) }}%</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ data().conversionRate | number: '1.1-1' }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
@@ -48,7 +48,7 @@
           @if (reengagement().reengagementMomChange !== 0) {
             <div class="flex items-center gap-2">
               <span class="text-2xl font-semibold" [class]="reengagement().reengagementMomChange >= 0 ? 'text-green-600' : 'text-red-600'">
-                {{ reengagement().reengagementMomChange > 0 ? '+' : '' }}{{ reengagement().reengagementMomChange.toFixed(1) }}%
+                {{ reengagement().reengagementMomChange > 0 ? '+' : '' }}{{ reengagement().reengagementMomChange | number: '1.1-1' }}%
               </span>
               <i
                 class="text-sm"

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -74,7 +74,7 @@
         @for (action of attentionActions(); track action.title) {
           <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
             <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
-              <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
+              <i [class]="(action.actionType | marketingActionIcon) + ' text-red-600'"></i>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center justify-between gap-2">
@@ -113,7 +113,7 @@
         @for (action of performingActions(); track action.title) {
           <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
             <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
-              <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+              <i [class]="(action.actionType | marketingActionIcon) + ' text-green-600'"></i>
             </div>
             <div class="flex-1 min-w-0">
               <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -33,7 +33,7 @@
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Re-engagement Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().reengagement!.reengagementRate.toFixed(1) }}%</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ reengagement().reengagementRate.toFixed(1) }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
@@ -45,14 +45,14 @@
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Growth</span>
-          @if (data().reengagement!.reengagementMomChange !== 0) {
+          @if (reengagement().reengagementMomChange !== 0) {
             <div class="flex items-center gap-2">
-              <span class="text-2xl font-semibold" [class]="data().reengagement!.reengagementMomChange >= 0 ? 'text-green-600' : 'text-red-600'">
-                {{ data().reengagement!.reengagementMomChange > 0 ? '+' : '' }}{{ data().reengagement!.reengagementMomChange.toFixed(1) }}%
+              <span class="text-2xl font-semibold" [class]="reengagement().reengagementMomChange >= 0 ? 'text-green-600' : 'text-red-600'">
+                {{ reengagement().reengagementMomChange > 0 ? '+' : '' }}{{ reengagement().reengagementMomChange.toFixed(1) }}%
               </span>
               <i
                 class="text-sm"
-                [class]="data().reengagement!.reengagementMomChange >= 0 ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
+                [class]="reengagement().reengagementMomChange >= 0 ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>
           } @else {
             <span class="text-2xl font-semibold text-gray-500">0%</span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -32,25 +32,27 @@
     <div class="flex gap-4" data-testid="flywheel-conversion-drawer-stats">
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Conversion Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().conversionRate }}%</span>
+          <span class="text-sm text-gray-500">Re-engagement Rate</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ data().reengagement!.reengagementRate.toFixed(1) }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Event Attendees</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ formattedEventAttendees() }}</span>
+          <span class="text-sm text-gray-500">Conversion Rate</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ data().conversionRate.toFixed(1) }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Growth</span>
-          @if (data().changePercentage !== 0) {
+          @if (data().reengagement!.reengagementMomChange !== 0) {
             <div class="flex items-center gap-2">
-              <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage }}%
+              <span class="text-2xl font-semibold" [class]="data().reengagement!.reengagementMomChange >= 0 ? 'text-green-600' : 'text-red-600'">
+                {{ data().reengagement!.reengagementMomChange > 0 ? '+' : '' }}{{ data().reengagement!.reengagementMomChange.toFixed(1) }}%
               </span>
-              <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
+              <i
+                class="text-sm"
+                [class]="data().reengagement!.reengagementMomChange >= 0 ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>
           } @else {
             <span class="text-2xl font-semibold text-gray-500">0%</span>
@@ -133,22 +135,22 @@
       </div>
     }
 
-    <!-- Conversion Funnel Chart -->
+    <!-- Re-engagement Funnel Chart -->
     <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="flywheel-conversion-drawer-funnel-section">
       <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Conversion Funnel (90-day window)</h3>
-        <p class="text-sm text-gray-600">Event attendees converting to community or working group membership</p>
+        <h3 class="text-sm font-semibold text-gray-900">Re-engagement Funnel</h3>
+        <p class="text-sm text-gray-600">Event attendees re-engaging with community, working groups, and newsletter</p>
       </div>
       <div class="h-[200px]" data-testid="flywheel-conversion-drawer-funnel-chart">
         <lfx-chart type="bar" [data]="funnelChartData()" [options]="funnelChartOptions" height="100%"></lfx-chart>
       </div>
     </div>
 
-    <!-- Conversion Rate Trend Chart -->
+    <!-- Re-engagement Rate Trend Chart -->
     <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="flywheel-conversion-drawer-trend-section">
       <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Conversion Rate Trend</h3>
-        <p class="text-sm text-gray-600">Monthly flywheel conversion rate over the last 6 months</p>
+        <h3 class="text-sm font-semibold text-gray-900">Re-engaged Members Trend</h3>
+        <p class="text-sm text-gray-600">Monthly re-engaged members (count) over the last 6 months</p>
       </div>
       @if (data().monthlyData.length > 1) {
         <div class="h-[200px]" data-testid="flywheel-conversion-drawer-trend-chart">

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
@@ -6,23 +6,18 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import {
-  createHorizontalBarChartOptions,
-  createLineChartOptions,
-  DASHBOARD_TOOLTIP_CONFIG,
-  lfxColors,
-  MARKETING_ACTION_ICON_MAP,
-} from '@lfx-one/shared/constants';
-import { formatNumber, hexToRgba } from '@lfx-one/shared/utils';
+import { createHorizontalBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { ChartData, ChartOptions } from 'chart.js';
-import type { FlywheelConversionResponse, MarketingActionType, MarketingRecommendedAction, MarketingKeyInsight } from '@lfx-one/shared/interfaces';
+import type { FlywheelConversionResponse, MarketingKeyInsight, MarketingRecommendedAction } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-flywheel-conversion-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, TagComponent],
+  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, TagComponent, MarketingActionIconPipe],
   templateUrl: './flywheel-conversion-drawer.component.html',
   styleUrl: './flywheel-conversion-drawer.component.scss',
 })
@@ -78,14 +73,15 @@ export class FlywheelConversionDrawerComponent {
   protected readonly reengagementRate: Signal<string> = computed(() => `${this.reengagement().reengagementRate.toFixed(1)}%`);
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly trendChartData: Signal<ChartData<'line'>> = this.initTrendChartData();
   protected readonly funnelChartData: Signal<ChartData<'bar'>> = this.initFunnelChartData();
 
@@ -158,10 +154,6 @@ export class FlywheelConversionDrawerComponent {
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
-  }
-
-  protected actionIcon(type: MarketingActionType): string {
-    return MARKETING_ACTION_ICON_MAP[type];
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DecimalPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -17,7 +18,7 @@ import type { FlywheelConversionResponse, MarketingKeyInsight, MarketingRecommen
 @Component({
   selector: 'lfx-flywheel-conversion-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, TagComponent, MarketingActionIconPipe],
+  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule, ChartComponent, TagComponent, MarketingActionIconPipe],
   templateUrl: './flywheel-conversion-drawer.component.html',
   styleUrl: './flywheel-conversion-drawer.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
@@ -35,7 +35,15 @@ export class FlywheelConversionDrawerComponent {
     conversionRate: 0,
     changePercentage: 0,
     trend: 'up',
-    funnel: { eventAttendees: 0, convertedToNewsletter: 0, convertedToCommunity: 0, convertedToWorkingGroup: 0 },
+    funnel: {
+      eventAttendees: 0,
+      convertedToNewsletter: 0,
+      convertedToCommunity: 0,
+      convertedToWorkingGroup: 0,
+      convertedToTraining: 0,
+      convertedToCode: 0,
+      convertedToWeb: 0,
+    },
     reengagement: {
       totalReengaged: 0,
       reengagementRate: 0,
@@ -52,6 +60,7 @@ export class FlywheelConversionDrawerComponent {
 
   // === Computed Signals ===
   protected readonly formattedEventAttendees: Signal<string> = computed(() => formatNumber(this.data().funnel.eventAttendees));
+  protected readonly reengagementRate: Signal<string> = computed(() => `${this.data().reengagement!.reengagementRate.toFixed(1)}%`);
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
   protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
@@ -71,7 +80,7 @@ export class FlywheelConversionDrawerComponent {
       tooltip: {
         ...DASHBOARD_TOOLTIP_CONFIG,
         callbacks: {
-          label: (ctx) => ` ${(ctx.parsed.y ?? 0).toFixed(1)}% conversion rate`,
+          label: (ctx) => ` ${formatNumber(ctx.parsed.y ?? 0)} re-engaged`,
         },
       },
     },
@@ -89,7 +98,7 @@ export class FlywheelConversionDrawerComponent {
         ticks: {
           color: lfxColors.gray[500],
           font: { size: 11 },
-          callback: (value) => `${Number(value).toFixed(1)}%`,
+          callback: (value) => formatNumber(Number(value)),
         },
       },
     },
@@ -143,21 +152,22 @@ export class FlywheelConversionDrawerComponent {
   // === Private Initializers ===
   private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
     return computed(() => {
-      const { conversionRate, changePercentage, funnel, monthlyData } = this.data();
+      const { conversionRate, funnel, monthlyData } = this.data();
+      const reengagement = this.data().reengagement!;
       const actions: MarketingRecommendedAction[] = [];
 
       if (conversionRate === 0 && funnel.eventAttendees === 0 && monthlyData.length === 0) {
         return actions;
       }
 
-      // Low WG conversion relative to community conversion
-      if (funnel.eventAttendees > 0 && funnel.convertedToWorkingGroup > 0 && funnel.convertedToCommunity > 0) {
-        const wgRate = (funnel.convertedToWorkingGroup / funnel.eventAttendees) * 100;
-        const communityRate = (funnel.convertedToCommunity / funnel.eventAttendees) * 100;
+      // Low WG re-engagement relative to community re-engagement
+      if (funnel.eventAttendees > 0 && reengagement.reengagedToWorkingGroup > 0 && reengagement.reengagedToCommunity > 0) {
+        const wgRate = (reengagement.reengagedToWorkingGroup / funnel.eventAttendees) * 100;
+        const communityRate = (reengagement.reengagedToCommunity / funnel.eventAttendees) * 100;
         if (wgRate < communityRate * 0.5) {
           actions.push({
-            title: 'Improve working group conversion path',
-            description: `WG conversion at ${wgRate.toFixed(1)}% vs ${communityRate.toFixed(1)}% for community — attendees need clearer path to participate`,
+            title: 'Improve working group re-engagement path',
+            description: `WG re-engagement at ${wgRate.toFixed(1)}% vs ${communityRate.toFixed(1)}% for community — attendees need clearer path to participate`,
             priority: 'high',
             dueLabel: 'This quarter',
             actionType: 'conversion',
@@ -165,22 +175,22 @@ export class FlywheelConversionDrawerComponent {
         }
       }
 
-      // Declining conversion rate
-      if (changePercentage < -5) {
+      // Declining re-engagement rate
+      if (reengagement.reengagementMomChange < -5) {
         actions.push({
-          title: 'Address conversion rate decline',
-          description: `Flywheel conversion dropped ${Math.abs(changePercentage)}% — review post-event follow-up effectiveness`,
+          title: 'Address re-engagement rate decline',
+          description: `Re-engagement dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% MoM — review post-event follow-up effectiveness`,
           priority: 'high',
           dueLabel: 'This month',
           actionType: 'decline',
         });
       }
 
-      // Low overall conversion
-      if (conversionRate > 0 && conversionRate < 10 && funnel.eventAttendees > 0) {
+      // Low overall re-engagement
+      if (reengagement.reengagementRate > 0 && reengagement.reengagementRate < 10 && funnel.eventAttendees > 0) {
         actions.push({
           title: 'Add post-event engagement CTAs',
-          description: `Only ${conversionRate}% overall conversion — add community join and working group prompts to event follow-ups`,
+          description: `Only ${reengagement.reengagementRate.toFixed(1)}% re-engagement — add community join and working group prompts to event follow-ups`,
           priority: 'medium',
           dueLabel: 'Next event',
           actionType: 'content',
@@ -190,7 +200,7 @@ export class FlywheelConversionDrawerComponent {
       if (actions.length === 0) {
         actions.push({
           title: 'Continue flywheel optimization',
-          description: `${conversionRate}% conversion rate${changePercentage > 0 ? ` — improving ${changePercentage}%` : ''} across ${formatNumber(funnel.eventAttendees)} attendees`,
+          description: `${reengagement.reengagementRate.toFixed(1)}% re-engagement rate${reengagement.reengagementMomChange > 0 ? ` — improving ${reengagement.reengagementMomChange.toFixed(1)}%` : ''} across ${formatNumber(funnel.eventAttendees)} attendees`,
           priority: 'low',
           dueLabel: 'Ongoing',
           actionType: 'growth',
@@ -203,50 +213,58 @@ export class FlywheelConversionDrawerComponent {
 
   private initKeyInsights(): Signal<MarketingKeyInsight[]> {
     return computed(() => {
-      const { conversionRate, changePercentage, funnel, monthlyData } = this.data();
+      const { conversionRate, funnel, monthlyData } = this.data();
+      const reengagement = this.data().reengagement!;
       const insights: MarketingKeyInsight[] = [];
 
       if (conversionRate === 0 && funnel.eventAttendees === 0 && monthlyData.length === 0) {
         return insights;
       }
 
-      // Best conversion path
+      // Best re-engagement path
       if (funnel.eventAttendees > 0) {
         const paths = [
-          { name: 'Community', value: funnel.convertedToCommunity },
-          { name: 'Working group', value: funnel.convertedToWorkingGroup },
+          { name: 'Community', value: reengagement.reengagedToCommunity },
+          { name: 'Working group', value: reengagement.reengagedToWorkingGroup },
+          { name: 'Newsletter', value: reengagement.reengagedToNewsletter },
+          { name: 'Training', value: reengagement.reengagedToTraining },
+          { name: 'Code', value: reengagement.reengagedToCode },
+          { name: 'Web', value: reengagement.reengagedToWeb },
         ]
           .filter((p) => p.value > 0)
           .sort((a, b) => b.value - a.value);
 
         if (paths.length > 0) {
           const bestRate = (paths[0].value / funnel.eventAttendees) * 100;
-          insights.push({ text: `${paths[0].name} is the highest conversion path at ${bestRate.toFixed(1)}% of attendees`, type: 'driver' });
+          insights.push({ text: `${paths[0].name} is the highest re-engagement path at ${bestRate.toFixed(1)}% of attendees`, type: 'driver' });
         }
 
         // Weakest path
         if (paths.length > 1) {
           const worstRate = (paths[paths.length - 1].value / funnel.eventAttendees) * 100;
-          insights.push({ text: `${paths[paths.length - 1].name} conversion lowest at ${worstRate.toFixed(1)}%`, type: 'warning' });
+          insights.push({ text: `${paths[paths.length - 1].name} re-engagement lowest at ${worstRate.toFixed(1)}%`, type: 'warning' });
         }
       }
 
-      // Conversion trend
-      if (changePercentage > 3) {
-        insights.push({ text: `Conversion rate trending up ${changePercentage}% — flywheel is accelerating`, type: 'driver' });
-      } else if (changePercentage < -3) {
-        insights.push({ text: `Conversion rate dropped ${Math.abs(changePercentage)}% — flywheel is slowing`, type: 'warning' });
+      // Re-engagement MoM trend
+      if (reengagement.reengagementMomChange > 3) {
+        insights.push({ text: `Re-engagement rate trending up ${reengagement.reengagementMomChange.toFixed(1)}% — flywheel is accelerating`, type: 'driver' });
+      } else if (reengagement.reengagementMomChange < -3) {
+        insights.push({
+          text: `Re-engagement rate dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% — flywheel is slowing`,
+          type: 'warning',
+        });
       }
 
-      // Monthly trend consistency
+      // Re-engaged count trend (monthlyData.value = TOTAL_REENGAGED)
       if (monthlyData.length >= 3) {
         const recent3 = monthlyData.slice(-3);
         const isGrowing = recent3[0].value < recent3[1].value && recent3[1].value < recent3[2].value;
         const isShrinking = recent3[0].value > recent3[1].value && recent3[1].value > recent3[2].value;
         if (isGrowing) {
-          insights.push({ text: 'Conversion rate growing for 3 consecutive months', type: 'driver' });
+          insights.push({ text: `Re-engaged members growing for 3 consecutive months — ${formatNumber(recent3[2].value)} this month`, type: 'driver' });
         } else if (isShrinking) {
-          insights.push({ text: 'Conversion rate declining for 3 consecutive months', type: 'warning' });
+          insights.push({ text: `Re-engaged members declining for 3 consecutive months — ${formatNumber(recent3[2].value)} this month`, type: 'warning' });
         }
       }
 
@@ -278,12 +296,37 @@ export class FlywheelConversionDrawerComponent {
   private initFunnelChartData(): Signal<ChartData<'bar'>> {
     return computed(() => {
       const { funnel } = this.data();
+      const reengagement = this.data().reengagement!;
       return {
-        labels: ['Event Attendees', 'Converted to Community', 'Converted to WG'],
+        labels: [
+          'Event Attendees',
+          'Re-engaged to Community',
+          'Re-engaged to WG',
+          'Re-engaged to Newsletter',
+          'Re-engaged to Training',
+          'Re-engaged to Code',
+          'Re-engaged to Web',
+        ],
         datasets: [
           {
-            data: [funnel.eventAttendees, funnel.convertedToCommunity, funnel.convertedToWorkingGroup],
-            backgroundColor: [lfxColors.blue[700], lfxColors.blue[500], lfxColors.blue[400], lfxColors.blue[300]],
+            data: [
+              funnel.eventAttendees,
+              reengagement.reengagedToCommunity,
+              reengagement.reengagedToWorkingGroup,
+              reengagement.reengagedToNewsletter,
+              reengagement.reengagedToTraining,
+              reengagement.reengagedToCode,
+              reengagement.reengagedToWeb,
+            ],
+            backgroundColor: [
+              lfxColors.blue[700],
+              lfxColors.blue[500],
+              lfxColors.blue[400],
+              lfxColors.blue[300],
+              lfxColors.emerald[600],
+              lfxColors.emerald[500],
+              lfxColors.emerald[400],
+            ],
             borderRadius: { topLeft: 0, bottomLeft: 0, topRight: 4, bottomRight: 4 },
             borderSkipped: 'start',
           },

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
@@ -58,9 +58,24 @@ export class FlywheelConversionDrawerComponent {
     monthlyData: [],
   });
 
+  private readonly defaultReengagement: NonNullable<FlywheelConversionResponse['reengagement']> = {
+    totalReengaged: 0,
+    reengagementRate: 0,
+    reengagementMomChange: 0,
+    reengagedToNewsletter: 0,
+    reengagedToCommunity: 0,
+    reengagedToWorkingGroup: 0,
+    reengagedToTraining: 0,
+    reengagedToCode: 0,
+    reengagedToWeb: 0,
+  };
+
   // === Computed Signals ===
   protected readonly formattedEventAttendees: Signal<string> = computed(() => formatNumber(this.data().funnel.eventAttendees));
-  protected readonly reengagementRate: Signal<string> = computed(() => `${this.data().reengagement!.reengagementRate.toFixed(1)}%`);
+  protected readonly reengagement: Signal<NonNullable<FlywheelConversionResponse['reengagement']>> = computed(
+    () => this.data().reengagement ?? this.defaultReengagement
+  );
+  protected readonly reengagementRate: Signal<string> = computed(() => `${this.reengagement().reengagementRate.toFixed(1)}%`);
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
   protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
@@ -153,7 +168,7 @@ export class FlywheelConversionDrawerComponent {
   private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
     return computed(() => {
       const { conversionRate, funnel, monthlyData } = this.data();
-      const reengagement = this.data().reengagement!;
+      const reengagement = this.reengagement();
       const actions: MarketingRecommendedAction[] = [];
 
       if (conversionRate === 0 && funnel.eventAttendees === 0 && monthlyData.length === 0) {
@@ -214,7 +229,7 @@ export class FlywheelConversionDrawerComponent {
   private initKeyInsights(): Signal<MarketingKeyInsight[]> {
     return computed(() => {
       const { conversionRate, funnel, monthlyData } = this.data();
-      const reengagement = this.data().reengagement!;
+      const reengagement = this.reengagement();
       const insights: MarketingKeyInsight[] = [];
 
       if (conversionRate === 0 && funnel.eventAttendees === 0 && monthlyData.length === 0) {
@@ -296,7 +311,7 @@ export class FlywheelConversionDrawerComponent {
   private initFunnelChartData(): Signal<ChartData<'bar'>> {
     return computed(() => {
       const { funnel } = this.data();
-      const reengagement = this.data().reengagement!;
+      const reengagement = this.reengagement();
       return {
         labels: [
           'Event Attendees',

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -10,11 +10,7 @@
 
     <div class="flex items-center gap-4">
       <!-- Filter Pills -->
-      <lfx-filter-pills
-        [options]="filterOptions"
-        [selectedFilter]="selectedFilter()"
-        (filterChange)="selectedFilter.set($any($event))"
-        data-testid="ed-evolution-filters" />
+      <lfx-filter-pills [options]="filterOptions" [selectedFilter]="selectedFilter()" (filterChange)="setFilter($event)" data-testid="ed-evolution-filters" />
 
       <!-- Carousel Controls -->
       <div class="flex items-center gap-2">
@@ -38,123 +34,128 @@
     </div>
   </div>
 
+  <!-- Reusable card template used by both North Star and non-North-Star loops -->
+  <ng-template #metricCardTpl let-card>
+    @switch (card.customContentType) {
+      @case ('dual-signal') {
+        <!-- Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact) -->
+        <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
+          <lfx-metric-card
+            [title]="card.title"
+            [icon]="card.icon"
+            [testId]="card.testId"
+            [chartType]="card.chartType"
+            [clickable]="!!card.drawerType"
+            [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+            (cardClick)="handleCardClick(card.drawerType!)">
+            <ng-template #customContent>
+              <div class="flex flex-col gap-0 flex-1">
+                @if (card.dualSignals) {
+                  @for (row of card.dualSignals; track row.label; let last = $last) {
+                    <div class="flex flex-col gap-1 py-2">
+                      <div class="flex items-center justify-between">
+                        <span class="text-xs text-gray-500">{{ row.label }}</span>
+                        @if (row.changePercentage) {
+                          <span class="text-xs font-medium" [class.text-emerald-600]="row.trend === 'up'" [class.text-red-600]="row.trend === 'down'">
+                            {{ row.changePercentage }}
+                          </span>
+                        }
+                      </div>
+                      <div class="flex items-center gap-3">
+                        <span class="text-lg font-semibold text-gray-900 flex-shrink-0">{{ row.value }}</span>
+                        @if (row.chartData) {
+                          <div class="flex-1 h-8">
+                            <lfx-chart type="line" [data]="row.chartData" [options]="noTooltipChartOptions" height="100%"></lfx-chart>
+                          </div>
+                        }
+                      </div>
+                    </div>
+                    @if (!last) {
+                      <div class="border-t border-gray-100"></div>
+                    }
+                  }
+                }
+                @if (card.caption) {
+                  <div class="text-[10px] text-gray-400 mt-1">{{ card.caption }}</div>
+                }
+              </div>
+            </ng-template>
+          </lfx-metric-card>
+        </div>
+      }
+      @case ('funnel') {
+        <!-- Funnel Card (Flywheel Conversion) -->
+        <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
+          <lfx-metric-card
+            [title]="card.title"
+            [icon]="card.icon"
+            [testId]="card.testId"
+            [chartType]="card.chartType"
+            [clickable]="!!card.drawerType"
+            [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+            (cardClick)="handleCardClick(card.drawerType!)">
+            <ng-template #customContent>
+              <div class="flex flex-col gap-2 flex-1">
+                <!-- Primary Value + Trend -->
+                <div class="flex items-center gap-2">
+                  <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
+                  @if (card.changePercentage) {
+                    <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
+                      {{ card.changePercentage }}
+                    </span>
+                  }
+                </div>
+
+                <!-- Mini Funnel Step-Down -->
+                @if (card.funnelSteps) {
+                  <div class="flex items-center gap-1">
+                    @for (step of card.funnelSteps; track step.label; let last = $last) {
+                      <div class="flex flex-col items-center gap-0 flex-1 min-w-0">
+                        <span class="text-[10px] text-gray-400 truncate">{{ step.label }}</span>
+                        <span class="text-xs font-semibold text-gray-700">{{ step.value }}</span>
+                      </div>
+                      @if (!last) {
+                        <i class="fa-light fa-chevron-right text-[8px] text-gray-300 flex-shrink-0"></i>
+                      }
+                    }
+                  </div>
+                }
+
+                @if (card.subtitle) {
+                  <div class="text-[10px] text-gray-400">{{ card.subtitle }}</div>
+                }
+              </div>
+            </ng-template>
+          </lfx-metric-card>
+        </div>
+      }
+      @default {
+        <!-- Standard Single-Signal Card -->
+        <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
+          <lfx-metric-card
+            [title]="card.title"
+            [icon]="card.icon"
+            [testId]="card.testId"
+            [chartType]="card.chartType"
+            [chartData]="card.chartData"
+            [chartOptions]="card.chartOptions"
+            [value]="card.value"
+            [subtitle]="card.subtitle"
+            [trend]="card.trend"
+            [changePercentage]="card.changePercentage"
+            [clickable]="!!card.drawerType"
+            (cardClick)="handleCardClick(card.drawerType!)">
+          </lfx-metric-card>
+        </div>
+      }
+    }
+  </ng-template>
+
   <!-- Carousel Container -->
   <div class="relative overflow-hidden">
     <div lfxScrollShadow [scrollDistance]="320" class="flex gap-4 overflow-x-auto hide-scrollbar scroll-smooth" data-testid="ed-evolution-carousel">
       @for (card of northStarCards(); track card.testId) {
-        @switch (card.customContentType) {
-          @case ('dual-signal') {
-            <!-- Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact) -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
-              <lfx-metric-card
-                [title]="card.title"
-                [icon]="card.icon"
-                [testId]="card.testId"
-                [chartType]="card.chartType"
-                [clickable]="!!card.drawerType"
-                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
-                (cardClick)="handleCardClick(card.drawerType!)">
-                <ng-template #customContent>
-                  <div class="flex flex-col gap-0 flex-1">
-                    @if (card.dualSignals) {
-                      @for (row of card.dualSignals; track row.label; let last = $last) {
-                        <div class="flex flex-col gap-1 py-2">
-                          <div class="flex items-center justify-between">
-                            <span class="text-xs text-gray-500">{{ row.label }}</span>
-                            @if (row.changePercentage) {
-                              <span class="text-xs font-medium" [class.text-emerald-600]="row.trend === 'up'" [class.text-red-600]="row.trend === 'down'">
-                                {{ row.changePercentage }}
-                              </span>
-                            }
-                          </div>
-                          <div class="flex items-center gap-3">
-                            <span class="text-lg font-semibold text-gray-900 flex-shrink-0">{{ row.value }}</span>
-                            @if (row.chartData) {
-                              <div class="flex-1 h-8">
-                                <lfx-chart type="line" [data]="row.chartData" [options]="noTooltipChartOptions" height="100%"></lfx-chart>
-                              </div>
-                            }
-                          </div>
-                        </div>
-                        @if (!last) {
-                          <div class="border-t border-gray-100"></div>
-                        }
-                      }
-                    }
-                    @if (card.caption) {
-                      <div class="text-[10px] text-gray-400 mt-1">{{ card.caption }}</div>
-                    }
-                  </div>
-                </ng-template>
-              </lfx-metric-card>
-            </div>
-          }
-          @case ('funnel') {
-            <!-- Funnel Card (Flywheel Conversion) -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
-              <lfx-metric-card
-                [title]="card.title"
-                [icon]="card.icon"
-                [testId]="card.testId"
-                [chartType]="card.chartType"
-                [clickable]="!!card.drawerType"
-                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
-                (cardClick)="handleCardClick(card.drawerType!)">
-                <ng-template #customContent>
-                  <div class="flex flex-col gap-2 flex-1">
-                    <!-- Primary Value + Trend -->
-                    <div class="flex items-center gap-2">
-                      <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
-                      @if (card.changePercentage) {
-                        <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
-                          {{ card.changePercentage }}
-                        </span>
-                      }
-                    </div>
-
-                    <!-- Mini Funnel Step-Down -->
-                    @if (card.funnelSteps) {
-                      <div class="flex items-center gap-1">
-                        @for (step of card.funnelSteps; track step.label; let last = $last) {
-                          <div class="flex flex-col items-center gap-0 flex-1 min-w-0">
-                            <span class="text-[10px] text-gray-400 truncate">{{ step.label }}</span>
-                            <span class="text-xs font-semibold text-gray-700">{{ step.value }}</span>
-                          </div>
-                          @if (!last) {
-                            <i class="fa-light fa-chevron-right text-[8px] text-gray-300 flex-shrink-0"></i>
-                          }
-                        }
-                      </div>
-                    }
-
-                    @if (card.subtitle) {
-                      <div class="text-[10px] text-gray-400">{{ card.subtitle }}</div>
-                    }
-                  </div>
-                </ng-template>
-              </lfx-metric-card>
-            </div>
-          }
-          @default {
-            <!-- Standard Single-Signal Card -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
-              <lfx-metric-card
-                [title]="card.title"
-                [icon]="card.icon"
-                [testId]="card.testId"
-                [chartType]="card.chartType"
-                [chartData]="card.chartData"
-                [chartOptions]="card.chartOptions"
-                [value]="card.value"
-                [subtitle]="card.subtitle"
-                [trend]="card.trend"
-                [changePercentage]="card.changePercentage"
-                [clickable]="!!card.drawerType"
-                (cardClick)="handleCardClick(card.drawerType!)">
-              </lfx-metric-card>
-            </div>
-          }
-        }
+        <ng-container *ngTemplateOutlet="metricCardTpl; context: { $implicit: card }"></ng-container>
       }
 
       <!-- Marketing Metrics Key Insights Card (between North Star and Brand/Influence) -->
@@ -190,117 +191,7 @@
       }
 
       @for (card of nonNorthStarCards(); track card.testId) {
-        @switch (card.customContentType) {
-          @case ('dual-signal') {
-            <!-- Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact) -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
-              <lfx-metric-card
-                [title]="card.title"
-                [icon]="card.icon"
-                [testId]="card.testId"
-                [chartType]="card.chartType"
-                [clickable]="!!card.drawerType"
-                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
-                (cardClick)="handleCardClick(card.drawerType!)">
-                <ng-template #customContent>
-                  <div class="flex flex-col gap-0 flex-1">
-                    @if (card.dualSignals) {
-                      @for (row of card.dualSignals; track row.label; let last = $last) {
-                        <div class="flex flex-col gap-1 py-2">
-                          <div class="flex items-center justify-between">
-                            <span class="text-xs text-gray-500">{{ row.label }}</span>
-                            @if (row.changePercentage) {
-                              <span class="text-xs font-medium" [class.text-emerald-600]="row.trend === 'up'" [class.text-red-600]="row.trend === 'down'">
-                                {{ row.changePercentage }}
-                              </span>
-                            }
-                          </div>
-                          <div class="flex items-center gap-3">
-                            <span class="text-lg font-semibold text-gray-900 flex-shrink-0">{{ row.value }}</span>
-                            @if (row.chartData) {
-                              <div class="flex-1 h-8">
-                                <lfx-chart type="line" [data]="row.chartData" [options]="noTooltipChartOptions" height="100%"></lfx-chart>
-                              </div>
-                            }
-                          </div>
-                        </div>
-                        @if (!last) {
-                          <div class="border-t border-gray-100"></div>
-                        }
-                      }
-                    }
-                    @if (card.caption) {
-                      <div class="text-[10px] text-gray-400 mt-1">{{ card.caption }}</div>
-                    }
-                  </div>
-                </ng-template>
-              </lfx-metric-card>
-            </div>
-          }
-          @case ('funnel') {
-            <!-- Funnel Card (Flywheel Conversion) -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
-              <lfx-metric-card
-                [title]="card.title"
-                [icon]="card.icon"
-                [testId]="card.testId"
-                [chartType]="card.chartType"
-                [clickable]="!!card.drawerType"
-                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
-                (cardClick)="handleCardClick(card.drawerType!)">
-                <ng-template #customContent>
-                  <div class="flex flex-col gap-2 flex-1">
-                    <div class="flex items-center gap-2">
-                      <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
-                      @if (card.changePercentage) {
-                        <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
-                          {{ card.changePercentage }}
-                        </span>
-                      }
-                    </div>
-
-                    @if (card.funnelSteps) {
-                      <div class="flex items-center gap-1">
-                        @for (step of card.funnelSteps; track step.label; let last = $last) {
-                          <div class="flex flex-col items-center gap-0 flex-1 min-w-0">
-                            <span class="text-[10px] text-gray-400 truncate">{{ step.label }}</span>
-                            <span class="text-xs font-semibold text-gray-700">{{ step.value }}</span>
-                          </div>
-                          @if (!last) {
-                            <i class="fa-light fa-chevron-right text-[8px] text-gray-300 flex-shrink-0"></i>
-                          }
-                        }
-                      </div>
-                    }
-
-                    @if (card.subtitle) {
-                      <div class="text-[10px] text-gray-400">{{ card.subtitle }}</div>
-                    }
-                  </div>
-                </ng-template>
-              </lfx-metric-card>
-            </div>
-          }
-          @default {
-            <!-- Standard Single-Signal Card -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
-              <lfx-metric-card
-                [title]="card.title"
-                [icon]="card.icon"
-                [testId]="card.testId"
-                [chartType]="card.chartType"
-                [chartData]="card.chartData"
-                [chartOptions]="card.chartOptions"
-                [value]="card.value"
-                [subtitle]="card.subtitle"
-                [trend]="card.trend"
-                [changePercentage]="card.changePercentage"
-                [clickable]="!!card.drawerType"
-                (cardClick)="handleCardClick(card.drawerType!)">
-              </lfx-metric-card>
-            </div>
-          }
-        }
+        <ng-container *ngTemplateOutlet="metricCardTpl; context: { $implicit: card }"></ng-container>
       }
     </div>
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -45,7 +45,7 @@
         @switch (card.customContentType) {
           @case ('dual-signal') {
             <!-- Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact) -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
               <lfx-metric-card
                 [title]="card.title"
                 [icon]="card.icon"
@@ -91,7 +91,7 @@
           }
           @case ('funnel') {
             <!-- Funnel Card (Flywheel Conversion) -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
               <lfx-metric-card
                 [title]="card.title"
                 [icon]="card.icon"
@@ -137,7 +137,7 @@
           }
           @default {
             <!-- Standard Single-Signal Card -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
               <lfx-metric-card
                 [title]="card.title"
                 [icon]="card.icon"
@@ -193,7 +193,7 @@
         @switch (card.customContentType) {
           @case ('dual-signal') {
             <!-- Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact) -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
               <lfx-metric-card
                 [title]="card.title"
                 [icon]="card.icon"
@@ -239,7 +239,7 @@
           }
           @case ('funnel') {
             <!-- Funnel Card (Flywheel Conversion) -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
               <lfx-metric-card
                 [title]="card.title"
                 [icon]="card.icon"
@@ -283,7 +283,7 @@
           }
           @default {
             <!-- Standard Single-Signal Card -->
-            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" class="flex-shrink-0">
               <lfx-metric-card
                 [title]="card.title"
                 [icon]="card.icon"
@@ -319,10 +319,10 @@
       aria-hidden="true"></div>
   </div>
 
-  <!-- Prototype indicator -->
+  <!-- Data source hint -->
   <div class="flex items-center gap-1 mt-2 text-xs text-gray-400">
     <i class="fa-light fa-circle-info"></i>
-    <span>Hover over any card for data source details · Prototype with dummy data</span>
+    <span>Hover over any card for data source details</span>
   </div>
 </section>
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -1,145 +1,306 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<section data-testid="marketing-overview-section">
+<section data-testid="ed-evolution-section">
   <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
     <div class="flex flex-col gap-1">
       <h2 class="mb-0">Executive Director Overview</h2>
-      <p class="text-sm text-gray-500 mb-0">North Star KPIs · Marketing Metrics</p>
+      <p class="text-sm text-gray-500 mb-0">North Star KPIs · Brand · Influence</p>
     </div>
 
-    <!-- Carousel Controls -->
-    <div class="flex items-center gap-2">
-      <lfx-button
-        icon="fa-light fa-chevron-left"
-        [outlined]="true"
-        severity="secondary"
-        size="small"
-        ariaLabel="Scroll left"
-        (onClick)="scrollShadowDirective()?.scrollLeft()"
-        data-testid="marketing-overview-carousel-prev" />
-      <lfx-button
-        icon="fa-light fa-chevron-right"
-        [outlined]="true"
-        severity="secondary"
-        size="small"
-        ariaLabel="Scroll right"
-        (onClick)="scrollShadowDirective()?.scrollRight()"
-        data-testid="marketing-overview-carousel-next" />
+    <div class="flex items-center gap-4">
+      <!-- Filter Pills -->
+      <lfx-filter-pills
+        [options]="filterOptions"
+        [selectedFilter]="selectedFilter()"
+        (filterChange)="selectedFilter.set($any($event))"
+        data-testid="ed-evolution-filters" />
+
+      <!-- Carousel Controls -->
+      <div class="flex items-center gap-2">
+        <lfx-button
+          icon="fa-light fa-chevron-left"
+          [outlined]="true"
+          severity="secondary"
+          size="small"
+          ariaLabel="Scroll left"
+          (onClick)="scrollShadowDirective()?.scrollLeft()"
+          data-testid="ed-evolution-carousel-prev" />
+        <lfx-button
+          icon="fa-light fa-chevron-right"
+          [outlined]="true"
+          severity="secondary"
+          size="small"
+          ariaLabel="Scroll right"
+          (onClick)="scrollShadowDirective()?.scrollRight()"
+          data-testid="ed-evolution-carousel-next" />
+      </div>
     </div>
   </div>
 
   <!-- Carousel Container -->
   <div class="relative overflow-hidden">
-    <div lfxScrollShadow [scrollDistance]="320" class="flex gap-4 overflow-x-auto hide-scrollbar scroll-smooth" data-testid="marketing-overview-carousel">
-      <!-- North Star Metrics -->
-      <lfx-metric-card
-        title="Flywheel Conversion"
-        icon="fa-light fa-arrows-spin"
-        chartType="line"
-        [chartData]="flywheelChartData()"
-        [chartOptions]="noTooltipChartOptions"
-        [value]="marketingData().flywheelConversion.conversionRate > 0 ? marketingData().flywheelConversion.conversionRate + '%' : undefined"
-        [changePercentage]="
-          marketingData().flywheelConversion.changePercentage !== 0
-            ? (marketingData().flywheelConversion.changePercentage > 0 ? '+' : '') + marketingData().flywheelConversion.changePercentage + '%'
-            : undefined
-        "
-        [trend]="marketingData().flywheelConversion.trend"
-        subtitle="Event attendee → community/WG within 90 days"
-        testId="flywheel-pulse-conversion"
-        [loading]="marketingDataLoading()"
-        [clickable]="true"
-        (cardClick)="handleCardClick(DashboardDrawerType.NorthStarFlywheelConversion)"></lfx-metric-card>
+    <div lfxScrollShadow [scrollDistance]="320" class="flex gap-4 overflow-x-auto hide-scrollbar scroll-smooth" data-testid="ed-evolution-carousel">
+      @for (card of northStarCards(); track card.testId) {
+        @switch (card.customContentType) {
+          @case ('dual-signal') {
+            <!-- Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact) -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [clickable]="!!card.drawerType"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+                (cardClick)="handleCardClick(card.drawerType!)">
+                <ng-template #customContent>
+                  <div class="flex flex-col gap-0 flex-1">
+                    @if (card.dualSignals) {
+                      @for (row of card.dualSignals; track row.label; let last = $last) {
+                        <div class="flex flex-col gap-1 py-2">
+                          <div class="flex items-center justify-between">
+                            <span class="text-xs text-gray-500">{{ row.label }}</span>
+                            @if (row.changePercentage) {
+                              <span class="text-xs font-medium" [class.text-emerald-600]="row.trend === 'up'" [class.text-red-600]="row.trend === 'down'">
+                                {{ row.changePercentage }}
+                              </span>
+                            }
+                          </div>
+                          <div class="flex items-center gap-3">
+                            <span class="text-lg font-semibold text-gray-900 flex-shrink-0">{{ row.value }}</span>
+                            @if (row.chartData) {
+                              <div class="flex-1 h-8">
+                                <lfx-chart type="line" [data]="row.chartData" [options]="noTooltipChartOptions" height="100%"></lfx-chart>
+                              </div>
+                            }
+                          </div>
+                        </div>
+                        @if (!last) {
+                          <div class="border-t border-gray-100"></div>
+                        }
+                      }
+                    }
+                    @if (card.caption) {
+                      <div class="text-[10px] text-gray-400 mt-1">{{ card.caption }}</div>
+                    }
+                  </div>
+                </ng-template>
+              </lfx-metric-card>
+            </div>
+          }
+          @case ('funnel') {
+            <!-- Funnel Card (Flywheel Conversion) -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [clickable]="!!card.drawerType"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+                (cardClick)="handleCardClick(card.drawerType!)">
+                <ng-template #customContent>
+                  <div class="flex flex-col gap-2 flex-1">
+                    <!-- Primary Value + Trend -->
+                    <div class="flex items-center gap-2">
+                      <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
+                      @if (card.changePercentage) {
+                        <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
+                          {{ card.changePercentage }}
+                        </span>
+                      }
+                    </div>
 
-      <lfx-metric-card
-        title="Member Growth"
-        icon="fa-light fa-user-group"
-        chartType="line"
-        [chartData]="memberGrowthChartData()"
-        [chartOptions]="noTooltipChartOptions"
-        [value]="marketingData().memberAcquisition.totalMembers > 0 ? formatNumber(marketingData().memberAcquisition.totalMembers) : undefined"
-        [changePercentage]="
-          marketingData().memberAcquisition.newMembersThisQuarter > 0
-            ? '+' + marketingData().memberAcquisition.newMembersThisQuarter + ' this quarter'
-            : undefined
-        "
-        trend="up"
-        [subtitle]="
-          marketingData().memberRetention.renewalRate > 0
-            ? marketingData().memberRetention.renewalRate + '% retention · NRR ' + marketingData().memberRetention.netRevenueRetention + '%'
-            : undefined
-        "
-        testId="flywheel-pulse-member-growth"
-        [loading]="marketingDataLoading()"
-        [clickable]="true"
-        (cardClick)="handleCardClick(DashboardDrawerType.NorthStarMemberAcquisition)"></lfx-metric-card>
+                    <!-- Mini Funnel Step-Down -->
+                    @if (card.funnelSteps) {
+                      <div class="flex items-center gap-1">
+                        @for (step of card.funnelSteps; track step.label; let last = $last) {
+                          <div class="flex flex-col items-center gap-0 flex-1 min-w-0">
+                            <span class="text-[10px] text-gray-400 truncate">{{ step.label }}</span>
+                            <span class="text-xs font-semibold text-gray-700">{{ step.value }}</span>
+                          </div>
+                          @if (!last) {
+                            <i class="fa-light fa-chevron-right text-[8px] text-gray-300 flex-shrink-0"></i>
+                          }
+                        }
+                      </div>
+                    }
 
-      <lfx-metric-card
-        title="Engaged Community"
-        icon="fa-light fa-people-group"
-        chartType="line"
-        [chartData]="engagedCommunityChartData()"
-        [chartOptions]="noTooltipChartOptions"
-        [value]="marketingData().engagedCommunity.totalMembers > 0 ? formatNumber(marketingData().engagedCommunity.totalMembers) : undefined"
-        [changePercentage]="
-          marketingData().engagedCommunity.changePercentage !== 0
-            ? (marketingData().engagedCommunity.changePercentage > 0 ? '↑ +' : '↓ ') + marketingData().engagedCommunity.changePercentage + '%'
-            : undefined
-        "
-        [trend]="marketingData().engagedCommunity.trend"
-        subtitle="Community + Working Groups + Certified"
-        testId="flywheel-pulse-share-of-voice"
-        [loading]="marketingDataLoading()"
-        [clickable]="true"
-        (cardClick)="handleCardClick(DashboardDrawerType.NorthStarEngagedCommunity)"></lfx-metric-card>
+                    @if (card.subtitle) {
+                      <div class="text-[10px] text-gray-400">{{ card.subtitle }}</div>
+                    }
+                  </div>
+                </ng-template>
+              </lfx-metric-card>
+            </div>
+          }
+          @default {
+            <!-- Standard Single-Signal Card -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [chartData]="card.chartData"
+                [chartOptions]="card.chartOptions"
+                [value]="card.value"
+                [subtitle]="card.subtitle"
+                [trend]="card.trend"
+                [changePercentage]="card.changePercentage"
+                [clickable]="!!card.drawerType"
+                (cardClick)="handleCardClick(card.drawerType!)">
+              </lfx-metric-card>
+            </div>
+          }
+        }
+      }
 
-      <!-- Marketing Metrics Key Insights Card -->
-      <lfx-card styleClass="flex-shrink-0 w-[calc(100vw-3rem)] md:w-80 h-full" data-testid="marketing-overview-key-insights">
-        <div class="flex flex-col h-full">
-          <div class="flex items-center gap-2 mb-3">
-            <i class="fa-light fa-lightbulb w-4 h-4 text-gray-500 flex-shrink-0"></i>
-            <h5 class="text-sm font-medium">Marketing Metrics</h5>
+      <!-- Marketing Metrics Key Insights Card (between North Star and Brand/Influence) -->
+      @if (showInsightsCard()) {
+        <lfx-card styleClass="flex-shrink-0 w-[calc(100vw-3rem)] md:w-80 h-full" data-testid="marketing-overview-key-insights">
+          <div class="flex flex-col h-full">
+            <div class="flex items-center gap-2 mb-3">
+              <i class="fa-light fa-lightbulb w-4 h-4 text-gray-500 flex-shrink-0"></i>
+              <h5 class="text-sm font-medium">Marketing Metrics</h5>
+            </div>
+            <div class="flex-1 flex flex-col gap-1.5 p-3 bg-gray-50 rounded-lg">
+              <h6 class="flex items-center gap-1.5 text-xs font-semibold text-gray-900 mb-1">
+                <i class="fa-light fa-lightbulb text-gray-400"></i>
+                Key Insights
+              </h6>
+              @for (insight of marketingInsights(); track insight) {
+                <div class="flex items-start gap-1.5 text-xs text-gray-700 leading-snug">
+                  <span class="mt-1.5 w-1 h-1 rounded-full bg-gray-400 flex-shrink-0"></span>
+                  <span>{{ insight }}</span>
+                </div>
+              }
+            </div>
+            <div class="mt-2 text-right">
+              <lfx-button
+                label="View details"
+                [link]="true"
+                size="small"
+                (onClick)="handleCardClick(DashboardDrawerType.NorthStarEngagedCommunity)"
+                data-testid="marketing-overview-insights-view-details" />
+            </div>
           </div>
-          <div class="flex-1 flex flex-col gap-1.5 p-3 bg-gray-50 rounded-lg">
-            <h6 class="flex items-center gap-1.5 text-xs font-semibold text-gray-900 mb-1">
-              <i class="fa-light fa-lightbulb text-gray-400"></i>
-              Key Insights
-            </h6>
-            @for (insight of marketingInsights(); track insight) {
-              <div class="flex items-start gap-1.5 text-xs text-gray-700 leading-snug">
-                <span class="mt-1.5 w-1 h-1 rounded-full bg-gray-400 flex-shrink-0"></span>
-                <span>{{ insight }}</span>
-              </div>
-            }
-          </div>
-          <div class="mt-2 text-right">
-            <lfx-button
-              label="View details"
-              [link]="true"
-              size="small"
-              (onClick)="handleCardClick(DashboardDrawerType.MarketingEmailCtr)"
-              data-testid="marketing-overview-insights-view-details" />
-          </div>
-        </div>
-      </lfx-card>
+        </lfx-card>
+      }
 
-      <!-- Marketing Cards -->
-      @for (card of marketingCards(); track card.testId) {
-        <lfx-metric-card
-          [title]="card.title"
-          [icon]="card.icon"
-          [testId]="card.testId"
-          [chartType]="card.chartType"
-          [chartData]="card.chartData"
-          [chartOptions]="card.chartOptions"
-          [value]="card.value"
-          [subtitle]="card.subtitle"
-          [trend]="card.trend"
-          [changePercentage]="card.changePercentage"
-          [loading]="card.loading"
-          [clickable]="!!card.drawerType"
-          (cardClick)="handleCardClick(card.drawerType!)"></lfx-metric-card>
+      @for (card of nonNorthStarCards(); track card.testId) {
+        @switch (card.customContentType) {
+          @case ('dual-signal') {
+            <!-- Dual-Signal Card (Brand Reach, Brand Health, Revenue Impact) -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [clickable]="!!card.drawerType"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+                (cardClick)="handleCardClick(card.drawerType!)">
+                <ng-template #customContent>
+                  <div class="flex flex-col gap-0 flex-1">
+                    @if (card.dualSignals) {
+                      @for (row of card.dualSignals; track row.label; let last = $last) {
+                        <div class="flex flex-col gap-1 py-2">
+                          <div class="flex items-center justify-between">
+                            <span class="text-xs text-gray-500">{{ row.label }}</span>
+                            @if (row.changePercentage) {
+                              <span class="text-xs font-medium" [class.text-emerald-600]="row.trend === 'up'" [class.text-red-600]="row.trend === 'down'">
+                                {{ row.changePercentage }}
+                              </span>
+                            }
+                          </div>
+                          <div class="flex items-center gap-3">
+                            <span class="text-lg font-semibold text-gray-900 flex-shrink-0">{{ row.value }}</span>
+                            @if (row.chartData) {
+                              <div class="flex-1 h-8">
+                                <lfx-chart type="line" [data]="row.chartData" [options]="noTooltipChartOptions" height="100%"></lfx-chart>
+                              </div>
+                            }
+                          </div>
+                        </div>
+                        @if (!last) {
+                          <div class="border-t border-gray-100"></div>
+                        }
+                      }
+                    }
+                    @if (card.caption) {
+                      <div class="text-[10px] text-gray-400 mt-1">{{ card.caption }}</div>
+                    }
+                  </div>
+                </ng-template>
+              </lfx-metric-card>
+            </div>
+          }
+          @case ('funnel') {
+            <!-- Funnel Card (Flywheel Conversion) -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [clickable]="!!card.drawerType"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+                (cardClick)="handleCardClick(card.drawerType!)">
+                <ng-template #customContent>
+                  <div class="flex flex-col gap-2 flex-1">
+                    <div class="flex items-center gap-2">
+                      <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
+                      @if (card.changePercentage) {
+                        <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
+                          {{ card.changePercentage }}
+                        </span>
+                      }
+                    </div>
+
+                    @if (card.funnelSteps) {
+                      <div class="flex items-center gap-1">
+                        @for (step of card.funnelSteps; track step.label; let last = $last) {
+                          <div class="flex flex-col items-center gap-0 flex-1 min-w-0">
+                            <span class="text-[10px] text-gray-400 truncate">{{ step.label }}</span>
+                            <span class="text-xs font-semibold text-gray-700">{{ step.value }}</span>
+                          </div>
+                          @if (!last) {
+                            <i class="fa-light fa-chevron-right text-[8px] text-gray-300 flex-shrink-0"></i>
+                          }
+                        }
+                      </div>
+                    }
+
+                    @if (card.subtitle) {
+                      <div class="text-[10px] text-gray-400">{{ card.subtitle }}</div>
+                    }
+                  </div>
+                </ng-template>
+              </lfx-metric-card>
+            </div>
+          }
+          @default {
+            <!-- Standard Single-Signal Card -->
+            <div [pTooltip]="card.tooltipText!" tooltipPosition="top" [escape]="false" class="flex-shrink-0">
+              <lfx-metric-card
+                [title]="card.title"
+                [icon]="card.icon"
+                [testId]="card.testId"
+                [chartType]="card.chartType"
+                [chartData]="card.chartData"
+                [chartOptions]="card.chartOptions"
+                [value]="card.value"
+                [subtitle]="card.subtitle"
+                [trend]="card.trend"
+                [changePercentage]="card.changePercentage"
+                [clickable]="!!card.drawerType"
+                (cardClick)="handleCardClick(card.drawerType!)">
+              </lfx-metric-card>
+            </div>
+          }
+        }
       }
     </div>
 
@@ -147,23 +308,68 @@
     <div
       class="absolute top-0 bottom-0 right-0 w-32 z-10 pointer-events-none bg-[linear-gradient(to_right,transparent,#f9fafb)] transition-opacity duration-200"
       [class.opacity-0]="!scrollShadowDirective()?.showRightShadow()"
-      data-testid="marketing-overview-shadow-right"
+      data-testid="ed-evolution-shadow-right"
       aria-hidden="true"></div>
 
     <!-- Left shadow fade -->
     <div
       class="absolute top-0 bottom-0 left-0 w-32 z-10 pointer-events-none bg-[linear-gradient(to_left,transparent,#f9fafb)] transition-opacity duration-200"
       [class.opacity-0]="!scrollShadowDirective()?.showLeftShadow()"
-      data-testid="marketing-overview-shadow-left"
+      data-testid="ed-evolution-shadow-left"
       aria-hidden="true"></div>
+  </div>
+
+  <!-- Prototype indicator -->
+  <div class="flex items-center gap-1 mt-2 text-xs text-gray-400">
+    <i class="fa-light fa-circle-info"></i>
+    <span>Hover over any card for data source details · Prototype with dummy data</span>
   </div>
 </section>
 
-<!-- Drill-Down Drawers
-  Note: [visible] uses a computed expression from activeDrawer() signal.
-  This matches the established pattern in foundation-health and organization-involvement drawers.
-  Signal updates are synchronous — handleDrawerClose() sets activeDrawer(null) in the same
-  change detection cycle, so no flicker occurs on backdrop dismiss. -->
+<!-- Drill-Down Drawers -->
+
+<!-- North Star Drawers -->
+<lfx-flywheel-conversion-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.NorthStarFlywheelConversion"
+  [data]="flywheelData()"
+  (visibleChange)="handleDrawerClose()"></lfx-flywheel-conversion-drawer>
+
+<lfx-member-acquisition-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.NorthStarMemberAcquisition"
+  [data]="memberAcquisitionData()"
+  [retentionData]="memberRetentionData()"
+  [revenueImpactData]="revenueImpactData()"
+  (visibleChange)="handleDrawerClose()"></lfx-member-acquisition-drawer>
+
+<lfx-engaged-community-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.NorthStarEngagedCommunity"
+  [data]="engagedCommunityData()"
+  [brandReachData]="brandReachData()"
+  (visibleChange)="handleDrawerClose()"></lfx-engaged-community-drawer>
+
+<lfx-event-growth-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.NorthStarEventGrowth"
+  [data]="eventGrowthData()"
+  (visibleChange)="handleDrawerClose()"></lfx-event-growth-drawer>
+
+<!-- Brand Drawers -->
+<lfx-brand-reach-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.BrandReach"
+  [data]="brandReachData()"
+  (visibleChange)="handleDrawerClose()"></lfx-brand-reach-drawer>
+
+<lfx-brand-health-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.BrandHealth"
+  [data]="brandHealthData()"
+  (visibleChange)="handleDrawerClose()"></lfx-brand-health-drawer>
+
+<!-- Influence Drawer -->
+<lfx-revenue-impact-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.RevenueImpact"
+  [data]="revenueImpactData()"
+  (visibleChange)="handleDrawerClose()"></lfx-revenue-impact-drawer>
+
+<!-- Existing Marketing Drawers (accessible from Brand Reach / Engaged Community drawers in future) -->
 <lfx-website-visits-drawer
   [visible]="activeDrawer() === DashboardDrawerType.MarketingWebsiteVisits"
   (visibleChange)="handleDrawerClose()"></lfx-website-visits-drawer>
@@ -177,20 +383,3 @@
 <lfx-social-media-drawer
   [visible]="activeDrawer() === DashboardDrawerType.MarketingSocialMedia"
   (visibleChange)="handleDrawerClose()"></lfx-social-media-drawer>
-
-<!-- North Star Drawers -->
-<lfx-engaged-community-drawer
-  [visible]="activeDrawer() === DashboardDrawerType.NorthStarEngagedCommunity"
-  (visibleChange)="handleDrawerClose()"
-  [data]="marketingData().engagedCommunity"></lfx-engaged-community-drawer>
-
-<lfx-member-acquisition-drawer
-  [visible]="activeDrawer() === DashboardDrawerType.NorthStarMemberAcquisition"
-  (visibleChange)="handleDrawerClose()"
-  [data]="marketingData().memberAcquisition"
-  [retentionData]="marketingData().memberRetention"></lfx-member-acquisition-drawer>
-
-<lfx-flywheel-conversion-drawer
-  [visible]="activeDrawer() === DashboardDrawerType.NorthStarFlywheelConversion"
-  (visibleChange)="handleDrawerClose()"
-  [data]="marketingData().flywheelConversion"></lfx-flywheel-conversion-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -276,7 +276,7 @@ export class MarketingOverviewComponent {
           unit: '%',
         },
         {
-          label: 'Flywheel conversion',
+          label: 'Flywheel re-engagement',
           change: data.flywheel.reengagement?.reengagementMomChange ?? 0,
           detail: `${(data.flywheel.reengagement?.reengagementRate ?? 0).toFixed(1)}%`,
           unit: 'pp',

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -1,40 +1,146 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { afterNextRender, ChangeDetectionStrategy, Component, computed, inject, signal, Signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal, viewChild } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { ChartComponent } from '@components/chart/chart.component';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { MetricCardComponent } from '@components/metric-card/metric-card.component';
 
-import { MARKETING_OVERVIEW_METRICS, NO_TOOLTIP_CHART_OPTIONS } from '@lfx-one/shared/constants';
-import { lfxColors } from '@lfx-one/shared/constants';
+import { buildEdEvolutionMetrics, ED_EVOLUTION_FILTER_OPTIONS, NO_TOOLTIP_CHART_OPTIONS } from '@lfx-one/shared/constants';
 import {
+  BrandHealthResponse,
+  BrandReachResponse,
   DashboardDrawerType,
   DashboardMetricCard,
-  EmailCtrResponse,
+  EdEvolutionData,
   EngagedCommunitySizeResponse,
+  EventGrowthResponse,
   FlywheelConversionResponse,
   MemberAcquisitionResponse,
   MemberRetentionResponse,
-  SocialMediaResponse,
-  SocialReachResponse,
-  WebActivitiesSummaryResponse,
+  MetricCategory,
+  RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
-import { formatNumber, hexToRgba } from '@lfx-one/shared/utils';
+import { formatNumber } from '@lfx-one/shared/utils';
+
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
-
 import { ScrollShadowDirective } from '@shared/directives/scroll-shadow.directive';
-import { catchError, combineLatest, filter, finalize, forkJoin, map, of, switchMap, tap } from 'rxjs';
+import { TooltipModule } from 'primeng/tooltip';
+import { catchError, forkJoin, map, Observable, of, switchMap } from 'rxjs';
 
+import { BrandHealthDrawerComponent } from '../brand-health-drawer/brand-health-drawer.component';
+import { BrandReachDrawerComponent } from '../brand-reach-drawer/brand-reach-drawer.component';
 import { EmailCtrDrawerComponent } from '../email-ctr-drawer/email-ctr-drawer.component';
 import { EngagedCommunityDrawerComponent } from '../engaged-community-drawer/engaged-community-drawer.component';
+import { EventGrowthDrawerComponent } from '../event-growth-drawer/event-growth-drawer.component';
 import { FlywheelConversionDrawerComponent } from '../flywheel-conversion-drawer/flywheel-conversion-drawer.component';
 import { MemberAcquisitionDrawerComponent } from '../member-acquisition-drawer/member-acquisition-drawer.component';
 import { PaidSocialReachDrawerComponent } from '../paid-social-reach-drawer/paid-social-reach-drawer.component';
+import { RevenueImpactDrawerComponent } from '../revenue-impact-drawer/revenue-impact-drawer.component';
 import { SocialMediaDrawerComponent } from '../social-media-drawer/social-media-drawer.component';
 import { WebsiteVisitsDrawerComponent } from '../website-visits-drawer/website-visits-drawer.component';
+
+const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
+  flywheel: {
+    conversionRate: 0,
+    changePercentage: 0,
+    trend: 'up',
+    funnel: {
+      eventAttendees: 0,
+      convertedToNewsletter: 0,
+      convertedToCommunity: 0,
+      convertedToWorkingGroup: 0,
+      convertedToTraining: 0,
+      convertedToCode: 0,
+      convertedToWeb: 0,
+    },
+    reengagement: {
+      totalReengaged: 0,
+      reengagementRate: 0,
+      reengagementMomChange: 0,
+      reengagedToNewsletter: 0,
+      reengagedToCommunity: 0,
+      reengagedToWorkingGroup: 0,
+      reengagedToTraining: 0,
+      reengagedToCode: 0,
+      reengagedToWeb: 0,
+    },
+    monthlyData: [],
+  },
+  memberAcquisition: {
+    totalMembers: 0,
+    totalMembersMonthlyData: [],
+    totalMembersMonthlyLabels: [],
+    newMembersThisQuarter: 0,
+    newMemberRevenue: 0,
+    changePercentage: 0,
+    trend: 'up',
+    quarterlyData: [],
+  },
+  memberRetention: {
+    renewalRate: 0,
+    netRevenueRetention: 0,
+    changePercentage: 0,
+    trend: 'up',
+    target: 0,
+    monthlyData: [],
+  },
+  engagedCommunity: {
+    totalMembers: 0,
+    changePercentage: 0,
+    trend: 'up',
+    breakdown: { newsletterSubscribers: 0, communityMembers: 0, workingGroupMembers: 0, certifiedIndividuals: 0 },
+    monthlyData: [],
+  },
+  eventGrowth: {
+    totalAttendees: 0,
+    totalRegistrants: 0,
+    totalEvents: 0,
+    totalRevenue: 0,
+    revenuePerAttendee: 0,
+    attendeeYoyChange: 0,
+    registrantYoyChange: 0,
+    revenueYoyChange: 0,
+    trend: 'up',
+    monthlyData: [],
+    topEvents: [],
+  },
+  brandReach: {
+    totalSocialFollowers: 0,
+    totalMonthlySessions: 0,
+    activePlatforms: 0,
+    changePercentage: 0,
+    trend: 'up',
+    socialPlatforms: [],
+    websiteDomains: [],
+    weeklyTrend: [],
+  },
+  brandHealth: {
+    totalMentions: 0,
+    sentiment: { positive: 0, neutral: 0, negative: 0 },
+    sentimentMomChangePp: 0,
+    trend: 'up',
+    monthlyMentions: [],
+    topProjects: [],
+  },
+  revenueImpact: {
+    pipelineInfluenced: 0,
+    revenueAttributed: 0,
+    matchRate: 0,
+    changePercentage: 0,
+    trend: 'up',
+    attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+    engagementTypes: [],
+    paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0, monthlyTrend: [] },
+    attributionChannels: [],
+    projectBreakdown: [],
+    eventRegistrationAttribution: { channelBreakdown: [], monthlyTrend: [] },
+  },
+};
 
 @Component({
   selector: 'lfx-marketing-overview',
@@ -42,9 +148,13 @@ import { WebsiteVisitsDrawerComponent } from '../website-visits-drawer/website-v
   imports: [
     ButtonComponent,
     CardComponent,
+    ChartComponent,
+    FilterPillsComponent,
     MetricCardComponent,
     ScrollShadowDirective,
+    TooltipModule,
 
+    // Existing drawers
     WebsiteVisitsDrawerComponent,
     EmailCtrDrawerComponent,
     PaidSocialReachDrawerComponent,
@@ -52,109 +162,56 @@ import { WebsiteVisitsDrawerComponent } from '../website-visits-drawer/website-v
     EngagedCommunityDrawerComponent,
     MemberAcquisitionDrawerComponent,
     FlywheelConversionDrawerComponent,
+
+    // New prototype drawers
+    EventGrowthDrawerComponent,
+    BrandReachDrawerComponent,
+    BrandHealthDrawerComponent,
+    RevenueImpactDrawerComponent,
   ],
   templateUrl: './marketing-overview.component.html',
   styleUrl: './marketing-overview.component.scss',
 })
 export class MarketingOverviewComponent {
-  public readonly scrollShadowDirective = viewChild(ScrollShadowDirective);
-
   // === Services ===
   private readonly analyticsService = inject(AnalyticsService);
   private readonly projectContextService = inject(ProjectContextService);
 
-  // === WritableSignals ===
-  protected readonly marketingDataLoading = signal(true);
-  private readonly browserReady = signal(false);
-  public readonly activeDrawer = signal<DashboardDrawerType | null>(null);
-
-  // === Observables ===
-  private readonly selectedFoundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(
-    map((foundation) => ({ slug: foundation?.slug || '', name: foundation?.name || '' }))
-  );
+  public readonly scrollShadowDirective = viewChild(ScrollShadowDirective);
 
   // === Constants ===
+  protected readonly filterOptions = ED_EVOLUTION_FILTER_OPTIONS;
+  protected readonly noTooltipChartOptions = NO_TOOLTIP_CHART_OPTIONS;
   protected readonly DashboardDrawerType = DashboardDrawerType;
 
+  // === WritableSignals ===
+  public readonly selectedFilter = signal<'all' | MetricCategory>('all');
+  public readonly activeDrawer = signal<DashboardDrawerType | null>(null);
+
   // === Computed Signals ===
+  protected readonly edEvolutionData: Signal<EdEvolutionData> = this.initEdEvolutionData();
+
+  protected readonly flywheelData = computed<FlywheelConversionResponse>(() => this.edEvolutionData().flywheel);
+  protected readonly memberAcquisitionData = computed<MemberAcquisitionResponse>(() => this.edEvolutionData().memberAcquisition);
+  protected readonly memberRetentionData = computed<MemberRetentionResponse>(() => this.edEvolutionData().memberRetention);
+  protected readonly engagedCommunityData = computed<EngagedCommunitySizeResponse>(() => this.edEvolutionData().engagedCommunity);
+  protected readonly eventGrowthData = computed<EventGrowthResponse>(() => this.edEvolutionData().eventGrowth);
+  protected readonly brandReachData = computed<BrandReachResponse>(() => this.edEvolutionData().brandReach);
+  protected readonly brandHealthData = computed<BrandHealthResponse>(() => this.edEvolutionData().brandHealth);
+  protected readonly revenueImpactData = computed<RevenueImpactResponse>(() => this.edEvolutionData().revenueImpact);
+
+  protected readonly filteredCards = computed<DashboardMetricCard[]>(() => {
+    const cards = buildEdEvolutionMetrics(this.edEvolutionData());
+    const filterKey = this.selectedFilter();
+    if (filterKey === 'all') return cards;
+    return cards.filter((card) => card.category === filterKey);
+  });
+
+  protected readonly northStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category === 'memberships'));
+  protected readonly nonNorthStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category !== 'memberships'));
+  protected readonly showInsightsCard = computed<boolean>(() => this.northStarCards().length > 0);
+
   protected readonly marketingInsights: Signal<string[]> = this.initMarketingInsights();
-  protected readonly marketingData: Signal<{
-    webActivities: WebActivitiesSummaryResponse;
-    emailCtr: EmailCtrResponse;
-    socialReach: SocialReachResponse;
-    socialMedia: SocialMediaResponse;
-    memberRetention: MemberRetentionResponse;
-    memberAcquisition: MemberAcquisitionResponse;
-    engagedCommunity: EngagedCommunitySizeResponse;
-    flywheelConversion: FlywheelConversionResponse;
-  }> = this.initMarketingData();
-  protected readonly marketingCards: Signal<DashboardMetricCard[]> = this.initMarketingCards();
-  protected readonly formatNumber = formatNumber;
-  protected readonly noTooltipChartOptions = NO_TOOLTIP_CHART_OPTIONS;
-
-  // North Star sparkline chart data
-  protected readonly memberGrowthChartData = computed(() => {
-    const { totalMembersMonthlyData, totalMembersMonthlyLabels } = this.marketingData().memberAcquisition;
-    if (totalMembersMonthlyData.length === 0) return undefined;
-    return {
-      labels: totalMembersMonthlyLabels,
-      datasets: [
-        {
-          data: totalMembersMonthlyData,
-          borderColor: lfxColors.blue[500],
-          backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-          fill: true,
-          tension: 0.4,
-          borderWidth: 2,
-          pointRadius: 0,
-        },
-      ],
-    };
-  });
-
-  protected readonly flywheelChartData = computed(() => {
-    const { monthlyData } = this.marketingData().flywheelConversion;
-    if (monthlyData.length === 0) return undefined;
-    return {
-      labels: monthlyData.map((d) => d.month),
-      datasets: [
-        {
-          data: monthlyData.map((d) => d.value),
-          borderColor: lfxColors.blue[500],
-          backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-          fill: true,
-          tension: 0.4,
-          borderWidth: 2,
-          pointRadius: 0,
-        },
-      ],
-    };
-  });
-
-  protected readonly engagedCommunityChartData = computed(() => {
-    const { monthlyData } = this.marketingData().engagedCommunity;
-    if (monthlyData.length === 0) return undefined;
-    return {
-      labels: monthlyData.map((d) => d.month),
-      datasets: [
-        {
-          data: monthlyData.map((d) => d.value),
-          borderColor: lfxColors.blue[500],
-          backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-          fill: true,
-          tension: 0.4,
-          borderWidth: 2,
-          pointRadius: 0,
-        },
-      ],
-    };
-  });
-
-  public constructor() {
-    afterNextRender(() => {
-      this.browserReady.set(true);
-    });
-  }
 
   // === Public Methods ===
   public handleCardClick(drawerType: DashboardDrawerType): void {
@@ -166,375 +223,78 @@ export class MarketingOverviewComponent {
   }
 
   // === Private Initializers ===
-  private initMarketingCards(): Signal<DashboardMetricCard[]> {
-    return computed(() => {
-      const { webActivities, emailCtr, socialReach, socialMedia } = this.marketingData();
-      const loading = this.marketingDataLoading();
+  private initEdEvolutionData(): Signal<EdEvolutionData> {
+    // ED dashboard intentionally falls back to `tlf` (the umbrella foundation) when no specific
+    // foundation is selected — that is the default "all foundations" view for executive directors.
+    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.slug || 'tlf'));
 
-      return MARKETING_OVERVIEW_METRICS.map((card) => {
-        switch (card.drawerType) {
-          case DashboardDrawerType.MarketingWebsiteVisits:
-            return this.transformWebsiteVisits(card, webActivities, loading);
-          case DashboardDrawerType.MarketingEmailCtr:
-            return this.transformEmailCtr(card, emailCtr, loading);
-          case DashboardDrawerType.MarketingPaidSocialReach:
-            return this.transformSocialReach(card, socialReach, loading);
-          case DashboardDrawerType.MarketingSocialMedia:
-            return this.transformSocialMedia(card, socialMedia, loading);
-          default:
-            return card;
-        }
-      });
-    });
-  }
-
-  private initMarketingData(): Signal<{
-    webActivities: WebActivitiesSummaryResponse;
-    emailCtr: EmailCtrResponse;
-    socialReach: SocialReachResponse;
-    socialMedia: SocialMediaResponse;
-    memberRetention: MemberRetentionResponse;
-    memberAcquisition: MemberAcquisitionResponse;
-    engagedCommunity: EngagedCommunitySizeResponse;
-    flywheelConversion: FlywheelConversionResponse;
-  }> {
-    const defaultWebActivities: WebActivitiesSummaryResponse = {
-      totalSessions: 0,
-      totalPageViews: 0,
-      domainGroups: [],
-      dailyData: [],
-      dailyLabels: [],
-    };
-
-    const defaultEmailCtr: EmailCtrResponse = {
-      currentCtr: 0,
-      changePercentage: 0,
-      trend: 'up',
-      monthlyData: [],
-      monthlyLabels: [],
-      campaignGroups: [],
-      monthlySends: [],
-      monthlyOpens: [],
-    };
-
-    const defaultSocialReach: SocialReachResponse = {
-      totalReach: 0,
-      roas: 0,
-      totalSpend: 0,
-      totalRevenue: 0,
-      changePercentage: 0,
-      trend: 'up',
-      monthlyData: [],
-      monthlyLabels: [],
-      monthlyRoas: [],
-      channelGroups: [],
-    };
-
-    const defaultSocialMedia: SocialMediaResponse = {
-      totalFollowers: 0,
-      totalPlatforms: 0,
-      changePercentage: 0,
-      trend: 'up',
-      platforms: [],
-      monthlyData: [],
-    };
-
-    const defaultMemberRetention: MemberRetentionResponse = {
-      renewalRate: 0,
-      netRevenueRetention: 0,
-      changePercentage: 0,
-      trend: 'up',
-      target: 85,
-      monthlyData: [],
-    };
-
-    const defaultMemberAcquisition: MemberAcquisitionResponse = {
-      totalMembers: 0,
-      totalMembersMonthlyData: [],
-      totalMembersMonthlyLabels: [],
-      newMembersThisQuarter: 0,
-      newMemberRevenue: 0,
-      changePercentage: 0,
-      trend: 'up',
-      quarterlyData: [],
-    };
-
-    const defaultEngagedCommunity: EngagedCommunitySizeResponse = {
-      totalMembers: 0,
-      changePercentage: 0,
-      trend: 'up',
-      breakdown: {
-        newsletterSubscribers: 0,
-        communityMembers: 0,
-        workingGroupMembers: 0,
-        certifiedIndividuals: 0,
-      },
-      monthlyData: [],
-    };
-
-    const defaultFlywheelConversion: FlywheelConversionResponse = {
-      conversionRate: 0,
-      changePercentage: 0,
-      trend: 'up',
-      funnel: {
-        eventAttendees: 0,
-        convertedToNewsletter: 0,
-        convertedToCommunity: 0,
-        convertedToWorkingGroup: 0,
-      },
-      reengagement: {
-        totalReengaged: 0,
-        reengagementRate: 0,
-        reengagementMomChange: 0,
-        reengagedToNewsletter: 0,
-        reengagedToCommunity: 0,
-        reengagedToWorkingGroup: 0,
-        reengagedToTraining: 0,
-        reengagedToCode: 0,
-        reengagedToWeb: 0,
-      },
-      monthlyData: [],
-    };
-
-    const defaultValue = {
-      webActivities: defaultWebActivities,
-      emailCtr: defaultEmailCtr,
-      socialReach: defaultSocialReach,
-      socialMedia: defaultSocialMedia,
-      memberRetention: defaultMemberRetention,
-      memberAcquisition: defaultMemberAcquisition,
-      engagedCommunity: defaultEngagedCommunity,
-      flywheelConversion: defaultFlywheelConversion,
-    };
+    // Per-call catchError ensures a single failing Snowflake query degrades only its own card
+    // rather than taking down the whole dashboard; errors are still logged for visibility.
+    const safe = <T>(key: keyof EdEvolutionData, obs: Observable<T>): Observable<T> =>
+      obs.pipe(
+        catchError((err) => {
+          console.error(`[marketing-overview] Failed to load ${String(key)}:`, err);
+          return of(EMPTY_ED_EVOLUTION_DATA[key] as T);
+        })
+      );
 
     return toSignal(
-      combineLatest([toObservable(this.browserReady), this.selectedFoundation$]).pipe(
-        filter(([ready, foundation]) => ready && !!foundation.slug),
-        map(([, foundation]) => foundation),
-        tap(() => {
-          this.marketingDataLoading.set(true);
-          this.activeDrawer.set(null);
-        }),
-        switchMap((foundation) =>
+      foundation$.pipe(
+        switchMap((slug) =>
           forkJoin({
-            webActivities: this.analyticsService.getWebActivitiesSummary(foundation.slug).pipe(catchError(() => of(defaultWebActivities))),
-            emailCtr: this.analyticsService.getEmailCtr(foundation.name).pipe(catchError(() => of(defaultEmailCtr))),
-            socialReach: this.analyticsService.getSocialReach(foundation.name).pipe(catchError(() => of(defaultSocialReach))),
-            socialMedia: this.analyticsService.getSocialMedia(foundation.name).pipe(catchError(() => of(defaultSocialMedia))),
-            memberRetention: this.analyticsService.getMemberRetention(foundation.slug).pipe(catchError(() => of(defaultMemberRetention))),
-            memberAcquisition: this.analyticsService.getMemberAcquisition(foundation.slug).pipe(catchError(() => of(defaultMemberAcquisition))),
-            engagedCommunity: this.analyticsService.getEngagedCommunity(foundation.slug).pipe(catchError(() => of(defaultEngagedCommunity))),
-            flywheelConversion: this.analyticsService.getFlywheelConversion(foundation.slug).pipe(catchError(() => of(defaultFlywheelConversion))),
-          }).pipe(tap(() => this.marketingDataLoading.set(false)))
-        ),
-        finalize(() => this.marketingDataLoading.set(false))
+            flywheel: safe('flywheel', this.analyticsService.getFlywheelConversion(slug)),
+            memberAcquisition: safe('memberAcquisition', this.analyticsService.getMemberAcquisition(slug)),
+            memberRetention: safe('memberRetention', this.analyticsService.getMemberRetention(slug)),
+            engagedCommunity: safe('engagedCommunity', this.analyticsService.getEngagedCommunity(slug)),
+            eventGrowth: safe('eventGrowth', this.analyticsService.getEventGrowth(slug)),
+            brandReach: safe('brandReach', this.analyticsService.getBrandReach(slug)),
+            brandHealth: safe('brandHealth', this.analyticsService.getBrandHealth(slug)),
+            revenueImpact: safe('revenueImpact', this.analyticsService.getRevenueImpact(slug)),
+          })
+        )
       ),
-      { initialValue: defaultValue }
-    );
+      { initialValue: EMPTY_ED_EVOLUTION_DATA }
+    ) as Signal<EdEvolutionData>;
   }
 
   private initMarketingInsights(): Signal<string[]> {
     return computed(() => {
-      const data = this.marketingData();
-      if (this.marketingDataLoading()) {
-        return [];
-      }
-
-      // Collect all metrics that have meaningful data and a change percentage
-      const signals: { label: string; change: number; detail: string }[] = [];
-
-      if (data.socialMedia.totalFollowers > 0) {
-        signals.push({
-          label: 'Social followers',
-          change: data.socialMedia.changePercentage,
-          detail: formatNumber(data.socialMedia.totalFollowers),
-        });
-      }
-
-      if (data.socialReach.totalReach > 0) {
-        signals.push({
-          label: 'Paid social reach',
-          change: data.socialReach.changePercentage,
-          detail: formatNumber(data.socialReach.totalReach),
-        });
-      }
-
-      if (data.engagedCommunity.totalMembers > 0) {
-        signals.push({
+      const data = this.edEvolutionData();
+      // `unit: 'pp'` indicates the change value is a percentage-point delta (difference
+      // between two percentages). Rendering it as "%" would misrepresent the metric.
+      const signals: { label: string; change: number; detail: string; unit: '%' | 'pp' }[] = [
+        {
           label: 'Engaged community',
           change: data.engagedCommunity.changePercentage,
           detail: formatNumber(data.engagedCommunity.totalMembers),
-        });
-      }
-
-      if (data.memberAcquisition.totalMembers > 0) {
-        signals.push({
+          unit: '%',
+        },
+        {
           label: 'Member base',
           change: data.memberAcquisition.changePercentage,
           detail: formatNumber(data.memberAcquisition.totalMembers),
-        });
-      }
-
-      if (data.flywheelConversion.conversionRate > 0) {
-        signals.push({
+          unit: '%',
+        },
+        {
           label: 'Flywheel conversion',
-          change: data.flywheelConversion.changePercentage,
-          detail: `${data.flywheelConversion.conversionRate}%`,
-        });
-      }
-
-      if (data.memberRetention.renewalRate > 0) {
-        signals.push({
+          change: data.flywheel.reengagement?.reengagementMomChange ?? 0,
+          detail: `${(data.flywheel.reengagement?.reengagementRate ?? 0).toFixed(1)}%`,
+          unit: 'pp',
+        },
+        {
           label: 'Member retention',
           change: data.memberRetention.changePercentage,
-          detail: `${data.memberRetention.renewalRate}%`,
-        });
-      }
+          detail: `${data.memberRetention.renewalRate.toFixed(1)}%`,
+          unit: '%',
+        },
+      ];
 
-      // Sort by absolute change magnitude — biggest movers first
       const sorted = signals.filter((s) => s.change !== 0).sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
 
-      const insights: string[] = [];
-
-      // Top movers — up to 3, biggest changes across all metrics
-      for (const signal of sorted.slice(0, 3)) {
-        const direction = signal.change > 0 ? 'up' : 'down';
-        insights.push(`${signal.label} is ${direction} ${Math.abs(signal.change)}% — now at ${signal.detail}`);
-      }
-
-      // If fewer than 2 insights from movers, add a steady-state summary
-      if (insights.length < 2 && data.webActivities.totalSessions > 0) {
-        insights.push(`${formatNumber(data.webActivities.totalSessions)} website sessions in the last 30 days`);
-      }
-
-      return insights;
+      return sorted.slice(0, 3).map((s) => {
+        const direction = s.change > 0 ? 'up' : 'down';
+        return `${s.label} is ${direction} ${Math.abs(s.change).toFixed(1)}${s.unit} — now at ${s.detail}`;
+      });
     });
-  }
-
-  // === Private Helpers ===
-  private transformWebsiteVisits(card: DashboardMetricCard, data: WebActivitiesSummaryResponse, loading: boolean): DashboardMetricCard {
-    return {
-      ...card,
-      loading,
-      value: data.totalSessions > 0 ? formatNumber(data.totalSessions) : undefined,
-      subtitle: data.totalSessions > 0 ? `Last 30 days · ${formatNumber(data.totalPageViews)} page views` : undefined,
-      chartData:
-        data.dailyData.length > 0
-          ? {
-              labels: data.dailyLabels,
-              datasets: [
-                {
-                  data: data.dailyData,
-                  borderColor: lfxColors.blue[500],
-                  backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-                  fill: true,
-                  tension: 0.4,
-                  borderWidth: 2,
-                  pointRadius: 0,
-                },
-              ],
-            }
-          : card.chartData,
-      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-    };
-  }
-
-  private transformEmailCtr(card: DashboardMetricCard, data: EmailCtrResponse, loading: boolean): DashboardMetricCard {
-    return {
-      ...card,
-      loading,
-      value: data.currentCtr > 0 ? `${data.currentCtr.toFixed(1)}%` : undefined,
-      subtitle: data.currentCtr > 0 ? 'Last 6 months' : undefined,
-      changePercentage: data.changePercentage !== 0 ? `${data.changePercentage}%` : undefined,
-      trend: data.trend,
-      chartData:
-        data.monthlyData.length > 0
-          ? {
-              labels: data.monthlyLabels,
-              datasets: [
-                {
-                  data: data.monthlyData,
-                  borderColor: lfxColors.blue[500],
-                  backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-                  fill: true,
-                  tension: 0.4,
-                  borderWidth: 2,
-                  pointRadius: 0,
-                },
-              ],
-            }
-          : card.chartData,
-      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-    };
-  }
-
-  private transformSocialReach(card: DashboardMetricCard, data: SocialReachResponse, loading: boolean): DashboardMetricCard {
-    return {
-      ...card,
-      loading,
-      value: this.getSocialReachValue(data),
-      subtitle: this.getSocialReachSubtitle(data),
-      changePercentage: data.changePercentage !== 0 ? `${data.changePercentage > 0 ? '+' : ''}${data.changePercentage}%` : undefined,
-      trend: data.trend,
-      chartData:
-        data.monthlyRoas && data.monthlyRoas.length > 0
-          ? {
-              labels: data.monthlyLabels,
-              datasets: [
-                {
-                  data: data.monthlyRoas,
-                  borderColor: lfxColors.blue[500],
-                  backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-                  fill: true,
-                  tension: 0.4,
-                  borderWidth: 2,
-                  pointRadius: 0,
-                },
-              ],
-            }
-          : card.chartData,
-      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-    };
-  }
-
-  private transformSocialMedia(card: DashboardMetricCard, data: SocialMediaResponse, loading: boolean): DashboardMetricCard {
-    return {
-      ...card,
-      loading,
-      value: data.totalFollowers > 0 ? formatNumber(data.totalFollowers) : undefined,
-      subtitle: data.totalFollowers > 0 ? `${data.totalPlatforms} platforms · Last 6 months` : undefined,
-      changePercentage: data.changePercentage !== 0 ? `${data.changePercentage > 0 ? '+' : ''}${data.changePercentage}%` : undefined,
-      trend: data.trend,
-      chartData:
-        data.monthlyData.length > 0
-          ? {
-              labels: data.monthlyData.map((d) => d.month),
-              datasets: [
-                {
-                  data: data.monthlyData.map((d) => d.totalFollowers),
-                  borderColor: lfxColors.blue[500],
-                  backgroundColor: hexToRgba(lfxColors.blue[500], 0.1),
-                  fill: true,
-                  tension: 0.4,
-                  borderWidth: 2,
-                  pointRadius: 0,
-                },
-              ],
-            }
-          : card.chartData,
-      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-    };
-  }
-
-  private getSocialReachValue(data: SocialReachResponse): string | undefined {
-    if (data.roas > 0) return `${data.roas.toFixed(2)}x`;
-    if (data.totalReach > 0) return formatNumber(data.totalReach);
-    return undefined;
-  }
-
-  private getSocialReachSubtitle(data: SocialReachResponse): string | undefined {
-    if (data.roas > 0) return 'ROAS · Last 6 months';
-    if (data.totalReach > 0) return 'Last 6 months';
-    return undefined;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -202,12 +202,7 @@ export class MarketingOverviewComponent {
   protected readonly brandHealthData = computed<BrandHealthResponse>(() => this.edEvolutionData().brandHealth);
   protected readonly revenueImpactData = computed<RevenueImpactResponse>(() => this.edEvolutionData().revenueImpact);
 
-  protected readonly filteredCards = computed<DashboardMetricCard[]>(() => {
-    const cards = buildEdEvolutionMetrics(this.edEvolutionData());
-    const filterKey = this.selectedFilter();
-    if (filterKey === 'all') return cards;
-    return cards.filter((card) => card.category === filterKey);
-  });
+  protected readonly filteredCards: Signal<DashboardMetricCard[]> = this.initFilteredCards();
 
   protected readonly northStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category === 'memberships'));
   protected readonly nonNorthStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category !== 'memberships'));
@@ -229,6 +224,15 @@ export class MarketingOverviewComponent {
   }
 
   // === Private Initializers ===
+  private initFilteredCards(): Signal<DashboardMetricCard[]> {
+    return computed<DashboardMetricCard[]>(() => {
+      const cards = buildEdEvolutionMetrics(this.edEvolutionData());
+      const filterKey = this.selectedFilter();
+      if (filterKey === 'all') return cards;
+      return cards.filter((card) => card.category === filterKey);
+    });
+  }
+
   private initEdEvolutionData(): Signal<EdEvolutionData> {
     // ED dashboard intentionally falls back to `tlf` (the umbrella foundation) when no specific
     // foundation is selected — that is the default "all foundations" view for executive directors.

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal, viewChild } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
@@ -146,6 +147,7 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
   selector: 'lfx-marketing-overview',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
+    NgTemplateOutlet,
     ButtonComponent,
     CardComponent,
     ChartComponent,
@@ -222,6 +224,10 @@ export class MarketingOverviewComponent {
     this.activeDrawer.set(null);
   }
 
+  public setFilter(value: string): void {
+    this.selectedFilter.set(value as 'all' | MetricCategory);
+  }
+
   // === Private Initializers ===
   private initEdEvolutionData(): Signal<EdEvolutionData> {
     // ED dashboard intentionally falls back to `tlf` (the umbrella foundation) when no specific
@@ -229,14 +235,9 @@ export class MarketingOverviewComponent {
     const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.slug || 'tlf'));
 
     // Per-call catchError ensures a single failing Snowflake query degrades only its own card
-    // rather than taking down the whole dashboard; errors are still logged for visibility.
-    const safe = <T>(key: keyof EdEvolutionData, obs: Observable<T>): Observable<T> =>
-      obs.pipe(
-        catchError((err) => {
-          console.error(`[marketing-overview] Failed to load ${String(key)}:`, err);
-          return of(EMPTY_ED_EVOLUTION_DATA[key] as T);
-        })
-      );
+    // rather than taking down the whole dashboard. Errors are swallowed client-side — the server
+    // logger already records the upstream failure.
+    const safe = <T>(key: keyof EdEvolutionData, obs: Observable<T>): Observable<T> => obs.pipe(catchError(() => of(EMPTY_ED_EVOLUTION_DATA[key] as T)));
 
     return toSignal(
       foundation$.pipe(

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -56,13 +56,13 @@
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Renewal Rate</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().renewalRate }}%</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().renewalRate.toFixed(1) }}%</span>
           </div>
         </lfx-card>
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Net Revenue Retention</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().netRevenueRetention }}%</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().netRevenueRetention.toFixed(1) }}%</span>
           </div>
         </lfx-card>
         <lfx-card styleClass="flex-1">
@@ -71,7 +71,7 @@
             @if (retentionData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="retentionData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ retentionData().changePercentage > 0 ? '+' : '' }}{{ retentionData().changePercentage }}%
+                  {{ retentionData().changePercentage > 0 ? '+' : '' }}{{ retentionData().changePercentage.toFixed(1) }}%
                 </span>
                 <i class="text-sm" [class]="retentionData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>
@@ -157,12 +157,80 @@
       </div>
     }
 
+    <!-- Sales Pipeline -->
+    @if (
+      revenueImpactData().pipelineInfluenced > 0 ||
+      revenueImpactData().revenueAttributed > 0 ||
+      revenueImpactData().matchRate > 0 ||
+      revenueImpactData().engagementTypes.length > 0
+    ) {
+      <div class="flex flex-col gap-4" data-testid="member-acquisition-drawer-pipeline-section">
+        <h3 class="text-sm font-semibold text-gray-900">Sales Pipeline</h3>
+        <div class="flex gap-4" data-testid="member-acquisition-drawer-pipeline-stats">
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Pipeline Influenced</span>
+              @if (revenueImpactData().pipelineInfluenced > 0) {
+                <span class="text-2xl font-semibold text-gray-900">{{ formatMoney(revenueImpactData().pipelineInfluenced) }}</span>
+              } @else {
+                <span class="text-2xl font-semibold text-gray-400">—</span>
+              }
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Revenue Attributed</span>
+              @if (revenueImpactData().revenueAttributed > 0) {
+                <span class="text-2xl font-semibold text-gray-900">{{ formatMoney(revenueImpactData().revenueAttributed) }}</span>
+              } @else {
+                <span class="text-2xl font-semibold text-gray-400">—</span>
+              }
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Match Rate</span>
+              @if (revenueImpactData().matchRate > 0) {
+                <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().matchRate.toFixed(1) }}%</span>
+              } @else {
+                <span class="text-2xl font-semibold text-gray-400">—</span>
+              }
+            </div>
+          </lfx-card>
+        </div>
+
+        <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-deal-breakdown">
+          <div class="flex flex-col gap-1">
+            <h3 class="text-sm font-semibold text-gray-900">Deal Pipeline Breakdown</h3>
+            <p class="text-sm text-gray-600">Deal status distribution across the membership pipeline</p>
+          </div>
+          @if (revenueImpactData().engagementTypes.length > 0) {
+            <div class="flex flex-col gap-3">
+              @for (engagement of revenueImpactData().engagementTypes; track engagement.type) {
+                <div class="flex flex-col gap-1" data-testid="member-acquisition-drawer-deal-row">
+                  <div class="flex items-center justify-between">
+                    <span class="text-sm font-medium text-gray-900">{{ engagement.type }}</span>
+                    <span class="text-sm font-semibold text-gray-900">{{ engagement.percentage.toFixed(1) }}%</span>
+                  </div>
+                  <div class="w-full h-2 bg-gray-100 rounded-full">
+                    <div class="h-2 bg-blue-500 rounded-full" [style.width.%]="engagement.percentage"></div>
+                  </div>
+                </div>
+              }
+            </div>
+          } @else {
+            <div class="flex items-center justify-center h-[80px] text-sm text-gray-400">Deal pipeline data not yet available</div>
+          }
+        </div>
+      </div>
+    }
+
     <!-- Total Members Trend -->
     @if (data().totalMembersMonthlyData.length > 1) {
       <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-total-members-section">
         <div class="flex flex-col gap-1">
           <h3 class="text-sm font-semibold text-gray-900">Total Members Over Time</h3>
-          <p class="text-sm text-gray-600">Cumulative membership growth over the last 12 months</p>
+          <p class="text-sm text-gray-600">Cumulative membership growth over the last 6 months</p>
         </div>
         <div class="h-[200px]" data-testid="member-acquisition-drawer-total-members-chart">
           <lfx-chart type="line" [data]="totalMembersChartData()" [options]="totalMembersChartOptions" height="100%"></lfx-chart>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -96,7 +96,7 @@
         @for (action of attentionActions(); track action.title) {
           <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
             <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
-              <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
+              <i [class]="(action.actionType | marketingActionIcon) + ' text-red-600'"></i>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center justify-between gap-2">
@@ -135,7 +135,7 @@
         @for (action of performingActions(); track action.title) {
           <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
             <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
-              <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+              <i [class]="(action.actionType | marketingActionIcon) + ' text-green-600'"></i>
             </div>
             <div class="flex-1 min-w-0">
               <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
@@ -171,7 +171,7 @@
             <div class="flex flex-col gap-1">
               <span class="text-sm text-gray-500">Pipeline Influenced</span>
               @if (revenueImpactData().pipelineInfluenced > 0) {
-                <span class="text-2xl font-semibold text-gray-900">{{ formatMoney(revenueImpactData().pipelineInfluenced) }}</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().pipelineInfluenced | formatMoney }}</span>
               } @else {
                 <span class="text-2xl font-semibold text-gray-400">—</span>
               }
@@ -181,7 +181,7 @@
             <div class="flex flex-col gap-1">
               <span class="text-sm text-gray-500">Revenue Attributed</span>
               @if (revenueImpactData().revenueAttributed > 0) {
-                <span class="text-2xl font-semibold text-gray-900">{{ formatMoney(revenueImpactData().revenueAttributed) }}</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().revenueAttributed | formatMoney }}</span>
               } @else {
                 <span class="text-2xl font-semibold text-gray-400">—</span>
               }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -56,13 +56,13 @@
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Renewal Rate</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().renewalRate.toFixed(1) }}%</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().renewalRate | number: '1.1-1' }}%</span>
           </div>
         </lfx-card>
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Net Revenue Retention</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().netRevenueRetention.toFixed(1) }}%</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().netRevenueRetention | number: '1.1-1' }}%</span>
           </div>
         </lfx-card>
         <lfx-card styleClass="flex-1">
@@ -71,7 +71,7 @@
             @if (retentionData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="retentionData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ retentionData().changePercentage > 0 ? '+' : '' }}{{ retentionData().changePercentage.toFixed(1) }}%
+                  {{ retentionData().changePercentage > 0 ? '+' : '' }}{{ retentionData().changePercentage | number: '1.1-1' }}%
                 </span>
                 <i class="text-sm" [class]="retentionData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>
@@ -191,7 +191,7 @@
             <div class="flex flex-col gap-1">
               <span class="text-sm text-gray-500">Match Rate</span>
               @if (revenueImpactData().matchRate > 0) {
-                <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().matchRate.toFixed(1) }}%</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().matchRate | number: '1.1-1' }}%</span>
               } @else {
                 <span class="text-2xl font-semibold text-gray-400">—</span>
               }
@@ -210,7 +210,7 @@
                 <div class="flex flex-col gap-1" data-testid="member-acquisition-drawer-deal-row">
                   <div class="flex items-center justify-between">
                     <span class="text-sm font-medium text-gray-900">{{ engagement.type }}</span>
-                    <span class="text-sm font-semibold text-gray-900">{{ engagement.percentage.toFixed(1) }}%</span>
+                    <span class="text-sm font-semibold text-gray-900">{{ engagement.percentage | number: '1.1-1' }}%</span>
                   </div>
                   <div class="w-full h-2 bg-gray-100 rounded-full">
                     <div class="h-2 bg-blue-500 rounded-full" [style.width.%]="engagement.percentage"></div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DecimalPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -24,7 +25,7 @@ import type {
 @Component({
   selector: 'lfx-member-acquisition-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, TagComponent, FormatMoneyPipe, MarketingActionIconPipe],
+  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule, ChartComponent, TagComponent, FormatMoneyPipe, MarketingActionIconPipe],
   templateUrl: './member-acquisition-drawer.component.html',
   styleUrl: './member-acquisition-drawer.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -6,8 +6,10 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { createBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors, MARKETING_ACTION_ICON_MAP } from '@lfx-one/shared/constants';
-import { formatNumber, hexToRgba } from '@lfx-one/shared/utils';
+import { createBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { formatCurrency, formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import { FormatMoneyPipe } from '@pipes/format-money.pipe';
+import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -16,14 +18,13 @@ import type {
   MemberRetentionResponse,
   MarketingRecommendedAction,
   MarketingKeyInsight,
-  MarketingActionType,
   RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-member-acquisition-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, TagComponent],
+  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, TagComponent, FormatMoneyPipe, MarketingActionIconPipe],
   templateUrl: './member-acquisition-drawer.component.html',
   styleUrl: './member-acquisition-drawer.component.scss',
 })
@@ -74,22 +75,13 @@ export class MemberAcquisitionDrawerComponent {
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
   protected readonly retentionActions: Signal<MarketingRecommendedAction[]> = this.initRetentionActions();
   protected readonly retentionInsights: Signal<MarketingKeyInsight[]> = this.initRetentionInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => [
-    ...this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium'),
-    ...this.retentionActions().filter((a) => a.priority === 'high' || a.priority === 'medium'),
-  ]);
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => [
-    ...this.keyInsights().filter((i) => i.type === 'warning'),
-    ...this.retentionInsights().filter((i) => i.type === 'warning'),
-  ]);
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => [
-    ...this.recommendedActions().filter((a) => a.priority === 'low'),
-    ...this.retentionActions().filter((a) => a.priority === 'low'),
-  ]);
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => [
-    ...this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info'),
-    ...this.retentionInsights().filter((i) => i.type === 'driver' || i.type === 'info'),
-  ]);
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() =>
+    splitByPriority([...this.recommendedActions(), ...this.retentionActions()], [...this.keyInsights(), ...this.retentionInsights()])
+  );
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly acquisitionChartData: Signal<ChartData<'bar'>> = this.initAcquisitionChartData();
 
   protected readonly acquisitionChartOptions: ChartOptions<'bar'> = createBarChartOptions({
@@ -139,16 +131,6 @@ export class MemberAcquisitionDrawerComponent {
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
-  }
-
-  protected actionIcon(type: MarketingActionType): string {
-    return MARKETING_ACTION_ICON_MAP[type];
-  }
-
-  protected formatMoney(value: number): string {
-    if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
-    if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
-    return `$${Math.round(value).toLocaleString()}`;
   }
 
   // === Private Initializers ===
@@ -213,7 +195,7 @@ export class MemberAcquisitionDrawerComponent {
           if (declinePct >= 15) {
             actions.push({
               title: 'Membership tier mix shifting down',
-              description: `Revenue per new member fell ${declinePct.toFixed(0)}% (${this.formatMoney(Math.abs(delta))}/member) — winning deals are smaller. Review tier positioning and sales qualification`,
+              description: `Revenue per new member fell ${declinePct.toFixed(0)}% (${formatCurrency(Math.abs(delta))}/member) — winning deals are smaller. Review tier positioning and sales qualification`,
               priority: 'high',
               dueLabel: 'This quarter',
               actionType: 'revenue',
@@ -246,7 +228,7 @@ export class MemberAcquisitionDrawerComponent {
       // Acquisition QoQ
       if (changePercentage >= 10) {
         insights.push({
-          text: `New member acquisition up ${changePercentage.toFixed(1)}% QoQ — ${newMembersThisQuarter} new members, ${this.formatMoney(newMemberRevenue)} revenue`,
+          text: `New member acquisition up ${changePercentage.toFixed(1)}% QoQ — ${newMembersThisQuarter} new members, ${formatCurrency(newMemberRevenue)} revenue`,
           type: 'driver',
         });
       } else if (changePercentage <= -10) {
@@ -262,7 +244,7 @@ export class MemberAcquisitionDrawerComponent {
         if (previousPerMember > 0 && recentPerMember > previousPerMember) {
           const growthPct = ((recentPerMember - previousPerMember) / previousPerMember) * 100;
           insights.push({
-            text: `Revenue per new member up ${growthPct.toFixed(0)}% QoQ to ${this.formatMoney(recentPerMember)} — tier mix improving`,
+            text: `Revenue per new member up ${growthPct.toFixed(0)}% QoQ to ${formatCurrency(recentPerMember)} — tier mix improving`,
             type: 'driver',
           });
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -17,6 +17,7 @@ import type {
   MarketingRecommendedAction,
   MarketingKeyInsight,
   MarketingActionType,
+  RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
 
 @Component({
@@ -49,6 +50,20 @@ export class MemberAcquisitionDrawerComponent {
     trend: 'up',
     target: 85,
     monthlyData: [],
+  });
+
+  public readonly revenueImpactData = input<RevenueImpactResponse>({
+    pipelineInfluenced: 0,
+    revenueAttributed: 0,
+    matchRate: 0,
+    changePercentage: 0,
+    trend: 'up',
+    attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+    engagementTypes: [],
+    paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0, monthlyTrend: [] },
+    attributionChannels: [],
+    projectBreakdown: [],
+    eventRegistrationAttribution: { channelBreakdown: [], monthlyTrend: [] },
   });
 
   // === Computed Signals ===
@@ -130,6 +145,12 @@ export class MemberAcquisitionDrawerComponent {
     return MARKETING_ACTION_ICON_MAP[type];
   }
 
+  protected formatMoney(value: number): string {
+    if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+    return `$${Math.round(value).toLocaleString()}`;
+  }
+
   // === Private Initializers ===
   private initTotalMembersChartData(): Signal<ChartData<'line'>> {
     return computed(() => {
@@ -154,33 +175,53 @@ export class MemberAcquisitionDrawerComponent {
 
   private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
     return computed(() => {
-      const { newMembersThisQuarter, newMemberRevenue, changePercentage, quarterlyData } = this.data();
+      const { newMembersThisQuarter, changePercentage, quarterlyData } = this.data();
       const actions: MarketingRecommendedAction[] = [];
 
       if (newMembersThisQuarter === 0 && quarterlyData.length === 0) {
         return actions;
       }
 
-      // Check if revenue per new member is declining (only flag if decline > 5%)
+      // Acquisition decline — tier on magnitude
+      if (changePercentage <= -15) {
+        actions.push({
+          title: 'Reverse acquisition decline',
+          description: `New member signups dropped ${Math.abs(changePercentage).toFixed(1)}% QoQ — review top-of-funnel channels, conversion paths, and outbound pipeline`,
+          priority: 'high',
+          dueLabel: 'This month',
+          actionType: 'decline',
+        });
+      } else if (changePercentage <= -5) {
+        actions.push({
+          title: 'Acquisition softening',
+          description: `New member signups down ${Math.abs(changePercentage).toFixed(1)}% QoQ — watch next quarter's pipeline and renewal mix`,
+          priority: 'medium',
+          dueLabel: 'Next quarter',
+          actionType: 'investigate',
+        });
+      }
+
+      // Revenue per new member — the tier-mix signal for an ED
       if (quarterlyData.length >= 2) {
         const recent = quarterlyData[quarterlyData.length - 1];
         const previous = quarterlyData[quarterlyData.length - 2];
         const recentPerMember = recent.newMembers > 0 ? recent.revenue / recent.newMembers : 0;
         const previousPerMember = previous.newMembers > 0 ? previous.revenue / previous.newMembers : 0;
-        if (previousPerMember > 0) {
+        if (previousPerMember > 0 && recentPerMember > 0) {
+          const delta = recentPerMember - previousPerMember;
           const declinePct = ((previousPerMember - recentPerMember) / previousPerMember) * 100;
-          if (declinePct > 15) {
+          if (declinePct >= 15) {
             actions.push({
-              title: 'Improve revenue per new member',
-              description: `Revenue per new member declined ${declinePct.toFixed(0)}% — review membership tier mix and onboarding`,
+              title: 'Membership tier mix shifting down',
+              description: `Revenue per new member fell ${declinePct.toFixed(0)}% (${this.formatMoney(Math.abs(delta))}/member) — winning deals are smaller. Review tier positioning and sales qualification`,
               priority: 'high',
               dueLabel: 'This quarter',
               actionType: 'revenue',
             });
-          } else if (declinePct > 5) {
+          } else if (declinePct >= 5) {
             actions.push({
-              title: 'Monitor revenue per new member',
-              description: `Revenue per new member declined ${declinePct.toFixed(0)}% — watch tier mix trends`,
+              title: 'Watch tier mix trend',
+              description: `Revenue per new member down ${declinePct.toFixed(0)}% QoQ — not yet urgent, but track whether next quarter's deals are smaller still`,
               priority: 'medium',
               dueLabel: 'Next quarter',
               actionType: 'revenue',
@@ -189,92 +230,60 @@ export class MemberAcquisitionDrawerComponent {
         }
       }
 
-      // Check if acquisition is declining
-      if (changePercentage < -10) {
-        actions.push({
-          title: 'Address acquisition decline',
-          description: `New member signups dropped ${Math.abs(changePercentage)}% — review marketing funnel and conversion paths`,
-          priority: 'high',
-          dueLabel: 'This month',
-          actionType: 'decline',
-        });
-      }
-
-      // Check revenue growth trend over 3+ quarters
-      if (quarterlyData.length >= 3) {
-        const recent3 = quarterlyData.slice(-3);
-        const revenueGrowing = recent3[0].revenue < recent3[1].revenue && recent3[1].revenue < recent3[2].revenue;
-        if (revenueGrowing && recent3[2].revenue > 0) {
-          const totalGrowth = (((recent3[2].revenue - recent3[0].revenue) / recent3[0].revenue) * 100).toFixed(0);
-          actions.push({
-            title: 'Scale current acquisition channels',
-            description: `New member revenue grew ${totalGrowth}% over 3 quarters — room to increase investment in efficient channels`,
-            priority: 'medium',
-            dueLabel: 'Next quarter',
-            actionType: 'growth',
-          });
-        }
-      }
-
-      if (actions.length === 0) {
-        actions.push({
-          title: 'Monitor acquisition performance',
-          description: `${newMembersThisQuarter} new members this quarter with $${formatNumber(newMemberRevenue)} in new revenue`,
-          priority: 'low',
-          dueLabel: 'Ongoing',
-          actionType: 'growth',
-        });
-      }
-
       return actions;
     });
   }
 
   private initKeyInsights(): Signal<MarketingKeyInsight[]> {
     return computed(() => {
-      const { newMembersThisQuarter, changePercentage, quarterlyData } = this.data();
+      const { newMembersThisQuarter, newMemberRevenue, changePercentage, quarterlyData } = this.data();
       const insights: MarketingKeyInsight[] = [];
 
       if (newMembersThisQuarter === 0 && quarterlyData.length === 0) {
         return insights;
       }
 
-      // Acquisition trend
-      if (changePercentage > 10) {
-        insights.push({ text: `New member acquisition up ${changePercentage}% quarter-over-quarter`, type: 'driver' });
-      } else if (changePercentage < -10) {
-        insights.push({ text: `New member acquisition down ${Math.abs(changePercentage)}% quarter-over-quarter`, type: 'warning' });
-      } else if (changePercentage !== 0) {
-        insights.push({ text: `Acquisition ${changePercentage > 0 ? 'up' : 'down'} ${Math.abs(changePercentage)}% — relatively stable`, type: 'info' });
+      // Acquisition QoQ
+      if (changePercentage >= 10) {
+        insights.push({
+          text: `New member acquisition up ${changePercentage.toFixed(1)}% QoQ — ${newMembersThisQuarter} new members, ${this.formatMoney(newMemberRevenue)} revenue`,
+          type: 'driver',
+        });
+      } else if (changePercentage <= -10) {
+        insights.push({ text: `New member acquisition down ${Math.abs(changePercentage).toFixed(1)}% QoQ`, type: 'warning' });
       }
 
-      // Revenue trend
+      // Revenue-per-member trend (the tier-mix signal)
       if (quarterlyData.length >= 2) {
         const recent = quarterlyData[quarterlyData.length - 1];
         const previous = quarterlyData[quarterlyData.length - 2];
-        if (previous.revenue > 0 && recent.revenue > previous.revenue) {
-          const growth = (((recent.revenue - previous.revenue) / previous.revenue) * 100).toFixed(0);
-          insights.push({ text: `New member revenue grew ${growth}% to $${formatNumber(recent.revenue)} — acquisition efficiency increasing`, type: 'driver' });
-        } else if (previous.revenue > 0 && recent.revenue < previous.revenue) {
-          insights.push({ text: `New member revenue declined to $${formatNumber(recent.revenue)} — review membership tier mix`, type: 'warning' });
+        const recentPerMember = recent.newMembers > 0 ? recent.revenue / recent.newMembers : 0;
+        const previousPerMember = previous.newMembers > 0 ? previous.revenue / previous.newMembers : 0;
+        if (previousPerMember > 0 && recentPerMember > previousPerMember) {
+          const growthPct = ((recentPerMember - previousPerMember) / previousPerMember) * 100;
+          insights.push({
+            text: `Revenue per new member up ${growthPct.toFixed(0)}% QoQ to ${this.formatMoney(recentPerMember)} — tier mix improving`,
+            type: 'driver',
+          });
         }
       }
 
-      // Best quarter check
+      // 3 consecutive quarters of revenue growth — strongest performing-well signal
+      if (quarterlyData.length >= 3) {
+        const recent3 = quarterlyData.slice(-3);
+        const revenueGrowing = recent3[0].revenue < recent3[1].revenue && recent3[1].revenue < recent3[2].revenue;
+        if (revenueGrowing && recent3[0].revenue > 0) {
+          const totalGrowth = ((recent3[2].revenue - recent3[0].revenue) / recent3[0].revenue) * 100;
+          insights.push({ text: `New member revenue grew ${totalGrowth.toFixed(0)}% over 3 quarters — scale efficient channels`, type: 'driver' });
+        }
+      }
+
+      // Best quarter in dataset
       if (quarterlyData.length >= 4) {
         const max = Math.max(...quarterlyData.map((q) => q.newMembers));
         const current = quarterlyData[quarterlyData.length - 1];
-        if (current.newMembers === max) {
-          insights.push({ text: `${current.quarter} is the strongest acquisition quarter in the dataset`, type: 'driver' });
-        }
-      }
-
-      // Consecutive growth
-      if (quarterlyData.length >= 3) {
-        const recent3 = quarterlyData.slice(-3);
-        const isGrowing = recent3[0].newMembers < recent3[1].newMembers && recent3[1].newMembers < recent3[2].newMembers;
-        if (isGrowing) {
-          insights.push({ text: 'Acquisition growing for 3 consecutive quarters', type: 'driver' });
+        if (current.newMembers === max && current.newMembers > 0) {
+          insights.push({ text: `${current.quarter} is the strongest acquisition quarter on record`, type: 'driver' });
         }
       }
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -33,13 +33,13 @@
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Renewal Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().renewalRate }}%</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ data().renewalRate.toFixed(1) }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Net Revenue Retention</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().netRevenueRetention }}%</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ data().netRevenueRetention.toFixed(1) }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
@@ -48,7 +48,7 @@
           @if (data().changePercentage !== 0) {
             <div class="flex items-center gap-2">
               <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage }}%
+                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage.toFixed(1) }}%
               </span>
               <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -33,13 +33,13 @@
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Renewal Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().renewalRate.toFixed(1) }}%</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ data().renewalRate | number: '1.1-1' }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Net Revenue Retention</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().netRevenueRetention.toFixed(1) }}%</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ data().netRevenueRetention | number: '1.1-1' }}%</span>
         </div>
       </lfx-card>
       <lfx-card styleClass="flex-1">
@@ -48,7 +48,7 @@
           @if (data().changePercentage !== 0) {
             <div class="flex items-center gap-2">
               <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage.toFixed(1) }}%
+                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage | number: '1.1-1' }}%
               </span>
               <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
             </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -72,7 +72,7 @@
         @for (action of attentionActions(); track action.title) {
           <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
             <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
-              <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
+              <i [class]="(action.actionType | marketingActionIcon) + ' text-red-600'"></i>
             </div>
             <div class="flex-1 min-w-0">
               <div class="flex items-center justify-between gap-2">
@@ -111,7 +111,7 @@
         @for (action of performingActions(); track action.title) {
           <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
             <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
-              <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+              <i [class]="(action.actionType | marketingActionIcon) + ' text-green-600'"></i>
             </div>
             <div class="flex-1 min-w-0">
               <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DecimalPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -14,7 +15,7 @@ import type { MarketingKeyInsight, MarketingRecommendedAction, MemberRetentionRe
 @Component({
   selector: 'lfx-member-retention-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, TagComponent, MarketingActionIconPipe],
+  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule, TagComponent, MarketingActionIconPipe],
   templateUrl: './member-retention-drawer.component.html',
   styleUrl: './member-retention-drawer.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -5,15 +5,16 @@ import { ChangeDetectionStrategy, Component, computed, input, model, Signal } fr
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
+import { splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { DrawerModule } from 'primeng/drawer';
 
-import { MARKETING_ACTION_ICON_MAP } from '@lfx-one/shared/constants';
-import type { MemberRetentionResponse, MarketingRecommendedAction, MarketingKeyInsight, MarketingActionType } from '@lfx-one/shared/interfaces';
+import type { MarketingKeyInsight, MarketingRecommendedAction, MemberRetentionResponse } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-member-retention-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, TagComponent],
+  imports: [ButtonComponent, CardComponent, DrawerModule, TagComponent, MarketingActionIconPipe],
   templateUrl: './member-retention-drawer.component.html',
   styleUrl: './member-retention-drawer.component.scss',
 })
@@ -34,22 +35,19 @@ export class MemberRetentionDrawerComponent {
   // === Computed Signals ===
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
-  }
-
-  protected actionIcon(type: MarketingActionType): string {
-    return MARKETING_ACTION_ICON_MAP[type];
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
@@ -52,11 +52,11 @@
             <div class="flex flex-col gap-1">
               <span class="text-sm text-gray-500">ROAS</span>
               <div class="flex items-center gap-2">
-                <span class="text-2xl font-semibold text-gray-900">{{ drawerData().roas.toFixed(1) }}x</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ drawerData().roas | number: '1.1-1' }}x</span>
                 @if (drawerData().changePercentage !== 0) {
                   <span class="text-sm font-medium" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
                     <i [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up' : 'fa-light fa-arrow-down'"></i>
-                    {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
+                    {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage | number: '1.1-1' }}%
                   </span>
                 }
               </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
@@ -52,11 +52,11 @@
             <div class="flex flex-col gap-1">
               <span class="text-sm text-gray-500">ROAS</span>
               <div class="flex items-center gap-2">
-                <span class="text-2xl font-semibold text-gray-900">{{ drawerData().roas.toFixed(2) }}x</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ drawerData().roas.toFixed(1) }}x</span>
                 @if (drawerData().changePercentage !== 0) {
                   <span class="text-sm font-medium" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
                     <i [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up' : 'fa-light fa-arrow-down'"></i>
-                    {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage }}%
+                    {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
                   </span>
                 }
               </div>
@@ -73,29 +73,28 @@
         }
       </div>
 
-      <!-- Recommended Actions -->
-      @if (recommendedActions().length > 0) {
-        <div class="flex flex-col gap-3" data-testid="paid-social-reach-drawer-actions">
+      <!-- FIRST FOLD: Needs Your Attention -->
+      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+        <div class="flex flex-col gap-4 p-4 bg-red-50 border border-red-200 rounded-lg" data-testid="paid-social-reach-drawer-attention">
           <div class="flex items-center gap-2">
-            <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900">
-              <i class="fa-light fa-lightbulb text-amber-500"></i>
-              Recommended Actions
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-red-800">
+              <i class="fa-light fa-triangle-exclamation text-red-500"></i>
+              Needs Your Attention
             </h3>
           </div>
-          @for (action of recommendedActions(); track action.title) {
-            <div class="flex items-start gap-3 p-4 border border-gray-200 rounded-lg">
-              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-gray-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-gray-600'"></i>
+
+          @for (action of attentionActions(); track action.title) {
+            <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
+              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
+                <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center justify-between gap-2">
                   <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
                   @if (action.priority === 'high') {
                     <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-                  } @else if (action.priority === 'medium') {
-                    <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
                   } @else {
-                    <lfx-tag value="Low Priority" severity="info" [rounded]="true" />
+                    <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
@@ -103,28 +102,46 @@
               </div>
             </div>
           }
+
+          @for (insight of attentionInsights(); track insight.text) {
+            <div class="flex items-center gap-2 text-sm px-1">
+              <i class="fa-light fa-triangle-exclamation text-red-500"></i>
+              <span class="text-red-800">{{ insight.text }}</span>
+            </div>
+          }
         </div>
       }
 
-      <!-- Key Insights -->
-      @if (keyInsights().length > 0) {
-        <div class="flex flex-col gap-3 p-4 bg-gray-50 rounded-lg" data-testid="paid-social-reach-drawer-insights">
+      <!-- SECOND FOLD: Performing Well -->
+      @if (performingActions().length > 0 || performingInsights().length > 0) {
+        <div class="flex flex-col gap-4 p-4 bg-green-50 border border-green-200 rounded-lg" data-testid="paid-social-reach-drawer-performing">
           <div class="flex items-center gap-2">
-            <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900">
-              <i class="fa-light fa-triangle-exclamation text-amber-500"></i>
-              Key Insights
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-green-800">
+              <i class="fa-light fa-check-circle text-green-500"></i>
+              Performing Well
             </h3>
           </div>
-          @for (insight of keyInsights(); track insight.text) {
-            <div class="flex items-center gap-2 text-sm">
+
+          @for (action of performingActions(); track action.title) {
+            <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
+              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
+                <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+              </div>
+              <div class="flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
+              </div>
+            </div>
+          }
+
+          @for (insight of performingInsights(); track insight.text) {
+            <div class="flex items-center gap-2 text-sm px-1">
               @if (insight.type === 'driver') {
-                <i class="fa-light fa-bullseye text-gray-500"></i>
-              } @else if (insight.type === 'warning') {
-                <i class="fa-light fa-triangle-exclamation text-amber-500"></i>
+                <i class="fa-light fa-bullseye text-green-500"></i>
               } @else {
                 <i class="fa-light fa-circle-info text-blue-500"></i>
               }
-              <span class="text-gray-700">{{ insight.text }}</span>
+              <span class="text-green-800">{{ insight.text }}</span>
             </div>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
@@ -86,7 +86,7 @@
           @for (action of attentionActions(); track action.title) {
             <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
               <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
+                <i [class]="(action.actionType | marketingActionIcon) + ' text-red-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center justify-between gap-2">
@@ -125,7 +125,7 @@
           @for (action of performingActions(); track action.title) {
             <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
               <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+                <i [class]="(action.actionType | marketingActionIcon) + ' text-green-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -7,22 +7,23 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { createBarChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors, MARKETING_ACTION_ICON_MAP } from '@lfx-one/shared/constants';
-import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
+import { createBarChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { formatCurrency, formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { MessageService } from 'primeng/api';
 import { catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
 
 import type { ChartData, ChartOptions } from 'chart.js';
-import type { SocialReachResponse, MarketingRecommendedAction, MarketingKeyInsight, MarketingActionType } from '@lfx-one/shared/interfaces';
+import type { SocialReachResponse, MarketingRecommendedAction, MarketingKeyInsight } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-paid-social-reach-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TagComponent],
+  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TagComponent, MarketingActionIconPipe],
   templateUrl: './paid-social-reach-drawer.component.html',
   styleUrl: './paid-social-reach-drawer.component.scss',
 })
@@ -44,14 +45,15 @@ export class PaidSocialReachDrawerComponent {
   protected readonly formattedTotalRevenue: Signal<string> = computed(() => formatCurrency(this.drawerData().totalRevenue));
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
   protected readonly roasChartData: Signal<ChartData<'bar'>> = this.initRoasChartData();
   protected readonly hasRoasData: Signal<boolean> = computed(() => {
@@ -141,10 +143,6 @@ export class PaidSocialReachDrawerComponent {
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
-  }
-
-  protected actionIcon(type: MarketingActionType): string {
-    return MARKETING_ACTION_ICON_MAP[type];
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -44,6 +44,14 @@ export class PaidSocialReachDrawerComponent {
   protected readonly formattedTotalRevenue: Signal<string> = computed(() => formatCurrency(this.drawerData().totalRevenue));
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
+    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
+  );
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
+    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
+  );
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
   protected readonly roasChartData: Signal<ChartData<'bar'>> = this.initRoasChartData();
   protected readonly hasRoasData: Signal<boolean> = computed(() => {
@@ -155,15 +163,15 @@ export class PaidSocialReachDrawerComponent {
     };
 
     const visible$ = toObservable(this.visible);
-    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.name || ''));
+    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.slug || ''));
 
     return toSignal(
       combineLatest([visible$, foundation$]).pipe(
-        filter(([isVisible, name]) => isVisible && !!name),
-        map(([, name]) => name),
+        filter(([isVisible, slug]) => isVisible && !!slug),
+        map(([, slug]) => slug),
         tap(() => this.drawerLoading.set(true)),
-        switchMap((foundationName) =>
-          this.analyticsService.getSocialReach(foundationName).pipe(
+        switchMap((foundationSlug) =>
+          this.analyticsService.getSocialReach(foundationSlug).pipe(
             tap(() => this.drawerLoading.set(false)),
             catchError(() => {
               this.drawerLoading.set(false);
@@ -183,45 +191,54 @@ export class PaidSocialReachDrawerComponent {
 
   private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
     return computed(() => {
-      const { roas, changePercentage, totalSpend, totalRevenue } = this.drawerData();
+      const { roas, changePercentage, totalSpend, totalRevenue, monthlyRoas } = this.drawerData();
       const actions: MarketingRecommendedAction[] = [];
 
-      if (roas > 0 && roas < 1) {
+      // Losing money — the most urgent signal (includes 0.00x — spend with no attributed revenue)
+      if (totalSpend > 0 && roas < 0.8) {
+        const lost = totalSpend - totalRevenue;
         actions.push({
-          title: 'Review ad spend efficiency',
-          description: `ROAS is ${roas.toFixed(2)}x — spending more than earning. Pause underperforming campaigns`,
+          title: 'Cut or pause losing campaigns',
+          description: `ROAS is ${roas.toFixed(2)}x — ${formatCurrency(lost)} spent above revenue earned. Pause bottom-performing campaigns before next cycle`,
           priority: 'high',
           dueLabel: 'This week',
           actionType: 'decline',
         });
-      } else if (changePercentage < -10) {
+      } else if (totalSpend > 0 && roas >= 0.8 && roas < 1) {
         actions.push({
-          title: 'Investigate reach decline',
-          description: `Impressions dropped ${Math.abs(changePercentage)}% — review targeting and bid strategy`,
-          priority: 'high',
-          dueLabel: 'Next campaign',
+          title: 'Campaigns at break-even',
+          description: `ROAS is ${roas.toFixed(2)}x on ${formatCurrency(totalSpend)} spend — not yet profitable. Fix creative and targeting before scaling budget`,
+          priority: 'medium',
+          dueLabel: 'This month',
           actionType: 'investigate',
         });
       }
 
-      if (actions.length === 0) {
-        if (roas > 1) {
+      // ROAS trending down — separate from absolute level
+      if (monthlyRoas && monthlyRoas.length >= 3) {
+        const recent3 = monthlyRoas.slice(-3);
+        const falling = recent3[0] > recent3[1] && recent3[1] > recent3[2];
+        const drop = recent3[0] - recent3[2];
+        if (falling && drop >= 0.5) {
           actions.push({
-            title: 'Scale current campaigns',
-            description: `ROAS at ${roas.toFixed(2)}x with ${formatCurrency(totalRevenue)} revenue on ${formatCurrency(totalSpend)} spend — room to grow`,
-            priority: 'low',
-            dueLabel: 'Ongoing',
-            actionType: 'growth',
-          });
-        } else {
-          actions.push({
-            title: 'Monitor campaign performance',
-            description: `${formatNumber(this.drawerData().totalReach)} total impressions — tracking performance`,
-            priority: 'low',
-            dueLabel: 'Ongoing',
-            actionType: 'growth',
+            title: 'ROAS trending down 3 months straight',
+            description: `ROAS fell from ${recent3[0].toFixed(2)}x to ${recent3[2].toFixed(2)}x over 3 months — investigate audience saturation and creative fatigue`,
+            priority: 'medium',
+            dueLabel: 'This month',
+            actionType: 'investigate',
           });
         }
+      }
+
+      // Reach drop — separate from ROAS
+      if (changePercentage <= -10) {
+        actions.push({
+          title: 'Investigate reach decline',
+          description: `Impressions dropped ${Math.abs(changePercentage).toFixed(1)}% MoM — review targeting, bid strategy, and platform algorithm changes`,
+          priority: 'high',
+          dueLabel: 'Next campaign',
+          actionType: 'investigate',
+        });
       }
 
       return actions;
@@ -237,28 +254,23 @@ export class PaidSocialReachDrawerComponent {
         return insights;
       }
 
-      // ROAS insight
+      // ROAS tiers
       if (roas >= 3) {
         insights.push({
           text: `Strong ROAS at ${roas.toFixed(2)}x — ${formatCurrency(totalRevenue)} revenue on ${formatCurrency(totalSpend)} spend`,
           type: 'driver',
         });
-      } else if (roas >= 1) {
-        insights.push({ text: `ROAS at ${roas.toFixed(2)}x — profitable but room for optimization`, type: 'info' });
-      } else if (totalSpend > 0) {
-        insights.push({
-          text: `ROAS below break-even at ${roas.toFixed(2)}x — spending ${formatCurrency(totalSpend)} for ${formatCurrency(totalRevenue)} revenue`,
-          type: 'warning',
-        });
+      } else if (roas >= 2) {
+        insights.push({ text: `Healthy ROAS at ${roas.toFixed(2)}x — room to scale top campaigns`, type: 'driver' });
+      } else if (roas >= 1 && totalSpend > 0) {
+        insights.push({ text: `Profitable at ${roas.toFixed(2)}x ROAS — fix underperformers before scaling`, type: 'info' });
       }
 
-      // Impression trend
-      if (changePercentage !== 0) {
-        if (changePercentage > 0) {
-          insights.push({ text: `Impressions grew ${changePercentage}% month-over-month`, type: 'driver' });
-        } else {
-          insights.push({ text: `Impressions declined ${Math.abs(changePercentage)}% month-over-month`, type: 'warning' });
-        }
+      // Impressions trend
+      if (changePercentage >= 10) {
+        insights.push({ text: `Impressions grew ${changePercentage.toFixed(1)}% MoM to ${formatNumber(totalReach)}`, type: 'driver' });
+      } else if (changePercentage <= -5) {
+        insights.push({ text: `Impressions declined ${Math.abs(changePercentage).toFixed(1)}% MoM`, type: 'warning' });
       }
 
       // ROAS trend
@@ -266,10 +278,10 @@ export class PaidSocialReachDrawerComponent {
         const recent3 = monthlyRoas.slice(-3);
         const isDecreasing = recent3[0] > recent3[1] && recent3[1] > recent3[2];
         const isIncreasing = recent3[0] < recent3[1] && recent3[1] < recent3[2];
-        if (isDecreasing) {
-          insights.push({ text: 'ROAS declining for 3 consecutive months', type: 'warning' });
-        } else if (isIncreasing) {
-          insights.push({ text: 'ROAS improving for 3 consecutive months', type: 'driver' });
+        if (isIncreasing) {
+          insights.push({ text: `ROAS improving 3 months straight — now at ${recent3[2].toFixed(2)}x`, type: 'driver' });
+        } else if (isDecreasing) {
+          insights.push({ text: `ROAS declining 3 months straight — now at ${recent3[2].toFixed(2)}x`, type: 'warning' });
         }
       }
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DecimalPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
@@ -23,7 +24,7 @@ import type { SocialReachResponse, MarketingRecommendedAction, MarketingKeyInsig
 @Component({
   selector: 'lfx-paid-social-reach-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TagComponent, MarketingActionIconPipe],
+  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule, ChartComponent, SkeletonModule, TagComponent, MarketingActionIconPipe],
   templateUrl: './paid-social-reach-drawer.component.html',
   styleUrl: './paid-social-reach-drawer.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
@@ -7,6 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -167,14 +168,15 @@ export class RevenueImpactDrawerComponent {
   );
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
   protected onClose(): void {
     this.visible.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -59,7 +59,7 @@
             @if (drawerData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
+                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage | number: '1.1-1' }}%
                 </span>
                 <i class="text-sm" [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>
@@ -181,7 +181,7 @@
                   </div>
                 </td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ formatNumber(platform.followers) }}</td>
-                <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.engagementRate.toFixed(1) }}%</td>
+                <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.engagementRate | number: '1.1-1' }}%</td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.postsLast30Days }}</td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ formatNumber(platform.impressions) }}</td>
               </tr>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -59,7 +59,7 @@
             @if (drawerData().changePercentage !== 0) {
               <div class="flex items-center gap-2">
                 <span class="text-2xl font-semibold" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage }}%
+                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage.toFixed(1) }}%
                 </span>
                 <i class="text-sm" [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>
@@ -70,29 +70,28 @@
         </lfx-card>
       </div>
 
-      <!-- Recommended Actions -->
-      @if (recommendedActions().length > 0) {
-        <div class="flex flex-col gap-3" data-testid="social-media-drawer-actions">
+      <!-- FIRST FOLD: Needs Your Attention -->
+      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+        <div class="flex flex-col gap-4 p-4 bg-red-50 border border-red-200 rounded-lg" data-testid="social-media-drawer-attention">
           <div class="flex items-center gap-2">
-            <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900">
-              <i class="fa-light fa-lightbulb text-amber-500"></i>
-              Recommended Actions
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-red-800">
+              <i class="fa-light fa-triangle-exclamation text-red-500"></i>
+              Needs Your Attention
             </h3>
           </div>
-          @for (action of recommendedActions(); track action.title) {
-            <div class="flex items-start gap-3 p-4 border border-gray-200 rounded-lg">
-              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-gray-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-gray-600'"></i>
+
+          @for (action of attentionActions(); track action.title) {
+            <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
+              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
+                <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center justify-between gap-2">
                   <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
                   @if (action.priority === 'high') {
                     <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-                  } @else if (action.priority === 'medium') {
-                    <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
                   } @else {
-                    <lfx-tag value="Low Priority" severity="info" [rounded]="true" />
+                    <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
@@ -100,28 +99,46 @@
               </div>
             </div>
           }
+
+          @for (insight of attentionInsights(); track insight.text) {
+            <div class="flex items-center gap-2 text-sm px-1">
+              <i class="fa-light fa-triangle-exclamation text-red-500"></i>
+              <span class="text-red-800">{{ insight.text }}</span>
+            </div>
+          }
         </div>
       }
 
-      <!-- Key Insights -->
-      @if (keyInsights().length > 0) {
-        <div class="flex flex-col gap-3 p-4 bg-gray-50 rounded-lg" data-testid="social-media-drawer-insights">
+      <!-- SECOND FOLD: Performing Well -->
+      @if (performingActions().length > 0 || performingInsights().length > 0) {
+        <div class="flex flex-col gap-4 p-4 bg-green-50 border border-green-200 rounded-lg" data-testid="social-media-drawer-performing">
           <div class="flex items-center gap-2">
-            <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900">
-              <i class="fa-light fa-triangle-exclamation text-amber-500"></i>
-              Key Insights
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-green-800">
+              <i class="fa-light fa-check-circle text-green-500"></i>
+              Performing Well
             </h3>
           </div>
-          @for (insight of keyInsights(); track insight.text) {
-            <div class="flex items-center gap-2 text-sm">
+
+          @for (action of performingActions(); track action.title) {
+            <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
+              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
+                <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+              </div>
+              <div class="flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
+              </div>
+            </div>
+          }
+
+          @for (insight of performingInsights(); track insight.text) {
+            <div class="flex items-center gap-2 text-sm px-1">
               @if (insight.type === 'driver') {
-                <i class="fa-light fa-bullseye text-gray-500"></i>
-              } @else if (insight.type === 'warning') {
-                <i class="fa-light fa-triangle-exclamation text-amber-500"></i>
+                <i class="fa-light fa-bullseye text-green-500"></i>
               } @else {
                 <i class="fa-light fa-circle-info text-blue-500"></i>
               }
-              <span class="text-gray-700">{{ insight.text }}</span>
+              <span class="text-green-800">{{ insight.text }}</span>
             </div>
           }
         </div>
@@ -164,7 +181,7 @@
                   </div>
                 </td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ formatNumber(platform.followers) }}</td>
-                <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.engagementRate }}%</td>
+                <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.engagementRate.toFixed(1) }}%</td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ platform.postsLast30Days }}</td>
                 <td class="text-right py-2.5 px-3 text-gray-900">{{ formatNumber(platform.impressions) }}</td>
               </tr>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -83,7 +83,7 @@
           @for (action of attentionActions(); track action.title) {
             <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
               <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
+                <i [class]="(action.actionType | marketingActionIcon) + ' text-red-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center justify-between gap-2">
@@ -122,7 +122,7 @@
           @for (action of performingActions(); track action.title) {
             <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
               <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+                <i [class]="(action.actionType | marketingActionIcon) + ' text-green-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { DecimalPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
@@ -24,7 +25,7 @@ import type { SocialMediaResponse, MarketingRecommendedAction, MarketingKeyInsig
 @Component({
   selector: 'lfx-social-media-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TableComponent, TagComponent, MarketingActionIconPipe],
+  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule, ChartComponent, SkeletonModule, TableComponent, TagComponent, MarketingActionIconPipe],
   templateUrl: './social-media-drawer.component.html',
   styleUrl: './social-media-drawer.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -63,6 +63,14 @@ export class SocialMediaDrawerComponent {
   protected readonly formattedTotalFollowers: Signal<string> = computed(() => formatNumber(this.drawerData().totalFollowers));
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
+    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
+  );
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
+    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
+  );
   protected readonly followerTrendChartData: Signal<ChartData<'line'>> = this.initFollowerTrendChartData();
   protected readonly platformChartData: Signal<ChartData<'bar'>> = this.initPlatformChartData();
 
@@ -169,15 +177,15 @@ export class SocialMediaDrawerComponent {
     };
 
     const visible$ = toObservable(this.visible);
-    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.name || ''));
+    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.slug || ''));
 
     return toSignal(
       combineLatest([visible$, foundation$]).pipe(
-        filter(([isVisible, name]) => isVisible && !!name),
-        map(([, name]) => name),
+        filter(([isVisible, slug]) => isVisible && !!slug),
+        map(([, slug]) => slug),
         tap(() => this.drawerLoading.set(true)),
-        switchMap((foundationName) =>
-          this.analyticsService.getSocialMedia(foundationName).pipe(
+        switchMap((foundationSlug) =>
+          this.analyticsService.getSocialMedia(foundationSlug).pipe(
             tap(() => this.drawerLoading.set(false)),
             catchError(() => {
               this.drawerLoading.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -8,28 +8,23 @@ import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
-import {
-  createHorizontalBarChartOptions,
-  createLineChartOptions,
-  DASHBOARD_TOOLTIP_CONFIG,
-  lfxColors,
-  MARKETING_ACTION_ICON_MAP,
-} from '@lfx-one/shared/constants';
-import { formatNumber, hexToRgba } from '@lfx-one/shared/utils';
+import { createHorizontalBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { MessageService } from 'primeng/api';
 import { catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
 
 import type { ChartData, ChartOptions } from 'chart.js';
-import type { SocialMediaResponse, MarketingRecommendedAction, MarketingKeyInsight, MarketingActionType } from '@lfx-one/shared/interfaces';
+import type { SocialMediaResponse, MarketingRecommendedAction, MarketingKeyInsight } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-social-media-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TableComponent, TagComponent],
+  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TableComponent, TagComponent, MarketingActionIconPipe],
   templateUrl: './social-media-drawer.component.html',
   styleUrl: './social-media-drawer.component.scss',
 })
@@ -63,14 +58,15 @@ export class SocialMediaDrawerComponent {
   protected readonly formattedTotalFollowers: Signal<string> = computed(() => formatNumber(this.drawerData().totalFollowers));
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly followerTrendChartData: Signal<ChartData<'line'>> = this.initFollowerTrendChartData();
   protected readonly platformChartData: Signal<ChartData<'bar'>> = this.initPlatformChartData();
 
@@ -155,10 +151,6 @@ export class SocialMediaDrawerComponent {
   // === Protected Methods ===
   protected getIconClass(platformName: string): string {
     return this.platformIconMap[platformName] || 'fa-light fa-globe';
-  }
-
-  protected actionIcon(type: MarketingActionType): string {
-    return MARKETING_ACTION_ICON_MAP[type];
   }
 
   protected onClose(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -55,29 +55,28 @@
         </lfx-card>
       </div>
 
-      <!-- Recommended Actions -->
-      @if (recommendedActions().length > 0) {
-        <div class="flex flex-col gap-3" data-testid="website-visits-drawer-actions">
+      <!-- FIRST FOLD: Needs Your Attention -->
+      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+        <div class="flex flex-col gap-4 p-4 bg-red-50 border border-red-200 rounded-lg" data-testid="website-visits-drawer-attention">
           <div class="flex items-center gap-2">
-            <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900">
-              <i class="fa-light fa-lightbulb text-amber-500"></i>
-              Recommended Actions
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-red-800">
+              <i class="fa-light fa-triangle-exclamation text-red-500"></i>
+              Needs Your Attention
             </h3>
           </div>
-          @for (action of recommendedActions(); track action.title) {
-            <div class="flex items-start gap-3 p-4 border border-gray-200 rounded-lg">
-              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-gray-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-gray-600'"></i>
+
+          @for (action of attentionActions(); track action.title) {
+            <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
+              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
+                <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center justify-between gap-2">
                   <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
                   @if (action.priority === 'high') {
                     <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-                  } @else if (action.priority === 'medium') {
-                    <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
                   } @else {
-                    <lfx-tag value="Low Priority" severity="info" [rounded]="true" />
+                    <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
@@ -85,28 +84,46 @@
               </div>
             </div>
           }
+
+          @for (insight of attentionInsights(); track insight.text) {
+            <div class="flex items-center gap-2 text-sm px-1">
+              <i class="fa-light fa-triangle-exclamation text-red-500"></i>
+              <span class="text-red-800">{{ insight.text }}</span>
+            </div>
+          }
         </div>
       }
 
-      <!-- Key Insights -->
-      @if (keyInsights().length > 0) {
-        <div class="flex flex-col gap-3 p-4 bg-gray-50 rounded-lg" data-testid="website-visits-drawer-insights">
+      <!-- SECOND FOLD: Performing Well -->
+      @if (performingActions().length > 0 || performingInsights().length > 0) {
+        <div class="flex flex-col gap-4 p-4 bg-green-50 border border-green-200 rounded-lg" data-testid="website-visits-drawer-performing">
           <div class="flex items-center gap-2">
-            <h3 class="flex items-center gap-2 text-sm font-semibold text-gray-900">
-              <i class="fa-light fa-triangle-exclamation text-amber-500"></i>
-              Key Insights
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-green-800">
+              <i class="fa-light fa-check-circle text-green-500"></i>
+              Performing Well
             </h3>
           </div>
-          @for (insight of keyInsights(); track insight.text) {
-            <div class="flex items-center gap-2 text-sm">
+
+          @for (action of performingActions(); track action.title) {
+            <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
+              <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
+                <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+              </div>
+              <div class="flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
+              </div>
+            </div>
+          }
+
+          @for (insight of performingInsights(); track insight.text) {
+            <div class="flex items-center gap-2 text-sm px-1">
               @if (insight.type === 'driver') {
-                <i class="fa-light fa-bullseye text-gray-500"></i>
-              } @else if (insight.type === 'warning') {
-                <i class="fa-light fa-triangle-exclamation text-amber-500"></i>
+                <i class="fa-light fa-bullseye text-green-500"></i>
               } @else {
                 <i class="fa-light fa-circle-info text-blue-500"></i>
               }
-              <span class="text-gray-700">{{ insight.text }}</span>
+              <span class="text-green-800">{{ insight.text }}</span>
             </div>
           }
         </div>
@@ -115,8 +132,8 @@
       <!-- Daily Trend Chart -->
       <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="website-visits-drawer-trend-section">
         <div class="flex flex-col gap-1">
-          <h3 class="text-sm font-semibold text-gray-900">Daily Sessions</h3>
-          <p class="text-sm text-gray-600">Web activity over the last 30 days</p>
+          <h3 class="text-sm font-semibold text-gray-900">Weekly Sessions</h3>
+          <p class="text-sm text-gray-600">Web activity over the last 6 months (weekly)</p>
         </div>
         @if (drawerData().dailyData.length > 0) {
           <div class="h-[200px]" data-testid="website-visits-drawer-trend-chart">

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -68,7 +68,7 @@
           @for (action of attentionActions(); track action.title) {
             <div class="flex items-start gap-3 p-4 bg-white border border-red-200 rounded-lg">
               <div class="flex items-center justify-center w-9 h-9 rounded-full bg-red-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-red-600'"></i>
+                <i [class]="(action.actionType | marketingActionIcon) + ' text-red-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <div class="flex items-center justify-between gap-2">
@@ -107,7 +107,7 @@
           @for (action of performingActions(); track action.title) {
             <div class="flex items-start gap-3 p-4 bg-white border border-green-200 rounded-lg">
               <div class="flex items-center justify-center w-9 h-9 rounded-full bg-green-100 flex-shrink-0 mt-0.5">
-                <i [class]="actionIcon(action.actionType) + ' text-green-600'"></i>
+                <i [class]="(action.actionType | marketingActionIcon) + ' text-green-600'"></i>
               </div>
               <div class="flex-1 min-w-0">
                 <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -188,19 +188,19 @@ export class WebsiteVisitsDrawerComponent {
         return actions;
       }
 
-      // Check for declining trend in recent days
-      if (dailyData.length >= 14) {
+      // Check for declining trend over the 6-month weekly series
+      if (dailyData.length >= 8) {
         const firstHalf = dailyData.slice(0, Math.floor(dailyData.length / 2));
         const secondHalf = dailyData.slice(Math.floor(dailyData.length / 2));
         const firstAvg = firstHalf.reduce((s, v) => s + v, 0) / firstHalf.length;
         const secondAvg = secondHalf.reduce((s, v) => s + v, 0) / secondHalf.length;
-        if (secondAvg < firstAvg * 0.9) {
+        if (firstAvg > 0 && secondAvg < firstAvg * 0.9) {
           const decline = Math.round(((firstAvg - secondAvg) / firstAvg) * 100);
           actions.push({
             title: 'Investigate traffic decline',
-            description: `Sessions dropped ~${decline}% in the recent period — review traffic sources and content changes`,
+            description: `Sessions dropped ~${decline}% over recent weeks — review traffic sources and content changes`,
             priority: 'high',
-            dueLabel: 'This week',
+            dueLabel: 'This month',
             actionType: 'decline',
           });
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -7,28 +7,23 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import {
-  createHorizontalBarChartOptions,
-  createLineChartOptions,
-  DASHBOARD_TOOLTIP_CONFIG,
-  lfxColors,
-  MARKETING_ACTION_ICON_MAP,
-} from '@lfx-one/shared/constants';
-import { formatNumber, hexToRgba } from '@lfx-one/shared/utils';
+import { createHorizontalBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
 
 import type { ChartData, ChartOptions } from 'chart.js';
-import type { WebActivitiesSummaryResponse, MarketingRecommendedAction, MarketingKeyInsight, MarketingActionType } from '@lfx-one/shared/interfaces';
+import type { WebActivitiesSummaryResponse, MarketingRecommendedAction, MarketingKeyInsight } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-website-visits-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TagComponent],
+  imports: [ButtonComponent, CardComponent, DrawerModule, ChartComponent, SkeletonModule, TagComponent, MarketingActionIconPipe],
   templateUrl: './website-visits-drawer.component.html',
   styleUrl: './website-visits-drawer.component.scss',
 })
@@ -50,14 +45,15 @@ export class WebsiteVisitsDrawerComponent {
   protected readonly formattedTotalPageViews: Signal<string> = computed(() => formatNumber(this.drawerData().totalPageViews));
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
-  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
-    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
-  );
-  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
-  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
-  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
-    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
-  );
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
   protected readonly trendChartData: Signal<ChartData<'line'>> = this.initTrendChartData();
   protected readonly domainChartData: Signal<ChartData<'bar'>> = this.initDomainChartData();
 
@@ -136,10 +132,6 @@ export class WebsiteVisitsDrawerComponent {
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
-  }
-
-  protected actionIcon(type: MarketingActionType): string {
-    return MARKETING_ACTION_ICON_MAP[type];
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -50,6 +50,14 @@ export class WebsiteVisitsDrawerComponent {
   protected readonly formattedTotalPageViews: Signal<string> = computed(() => formatNumber(this.drawerData().totalPageViews));
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() =>
+    this.recommendedActions().filter((a) => a.priority === 'high' || a.priority === 'medium')
+  );
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.keyInsights().filter((i) => i.type === 'warning'));
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.recommendedActions().filter((a) => a.priority === 'low'));
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() =>
+    this.keyInsights().filter((i) => i.type === 'driver' || i.type === 'info')
+  );
   protected readonly trendChartData: Signal<ChartData<'line'>> = this.initTrendChartData();
   protected readonly domainChartData: Signal<ChartData<'bar'>> = this.initDomainChartData();
 
@@ -270,20 +278,24 @@ export class WebsiteVisitsDrawerComponent {
         }
       }
 
-      // Daily trend
-      if (dailyData.length >= 14) {
+      // Weekly trend — first half vs second half of 6-month window
+      if (dailyData.length >= 8) {
         const firstHalf = dailyData.slice(0, Math.floor(dailyData.length / 2));
         const secondHalf = dailyData.slice(Math.floor(dailyData.length / 2));
         const firstAvg = firstHalf.reduce((s, v) => s + v, 0) / firstHalf.length;
         const secondAvg = secondHalf.reduce((s, v) => s + v, 0) / secondHalf.length;
-        if (secondAvg > firstAvg * 1.1) {
+        if (firstAvg === 0 && secondAvg > 0) {
+          insights.push({ text: 'Sessions started growing from a zero baseline over the last 6 months', type: 'driver' });
+        } else if (firstAvg === 0) {
+          insights.push({ text: 'No session activity over the last 6 months', type: 'info' });
+        } else if (secondAvg > firstAvg * 1.1) {
           const growth = Math.round(((secondAvg - firstAvg) / firstAvg) * 100);
-          insights.push({ text: `Sessions trending up ~${growth}% in recent days`, type: 'driver' });
+          insights.push({ text: `Sessions trending up ~${growth}% over the last 6 months`, type: 'driver' });
         } else if (secondAvg < firstAvg * 0.9) {
           const decline = Math.round(((firstAvg - secondAvg) / firstAvg) * 100);
-          insights.push({ text: `Sessions trending down ~${decline}% in recent days`, type: 'warning' });
+          insights.push({ text: `Sessions trending down ~${decline}% over the last 6 months`, type: 'warning' });
         } else {
-          insights.push({ text: 'Session volume stable over the last 30 days', type: 'info' });
+          insights.push({ text: 'Session volume stable over the last 6 months', type: 'info' });
         }
       }
 

--- a/apps/lfx-one/src/app/shared/pipes/format-money.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/format-money.pipe.ts
@@ -5,6 +5,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { formatCurrency } from '@lfx-one/shared/utils';
 
 @Pipe({
+  standalone: true,
   name: 'formatMoney',
 })
 export class FormatMoneyPipe implements PipeTransform {

--- a/apps/lfx-one/src/app/shared/pipes/format-money.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/format-money.pipe.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Pipe, PipeTransform } from '@angular/core';
+import { formatCurrency } from '@lfx-one/shared/utils';
+
+@Pipe({
+  name: 'formatMoney',
+})
+export class FormatMoneyPipe implements PipeTransform {
+  public transform(value: number): string {
+    return formatCurrency(value);
+  }
+}

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2689,6 +2689,13 @@ export interface MarketingKeyInsight {
   type: 'driver' | 'warning' | 'info';
 }
 
+export interface MarketingSplitByPriority {
+  attentionActions: MarketingRecommendedAction[];
+  attentionInsights: MarketingKeyInsight[];
+  performingActions: MarketingRecommendedAction[];
+  performingInsights: MarketingKeyInsight[];
+}
+
 // ============================================
 // Social Reach (Marketing Dashboard)
 // ============================================

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -17,3 +17,4 @@ export * from './committee.utils';
 export * from './number.utils';
 export * from './platform.utils';
 export * from './project.utils';
+export * from './marketing.utils';

--- a/packages/shared/src/utils/marketing.utils.ts
+++ b/packages/shared/src/utils/marketing.utils.ts
@@ -1,14 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { MarketingKeyInsight, MarketingRecommendedAction } from '../interfaces/analytics-data.interface';
+import { MarketingKeyInsight, MarketingRecommendedAction, MarketingSplitByPriority } from '../interfaces/analytics-data.interface';
 
-export interface MarketingSplitByPriority {
-  attentionActions: MarketingRecommendedAction[];
-  attentionInsights: MarketingKeyInsight[];
-  performingActions: MarketingRecommendedAction[];
-  performingInsights: MarketingKeyInsight[];
-}
+export type { MarketingSplitByPriority };
 
 export function splitByPriority(actions: MarketingRecommendedAction[], insights: MarketingKeyInsight[]): MarketingSplitByPriority {
   return {

--- a/packages/shared/src/utils/marketing.utils.ts
+++ b/packages/shared/src/utils/marketing.utils.ts
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { MarketingKeyInsight, MarketingRecommendedAction } from '../interfaces/analytics-data.interface';
+
+export interface MarketingSplitByPriority {
+  attentionActions: MarketingRecommendedAction[];
+  attentionInsights: MarketingKeyInsight[];
+  performingActions: MarketingRecommendedAction[];
+  performingInsights: MarketingKeyInsight[];
+}
+
+export function splitByPriority(actions: MarketingRecommendedAction[], insights: MarketingKeyInsight[]): MarketingSplitByPriority {
+  return {
+    attentionActions: actions.filter((a) => a.priority === 'high' || a.priority === 'medium'),
+    attentionInsights: insights.filter((i) => i.type === 'warning'),
+    performingActions: actions.filter((a) => a.priority === 'low'),
+    performingInsights: insights.filter((i) => i.type === 'driver' || i.type === 'info'),
+  };
+}


### PR DESCRIPTION
## Summary

**PR 4/4 of #452 split** — wires the marketing overview shell and 8 existing drawer components to the new analytics endpoints. Final PR in the 4-way split.

- `marketing-overview.component` — removes mock data; orchestrates 8 KPI requests with `forkJoin` + per-stream `catchError` so one failing endpoint does not blank the whole page
- 8 existing drawers (email-ctr, engaged-community, flywheel-conversion, member-acquisition, member-retention, paid-social-reach, social-media, website-visits) — updated to consume the new `KPIResponse` shapes from `@lfx-one/shared` via signal inputs
- `flywheel-conversion-drawer` — guards the now-optional `reengagement` block from PR #454's shared interface (required where column-expanded Snowflake data is not yet deployed)
- `member-acquisition-drawer` — drops unused `DecimalPipe` import

## Stack order

1. #454 — backend + shared types (merged base: main)
2. #456 — client analytics service (base: #454)
3. #458 — 4 new drawer components (base: #456)
4. **This PR** (base: #458)

Once all 4 land, #452 will be closed without merging.

## Test plan

- [x] `yarn build` clean
- [x] `yarn lint` clean
- [x] `./check-headers.sh` — 906 files, all headers present
- [x] `yarn format` — no diffs
- [ ] Visual check in browser: overview renders, each drawer opens and loads live data from Snowflake
- [ ] Verify graceful degradation when a single endpoint errors (one card shows zero/empty, others still render)

JIRA: LFXV2-1468

🤖 Generated with [Claude Code](https://claude.com/claude-code)