### PR TITLE
fix(events): fix missing bind params for time and location filters in getMyEvents

### DIFF
--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -218,6 +218,9 @@ export class EventsService {
         ...(searchQuery ? [`%${searchQuery}%`] : []),
         ...roleFilterResult.binds,
         ...statusFilterResult.binds,
+        ...(startDateFrom ? [startDateFrom] : []),
+        ...(startDateTo ? [startDateTo] : []),
+        ...(country ? [country] : []),
       ];
       binds = [...affiliatedUpcomingBinds, ...registeredEventsBinds, ...userRegBinds, ...whereBinds];
 


### PR DESCRIPTION
## Summary: 

The upcoming events query in getMyEvents used ? placeholders for startDateFrom, startDateTo, and country filters, but their values were never added to the whereBinds array. This caused a Snowflake bind parameter mismatch at runtime whenever a user applied the "This Month" / "Next 3 Months" time filter or the country/location filter in the event-selection dialog.

Fix: Added the three missing values to whereBinds in events.service.ts:216–224 so the bind array matches the SQL placeholders when those filters are active.