### PR TITLE
refactor(logging): remove redundant controller error logs

### DIFF
--- a/.claude/rules/logging-patterns.md
+++ b/.claude/rules/logging-patterns.md
@@ -47,7 +47,9 @@ logger.success(undefined, 'nats_connect', startTime, metadata);
 
 **Controllers (HTTP Boundary):**
 
-- Always use `logger.startOperation()` / `logger.success()` / `logger.error()` for HTTP operations
+- Always use `logger.startOperation()` / `logger.success()` for HTTP operations
+- **Do NOT call `logger.error()` in controller catch blocks** — just call `next(error)`. The `apiErrorHandler` middleware logs all errors centrally with full structured context (error type, status code, request ID, path, method, user agent). Adding `logger.error()` before `next(error)` creates redundant logging.
+- **Exception**: Controllers that handle their own response in the catch block (e.g., SSE streaming with `res.end()`) must log errors themselves since `apiErrorHandler` is never reached.
 - Operation names should match HTTP semantics (e.g., `get_meeting_rsvps`, `create_meeting`)
 - Duration represents full HTTP request to response cycle
 - One startOperation per HTTP endpoint
@@ -76,9 +78,12 @@ logger.success(undefined, 'nats_connect', startTime, metadata);
 **Always use `err` field** for proper error serialization:
 
 ```typescript
-// CORRECT
+// CORRECT — in services or infrastructure (not in controller catch blocks)
 logger.error(req, 'operation', startTime, error, metadata);
 logger.error(undefined, 'operation', startTime, error, metadata);
+
+// CORRECT — in controller catch blocks (apiErrorHandler logs centrally)
+next(error);
 
 // INCORRECT
 serverLogger.error({ error: error.message }, 'message'); // Don't use serverLogger directly
@@ -139,7 +144,7 @@ This means: 0 INFO lines for read endpoints, 1 INFO line for write endpoints, al
 
 **ERROR** — Critical failures:
 
-- **In Controllers**: HTTP operation failures (via `logger.error()` with startTime)
+- **In Controllers**: Handled centrally by `apiErrorHandler` — controllers should NOT call `logger.error()` in catch blocks (just call `next(error)`)
 - System failures, unhandled exceptions
 - Critical errors requiring immediate attention
 - Operations that cannot continue
@@ -199,7 +204,7 @@ export const getUser = async (req: Request, res: Response, next: NextFunction) =
     logger.success(req, 'get_user', startTime, { userId: user.id });
     return res.json(user);
   } catch (error) {
-    logger.error(req, 'get_user', startTime, error, { userId: req.params.id });
+    // Do NOT call logger.error() here — apiErrorHandler logs centrally
     return next(error);
   }
 };
@@ -325,7 +330,8 @@ private async fetchFromNats(req: Request, slug: string): Promise<Project> {
 **For Controllers:**
 
 - [ ] Using `logger.startOperation()` for HTTP operations?
-- [ ] Calling `logger.success()` or `logger.error()` with `startTime`?
+- [ ] Calling `logger.success()` on the happy path with `startTime`?
+- [ ] Using bare `next(error)` in catch blocks (no `logger.error()`) — `apiErrorHandler` logs centrally?
 - [ ] Not duplicating service-level logging?
 
 **For Services:**

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -56,7 +56,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_active_weeks_streak', startTime, error);
       next(error);
     }
   }
@@ -86,7 +85,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_pull_requests_merged', startTime, error);
       next(error);
     }
   }
@@ -116,7 +114,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_code_commits', startTime, error);
       next(error);
     }
   }
@@ -147,7 +144,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_my_projects', startTime, error);
       next(error);
     }
   }
@@ -194,7 +190,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_certified_employees', startTime, error);
       next(error);
     }
   }
@@ -234,7 +229,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_membership_tier', startTime, error);
       next(error);
     }
   }
@@ -281,7 +275,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_organization_maintainers', startTime, error);
       next(error);
     }
   }
@@ -327,7 +320,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_organization_contributors', startTime, error);
       next(error);
     }
   }
@@ -367,7 +359,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_training_enrollments', startTime, error);
       next(error);
     }
   }
@@ -414,7 +405,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_event_attendance_monthly', startTime, error);
       next(error);
     }
   }
@@ -464,7 +454,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_project_issues_resolution', startTime, error);
       next(error);
     }
   }
@@ -512,7 +501,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_project_pull_requests_weekly', startTime, error);
       next(error);
     }
   }
@@ -545,7 +533,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_contributors_mentored', startTime, error);
       next(error);
     }
   }
@@ -593,7 +580,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_unique_contributors_weekly', startTime, error);
       next(error);
     }
   }
@@ -631,7 +617,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_total_projects', startTime, error);
       next(error);
     }
   }
@@ -668,7 +653,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_projects_detail', startTime, error);
       next(error);
     }
   }
@@ -705,7 +689,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_projects_lifecycle_distribution', startTime, error);
       next(error);
     }
   }
@@ -743,7 +726,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_total_members', startTime, error);
       next(error);
     }
   }
@@ -780,7 +762,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_active_contributors_monthly', startTime, error);
       next(error);
     }
   }
@@ -817,7 +798,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_contributors_distribution', startTime, error);
       next(error);
     }
   }
@@ -855,7 +835,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_software_value', startTime, error);
       next(error);
     }
   }
@@ -893,7 +872,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_value_concentration', startTime, error);
       next(error);
     }
   }
@@ -931,7 +909,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_maintainers', startTime, error);
       next(error);
     }
   }
@@ -968,7 +945,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_maintainers_monthly', startTime, error);
       next(error);
     }
   }
@@ -1005,7 +981,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_maintainers_distribution', startTime, error);
       next(error);
     }
   }
@@ -1042,7 +1017,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_events_quarterly', startTime, error);
       next(error);
     }
   }
@@ -1079,7 +1053,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_events_attendance_distribution', startTime, error);
       next(error);
     }
   }
@@ -1123,7 +1096,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_foundation_health_score_distribution', startTime, error);
       next(error);
     }
   }
@@ -1161,7 +1133,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_company_bus_factor', startTime, error);
       next(error);
     }
   }
@@ -1208,7 +1179,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_health_metrics_daily', startTime, error);
       next(error);
     }
   }
@@ -1255,7 +1225,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_unique_contributors_daily', startTime, error);
       next(error);
     }
   }
@@ -1302,7 +1271,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_health_events_monthly', startTime, error);
       next(error);
     }
   }
@@ -1349,7 +1317,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_code_commits_daily', startTime, error);
       next(error);
     }
   }
@@ -1395,7 +1362,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_contributors_monthly', startTime, error);
       next(error);
     }
   }
@@ -1440,7 +1406,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_contributors_project_distribution', startTime, error);
       next(error);
     }
   }
@@ -1486,7 +1451,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_maintainers_monthly', startTime, error);
       next(error);
     }
   }
@@ -1531,7 +1495,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_maintainers_distribution', startTime, error);
       next(error);
     }
   }
@@ -1576,7 +1539,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_maintainers_key_members', startTime, error);
       next(error);
     }
   }
@@ -1622,7 +1584,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_event_attendees_monthly', startTime, error);
       next(error);
     }
   }
@@ -1668,7 +1629,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_event_speakers_monthly', startTime, error);
       next(error);
     }
   }
@@ -1714,7 +1674,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_training_enrollments_monthly', startTime, error);
       next(error);
     }
   }
@@ -1759,7 +1718,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_training_enrollments_distribution', startTime, error);
       next(error);
     }
   }
@@ -1805,7 +1763,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_certified_employees_monthly', startTime, error);
       next(error);
     }
   }
@@ -1850,7 +1807,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_org_certified_employees_distribution', startTime, error);
       next(error);
     }
   }
@@ -1894,7 +1850,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_web_activities_summary', startTime, error);
       next(error);
     }
   }
@@ -1931,7 +1886,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_email_ctr', startTime, error);
       next(error);
     }
   }
@@ -1968,7 +1922,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_social_reach', startTime, error);
       next(error);
     }
   }
@@ -2005,7 +1958,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_social_media', startTime, error);
       next(error);
     }
   }
@@ -2045,7 +1997,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_member_retention', startTime, error);
       next(error);
     }
   }
@@ -2082,7 +2033,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_member_acquisition', startTime, error);
       next(error);
     }
   }
@@ -2119,7 +2069,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_engaged_community', startTime, error);
       next(error);
     }
   }
@@ -2156,7 +2105,6 @@ export class AnalyticsController {
 
       res.json(response);
     } catch (error) {
-      logger.error(req, 'get_flywheel_conversion', startTime, error);
       next(error);
     }
   }

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -528,7 +528,6 @@ export class CommitteeController {
 
       res.json(documents);
     } catch (error) {
-      logger.error(req, 'get_committee_documents', startTime, error, { committee_id: id });
       next(error);
     }
   }
@@ -595,7 +594,6 @@ export class CommitteeController {
 
       res.status(201).json(newDocument);
     } catch (error) {
-      logger.error(req, 'create_committee_document', startTime, error, { committee_id: id });
       next(error);
     }
   }
@@ -658,7 +656,6 @@ export class CommitteeController {
 
       res.status(204).send();
     } catch (error) {
-      logger.error(req, 'delete_committee_document', startTime, error, { committee_id: id, document_id: documentId });
       next(error);
     }
   }
@@ -699,7 +696,6 @@ export class CommitteeController {
 
       res.json(children);
     } catch (error) {
-      logger.error(req, 'get_committee_children', startTime, error, { parent_id: id });
       next(error);
     }
   }
@@ -809,7 +805,6 @@ export class CommitteeController {
       res.setHeader('Cache-Control', 'public, max-age=900'); // 15 minutes — reduces load from calendar clients polling every 15-60 minutes
       res.send(ics);
     } catch (error) {
-      logger.error(req, 'get_committee_calendar', startTime, error, { committee_id: id });
       next(error);
     }
   }

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -199,7 +199,10 @@ export class MeetingController {
       const [registrants, meetingWithInvitedStatus] = await Promise.all([
         // TODO: Remove this once we have a way to get the registrants count
         this.meetingService.getMeetingRegistrants(req, meeting.id).catch((error) => {
-          logger.error(req, 'get_meeting_by_id', startTime, error, { meeting_id: uid });
+          logger.warning(req, 'get_meeting_by_id', 'Failed to fetch registrants for meeting', {
+            meeting_id: uid,
+            err: error,
+          });
           return null;
         }),
         addInvitedStatusToMeeting(req, meeting, userEmail),
@@ -1467,7 +1470,6 @@ export class MeetingController {
 
       res.status(201).json(result);
     } catch (error) {
-      logger.error(req, 'upload_meeting_attachment', startTime, error, { meeting_id: uid, file_name: name });
       next(error);
     }
   }

--- a/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/past-meeting.controller.ts
@@ -57,8 +57,6 @@ export class PastMeetingController {
       // Send the meetings data to the client
       res.json({ data: meetings, page_token });
     } catch (error) {
-      // Log the error
-      logger.error(req, 'get_past_meetings', startTime, error);
       next(error);
     }
   }
@@ -98,9 +96,6 @@ export class PastMeetingController {
 
       res.json(meeting);
     } catch (error) {
-      logger.error(req, 'get_past_meeting_by_id', startTime, error, {
-        past_meeting_id: uid,
-      });
       next(error);
     }
   }
@@ -137,12 +132,6 @@ export class PastMeetingController {
       // Send the participants data to the client
       res.json(participants);
     } catch (error) {
-      // Log the error
-      logger.error(req, 'get_past_meeting_participants', startTime, error, {
-        past_meeting_id: uid,
-      });
-
-      // Send the error to the next middleware
       next(error);
     }
   }
@@ -190,12 +179,6 @@ export class PastMeetingController {
       // Send the recording data to the client
       res.json(recording);
     } catch (error) {
-      // Log the error
-      logger.error(req, 'get_past_meeting_recording', startTime, error, {
-        past_meeting_id: uid,
-      });
-
-      // Send the error to the next middleware
       next(error);
     }
   }
@@ -243,12 +226,6 @@ export class PastMeetingController {
       // Send the summary data to the client
       res.json(summary);
     } catch (error) {
-      // Log the error
-      logger.error(req, 'get_past_meeting_summary', startTime, error, {
-        past_meeting_id: uid,
-      });
-
-      // Send the error to the next middleware
       next(error);
     }
   }
@@ -285,12 +262,6 @@ export class PastMeetingController {
       // Send the attachments data to the client
       res.json(attachments);
     } catch (error) {
-      // Log the error
-      logger.error(req, 'get_past_meeting_attachments', startTime, error, {
-        past_meeting_id: uid,
-      });
-
-      // Send the error to the next middleware
       next(error);
     }
   }
@@ -343,13 +314,6 @@ export class PastMeetingController {
       // Send the updated summary data to the client
       res.json(updatedSummary);
     } catch (error) {
-      // Log the error
-      logger.error(req, 'update_past_meeting_summary', startTime, error, {
-        past_meeting_id: uid,
-        summary_uid: summaryUid,
-      });
-
-      // Send the error to the next middleware
       next(error);
     }
   }
@@ -387,10 +351,6 @@ export class PastMeetingController {
 
       res.json(attachment);
     } catch (error) {
-      logger.error(req, 'get_past_meeting_attachment', startTime, error, {
-        past_meeting_id: uid,
-        attachment_id: attachmentId,
-      });
       next(error);
     }
   }
@@ -428,10 +388,6 @@ export class PastMeetingController {
 
       res.json(result);
     } catch (error) {
-      logger.error(req, 'get_past_meeting_attachment_download_url', startTime, error, {
-        past_meeting_id: uid,
-        attachment_id: attachmentId,
-      });
       next(error);
     }
   }

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -760,7 +760,6 @@ export class ProfileController {
 
       res.json(displayIdentities);
     } catch (error) {
-      logger.error(req, 'get_identities', startTime, error);
       next(error);
     }
   }
@@ -796,7 +795,6 @@ export class ProfileController {
 
       res.json(workExperiences);
     } catch (error) {
-      logger.error(req, 'get_work_experiences', startTime, error);
       next(error);
     }
   }
@@ -832,7 +830,6 @@ export class ProfileController {
 
       res.json(affiliations);
     } catch (error) {
-      logger.error(req, 'get_project_affiliations', startTime, error);
       next(error);
     }
   }
@@ -917,7 +914,6 @@ export class ProfileController {
       logger.success(req, 'reject_identity', startTime, { lfid, identity_id: identityId });
       res.json({ success: true });
     } catch (error) {
-      logger.error(req, 'reject_identity', startTime, error);
       next(error);
     }
   }
@@ -962,7 +958,6 @@ export class ProfileController {
       logger.success(req, 'confirm_work_experience', startTime, { lfid, work_experience_id: workExperienceId });
       res.json({ success: true });
     } catch (error) {
-      logger.error(req, 'confirm_work_experience', startTime, error);
       next(error);
     }
   }
@@ -1019,7 +1014,6 @@ export class ProfileController {
       logger.success(req, 'patch_project_affiliation', startTime, { lfid, project_id: projectId, affiliation_count: affiliations.length });
       res.json({ success: true });
     } catch (error) {
-      logger.error(req, 'patch_project_affiliation', startTime, error);
       next(error);
     }
   }
@@ -1064,7 +1058,6 @@ export class ProfileController {
       logger.success(req, 'delete_work_experience', startTime, { lfid, work_experience_id: workExperienceId });
       res.json({ success: true });
     } catch (error) {
-      logger.error(req, 'delete_work_experience', startTime, error);
       next(error);
     }
   }
@@ -1131,7 +1124,6 @@ export class ProfileController {
       logger.success(req, 'update_work_experience', startTime, { lfid, work_experience_id: workExperienceId });
       res.json({ success: true });
     } catch (error) {
-      logger.error(req, 'update_work_experience', startTime, error);
       next(error);
     }
   }
@@ -1186,7 +1178,6 @@ export class ProfileController {
       logger.success(req, 'create_work_experience', startTime, { lfid });
       res.status(201).json({ success: true });
     } catch (error) {
-      logger.error(req, 'create_work_experience', startTime, error);
       next(error);
     }
   }
@@ -1613,7 +1604,6 @@ export class ProfileController {
         }
       }
     } catch (error) {
-      logger.error(req, 'send_email_verification', startTime, error);
       next(error);
     }
   }
@@ -1758,7 +1748,6 @@ export class ProfileController {
       logger.success(req, 'verify_and_link_email', startTime, { email });
       res.json({ success: true, message: 'Email identity verified and linked successfully' });
     } catch (error) {
-      logger.error(req, 'verify_and_link_email', startTime, error);
       next(error);
     }
   }

--- a/apps/lfx-one/src/server/controllers/training.controller.ts
+++ b/apps/lfx-one/src/server/controllers/training.controller.ts
@@ -40,7 +40,6 @@ export class TrainingController {
 
       res.json(certifications);
     } catch (error) {
-      logger.error(req, 'get_certifications', startTime, error);
       next(error);
     }
   }
@@ -70,7 +69,6 @@ export class TrainingController {
 
       res.json(enrollments);
     } catch (error) {
-      logger.error(req, 'get_enrollments', startTime, error);
       next(error);
     }
   }

--- a/apps/lfx-one/src/server/middleware/error-handler.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/error-handler.middleware.ts
@@ -28,10 +28,12 @@ export function apiErrorHandler(error: Error | BaseApiError, req: Request, res: 
     return;
   }
 
-  const operation = getOperationFromPath(req.path);
-
-  // Try to get the operation start time if it was tracked, otherwise use current time
-  const startTime = logger.getOperationStartTime(req, operation) || Date.now();
+  // Prefer the controller's registered operation name and start time over path-derived values.
+  // Controllers register operations via logger.startOperation(req, 'get_meetings', ...),
+  // which won't match the path-derived name (e.g., 'api_meetings').
+  const lastOp = logger.getLastOperation(req);
+  const operation = lastOp?.operation || getOperationFromPath(req.path);
+  const startTime = lastOp?.startTime || Date.now();
 
   // Handle our structured API errors
   if (isBaseApiError(error)) {

--- a/apps/lfx-one/src/server/services/logger.service.ts
+++ b/apps/lfx-one/src/server/services/logger.service.ts
@@ -436,6 +436,24 @@ export class LoggerService {
   }
 
   /**
+   * Gets the last registered operation for a request.
+   * Used by apiErrorHandler to find the controller's operation name and start time
+   * without needing to derive it from the request path.
+   */
+  public getLastOperation(req: Request): OperationState | undefined {
+    const stack = this.operationStacks.get(req);
+    if (!stack || stack.size === 0) return undefined;
+
+    let latest: OperationState | undefined;
+    for (const op of stack.values()) {
+      if (!latest || op.startTime > latest.startTime) {
+        latest = op;
+      }
+    }
+    return latest;
+  }
+
+  /**
    * Get or create the operation stack for a request
    */
   private getOperationStack(req: Request): Map<string, OperationState> {


### PR DESCRIPTION
## Summary
- Removed ~70 redundant `logger.error()` calls from controller catch blocks across 6 controllers (analytics, committee, meeting, past-meeting, profile, training)
- `apiErrorHandler` middleware already logs all errors centrally with richer structured context (error_type, status_code, request_id, path, method, user_agent)
- Updated `logging-patterns.md` rule file — the example code was teaching AI tools to add `logger.error()` before `next(error)`, which is the root cause of this pattern spreading

## What was wrong
The controller example in `.claude/rules/logging-patterns.md` showed:
```typescript
} catch (error) {
    logger.error(req, 'get_user', startTime, error, { userId: req.params.id });
    return next(error);
}
```
AI tools replicated this pattern literally. The `apiErrorHandler` has `skipIfLogged: true` which masked the duplication, but it meant the error handler's richer log was silently skipped in favor of the controller's less informative one.

## Legitimate `logger.error` kept in controllers
- **copilot.controller.ts** — SSE streaming, handles its own response (apiErrorHandler never reached)
- **profile.controller.ts** — redirect-based error handling (res.redirect, not next(error))
- **meeting.controller.ts** — batch processing helper (catches to continue processing)
- **past-meeting.controller.ts** — `addParticipantsCount` helper (returns defaults on error)

🤖 Generated with [Claude Code](https://claude.ai/code)