### PR TITLE
feat(filters): add data-driven foundation/project filters to me lens

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -93,22 +93,18 @@
                 control="foundationFilter"
                 size="small"
                 [options]="foundationOptions()"
-                placeholder="All Foundations"
-                [showClear]="true"
                 styleClass="w-full"
                 (onChange)="onFoundationFilterChange($event.value)"
                 data-testid="committee-foundation-filter"></lfx-select>
             </div>
           }
-          @if (showProjectFilter() && projectOptions().length > 0) {
+          @if (showProjectFilter()) {
             <div class="w-full sm:w-48">
               <lfx-select
                 [form]="searchForm"
                 control="projectFilter"
                 size="small"
                 [options]="projectOptions()"
-                placeholder="All Projects"
-                [showClear]="true"
                 styleClass="w-full"
                 (onChange)="onProjectFilterChange($event.value)"
                 data-testid="committee-project-filter"></lfx-select>

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -90,8 +90,8 @@ export class CommitteeDashboardComponent {
   public canCreateGroup: Signal<boolean>;
 
   // Foundation and project filter options (separate dropdowns)
-  public foundationOptions: Signal<{ label: string; value: string }[]> = this.initializeFoundationOptions();
-  public projectOptions: Signal<{ label: string; value: string }[]> = this.initializeProjectOptions();
+  public foundationOptions: Signal<{ label: string; value: string | null }[]> = this.initializeFoundationOptions();
+  public projectOptions: Signal<{ label: string; value: string | null }[]> = this.initializeProjectOptions();
 
   // Lens
   public readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
@@ -199,20 +199,16 @@ export class CommitteeDashboardComponent {
     const project$ = toObservable(this.project);
     const refresh$ = toObservable(this.refresh);
     const lens$ = toObservable(this.lensService.activeLens);
-    const projectFilter$ = toObservable(this.projectFilter);
-    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([project$, refresh$, lens$, projectFilter$, foundationFilter$]).pipe(
-        switchMap(([project, , lens, projectFilter, foundationFilter]) => {
-          this.myCommitteesLoading.set(true);
+      combineLatest([project$, refresh$, lens$]).pipe(
+        switchMap(([project, , lens]) => {
           if (lens !== 'me' && !project?.uid) {
             this.myCommitteesLoading.set(false);
             return of([] as MyCommittee[]);
           }
-          const projectUid = lens === 'me' ? (projectFilter ?? undefined) : project!.uid;
-          const foundationUid = lens === 'me' ? (foundationFilter ?? undefined) : undefined;
-          return this.committeeService.getMyCommittees(projectUid, foundationUid).pipe(
+          this.myCommitteesLoading.set(true);
+          return this.committeeService.getMyCommittees().pipe(
             catchError((error) => {
               console.error('Failed to load my committees:', error);
               this.myCommitteesLoading.set(false);
@@ -316,22 +312,39 @@ export class CommitteeDashboardComponent {
     });
   }
 
-  private initializeFoundationOptions(): Signal<{ label: string; value: string }[]> {
+  private initializeFoundationOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const projects = this.personaService.detectedProjects();
-      return projects.filter((p) => p.isFoundation).map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+      const items = this.myCommittees();
+      const seen = new Map<string, string>();
+      for (const item of items) {
+        if (item.is_foundation && item.project_uid && !seen.has(item.project_uid)) {
+          seen.set(item.project_uid, item.project_name || item.project_uid);
+        }
+      }
+      const options = [...seen.entries()]
+        .map(([uid, name]) => ({ label: name, value: uid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+      return [{ label: 'All Foundations', value: null }, ...options];
     });
   }
 
-  private initializeProjectOptions(): Signal<{ label: string; value: string }[]> {
+  private initializeProjectOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const projects = this.personaService.detectedProjects();
+      const items = this.myCommittees();
       const foundation = this.foundationFilter();
-      let candidates = projects.filter((p) => !p.isFoundation);
-      if (foundation) {
-        candidates = candidates.filter((p) => p.parentProjectUid === foundation);
+      const seen = new Map<string, string>();
+      for (const item of items) {
+        if (!item.is_foundation && item.project_uid && !seen.has(item.project_uid)) {
+          if (foundation && item.parent_project_uid !== foundation) {
+            continue;
+          }
+          seen.set(item.project_uid, item.project_name || item.project_uid);
+        }
       }
-      return candidates.map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+      const options = [...seen.entries()]
+        .map(([uid, name]) => ({ label: name, value: uid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+      return [{ label: 'All Projects', value: null }, ...options];
     });
   }
 
@@ -372,18 +385,30 @@ export class CommitteeDashboardComponent {
 
   private initializeFilteredMyCommittees(): Signal<MyCommittee[]> {
     return computed(() => {
-      const committees = this.myCommittees();
-      const searchTerm = this.searchTerm()?.toLowerCase() || '';
-      if (!searchTerm) {
-        return committees;
+      let filtered: MyCommittee[] = this.myCommittees();
+
+      // Apply foundation/project filter (client-side)
+      const project = this.projectFilter();
+      const foundation = this.foundationFilter();
+      if (project) {
+        filtered = filtered.filter((c) => c.project_uid === project);
+      } else if (foundation) {
+        filtered = filtered.filter((c) => c.project_uid === foundation || (c.parent_project_uid === foundation && !c.is_foundation));
       }
-      return committees.filter(
-        (committee) =>
-          committee.name.toLowerCase().includes(searchTerm) ||
-          committee.display_name?.toLowerCase().includes(searchTerm) ||
-          committee.description?.toLowerCase().includes(searchTerm) ||
-          committee.category?.toLowerCase().includes(searchTerm)
-      );
+
+      // Apply search filter
+      const searchTerm = this.searchTerm()?.toLowerCase() || '';
+      if (searchTerm) {
+        filtered = filtered.filter(
+          (committee) =>
+            committee.name.toLowerCase().includes(searchTerm) ||
+            committee.display_name?.toLowerCase().includes(searchTerm) ||
+            committee.description?.toLowerCase().includes(searchTerm) ||
+            committee.category?.toLowerCase().includes(searchTerm)
+        );
+      }
+
+      return filtered;
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -208,8 +208,7 @@ export class CommitteeDashboardComponent {
             return of([] as MyCommittee[]);
           }
           this.myCommitteesLoading.set(true);
-          const projectUid = lens === 'me' ? undefined : project!.uid;
-          return this.committeeService.getMyCommittees(projectUid).pipe(
+          return this.committeeService.getMyCommittees().pipe(
             catchError((error) => {
               console.error('Failed to load my committees:', error);
               this.myCommitteesLoading.set(false);

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -208,7 +208,8 @@ export class CommitteeDashboardComponent {
             return of([] as MyCommittee[]);
           }
           this.myCommitteesLoading.set(true);
-          return this.committeeService.getMyCommittees().pipe(
+          const projectUid = lens === 'me' ? undefined : project!.uid;
+          return this.committeeService.getMyCommittees(projectUid).pipe(
             catchError((error) => {
               console.error('Failed to load my committees:', error);
               this.myCommitteesLoading.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
@@ -56,7 +56,7 @@ export class MyMeetingsComponent {
   private initRawMeetings() {
     return this.initLensSwitchedData<Meeting>(
       this.upcomingLoading,
-      () => this.userService.getUserMeetings(),
+      () => this.userService.getUserMeetings(100),
       (uid) => this.meetingService.getUpcomingMeetingsByProject(uid, 100)
     );
   }
@@ -64,7 +64,7 @@ export class MyMeetingsComponent {
   private initRawPastMeetings() {
     return this.initLensSwitchedData<PastMeeting>(
       this.pastLoading,
-      () => this.userService.getUserPastMeetings(),
+      () => this.userService.getUserPastMeetings(50),
       (uid) => this.meetingService.getPastMeetingsByProject(uid, 50)
     );
   }

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
@@ -56,7 +56,7 @@ export class MyMeetingsComponent {
   private initRawMeetings() {
     return this.initLensSwitchedData<Meeting>(
       this.upcomingLoading,
-      () => this.userService.getUserMeetings(100),
+      () => this.userService.getUserMeetings(),
       (uid) => this.meetingService.getUpcomingMeetingsByProject(uid, 100)
     );
   }
@@ -64,7 +64,7 @@ export class MyMeetingsComponent {
   private initRawPastMeetings() {
     return this.initLensSwitchedData<PastMeeting>(
       this.pastLoading,
-      () => this.userService.getUserPastMeetings(50),
+      () => this.userService.getUserPastMeetings(),
       (uid) => this.meetingService.getPastMeetingsByProject(uid, 50)
     );
   }

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
@@ -25,8 +25,6 @@
             control="foundationFilter"
             size="small"
             [options]="foundationOptions()"
-            placeholder="All Foundations"
-            [showClear]="true"
             styleClass="w-full"
             (onChange)="foundationFilterChange.emit($event.value)"
             data-testid="mailing-list-foundation-filter">
@@ -34,15 +32,13 @@
         </div>
       }
       <!-- Project Filter Dropdown (Me lens only, cascading from foundation) -->
-      @if (showProjectFilter() && projectOptions().length > 0) {
+      @if (showProjectFilter()) {
         <div class="w-full sm:w-48">
           <lfx-select
             [form]="searchForm()"
             control="projectFilter"
             size="small"
             [options]="projectOptions()"
-            placeholder="All Projects"
-            [showClear]="true"
             styleClass="w-full"
             (onChange)="projectFilterChange.emit($event.value)"
             data-testid="mailing-list-project-filter">

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts
@@ -54,8 +54,8 @@ export class MailingListTableComponent {
   public searchForm = input.required<FormGroup>();
   public committeeFilterOptions = input.required<FilterOption[]>();
   public statusFilterOptions = input.required<FilterOption[]>();
-  public foundationOptions = input<{ label: string; value: string }[]>([]);
-  public projectOptions = input<{ label: string; value: string }[]>([]);
+  public foundationOptions = input<{ label: string; value: string | null }[]>([]);
+  public projectOptions = input<{ label: string; value: string | null }[]>([]);
   public showFoundationFilter = input<boolean>(false);
   public showProjectFilter = input<boolean>(false);
   public loading = input<boolean>(false);

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -61,8 +61,8 @@ export class MailingListDashboardComponent {
   // Foundation + Project filter (Me lens only)
   public foundationFilter: WritableSignal<string | null> = signal<string | null>(null);
   public projectFilter: WritableSignal<string | null> = signal<string | null>(null);
-  public foundationOptions: Signal<{ label: string; value: string }[]> = this.initializeFoundationOptions();
-  public projectOptions: Signal<{ label: string; value: string }[]> = this.initializeProjectOptions();
+  public foundationOptions: Signal<{ label: string; value: string | null }[]> = this.initializeFoundationOptions();
+  public projectOptions: Signal<{ label: string; value: string | null }[]> = this.initializeProjectOptions();
 
   // Complex computed/toSignal signals
   public readonly project: Signal<ProjectContext | null> = this.initProject();
@@ -241,6 +241,17 @@ export class MailingListDashboardComponent {
     return computed(() => {
       let filtered: GroupsIOMailingList[] = this.isMeLens() ? this.myMailingLists() : this.mailingLists();
 
+      // Apply foundation/project filter (client-side, Me lens only)
+      if (this.isMeLens()) {
+        const project = this.projectFilter();
+        const foundation = this.foundationFilter();
+        if (project) {
+          filtered = filtered.filter((ml) => ml.project_uid === project);
+        } else if (foundation) {
+          filtered = filtered.filter((ml) => ml.project_uid === foundation || (ml.parent_project_uid === foundation && !ml.is_foundation));
+        }
+      }
+
       // Apply search filter
       const searchTerm = this.searchTerm()?.toLowerCase() || '';
       if (searchTerm) {
@@ -329,39 +340,54 @@ export class MailingListDashboardComponent {
     return computed(() => this.servicesLoaded() && this.availableServices().length === 0);
   }
 
-  private initializeFoundationOptions(): Signal<{ label: string; value: string }[]> {
+  private initializeFoundationOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const projects = this.personaService.detectedProjects();
-      return projects.filter((p) => p.isFoundation).map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+      const items = this.myMailingLists();
+      const seen = new Map<string, string>();
+      for (const item of items) {
+        if (item.is_foundation && item.project_uid && !seen.has(item.project_uid)) {
+          seen.set(item.project_uid, item.project_name || item.project_uid);
+        }
+      }
+      const options = [...seen.entries()]
+        .map(([uid, name]) => ({ label: name, value: uid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+      return [{ label: 'All Foundations', value: null }, ...options];
     });
   }
 
-  private initializeProjectOptions(): Signal<{ label: string; value: string }[]> {
+  private initializeProjectOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const projects = this.personaService.detectedProjects();
+      const items = this.myMailingLists();
       const foundation = this.foundationFilter();
-      let candidates = projects.filter((p) => !p.isFoundation);
-      if (foundation) {
-        candidates = candidates.filter((p) => p.parentProjectUid === foundation);
+      const seen = new Map<string, string>();
+      for (const item of items) {
+        if (!item.is_foundation && item.project_uid && !seen.has(item.project_uid)) {
+          if (foundation && item.parent_project_uid !== foundation) {
+            continue;
+          }
+          seen.set(item.project_uid, item.project_name || item.project_uid);
+        }
       }
-      return candidates.map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+      const options = [...seen.entries()]
+        .map(([uid, name]) => ({ label: name, value: uid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+      return [{ label: 'All Projects', value: null }, ...options];
     });
   }
 
   private initMyMailingLists(): Signal<MyMailingList[]> {
     const lens$ = toObservable(this.lensService.activeLens);
-    const projectFilter$ = toObservable(this.projectFilter);
-    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([lens$, this.refresh, projectFilter$, foundationFilter$]).pipe(
-        switchMap(([lens, , projectFilter, foundationFilter]) => {
+      combineLatest([lens$, this.refresh]).pipe(
+        switchMap(([lens]) => {
           if (lens !== 'me') {
             this.myMailingListsLoading.set(false);
             return of([] as MyMailingList[]);
           }
           this.myMailingListsLoading.set(true);
-          return this.mailingListService.getMyMailingLists(projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
+          return this.mailingListService.getMyMailingLists().pipe(
             catchError(() => {
               this.myMailingListsLoading.set(false);
               return of([] as MyMailingList[]);

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.html
@@ -22,8 +22,6 @@
         control="foundationFilter"
         size="small"
         [options]="foundationOptions()"
-        placeholder="All Foundations"
-        [showClear]="true"
         styleClass="w-full"
         (onChange)="onFoundationFilterChange($event.value)"
         data-testid="foundation-filter-dropdown"></lfx-select>
@@ -31,15 +29,13 @@
   }
 
   <!-- Project Filter Dropdown -->
-  @if (showProjectFilter() && projectOptions().length > 0) {
+  @if (showProjectFilter()) {
     <div class="w-full sm:w-48">
       <lfx-select
         [form]="searchForm"
         control="projectFilter"
         size="small"
         [options]="projectOptions()"
-        placeholder="All Projects"
-        [showClear]="true"
         styleClass="w-full"
         (onChange)="onProjectFilterChange($event.value)"
         data-testid="project-filter-dropdown"></lfx-select>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.ts
@@ -15,8 +15,8 @@ import { SelectComponent } from '@components/select/select.component';
 })
 export class MeetingsTopBarComponent implements OnInit {
   public meetingTypeOptions = input.required<{ label: string; value: string | null }[]>();
-  public foundationOptions = input<{ label: string; value: string }[]>([]);
-  public projectOptions = input<{ label: string; value: string }[]>([]);
+  public foundationOptions = input<{ label: string; value: string | null }[]>([]);
+  public projectOptions = input<{ label: string; value: string | null }[]>([]);
   public showFoundationFilter = input<boolean>(false);
   public showProjectFilter = input<boolean>(false);
   public readonly initialTimeFilter = input<'upcoming' | 'past'>('upcoming');

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -69,8 +69,8 @@ export class MeetingsDashboardComponent {
   public projectFilter: WritableSignal<string | null>;
   public showFoundationFilter: Signal<boolean>;
   public showProjectFilter: Signal<boolean>;
-  public foundationOptions: Signal<{ label: string; value: string }[]>;
-  public projectOptions: Signal<{ label: string; value: string }[]>;
+  public foundationOptions: Signal<{ label: string; value: string | null }[]>;
+  public projectOptions: Signal<{ label: string; value: string | null }[]>;
   public project: Signal<ProjectContext | null>;
   public isMaintainer: Signal<boolean>;
   public isFoundationContext: Signal<boolean>;
@@ -83,6 +83,8 @@ export class MeetingsDashboardComponent {
   // Raw user meetings cached for client-side filtering (Me lens only)
   private rawUserMeetings: Signal<Meeting[]>;
   private rawUserPastMeetings: Signal<PastMeeting[]>;
+  // Time-filtered meetings for deriving filter options (applies hasMeetingEnded for upcoming)
+  private timeFilteredMeetings: Signal<(Meeting | PastMeeting)[]>;
 
   private upcomingPageToken = signal<string | undefined>(undefined);
   private pastPageToken = signal<string | undefined>(undefined);
@@ -117,10 +119,6 @@ export class MeetingsDashboardComponent {
     this.meetingTypeFilter = signal<string | null>(null);
     this.foundationFilter = signal<string | null>(null);
     this.projectFilter = signal<string | null>(null);
-    this.foundationOptions = this.initializeFoundationOptions();
-    this.projectOptions = this.initializeProjectOptions();
-    this.showFoundationFilter = computed(() => this.activeLens() === 'me' && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
-    this.showProjectFilter = computed(() => this.activeLens() === 'me' && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
     this.hasMore = computed(() => this.activeLens() !== 'me' && (this.timeFilter() === 'past' ? !!this.pastPageToken() : !!this.upcomingPageToken()));
 
     // Initialize meeting type options
@@ -129,6 +127,19 @@ export class MeetingsDashboardComponent {
     // Initialize Me lens data (fetched once, filtered client-side)
     this.rawUserMeetings = this.initializeRawUserMeetings();
     this.rawUserPastMeetings = this.initializeRawUserPastMeetings();
+    this.timeFilteredMeetings = computed(() => {
+      if (this.timeFilter() === 'past') {
+        return this.rawUserPastMeetings();
+      }
+      return this.filterAndSortUpcomingMeetings(this.rawUserMeetings());
+    });
+
+    // Filter options derived from time-filtered meetings (only show projects with meetings in current view)
+    this.foundationOptions = this.initializeFoundationOptions();
+    this.projectOptions = this.initializeProjectOptions();
+    // Show filter when there's at least one real option (beyond the "All" entry) and user has the right persona role
+    this.showFoundationFilter = computed(() => this.activeLens() === 'me' && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
+    this.showProjectFilter = computed(() => this.activeLens() === 'me' && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
 
     // Initialize data with reactive pattern
     this.upcomingMeetings = this.initializeUpcomingMeetings();
@@ -194,12 +205,14 @@ export class MeetingsDashboardComponent {
 
     // Me lens: client-side filtering on cached data (no additional API calls)
     const rawUserMeetings$ = toObservable(this.rawUserMeetings);
-    const meLens$ = combineLatest([lens$, timeFilter$, searchQuery$, meetingType$, rawUserMeetings$]).pipe(
-      switchMap(([lens, timeFilter, searchQuery, meetingType, rawMeetings]) => {
+    const foundationFilter$ = toObservable(this.foundationFilter);
+    const projectFilter$ = toObservable(this.projectFilter);
+    const meLens$ = combineLatest([lens$, timeFilter$, searchQuery$, meetingType$, rawUserMeetings$, foundationFilter$, projectFilter$]).pipe(
+      switchMap(([lens, timeFilter, searchQuery, meetingType, rawMeetings, foundation, project]) => {
         if (lens !== 'me' || timeFilter !== 'upcoming') {
           return of<PageResult<Meeting>>({ data: [], page_token: undefined, reset: true });
         }
-        const filtered = this.filterBySearchAndType(rawMeetings, searchQuery, meetingType);
+        const filtered = this.filterMeLensMeetings(rawMeetings, searchQuery, meetingType, foundation, project);
         return of<PageResult<Meeting>>({ data: filtered, page_token: undefined, reset: true });
       })
     );
@@ -269,12 +282,14 @@ export class MeetingsDashboardComponent {
 
     // Me lens: client-side filtering on cached data (no additional API calls)
     const rawUserPastMeetings$ = toObservable(this.rawUserPastMeetings);
-    const meLens$ = combineLatest([lens$, timeFilter$, searchQuery$, meetingType$, rawUserPastMeetings$]).pipe(
-      switchMap(([lens, timeFilter, searchQuery, meetingType, rawPastMeetings]) => {
+    const pastFoundationFilter$ = toObservable(this.foundationFilter);
+    const pastProjectFilter$ = toObservable(this.projectFilter);
+    const meLens$ = combineLatest([lens$, timeFilter$, searchQuery$, meetingType$, rawUserPastMeetings$, pastFoundationFilter$, pastProjectFilter$]).pipe(
+      switchMap(([lens, timeFilter, searchQuery, meetingType, rawPastMeetings, foundation, project]) => {
         if (lens !== 'me' || timeFilter !== 'past') {
           return of<PageResult<PastMeeting>>({ data: [], page_token: undefined, reset: true });
         }
-        const filtered = this.filterBySearchAndType(rawPastMeetings, searchQuery, meetingType);
+        const filtered = this.filterMeLensMeetings(rawPastMeetings, searchQuery, meetingType, foundation, project);
         return of<PageResult<PastMeeting>>({ data: filtered, page_token: undefined, reset: true });
       })
     );
@@ -342,17 +357,15 @@ export class MeetingsDashboardComponent {
 
   private initializeRawUserMeetings(): Signal<Meeting[]> {
     const lens$ = toObservable(this.activeLens);
-    const projectFilter$ = toObservable(this.projectFilter);
-    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([lens$, this.refresh$, projectFilter$, foundationFilter$]).pipe(
-        switchMap(([lens, , projectFilter, foundationFilter]) => {
+      combineLatest([lens$, this.refresh$]).pipe(
+        switchMap(([lens]) => {
           if (lens !== 'me') {
             return of([] as Meeting[]);
           }
           this.meetingsLoading.set(true);
-          return this.userService.getUserMeetings(undefined, projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
+          return this.userService.getUserMeetings().pipe(
             tap(() => this.meetingsLoading.set(false)),
             catchError(() => {
               this.meetingsLoading.set(false);
@@ -367,17 +380,15 @@ export class MeetingsDashboardComponent {
 
   private initializeRawUserPastMeetings(): Signal<PastMeeting[]> {
     const lens$ = toObservable(this.activeLens);
-    const projectFilter$ = toObservable(this.projectFilter);
-    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([lens$, this.refresh$, projectFilter$, foundationFilter$]).pipe(
-        switchMap(([lens, , projectFilter, foundationFilter]) => {
+      combineLatest([lens$, this.refresh$]).pipe(
+        switchMap(([lens]) => {
           if (lens !== 'me') {
             return of([] as PastMeeting[]);
           }
           this.pastMeetingsLoading.set(true);
-          return this.userService.getUserPastMeetings(undefined, projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
+          return this.userService.getUserPastMeetings().pipe(
             tap(() => this.pastMeetingsLoading.set(false)),
             catchError(() => {
               this.pastMeetingsLoading.set(false);
@@ -425,6 +436,27 @@ export class MeetingsDashboardComponent {
     });
   }
 
+  private filterMeLensMeetings<T extends Meeting>(
+    items: T[],
+    searchQuery: string,
+    meetingType: string | null,
+    foundation: string | null,
+    project: string | null
+  ): T[] {
+    let filtered = items;
+
+    if (project) {
+      filtered = filtered.filter((m) => m.project_uid === project);
+    } else if (foundation) {
+      // Show meetings for the foundation itself and its non-foundation children only.
+      // Sub-foundations (is_foundation: true with parent = this foundation) are their own
+      // top-level filter entries, so exclude them and their children here.
+      filtered = filtered.filter((m) => m.project_uid === foundation || (m.parent_project_uid === foundation && !m.is_foundation));
+    }
+
+    return this.filterBySearchAndType(filtered, searchQuery, meetingType);
+  }
+
   private filterBySearchAndType<T extends { title?: string; meeting_type?: string | null }>(items: T[], searchQuery: string, meetingType: string | null): T[] {
     let filtered = items;
     if (searchQuery) {
@@ -437,27 +469,46 @@ export class MeetingsDashboardComponent {
     return filtered;
   }
 
-  private initializeFoundationOptions(): Signal<{ label: string; value: string }[]> {
+  private initializeFoundationOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const projects = this.personaService.detectedProjects();
-      return projects.filter((p) => p.isFoundation).map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+      const meetings = this.timeFilteredMeetings();
+      const seen = new Map<string, string>();
+
+      for (const m of meetings) {
+        if (m.is_foundation && m.project_uid && !seen.has(m.project_uid)) {
+          seen.set(m.project_uid, m.project_name || m.project_uid);
+        }
+      }
+
+      const options = [...seen.entries()]
+        .map(([uid, name]) => ({ label: name, value: uid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+
+      return [{ label: 'All Foundations', value: null }, ...options];
     });
   }
 
-  private initializeProjectOptions(): Signal<{ label: string; value: string }[]> {
+  private initializeProjectOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const projects = this.personaService.detectedProjects();
+      const meetings = this.timeFilteredMeetings();
       const foundation = this.foundationFilter();
+      const seen = new Map<string, string>();
 
-      // Filter to non-foundation projects
-      let candidates = projects.filter((p) => !p.isFoundation);
-
-      // If a foundation is selected, show only its children
-      if (foundation) {
-        candidates = candidates.filter((p) => p.parentProjectUid === foundation);
+      for (const m of meetings) {
+        if (!m.is_foundation && m.project_uid && !seen.has(m.project_uid)) {
+          // If a foundation is selected, only show its children
+          if (foundation && m.parent_project_uid !== foundation) {
+            continue;
+          }
+          seen.set(m.project_uid, m.project_name || m.project_uid);
+        }
       }
 
-      return candidates.map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+      const options = [...seen.entries()]
+        .map(([uid, name]) => ({ label: name, value: uid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+
+      return [{ label: 'All Projects', value: null }, ...options];
     });
   }
 

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -22,23 +22,19 @@
             control="foundationFilter"
             size="small"
             [options]="foundationOptions()"
-            placeholder="All Foundations"
-            [showClear]="true"
             styleClass="w-full"
             (onChange)="onFoundationFilterChange($event.value)"
             data-testid="surveys-foundation-filter"></lfx-select>
         </div>
       }
 
-      @if (showProjectFilter() && projectOptions().length > 0) {
+      @if (showProjectFilter()) {
         <div class="w-full sm:w-48">
           <lfx-select
             [form]="searchForm"
             control="projectFilter"
             size="small"
             [options]="projectOptions()"
-            placeholder="All Projects"
-            [showClear]="true"
             styleClass="w-full"
             (onChange)="projectFilterChange.emit($event.value)"
             data-testid="surveys-project-filter"></lfx-select>
@@ -51,8 +47,6 @@
           control="group"
           size="small"
           [options]="groupOptions()"
-          placeholder="All Groups"
-          [showClear]="true"
           (valueChange)="onGroupChange($event)"
           data-testid="surveys-group-filter"></lfx-select>
       </div>
@@ -63,8 +57,6 @@
           control="surveyType"
           size="small"
           [options]="typeOptions()"
-          placeholder="All Types"
-          [showClear]="true"
           (valueChange)="onTypeChange($event)"
           data-testid="surveys-type-filter"></lfx-select>
       </div>
@@ -75,8 +67,6 @@
           control="status"
           size="small"
           [options]="statusOptions()"
-          placeholder="All Statuses"
-          [showClear]="true"
           (valueChange)="onStatusChange($event)"
           data-testid="surveys-status-filter"></lfx-select>
       </div>

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -53,8 +53,8 @@ export class SurveysTableComponent {
   public readonly surveys = input.required<Survey[]>();
   public readonly hasPMOAccess = input<boolean>(false);
   public readonly loading = input<boolean>(false);
-  public readonly foundationOptions = input<{ label: string; value: string }[]>([]);
-  public readonly projectOptions = input<{ label: string; value: string }[]>([]);
+  public readonly foundationOptions = input<{ label: string; value: string | null }[]>([]);
+  public readonly projectOptions = input<{ label: string; value: string | null }[]>([]);
   public readonly showFoundationFilter = input<boolean>(false);
   public readonly showProjectFilter = input<boolean>(false);
 

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
@@ -51,7 +51,7 @@
     </lfx-card>
   } @else {
     <lfx-surveys-table
-      [surveys]="isMeLens() ? mySurveys() : surveys()"
+      [surveys]="isMeLens() ? filteredMySurveys() : surveys()"
       [hasPMOAccess]="!isMeLens() && hasPMOAccess()"
       [loading]="isMeLens() ? mySurveysLoading() : loading()"
       [foundationOptions]="foundationOptions()"

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
@@ -28,8 +28,8 @@ export class SurveysDashboardComponent {
   // === Services ===
   private readonly surveyService = inject(SurveyService);
   private readonly lensService = inject(LensService);
-  private readonly projectContextService = inject(ProjectContextService);
   private readonly personaService = inject(PersonaService);
+  private readonly projectContextService = inject(ProjectContextService);
 
   // === Constants ===
   protected readonly surveyLabel = SURVEY_LABEL.singular;
@@ -57,8 +57,9 @@ export class SurveysDashboardComponent {
   protected readonly surveys: Signal<Survey[]> = this.initSurveys();
   protected readonly selectedListSurvey: Signal<Survey | null> = this.initSelectedListSurvey();
   protected readonly mySurveys: Signal<Survey[]> = this.initMySurveys();
-  protected readonly foundationOptions: Signal<{ label: string; value: string }[]> = this.initializeFoundationOptions();
-  protected readonly projectOptions: Signal<{ label: string; value: string }[]> = this.initializeProjectOptions();
+  protected readonly foundationOptions: Signal<{ label: string; value: string | null }[]> = this.initializeFoundationOptions();
+  protected readonly projectOptions: Signal<{ label: string; value: string | null }[]> = this.initializeProjectOptions();
+  protected readonly filteredMySurveys: Signal<Survey[]> = this.initFilteredMySurveys();
 
   protected onViewResults(surveyId: string): void {
     this.selectedSurveyId.set(surveyId);
@@ -137,18 +138,16 @@ export class SurveysDashboardComponent {
 
   private initMySurveys(): Signal<Survey[]> {
     const lens$ = toObservable(this.lensService.activeLens);
-    const projectFilter$ = toObservable(this.projectFilter);
-    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([lens$, this.refresh$, projectFilter$, foundationFilter$]).pipe(
-        switchMap(([lens, , projectFilter, foundationFilter]) => {
+      combineLatest([lens$, this.refresh$]).pipe(
+        switchMap(([lens]) => {
           if (lens !== 'me') {
             this.mySurveysLoading.set(false);
             return of([] as Survey[]);
           }
           this.mySurveysLoading.set(true);
-          return this.surveyService.getMySurveys(projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
+          return this.surveyService.getMySurveys().pipe(
             catchError(() => {
               this.mySurveysLoading.set(false);
               return of([] as Survey[]);
@@ -161,27 +160,53 @@ export class SurveysDashboardComponent {
     );
   }
 
-  private initializeFoundationOptions(): Signal<{ label: string; value: string }[]> {
+  private initializeFoundationOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const projects = this.personaService.detectedProjects();
-      return projects.filter((p) => p.isFoundation).map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+      const items = this.mySurveys();
+      const seen = new Map<string, string>();
+      for (const item of items) {
+        if (item.is_foundation && item.project_uid && !seen.has(item.project_uid)) {
+          seen.set(item.project_uid, item.project_name || item.project_uid);
+        }
+      }
+      const options = [...seen.entries()]
+        .map(([uid, name]) => ({ label: name, value: uid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+      return [{ label: 'All Foundations', value: null }, ...options];
     });
   }
 
-  private initializeProjectOptions(): Signal<{ label: string; value: string }[]> {
+  private initializeProjectOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const projects = this.personaService.detectedProjects();
+      const items = this.mySurveys();
+      const foundation = this.foundationFilter();
+      const seen = new Map<string, string>();
+      for (const item of items) {
+        if (!item.is_foundation && item.project_uid && !seen.has(item.project_uid)) {
+          if (foundation && item.parent_project_uid !== foundation) continue;
+          seen.set(item.project_uid, item.project_name || item.project_uid);
+        }
+      }
+      const options = [...seen.entries()]
+        .map(([uid, name]) => ({ label: name, value: uid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+      return [{ label: 'All Projects', value: null }, ...options];
+    });
+  }
+
+  private initFilteredMySurveys(): Signal<Survey[]> {
+    return computed(() => {
+      let filtered = this.mySurveys();
+      const project = this.projectFilter();
       const foundation = this.foundationFilter();
 
-      // Filter to non-foundation projects
-      let candidates = projects.filter((p) => !p.isFoundation);
-
-      // If a foundation is selected, show only its children
-      if (foundation) {
-        candidates = candidates.filter((p) => p.parentProjectUid === foundation);
+      if (project) {
+        filtered = filtered.filter((s) => s.project_uid === project);
+      } else if (foundation) {
+        filtered = filtered.filter((s) => s.project_uid === foundation || (s.parent_project_uid === foundation && !s.is_foundation));
       }
 
-      return candidates.map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+      return filtered;
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -22,8 +22,6 @@
             control="foundationFilter"
             size="small"
             [options]="foundationOptions()"
-            placeholder="All Foundations"
-            [showClear]="true"
             [filter]="true"
             filterPlaceholder="Search foundations..."
             styleClass="w-full"
@@ -32,15 +30,13 @@
           </lfx-select>
         </div>
       }
-      @if (showProjectFilter() && projectOptions().length > 0) {
+      @if (showProjectFilter()) {
         <div class="w-full sm:w-56">
           <lfx-select
             [form]="searchForm"
             control="projectFilter"
             size="small"
             [options]="projectOptions()"
-            placeholder="All Projects"
-            [showClear]="true"
             [filter]="true"
             filterPlaceholder="Search projects..."
             styleClass="w-full"
@@ -56,8 +52,6 @@
           control="group"
           size="small"
           [options]="groupOptions()"
-          placeholder="All Groups"
-          [showClear]="true"
           [filter]="true"
           filterPlaceholder="Search groups..."
           data-testid="votes-group-filter"></lfx-select>
@@ -69,8 +63,6 @@
           control="status"
           size="small"
           [options]="statusOptions()"
-          placeholder="All Statuses"
-          [showClear]="true"
           data-testid="votes-status-filter"></lfx-select>
       </div>
 

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -64,8 +64,8 @@ export class VotesTableComponent implements OnInit {
   public readonly first = input<number>(0);
   public readonly lazy = input<boolean>(false);
   public readonly groupOptions = input<{ label: string; value: string | null }[]>([{ label: 'All Groups', value: null }]);
-  public readonly foundationOptions = input<{ label: string; value: string }[]>([]);
-  public readonly projectOptions = input<{ label: string; value: string }[]>([]);
+  public readonly foundationOptions = input<{ label: string; value: string | null }[]>([]);
+  public readonly projectOptions = input<{ label: string; value: string | null }[]>([]);
   public readonly showFoundationFilter = input<boolean>(false);
   public readonly showProjectFilter = input<boolean>(false);
 

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -47,10 +47,10 @@
     </lfx-card>
   } @else {
     <lfx-votes-table
-      [votes]="isMeLens() ? myVotes() : votes()"
+      [votes]="isMeLens() ? filteredMyVotes() : votes()"
       [hasPMOAccess]="!isMeLens() && hasPMOAccess()"
       [loading]="isMeLens() ? myVotesLoading() : loading()"
-      [totalRecords]="isMeLens() ? myVotes().length : totalRecords()"
+      [totalRecords]="isMeLens() ? filteredMyVotes().length : totalRecords()"
       [rowsPerPage]="rowsPerPage()"
       [first]="isMeLens() ? 0 : currentFirst()"
       [lazy]="!isMeLens()"

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -75,8 +75,9 @@ export class VotesDashboardComponent {
   protected readonly selectedListVote: Signal<Vote | null> = this.initSelectedListVote();
   protected readonly myVotes: Signal<Vote[]> = this.initMyVotes();
   protected readonly totalCount: Signal<number> = this.initTotalCount();
-  protected readonly foundationOptions: Signal<{ label: string; value: string }[]> = this.initializeFoundationOptions();
-  protected readonly projectOptions: Signal<{ label: string; value: string }[]> = this.initializeProjectOptions();
+  protected readonly foundationOptions: Signal<{ label: string; value: string | null }[]> = this.initializeFoundationOptions();
+  protected readonly projectOptions: Signal<{ label: string; value: string | null }[]> = this.initializeProjectOptions();
+  protected readonly filteredMyVotes: Signal<Vote[]> = this.initFilteredMyVotes();
 
   protected onViewVote(voteId: string): void {
     this.selectedVoteId.set(voteId);
@@ -256,18 +257,16 @@ export class VotesDashboardComponent {
 
   private initMyVotes(): Signal<Vote[]> {
     const lens$ = toObservable(this.lensService.activeLens);
-    const projectFilter$ = toObservable(this.projectFilter);
-    const foundationFilter$ = toObservable(this.foundationFilter);
 
     return toSignal(
-      combineLatest([lens$, this.refresh$, projectFilter$, foundationFilter$]).pipe(
-        switchMap(([lens, , projectFilter, foundationFilter]) => {
+      combineLatest([lens$, this.refresh$]).pipe(
+        switchMap(([lens]) => {
           if (lens !== 'me') {
             this.myVotesLoading.set(false);
             return of([] as Vote[]);
           }
           this.myVotesLoading.set(true);
-          return this.voteService.getMyVotes(projectFilter ?? undefined, foundationFilter ?? undefined).pipe(
+          return this.voteService.getMyVotes().pipe(
             catchError(() => {
               this.myVotesLoading.set(false);
               return of([] as Vote[]);
@@ -280,24 +279,53 @@ export class VotesDashboardComponent {
     );
   }
 
-  private initializeFoundationOptions(): Signal<{ label: string; value: string }[]> {
+  private initializeFoundationOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      return this.personaService
-        .detectedProjects()
-        .filter((p) => p.isFoundation)
-        .map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+      const items = this.myVotes();
+      const seen = new Map<string, string>();
+      for (const item of items) {
+        if (item.is_foundation && item.project_uid && !seen.has(item.project_uid)) {
+          seen.set(item.project_uid, item.project_name || item.project_uid);
+        }
+      }
+      const options = [...seen.entries()]
+        .map(([uid, name]) => ({ label: name, value: uid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+      return [{ label: 'All Foundations', value: null }, ...options];
     });
   }
 
-  private initializeProjectOptions(): Signal<{ label: string; value: string }[]> {
+  private initializeProjectOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const projects = this.personaService.detectedProjects();
+      const items = this.myVotes();
       const foundation = this.foundationFilter();
-      let candidates = projects.filter((p) => !p.isFoundation);
-      if (foundation) {
-        candidates = candidates.filter((p) => p.parentProjectUid === foundation);
+      const seen = new Map<string, string>();
+      for (const item of items) {
+        if (!item.is_foundation && item.project_uid && !seen.has(item.project_uid)) {
+          if (foundation && item.parent_project_uid !== foundation) continue;
+          seen.set(item.project_uid, item.project_name || item.project_uid);
+        }
       }
-      return candidates.map((p) => ({ label: p.projectName ?? p.projectSlug, value: p.projectUid }));
+      const options = [...seen.entries()]
+        .map(([uid, name]) => ({ label: name, value: uid }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+      return [{ label: 'All Projects', value: null }, ...options];
+    });
+  }
+
+  private initFilteredMyVotes(): Signal<Vote[]> {
+    return computed(() => {
+      let filtered = this.myVotes();
+      const project = this.projectFilter();
+      const foundation = this.foundationFilter();
+
+      if (project) {
+        filtered = filtered.filter((v) => v.project_uid === project);
+      } else if (foundation) {
+        filtered = filtered.filter((v) => v.project_uid === foundation || (v.parent_project_uid === foundation && !v.is_foundation));
+      }
+
+      return filtered;
     });
   }
 }

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -133,7 +133,11 @@ export class CommitteeService {
   // ── My Committees ─────────────────────────────────────────────────────────
 
   /** Get all committees for the current user */
-  public getMyCommittees(): Observable<MyCommittee[]> {
-    return this.http.get<MyCommittee[]>('/api/committees/my-committees').pipe(catchError(() => of([])));
+  public getMyCommittees(projectUid?: string): Observable<MyCommittee[]> {
+    let params = new HttpParams();
+    if (projectUid) {
+      params = params.set('project_uid', projectUid);
+    }
+    return this.http.get<MyCommittee[]>('/api/committees/my-committees', { params }).pipe(catchError(() => of([])));
   }
 }

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -133,11 +133,7 @@ export class CommitteeService {
   // ── My Committees ─────────────────────────────────────────────────────────
 
   /** Get all committees for the current user */
-  public getMyCommittees(projectUid?: string): Observable<MyCommittee[]> {
-    let params = new HttpParams();
-    if (projectUid) {
-      params = params.set('project_uid', projectUid);
-    }
-    return this.http.get<MyCommittee[]>('/api/committees/my-committees', { params }).pipe(catchError(() => of([])));
+  public getMyCommittees(): Observable<MyCommittee[]> {
+    return this.http.get<MyCommittee[]>('/api/committees/my-committees').pipe(catchError(() => of([])));
   }
 }

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -132,15 +132,8 @@ export class CommitteeService {
 
   // ── My Committees ─────────────────────────────────────────────────────────
 
-  /** Get committees for the current user, optionally scoped to a project or foundation */
-  public getMyCommittees(projectUid?: string, foundationUid?: string): Observable<MyCommittee[]> {
-    let params = new HttpParams();
-    if (projectUid) {
-      params = params.set('project_uid', projectUid);
-    }
-    if (foundationUid) {
-      params = params.set('foundation_uid', foundationUid);
-    }
-    return this.http.get<MyCommittee[]>('/api/committees/my-committees', { params }).pipe(catchError(() => of([])));
+  /** Get all committees for the current user */
+  public getMyCommittees(): Observable<MyCommittee[]> {
+    return this.http.get<MyCommittee[]>('/api/committees/my-committees').pipe(catchError(() => of([])));
   }
 }

--- a/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/app/shared/services/mailing-list.service.ts
@@ -41,15 +41,8 @@ export class MailingListService {
     return this.http.get<GroupsIOMailingList[]>(this.baseUrl);
   }
 
-  public getMyMailingLists(projectUid?: string, foundationUid?: string): Observable<MyMailingList[]> {
-    let params = new HttpParams();
-    if (projectUid) {
-      params = params.set('project_uid', projectUid);
-    }
-    if (foundationUid) {
-      params = params.set('foundation_uid', foundationUid);
-    }
-    return this.http.get<MyMailingList[]>(`${this.baseUrl}/my-mailing-lists`, { params }).pipe(catchError(() => of([])));
+  public getMyMailingLists(): Observable<MyMailingList[]> {
+    return this.http.get<MyMailingList[]>(`${this.baseUrl}/my-mailing-lists`).pipe(catchError(() => of([])));
   }
 
   public getMailingList(uid: string): Observable<GroupsIOMailingList> {

--- a/apps/lfx-one/src/app/shared/services/survey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/survey.service.ts
@@ -45,6 +45,7 @@ export class SurveyService {
     return this.getSurveys(params);
   }
 
+  /** Returns surveys for the current user; foundation/project filtering is applied client-side. */
   public getMySurveys(): Observable<Survey[]> {
     return this.http.get<Survey[]>('/api/surveys/my-surveys').pipe(catchError(() => of([])));
   }

--- a/apps/lfx-one/src/app/shared/services/survey.service.ts
+++ b/apps/lfx-one/src/app/shared/services/survey.service.ts
@@ -45,15 +45,8 @@ export class SurveyService {
     return this.getSurveys(params);
   }
 
-  public getMySurveys(projectUid?: string, foundationUid?: string): Observable<Survey[]> {
-    let params = new HttpParams();
-    if (projectUid) {
-      params = params.set('project_uid', projectUid);
-    }
-    if (foundationUid) {
-      params = params.set('foundation_uid', foundationUid);
-    }
-    return this.http.get<Survey[]>('/api/surveys/my-surveys', { params }).pipe(catchError(() => of([])));
+  public getMySurveys(): Observable<Survey[]> {
+    return this.http.get<Survey[]>('/api/surveys/my-surveys').pipe(catchError(() => of([])));
   }
 
   public getSurvey(surveyUid: string, projectId?: string): Observable<Survey> {

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -145,10 +145,13 @@ export class UserService {
   /**
    * Gets all meetings for the current authenticated user
    * Returns meetings the user is registered for across all projects
-   * @param limit - Optional limit on number of meetings to return
    */
-  public getUserMeetings(): Observable<Meeting[]> {
-    return this.http.get<Meeting[]>('/api/user/meetings').pipe(
+  public getUserMeetings(limit?: number): Observable<Meeting[]> {
+    const params: Record<string, string> = {};
+    if (limit !== undefined) {
+      params['limit'] = limit.toString();
+    }
+    return this.http.get<Meeting[]>('/api/user/meetings', { params }).pipe(
       catchError((error) => {
         console.error('Failed to load user meetings:', error);
         return of([]);
@@ -158,10 +161,13 @@ export class UserService {
 
   /**
    * Gets past meetings for the current authenticated user
-   * @param limit - Optional limit on number of past meetings to return
    */
-  public getUserPastMeetings(): Observable<PastMeeting[]> {
-    return this.http.get<PastMeeting[]>('/api/user/past-meetings').pipe(
+  public getUserPastMeetings(limit?: number): Observable<PastMeeting[]> {
+    const params: Record<string, string> = {};
+    if (limit !== undefined) {
+      params['limit'] = limit.toString();
+    }
+    return this.http.get<PastMeeting[]>('/api/user/past-meetings', { params }).pipe(
       catchError((error) => {
         console.error('Failed to load user past meetings:', error);
         return of([]);

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -146,12 +146,8 @@ export class UserService {
    * Gets all meetings for the current authenticated user
    * Returns meetings the user is registered for across all projects
    */
-  public getUserMeetings(limit?: number): Observable<Meeting[]> {
-    const params: Record<string, string> = {};
-    if (limit !== undefined) {
-      params['limit'] = limit.toString();
-    }
-    return this.http.get<Meeting[]>('/api/user/meetings', { params }).pipe(
+  public getUserMeetings(): Observable<Meeting[]> {
+    return this.http.get<Meeting[]>('/api/user/meetings').pipe(
       catchError((error) => {
         console.error('Failed to load user meetings:', error);
         return of([]);
@@ -162,12 +158,8 @@ export class UserService {
   /**
    * Gets past meetings for the current authenticated user
    */
-  public getUserPastMeetings(limit?: number): Observable<PastMeeting[]> {
-    const params: Record<string, string> = {};
-    if (limit !== undefined) {
-      params['limit'] = limit.toString();
-    }
-    return this.http.get<PastMeeting[]>('/api/user/past-meetings', { params }).pipe(
+  public getUserPastMeetings(): Observable<PastMeeting[]> {
+    return this.http.get<PastMeeting[]>('/api/user/past-meetings').pipe(
       catchError((error) => {
         console.error('Failed to load user past meetings:', error);
         return of([]);

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -147,18 +147,8 @@ export class UserService {
    * Returns meetings the user is registered for across all projects
    * @param limit - Optional limit on number of meetings to return
    */
-  public getUserMeetings(limit?: number, projectUid?: string, foundationUid?: string): Observable<Meeting[]> {
-    const params: Record<string, string> = {};
-    if (limit !== undefined) {
-      params['limit'] = limit.toString();
-    }
-    if (projectUid) {
-      params['projectUid'] = projectUid;
-    }
-    if (foundationUid) {
-      params['foundation_uid'] = foundationUid;
-    }
-    return this.http.get<Meeting[]>('/api/user/meetings', { params }).pipe(
+  public getUserMeetings(): Observable<Meeting[]> {
+    return this.http.get<Meeting[]>('/api/user/meetings').pipe(
       catchError((error) => {
         console.error('Failed to load user meetings:', error);
         return of([]);
@@ -170,18 +160,8 @@ export class UserService {
    * Gets past meetings for the current authenticated user
    * @param limit - Optional limit on number of past meetings to return
    */
-  public getUserPastMeetings(limit?: number, projectUid?: string, foundationUid?: string): Observable<PastMeeting[]> {
-    const params: Record<string, string> = {};
-    if (limit !== undefined) {
-      params['limit'] = limit.toString();
-    }
-    if (projectUid) {
-      params['projectUid'] = projectUid;
-    }
-    if (foundationUid) {
-      params['foundation_uid'] = foundationUid;
-    }
-    return this.http.get<PastMeeting[]>('/api/user/past-meetings', { params }).pipe(
+  public getUserPastMeetings(): Observable<PastMeeting[]> {
+    return this.http.get<PastMeeting[]>('/api/user/past-meetings').pipe(
       catchError((error) => {
         console.error('Failed to load user past meetings:', error);
         return of([]);

--- a/apps/lfx-one/src/app/shared/services/vote.service.ts
+++ b/apps/lfx-one/src/app/shared/services/vote.service.ts
@@ -22,15 +22,8 @@ export class VoteService {
     );
   }
 
-  public getMyVotes(projectUid?: string, foundationUid?: string): Observable<Vote[]> {
-    let params = new HttpParams();
-    if (projectUid) {
-      params = params.set('project_uid', projectUid);
-    }
-    if (foundationUid) {
-      params = params.set('foundation_uid', foundationUid);
-    }
-    return this.http.get<Vote[]>('/api/votes/my-votes', { params }).pipe(catchError(() => of([])));
+  public getMyVotes(): Observable<Vote[]> {
+    return this.http.get<Vote[]>('/api/votes/my-votes').pipe(catchError(() => of([])));
   }
 
   public getVotesByProject(projectUid: string, pageSize?: number, orderBy?: string): Observable<Vote[]> {

--- a/apps/lfx-one/src/server/controllers/mailing-list.controller.ts
+++ b/apps/lfx-one/src/server/controllers/mailing-list.controller.ts
@@ -241,12 +241,10 @@ export class MailingListController {
    * GET /mailing-lists/my-mailing-lists
    */
   public async getMyMailingLists(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const projectUid = req.query['project_uid'] as string | undefined;
-    const foundationUid = req.query['foundation_uid'] as string | undefined;
-    const startTime = logger.startOperation(req, 'get_my_mailing_lists', { project_uid: projectUid, foundation_uid: foundationUid });
+    const startTime = logger.startOperation(req, 'get_my_mailing_lists');
 
     try {
-      const myMailingLists = await this.mailingListService.getMyMailingLists(req, projectUid, foundationUid);
+      const myMailingLists = await this.mailingListService.getMyMailingLists(req);
 
       logger.success(req, 'get_my_mailing_lists', startTime, {
         mailing_list_count: myMailingLists.length,

--- a/apps/lfx-one/src/server/controllers/survey.controller.ts
+++ b/apps/lfx-one/src/server/controllers/survey.controller.ts
@@ -70,20 +70,13 @@ export class SurveyController {
    * GET /surveys/my-surveys
    */
   public async getMySurveys(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const projectUid = req.query['project_uid'] as string | undefined;
-    const foundationUid = req.query['foundation_uid'] as string | undefined;
-    const startTime = logger.startOperation(req, 'get_my_surveys', {
-      project_uid: projectUid,
-      foundation_uid: foundationUid,
-    });
+    const startTime = logger.startOperation(req, 'get_my_surveys');
 
     try {
-      const mySurveys = await this.surveyService.getMySurveys(req, projectUid, foundationUid);
+      const mySurveys = await this.surveyService.getMySurveys(req);
 
       logger.success(req, 'get_my_surveys', startTime, {
         survey_count: mySurveys.length,
-        project_uid: projectUid,
-        foundation_uid: foundationUid,
       });
 
       res.json(mySurveys);

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -61,20 +61,13 @@ export class VoteController {
    * GET /votes/my-votes
    */
   public async getMyVotes(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const projectUid = req.query['project_uid'] as string | undefined;
-    const foundationUid = req.query['foundation_uid'] as string | undefined;
-    const startTime = logger.startOperation(req, 'get_my_votes', {
-      project_uid: projectUid,
-      foundation_uid: foundationUid,
-    });
+    const startTime = logger.startOperation(req, 'get_my_votes');
 
     try {
-      const myVotes = await this.voteService.getMyVotes(req, projectUid, foundationUid);
+      const myVotes = await this.voteService.getMyVotes(req);
 
       logger.success(req, 'get_my_votes', startTime, {
         vote_count: myVotes.length,
-        project_uid: projectUid,
-        foundation_uid: foundationUid,
       });
 
       res.json(myVotes);

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -469,6 +469,9 @@ export class CommitteeService {
 
     // Fetch all committee_member records for the current user (paginated)
     const tagsAll = [`username:${username}`];
+    if (projectUid) {
+      tagsAll.push(`project_uid:${projectUid}`);
+    }
 
     const memberships = await fetchAllQueryResources<CommitteeMember>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -21,6 +21,7 @@ import { Request } from 'express';
 import { getUsernameFromAuth } from '../utils/auth-helper';
 
 import { ResourceNotFoundError } from '../errors';
+import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { logger } from '../services/logger.service';
 import { AccessCheckService } from './access-check.service';
 import { ETagService } from './etag.service';
@@ -466,19 +467,18 @@ export class CommitteeService {
       return [];
     }
 
-    // Fetch all committee_member records for the current user
+    // Fetch all committee_member records for the current user (paginated)
     const tagsAll = [`username:${username}`];
-    if (projectUid) {
-      tagsAll.push(`project_uid:${projectUid}`);
-    }
 
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-      v: '1',
-      type: 'committee_member',
-      tags_all: tagsAll,
-    });
-
-    const memberships = resources.map((r) => r.data);
+    const memberships = await fetchAllQueryResources<CommitteeMember>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        v: '1',
+        type: 'committee_member',
+        page_size: 100,
+        tags_all: tagsAll,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
 
     if (memberships.length === 0) {
       return [];
@@ -522,19 +522,19 @@ export class CommitteeService {
       })
     );
 
-    const result = committees.filter((c): c is MyCommittee => c !== null);
+    let result = committees.filter((c): c is MyCommittee => c !== null);
 
-    // Filter by project_uid server-side if provided
+    // Filter by project or foundation if specified (used by document service)
     if (projectUid) {
-      return result.filter((c) => c.project_uid === projectUid);
+      result = result.filter((c) => c.project_uid === projectUid);
     } else if (foundationUid) {
-      logger.debug(req, 'get_my_committees', 'Filtering by foundation', { foundation_uid: foundationUid });
       const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
       const uidSet = new Set(uids);
-      return result.filter((c) => uidSet.has(c.project_uid));
+      result = result.filter((c) => uidSet.has(c.project_uid));
     }
 
-    return result;
+    // Enrich with project data (name, slug, is_foundation, parent_project_uid)
+    return this.projectService.enrichWithProjectData(req, result);
   }
 
   // ── Join / Leave Methods ────────────────────────────────────────────────────

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -468,6 +468,7 @@ export class CommitteeService {
     }
 
     // Fetch all committee_member records for the current user (paginated)
+    // When projectUid is provided (e.g. document service), scope the query for efficiency
     const tagsAll = [`username:${username}`];
     if (projectUid) {
       tagsAll.push(`project_uid:${projectUid}`);

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -343,7 +343,7 @@ export class MailingListService {
    * Fetches mailing lists the current user is a member of.
    * Queries by both email and username to ensure complete coverage.
    */
-  public async getMyMailingLists(req: Request, projectUid?: string, foundationUid?: string): Promise<MyMailingList[]> {
+  public async getMyMailingLists(req: Request): Promise<MyMailingList[]> {
     // Get user identity from auth context
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
@@ -352,7 +352,6 @@ export class MailingListService {
     logger.debug(req, 'get_my_mailing_lists', 'Fetching mailing lists for current user', {
       username,
       has_email: !!email,
-      project_uid: projectUid,
     });
 
     if (!username && !email) {
@@ -369,7 +368,7 @@ export class MailingListService {
             v: '1',
             type: 'groupsio_member',
             page_size: 100,
-            tags_all: projectUid ? [`email:${email}`, `project_uid:${projectUid}`] : [`email:${email}`],
+            tags_all: [`email:${email}`],
             ...(pageToken && { page_token: pageToken }),
           })
         )
@@ -383,7 +382,7 @@ export class MailingListService {
             v: '1',
             type: 'groupsio_member',
             page_size: 100,
-            tags_all: projectUid ? [`username:${username}`, `project_uid:${projectUid}`] : [`username:${username}`],
+            tags_all: [`username:${username}`],
             ...(pageToken && { page_token: pageToken }),
           })
         )
@@ -460,21 +459,13 @@ export class MailingListService {
       })
     );
 
-    const filtered = mailingLists.filter((ml): ml is MyMailingList => ml !== null);
-
-    // Post-fetch filtering by project_uid or foundation_uid
-    let result = filtered;
-    if (projectUid) {
-      result = filtered.filter((ml) => ml.project_uid === projectUid);
-    } else if (foundationUid) {
-      logger.debug(req, 'get_my_mailing_lists', 'Filtering by foundation', { foundation_uid: foundationUid });
-      const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
-      const uidSet = new Set(uids);
-      result = filtered.filter((ml) => uidSet.has(ml.project_uid));
-    }
+    const result = mailingLists.filter((ml): ml is MyMailingList => ml !== null);
 
     // Enrich with service data for correct email display in UI
-    return (await this.enrichWithServices(req, result)) as MyMailingList[];
+    const enrichedWithServices = (await this.enrichWithServices(req, result)) as MyMailingList[];
+
+    // Enrich with project data (name, slug, logo, etc.)
+    return this.projectService.enrichWithProjectData(req, enrichedWithServices);
   }
 
   // ============================================

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1153,6 +1153,10 @@ export class MeetingService {
     return newRegistrant;
   }
 
+  public async getMeetingProjectName<T extends Meeting>(req: Request, meetings: T[]): Promise<T[]> {
+    return this.projectService.enrichWithProjectData(req, meetings) as Promise<T[]>;
+  }
+
   /**
    * Fetches committee names for all unique committees referenced in meetings.
    * Returns a Map of committee UID -> committee name for merging into meeting data.
@@ -1196,17 +1200,4 @@ export class MeetingService {
     return nameMap;
   }
 
-  private async getMeetingProjectName(req: Request, meetings: Meeting[]): Promise<Meeting[]> {
-    const projectUids = [...new Set(meetings.map((m) => m.project_uid))];
-    const projects = await Promise.all(
-      projectUids.map(async (uid) => {
-        return await this.projectService.getProjectById(req, uid).catch(() => null);
-      })
-    );
-
-    return meetings.map((m) => {
-      const project = projects.find((p) => p?.uid === m.project_uid);
-      return { ...m, project_name: project?.name || '', project_slug: project?.slug || '' };
-    });
-  }
 }

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -460,13 +460,6 @@ export class PersonaDetectionService {
   }
 
   /**
-   * Compute whether a project is foundation-level using business criteria.
-   * Mirrors the lfx-pcc hasHealthMetricDashboard logic mapped to V2 project fields:
-   * - Stage must be 'Active'
-   * - Legal entity type must not be 'Internal Allocation'
-   * - Funding model must include 'Membership'
-   */
-  /**
    * Extract unique organizations from board_member detection extras
    * The persona service includes organization data (Salesforce account ID, name, website)
    * in board_member detection extras — map these to Account objects for UI consumption

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NatsSubjects } from '@lfx-one/shared/enums';
+import { computeIsFoundation } from '@lfx-one/shared/utils';
 import {
   Account,
   AffiliatedProjectUidsCacheEntry,
@@ -10,7 +11,6 @@ import {
   PersonaDetectionResponse,
   PersonaProject,
   PersonaType,
-  Project,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -307,7 +307,7 @@ export class PersonaDetectionService {
           const projectData = await this.projectService.getProjectById(req, project.project_uid, false);
           projectName = projectData?.name || null;
           parentProjectUid = projectData?.parent_uid || null;
-          isFoundation = this.computeIsFoundation(projectData);
+          isFoundation = computeIsFoundation(projectData);
           logoUrl = projectData?.logo_url || null;
           description = projectData?.description || null;
         } catch {
@@ -373,7 +373,7 @@ export class PersonaDetectionService {
           projectSlug: projectData?.slug || '',
           projectName: projectData?.name || null,
           parentProjectUid: projectData?.parent_uid || null,
-          isFoundation: this.computeIsFoundation(projectData),
+          isFoundation: computeIsFoundation(projectData),
           logoUrl: projectData?.logo_url || null,
           description: projectData?.description || null,
           detections: [],
@@ -466,19 +466,6 @@ export class PersonaDetectionService {
    * - Legal entity type must not be 'Internal Allocation'
    * - Funding model must include 'Membership'
    */
-  private computeIsFoundation(project: Project | null): boolean {
-    if (!project) {
-      return false;
-    }
-
-    return (
-      project.stage === 'Active' &&
-      project.legal_entity_type !== 'Internal Allocation' &&
-      Array.isArray(project.funding_model) &&
-      project.funding_model.includes('Membership')
-    );
-  }
-
   /**
    * Extract unique organizations from board_member detection extras
    * The persona service includes organization data (Salesforce account ID, name, website)

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3,6 +3,7 @@
 
 import { NATS_CONFIG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
+import { computeIsFoundation } from '@lfx-one/shared/utils';
 import {
   CodeCommitsDailyResponse,
   FoundationCodeCommitsDailyRow,
@@ -3412,6 +3413,46 @@ export class ProjectService {
     return uids;
   }
 
+  /**
+   * Enrich items that have a project_uid with project metadata (name, slug, is_foundation, parent_uid).
+   * Deduplicates project lookups across all items.
+   */
+  public async enrichWithProjectData<T extends { project_uid: string }>(
+    req: Request,
+    items: T[]
+  ): Promise<(T & { project_name: string; project_slug: string; is_foundation: boolean; parent_project_uid: string })[]> {
+    const projectUids = [...new Set(items.map((item) => item.project_uid).filter(Boolean))];
+
+    logger.debug(req, 'enrich_with_project_data', 'Enriching items with project metadata', {
+      item_count: items.length,
+      unique_projects: projectUids.length,
+    });
+
+    const projects = await Promise.all(
+      projectUids.map(async (uid) => {
+        return await this.getProjectById(req, uid, false).catch(() => null);
+      })
+    );
+
+    const projectMap = new Map(projects.filter((p): p is Project => p !== null).map((p) => [p.uid, p]));
+
+    logger.debug(req, 'enrich_with_project_data', 'Project enrichment complete', {
+      resolved: projectMap.size,
+      unresolved: projectUids.length - projectMap.size,
+    });
+
+    return items.map((item) => {
+      const project = projectMap.get(item.project_uid);
+      return {
+        ...item,
+        project_name: project?.name || '',
+        project_slug: project?.slug || '',
+        is_foundation: computeIsFoundation(project ?? null),
+        parent_project_uid: project?.parent_uid || '',
+      };
+    });
+  }
+
   private getRangeSuffix(range: string, convention: string = 'standard'): string {
     const map = ProjectService.rangeSuffixMap[convention];
     return map?.[range] ?? map?.['YTD'] ?? '_ytd';
@@ -3423,4 +3464,5 @@ export class ProjectService {
     const lastUnderscore = full.lastIndexOf('_');
     return { prefix: full.substring(0, lastUnderscore + 1), suffix: full.substring(lastUnderscore + 1) };
   }
+
 }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3428,11 +3428,16 @@ export class ProjectService {
       unique_projects: projectUids.length,
     });
 
-    const projects = await Promise.all(
-      projectUids.map(async (uid) => {
-        return await this.getProjectById(req, uid, false).catch(() => null);
-      })
-    );
+    const projects: (Project | null)[] = [];
+    const batchSize = 10;
+
+    for (let i = 0; i < projectUids.length; i += batchSize) {
+      const batch = projectUids.slice(i, i + batchSize);
+      const results = await Promise.all(
+        batch.map(async (uid) => this.getProjectById(req, uid, false).catch(() => null))
+      );
+      projects.push(...results);
+    }
 
     const projectMap = new Map(projects.filter((p): p is Project => p !== null).map((p) => [p.uid, p]));
 
@@ -3445,10 +3450,10 @@ export class ProjectService {
       const project = projectMap.get(item.project_uid);
       return {
         ...item,
-        project_name: project?.name || '',
-        project_slug: project?.slug || '',
+        project_name: project?.name || (item as any).project_name || '',
+        project_slug: project?.slug || (item as any).project_slug || '',
         is_foundation: computeIsFoundation(project ?? null),
-        parent_project_uid: project?.parent_uid || '',
+        parent_project_uid: project?.parent_uid || (item as any).parent_project_uid || '',
       };
     });
   }

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -169,7 +169,7 @@ export class SurveyService {
    * Fetches surveys the current user has responded to.
    * Queries survey_response records by email and username using filters_or.
    */
-  public async getMySurveys(req: Request, projectUid?: string, foundationUid?: string): Promise<Survey[]> {
+  public async getMySurveys(req: Request): Promise<Survey[]> {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
     const email = getEffectiveEmail(req);
@@ -177,8 +177,6 @@ export class SurveyService {
     logger.debug(req, 'get_my_surveys', 'Fetching surveys for current user', {
       username,
       has_email: !!email,
-      project_uid: projectUid,
-      foundation_uid: foundationUid,
     });
 
     if (!username && !email) {
@@ -201,7 +199,6 @@ export class SurveyService {
         type: 'survey_response',
         page_size: 100,
         filters_or: filtersOr,
-        ...(projectUid && { tags: `project_uid:${projectUid}` }),
         ...(pageToken && { page_token: pageToken }),
       })
     );
@@ -246,16 +243,12 @@ export class SurveyService {
         return new Date(b.survey_cutoff_date).getTime() - new Date(a.survey_cutoff_date).getTime();
       });
 
-    // Post-fetch safety net: filter by project_uid or foundation_uid if provided
-    if (projectUid) {
-      return sorted.filter((s) => s.committees?.some((c) => c.project_uid === projectUid));
-    } else if (foundationUid) {
-      logger.debug(req, 'get_my_surveys', 'Filtering by foundation', { foundation_uid: foundationUid });
-      const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
-      const uidSet = new Set(uids);
-      return sorted.filter((s) => s.committees?.some((c) => uidSet.has(c.project_uid)));
-    }
+    // Flatten project_uid from committees to top level for enrichment
+    const withProjectUid = sorted.map((s) => ({
+      ...s,
+      project_uid: s.committees?.[0]?.project_uid || '',
+    }));
 
-    return sorted;
+    return this.projectService.enrichWithProjectData(req, withProjectUid);
   }
 }

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -244,10 +244,13 @@ export class SurveyService {
       });
 
     // Flatten project_uid from committees to top level for enrichment
-    const withProjectUid = sorted.map((s) => ({
-      ...s,
-      project_uid: s.committees?.[0]?.project_uid || '',
-    }));
+    const withProjectUid = sorted.map((s) => {
+      const projectUids = [...new Set((s.committees ?? []).map((c) => c.project_uid).filter(Boolean))];
+      return {
+        ...s,
+        project_uid: projectUids.length === 1 ? projectUids[0] : '',
+      };
+    });
 
     return this.projectService.enrichWithProjectData(req, withProjectUid);
   }

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -506,7 +506,9 @@ export class UserService {
 
     const limited = limit !== undefined && limit > 0 ? meetings.slice(0, limit) : meetings;
 
-    return this.accessCheckService.addAccessToResources(req, limited, 'v1_meeting', 'organizer');
+    const enriched = await this.meetingService.getMeetingProjectName(req, limited);
+
+    return this.accessCheckService.addAccessToResources(req, enriched, 'v1_meeting', 'organizer');
   }
 
   /**
@@ -620,7 +622,9 @@ export class UserService {
 
     const limited = limit !== undefined && limit > 0 ? pastMeetings.slice(0, limit) : pastMeetings;
 
-    return this.accessCheckService.addAccessToResources(req, limited, 'v1_past_meeting', 'organizer');
+    const enriched = await this.meetingService.getMeetingProjectName(req, limited);
+
+    return this.accessCheckService.addAccessToResources(req, enriched, 'v1_past_meeting', 'organizer');
   }
 
   /**

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -256,7 +256,7 @@ export class VoteService {
    * Fetches votes the current user has been invited to.
    * Queries vote_response records by user_email and username using filters_or.
    */
-  public async getMyVotes(req: Request, projectUid?: string, foundationUid?: string): Promise<Vote[]> {
+  public async getMyVotes(req: Request): Promise<Vote[]> {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
     const email = getEffectiveEmail(req);
@@ -285,7 +285,6 @@ export class VoteService {
         type: 'vote_response',
         page_size: 100,
         filters_or: filtersOr,
-        ...(projectUid && { tags: `project_uid:${projectUid}` }),
         ...(pageToken && { page_token: pageToken }),
       })
     );
@@ -329,16 +328,6 @@ export class VoteService {
         return new Date(b.end_time).getTime() - new Date(a.end_time).getTime();
       });
 
-    // Post-fetch safety net: filter by project_uid or foundation_uid if provided
-    if (projectUid) {
-      return sorted.filter((v) => v.project_uid === projectUid);
-    } else if (foundationUid) {
-      logger.debug(req, 'get_my_votes', 'Filtering by foundation', { foundation_uid: foundationUid });
-      const uids = await this.projectService.getFoundationProjectUids(req, foundationUid);
-      const uidSet = new Set(uids);
-      return sorted.filter((v) => uidSet.has(v.project_uid));
-    }
-
-    return sorted;
+    return this.projectService.enrichWithProjectData(req, sorted);
   }
 }

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -156,6 +156,12 @@ export interface Committee {
   project_uid: string;
   /** Associated project name (populated from project data) */
   project_name?: string;
+  /** Project URL slug (enriched for filtering) */
+  project_slug?: string;
+  /** Whether the project is a foundation (top-level entity) */
+  is_foundation: boolean;
+  /** Parent project UID (for subprojects under a foundation) */
+  parent_project_uid: string;
   /** Foundation name this committee belongs to (populated from project hierarchy) */
   foundation_name?: string;
   /** Calendar visibility settings */

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -159,9 +159,9 @@ export interface Committee {
   /** Project URL slug (enriched for filtering) */
   project_slug?: string;
   /** Whether the project is a foundation (top-level entity) */
-  is_foundation: boolean;
+  is_foundation?: boolean;
   /** Parent project UID (for subprojects under a foundation) */
-  parent_project_uid: string;
+  parent_project_uid?: string;
   /** Foundation name this committee belongs to (populated from project hierarchy) */
   foundation_name?: string;
   /** Calendar visibility settings */

--- a/packages/shared/src/interfaces/mailing-list.interface.ts
+++ b/packages/shared/src/interfaces/mailing-list.interface.ts
@@ -103,9 +103,9 @@ export interface GroupsIOMailingList {
   /** Associated project slug (inherited from parent service) */
   project_slug: string;
   /** Whether the project is a foundation (top-level entity) */
-  is_foundation: boolean;
+  is_foundation?: boolean;
   /** Parent project UID (for subprojects under a foundation) */
-  parent_project_uid: string;
+  parent_project_uid?: string;
   /** Audit timestamp (nullable) */
   last_reviewed_at?: string | null;
   /** Auditor user ID (nullable) */

--- a/packages/shared/src/interfaces/mailing-list.interface.ts
+++ b/packages/shared/src/interfaces/mailing-list.interface.ts
@@ -102,6 +102,10 @@ export interface GroupsIOMailingList {
   project_name: string;
   /** Associated project slug (inherited from parent service) */
   project_slug: string;
+  /** Whether the project is a foundation (top-level entity) */
+  is_foundation: boolean;
+  /** Parent project UID (for subprojects under a foundation) */
+  parent_project_uid: string;
   /** Audit timestamp (nullable) */
   last_reviewed_at?: string | null;
   /** Auditor user ID (nullable) */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -235,9 +235,9 @@ export interface Meeting {
   /** Project slug */
   project_slug: string;
   /** Whether the project is a foundation (top-level entity) */
-  is_foundation: boolean;
+  is_foundation?: boolean;
   /** Parent project UID (for subprojects under a foundation) */
-  parent_project_uid: string;
+  parent_project_uid?: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -234,6 +234,10 @@ export interface Meeting {
   project_name: string;
   /** Project slug */
   project_slug: string;
+  /** Whether the project is a foundation (top-level entity) */
+  is_foundation: boolean;
+  /** Parent project UID (for subprojects under a foundation) */
+  parent_project_uid: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -183,6 +183,14 @@ export interface Vote {
   status: PollStatus;
   /** V2 project UID */
   project_uid: string;
+  /** Project display name (enriched for filtering) */
+  project_name: string;
+  /** Project URL slug (enriched for filtering) */
+  project_slug: string;
+  /** Whether the project is a foundation (top-level entity) */
+  is_foundation: boolean;
+  /** Parent project UID (for subprojects under a foundation) */
+  parent_project_uid: string;
   /** V2 committee UID */
   committee_uid?: string;
   /** Committee name */

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -184,13 +184,13 @@ export interface Vote {
   /** V2 project UID */
   project_uid: string;
   /** Project display name (enriched for filtering) */
-  project_name: string;
+  project_name?: string;
   /** Project URL slug (enriched for filtering) */
-  project_slug: string;
+  project_slug?: string;
   /** Whether the project is a foundation (top-level entity) */
-  is_foundation: boolean;
+  is_foundation?: boolean;
   /** Parent project UID (for subprojects under a foundation) */
-  parent_project_uid: string;
+  parent_project_uid?: string;
   /** V2 committee UID */
   committee_uid?: string;
   /** Committee name */

--- a/packages/shared/src/interfaces/survey.interface.ts
+++ b/packages/shared/src/interfaces/survey.interface.ts
@@ -75,6 +75,16 @@ export interface Survey {
   is_project_survey: boolean;
   /** Associated committees */
   committees: SurveyCommittee[];
+  /** Primary project UID (flattened from committees for filtering) */
+  project_uid: string;
+  /** Project display name (enriched for filtering) */
+  project_name: string;
+  /** Project URL slug (enriched for filtering) */
+  project_slug: string;
+  /** Whether the project is a foundation (top-level entity) */
+  is_foundation: boolean;
+  /** Parent project UID (for subprojects under a foundation) */
+  parent_project_uid: string;
   /** Committee category */
   committee_category: string;
   /** Total responses received */

--- a/packages/shared/src/interfaces/survey.interface.ts
+++ b/packages/shared/src/interfaces/survey.interface.ts
@@ -76,15 +76,15 @@ export interface Survey {
   /** Associated committees */
   committees: SurveyCommittee[];
   /** Primary project UID (flattened from committees for filtering) */
-  project_uid: string;
+  project_uid?: string;
   /** Project display name (enriched for filtering) */
-  project_name: string;
+  project_name?: string;
   /** Project URL slug (enriched for filtering) */
-  project_slug: string;
+  project_slug?: string;
   /** Whether the project is a foundation (top-level entity) */
-  is_foundation: boolean;
+  is_foundation?: boolean;
   /** Parent project UID (for subprojects under a foundation) */
-  parent_project_uid: string;
+  parent_project_uid?: string;
   /** Committee category */
   committee_category: string;
   /** Total responses received */

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { EnrichedPersonaProject, ProjectContext } from '../interfaces';
+import type { EnrichedPersonaProject, Project, ProjectContext } from '../interfaces';
 
 /**
  * Convert an EnrichedPersonaProject to a ProjectContext
@@ -21,4 +21,21 @@ export function toProjectContext(project: EnrichedPersonaProject): ProjectContex
  */
 export function isFoundationProject(project: EnrichedPersonaProject): boolean {
   return project.isFoundation;
+}
+
+/**
+ * Determine if a raw Project from the upstream API is a foundation (top-level entity).
+ * A foundation project is Active, not an Internal Allocation, and funded by Membership.
+ */
+export function computeIsFoundation(project: Project | null): boolean {
+  if (!project) {
+    return false;
+  }
+
+  return (
+    project.stage === 'Active' &&
+    project.legal_entity_type !== 'Internal Allocation' &&
+    Array.isArray(project.funding_model) &&
+    project.funding_model.includes('Membership')
+  );
 }


### PR DESCRIPTION
## Summary
- Replaces persona-based filter options with data-driven options derived from actual response data across meetings, votes, surveys, committees, and mailing lists
- Me lens filters now work client-side without re-fetching on filter change
- Adds `computeIsFoundation()` shared utility and `enrichWithProjectData()` on ProjectService for reusable project metadata enrichment
- Adds `is_foundation` and `parent_project_uid` to Meeting, Vote, Survey, Committee, and MailingList interfaces
- Fixes committees pagination bug (was truncating at 50 results via missing `fetchAllQueryResources`)
- Sub-foundations (e.g., AAIF under TLF) are excluded from parent foundation filter results — they appear as their own top-level filter entry
- All filter dropdowns use "All X" as a default selected option instead of clearable placeholders
- Filter visibility still gated by persona role checks (`hasBoardRole`/`hasProjectRole`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)