### PR TITLE
fix(meetings): add access checks and full pagination to me lens meetings

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -352,7 +352,7 @@ export class MeetingsDashboardComponent {
             return of([] as Meeting[]);
           }
           this.meetingsLoading.set(true);
-          return this.userService.getUserMeetings(100, projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
+          return this.userService.getUserMeetings(undefined, projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
             tap(() => this.meetingsLoading.set(false)),
             catchError(() => {
               this.meetingsLoading.set(false);
@@ -377,7 +377,7 @@ export class MeetingsDashboardComponent {
             return of([] as PastMeeting[]);
           }
           this.pastMeetingsLoading.set(true);
-          return this.userService.getUserPastMeetings(100, projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
+          return this.userService.getUserPastMeetings(undefined, projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
             tap(() => this.pastMeetingsLoading.set(false)),
             catchError(() => {
               this.pastMeetingsLoading.set(false);

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -32,6 +32,7 @@ import { ResourceNotFoundError } from '../errors';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
+import { AccessCheckService } from './access-check.service';
 import { logger } from './logger.service';
 import { MeetingService } from './meeting.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -48,6 +49,7 @@ export class UserService {
   private meetingService: MeetingService;
   private projectService: ProjectService;
   private microserviceProxy: MicroserviceProxyService;
+  private accessCheckService: AccessCheckService;
 
   private readonly twoWeeksMs = 14 * 24 * 60 * 60 * 1000;
   private readonly bufferMinutes = 40;
@@ -58,6 +60,7 @@ export class UserService {
     this.meetingService = new MeetingService();
     this.projectService = new ProjectService();
     this.microserviceProxy = new MicroserviceProxyService();
+    this.accessCheckService = new AccessCheckService();
   }
 
   /**
@@ -487,7 +490,17 @@ export class UserService {
       foundationProjectUids = new Set(uids);
     }
 
-    return this.fetchByIdFilterAndLimit<Meeting>(req, meetingIds, '/itx/meetings', 'get_user_meetings', projectUid, limit, foundationProjectUids);
+    const meetings = await this.fetchByIdFilterAndLimit<Meeting>(
+      req,
+      meetingIds,
+      '/itx/meetings',
+      'get_user_meetings',
+      projectUid,
+      limit,
+      foundationProjectUids
+    );
+
+    return this.accessCheckService.addAccessToResources(req, meetings, 'v1_meeting', 'organizer');
   }
 
   /**
@@ -501,33 +514,59 @@ export class UserService {
    * @returns Array of PastMeeting objects the user participated in
    */
   public async getUserPastMeetings(req: Request, email: string, projectUid?: string, limit?: number, foundationUid?: string): Promise<PastMeeting[]> {
-    // Step 1: Get past meeting participant records for this user via query service
+    // Step 1: Get all past meeting participant records for this user via query service
+    // Uses fetchAllQueryResources to auto-paginate through all pages and dual email+username
+    // lookup for complete coverage (same pattern as getPastMeetingOccurrenceIds)
     const normalizedEmail = email.toLowerCase();
-    const participantParams: Record<string, any> = {
-      type: 'v1_past_meeting_participant',
-      tags: `email:${normalizedEmail}`,
-      page_size: 100,
-    };
+    const username = await getUsernameFromAuth(req);
 
     // M2M token required: participant queries search across all participants in the index
     const m2mToken = await generateM2MToken(req);
     const headers = { Authorization: `Bearer ${m2mToken}` };
+    const pastMeetingIds = new Set<string>();
 
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(
-      req,
-      'LFX_V2_SERVICE',
-      '/query/resources',
-      'GET',
-      { ...participantParams, sort: 'updated_desc' },
-      undefined,
-      headers
-    );
-    const participants = resources.map((r) => r.data);
+    // Query by email
+    const emailParticipants = await fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(
+        req,
+        'LFX_V2_SERVICE',
+        '/query/resources',
+        'GET',
+        {
+          type: 'v1_past_meeting_participant',
+          tags: `email:${normalizedEmail}`,
+          page_size: 100,
+          ...(pageToken && { page_token: pageToken }),
+        },
+        undefined,
+        headers
+      )
+    ).catch(() => []);
+    emailParticipants.forEach((p) => p.meeting_and_occurrence_id && pastMeetingIds.add(p.meeting_and_occurrence_id));
 
-    // Deduplicate by meeting_and_occurrence_id (composite ID like "99152950841-1630560600000")
-    const pastMeetingIds = [...new Set(participants.map((p) => p.meeting_and_occurrence_id).filter(Boolean))];
+    // Also query by username for complete coverage
+    if (username) {
+      const plainUsername = stripAuthPrefix(username);
+      const usernameParticipants = await fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(
+          req,
+          'LFX_V2_SERVICE',
+          '/query/resources',
+          'GET',
+          {
+            type: 'v1_past_meeting_participant',
+            tags: `username:${plainUsername}`,
+            page_size: 100,
+            ...(pageToken && { page_token: pageToken }),
+          },
+          undefined,
+          headers
+        )
+      ).catch(() => []);
+      usernameParticipants.forEach((p) => p.meeting_and_occurrence_id && pastMeetingIds.add(p.meeting_and_occurrence_id));
+    }
 
-    if (pastMeetingIds.length === 0) {
+    if (pastMeetingIds.size === 0) {
       return [];
     }
 
@@ -538,7 +577,7 @@ export class UserService {
     }
 
     // Step 2: Fetch each past meeting and filter/limit
-    return this.fetchByIdFilterAndLimit<PastMeeting>(
+    const pastMeetings = await this.fetchByIdFilterAndLimit<PastMeeting>(
       req,
       pastMeetingIds,
       '/itx/past_meetings',
@@ -547,6 +586,8 @@ export class UserService {
       limit,
       foundationProjectUids
     );
+
+    return this.accessCheckService.addAccessToResources(req, pastMeetings, 'v1_past_meeting', 'organizer');
   }
 
   /**

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -523,6 +523,12 @@ export class UserService {
     // Step 1: Get all past meeting participant records for this user via query service
     // Uses fetchAllQueryResources to auto-paginate through all pages and dual email+username
     // lookup for complete coverage (same pattern as getPastMeetingOccurrenceIds)
+    logger.debug(req, 'get_user_past_meetings', 'Starting past meeting lookup for user', {
+      has_project_filter: !!projectUid,
+      has_foundation_filter: !!foundationUid,
+      limit,
+    });
+
     const normalizedEmail = email.toLowerCase();
     const username = await getUsernameFromAuth(req);
 
@@ -549,7 +555,7 @@ export class UserService {
       )
     ).catch((error) => {
       logger.warning(req, 'get_user_past_meetings', 'Email participant query failed, returning partial results', {
-        error: error instanceof Error ? error.message : String(error),
+        err: error,
       });
       return [];
     });
@@ -575,12 +581,17 @@ export class UserService {
         )
       ).catch((error) => {
         logger.warning(req, 'get_user_past_meetings', 'Username participant query failed, returning partial results', {
-          error: error instanceof Error ? error.message : String(error),
+          err: error,
         });
         return [];
       });
       usernameParticipants.forEach((p) => p.meeting_and_occurrence_id && pastMeetingIds.add(p.meeting_and_occurrence_id));
     }
+
+    logger.debug(req, 'get_user_past_meetings', 'Found past meeting participant IDs', {
+      total_ids: pastMeetingIds.size,
+      email_matches: emailParticipants.length,
+    });
 
     if (pastMeetingIds.size === 0) {
       return [];

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -496,11 +496,17 @@ export class UserService {
       '/itx/meetings',
       'get_user_meetings',
       projectUid,
-      limit,
+      undefined,
       foundationProjectUids
     );
 
-    return this.accessCheckService.addAccessToResources(req, meetings, 'v1_meeting', 'organizer');
+    // Sort by start_time ascending (soonest first) before applying limit
+    // so the limit returns the most relevant upcoming meetings
+    meetings.sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime());
+
+    const limited = limit !== undefined && limit > 0 ? meetings.slice(0, limit) : meetings;
+
+    return this.accessCheckService.addAccessToResources(req, limited, 'v1_meeting', 'organizer');
   }
 
   /**
@@ -541,7 +547,12 @@ export class UserService {
         undefined,
         headers
       )
-    ).catch(() => []);
+    ).catch((error) => {
+      logger.warning(req, 'get_user_past_meetings', 'Email participant query failed, returning partial results', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    });
     emailParticipants.forEach((p) => p.meeting_and_occurrence_id && pastMeetingIds.add(p.meeting_and_occurrence_id));
 
     // Also query by username for complete coverage
@@ -562,7 +573,12 @@ export class UserService {
           undefined,
           headers
         )
-      ).catch(() => []);
+      ).catch((error) => {
+        logger.warning(req, 'get_user_past_meetings', 'Username participant query failed, returning partial results', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return [];
+      });
       usernameParticipants.forEach((p) => p.meeting_and_occurrence_id && pastMeetingIds.add(p.meeting_and_occurrence_id));
     }
 
@@ -576,18 +592,24 @@ export class UserService {
       foundationProjectUids = new Set(uids);
     }
 
-    // Step 2: Fetch each past meeting and filter/limit
+    // Step 2: Fetch each past meeting and filter (limit applied after sorting)
     const pastMeetings = await this.fetchByIdFilterAndLimit<PastMeeting>(
       req,
       pastMeetingIds,
       '/itx/past_meetings',
       'get_user_past_meetings',
       projectUid,
-      limit,
+      undefined,
       foundationProjectUids
     );
 
-    return this.accessCheckService.addAccessToResources(req, pastMeetings, 'v1_past_meeting', 'organizer');
+    // Sort by scheduled_start_time descending (most recent first) before applying limit
+    // so the limit returns the most recent meetings rather than an arbitrary subset
+    pastMeetings.sort((a, b) => new Date(b.scheduled_start_time).getTime() - new Date(a.scheduled_start_time).getTime());
+
+    const limited = limit !== undefined && limit > 0 ? pastMeetings.slice(0, limit) : pastMeetings;
+
+    return this.accessCheckService.addAccessToResources(req, limited, 'v1_past_meeting', 'organizer');
   }
 
   /**


### PR DESCRIPTION
## Summary

- Add organizer access checks to `getUserMeetings` and `getUserPastMeetings` via batch `POST /access-check` (single call regardless of meeting count)
- Switch `getUserPastMeetings` from single-page query to `fetchAllQueryResources` for complete past meeting coverage across all pages
- Add dual email+username lookup for past meeting participants (was email-only, now matches the pattern used by `getPastMeetingOccurrenceIds` and `getUserRegisteredMeetingIds`)

## What was missing

1. **No access checks** — Me lens meetings were returned without `organizer` permission data, so the frontend couldn't determine edit/manage permissions. The project/foundation lens already does this via `accessCheckService.addAccessToResources`.

2. **Incomplete past meetings** — `getUserPastMeetings` only fetched the first page (100 records) of participant data. Users with more than 100 past meetings were missing results silently.

3. **Email-only lookup** — Past meeting participants were only queried by email, missing cases where the username is the matching identifier.

LFXV2-1463

🤖 Generated with [Claude Code](https://claude.ai/code)