### PR TITLE
feat(skills): add lfx-review-pr skill and enforcer

### DIFF
--- a/.claude/agents/code-standards-enforcer.md
+++ b/.claude/agents/code-standards-enforcer.md
@@ -1,0 +1,327 @@
+---
+name: code-standards-enforcer
+description: "Audits recently written or modified code against the project's CLAUDE.md rules, conventions, architecture docs, and referenced documentation. Covers Angular patterns, Express.js backend patterns, upstream API contract validation, SSR, Tailwind, TypeScript conventions, and more. Use after code changes or when reviewing PRs."
+model: inherit
+color: red
+memory: none
+---
+
+# Code Standards Enforcer
+
+You are an elite code standards enforcement specialist. Your singular mission is to audit recently written or modified code against the project's CLAUDE.md guidelines, rule files, and all referenced documentation, catching violations before they enter the codebase.
+
+## Your Primary Directive
+
+You must read and internalize the CLAUDE.md file(s) in the project and the user's global CLAUDE.md. Every rule, convention, pattern, and guideline described therein is law. You enforce these rules without exception. When CLAUDE.md references other documents (architecture docs, rule files in `.claude/rules/`, or any other referenced files), you must also read and reference those documents to understand the full scope of rules being enforced.
+
+## Enforcement Process
+
+### Step 1: Load All Reference Documents
+
+- Read the project's CLAUDE.md thoroughly
+- Read the user's global CLAUDE.md (~/.claude/CLAUDE.md)
+- Read contextual rule files from `.claude/rules/` (component-organization.md, development-rules.md, logging-patterns.md, commit-workflow.md)
+- If the project has a `.claude/skills/develop/references/` directory, read the reference files relevant to the changed file types (e.g., backend-endpoint.md for server changes, frontend-component.md for component changes)
+- Identify ALL referenced architecture documents and read the ones relevant to the changed files
+- Build a mental checklist of every enforceable rule
+
+### Step 2: Identify Recently Changed Code
+
+- Focus on the files that were recently created or modified
+- Use git status or diff if available to identify changed files
+- Review the full context of each changed file, not just the diff
+- Categorize changes: frontend component, backend endpoint, shared types, or mixed
+
+### Step 3: Upstream API Contract Validation (Backend Changes Only)
+
+**Skip this step entirely if the changes are frontend-only (no files under `src/server/`).** Only run upstream validation when backend proxy code was created or modified.
+
+**This is critical for any backend changes.** The LFX One backend is a thin proxy layer to external Go microservices. New or modified proxy endpoints MUST align with the upstream API contract.
+
+#### When to Check
+
+- Any new file in `src/server/services/`, `src/server/controllers/`, or `src/server/routes/`
+- Any modified service that calls `MicroserviceProxyService.proxyRequest()`
+- Any new API path or changed request/response shape
+
+For modifications to existing endpoints (not new ones), a lighter check is acceptable — verify the endpoint path still exists rather than a full schema comparison.
+
+#### How to Check
+
+Use the GitHub API to validate the upstream contract:
+
+```bash
+# Read the OpenAPI spec for the upstream service
+gh api repos/linuxfoundation/<repo-name>/contents/gen/http/openapi3.yaml \
+  --jq '.content' | base64 -d
+
+# Browse the Goa DSL design files
+gh api repos/linuxfoundation/<repo-name>/contents/design --jq '.[].name'
+
+# Read a specific Goa design file
+gh api repos/linuxfoundation/<repo-name>/contents/design/<file>.go \
+  --jq '.content' | base64 -d
+```
+
+#### Upstream Repo Map
+
+| Domain            | Repo                          |
+| ----------------- | ----------------------------- |
+| **Queries**       | `lfx-v2-query-service`        |
+| **Projects**      | `lfx-v2-project-service`      |
+| **Meetings**      | `lfx-v2-meeting-service`      |
+| **Mailing Lists** | `lfx-v2-mailing-list-service` |
+| **Committees**    | `lfx-v2-committee-service`    |
+| **Voting**        | `lfx-v2-voting-service`       |
+| **Surveys**       | `lfx-v2-survey-service`       |
+
+#### What to Validate
+
+- [ ] **Endpoint paths match upstream** — the proxy path maps to a real upstream endpoint
+- [ ] **HTTP methods match** — GET/POST/PUT/DELETE align with what upstream supports
+- [ ] **Request body/query params match upstream schema** — no extra fields the upstream ignores, no missing required fields
+- [ ] **Response shape matches** — interfaces align with what the upstream actually returns
+- [ ] **Query Service conventions** — uses `page_size` (NOT `limit`), `page_token` for cursor pagination, `filters` format is `field:value`
+- [ ] **No fabricated endpoints** — if the upstream doesn't expose it, the proxy shouldn't pretend it exists
+
+#### Severity
+
+- **Critical** — Proxy endpoint calls a non-existent upstream endpoint
+- **Critical** — Request/response shape doesn't match upstream contract
+- **Warning** — Uses `limit` instead of `page_size` for query service calls
+- **Warning** — Upstream contract could not be verified (gh api failed — log the reason; an unverified contract is not a passing check)
+
+### Step 4: Systematic Audit
+
+For each changed file, check against ALL applicable rules. Categories below:
+
+---
+
+#### Angular Component Rules
+
+- [ ] **Standalone components only** — no NgModules
+- [ ] **No CommonModule imports** — import specific directives/pipes instead
+- [ ] **No `<p-dialog>` in templates** — use PrimeNG DialogService with dynamic components
+- [ ] **Use LFX wrapper components** — don't use raw PrimeNG components (`<p-button>`, `<p-table>`, etc.) directly in feature module templates if an LFX wrapper exists in `shared/components/`
+- [ ] **No functions in HTML templates** — only signals, computed values, or pipes
+- [ ] **Tailwind CSS first** — avoid custom SCSS unless for PrimeNG overrides, complex animations, or pseudo-elements
+- [ ] **ReactiveFormsModule always** — never `(onInput)`, `(onChange)` event bindings to set values, never `[(ngModel)]` with FormsModule
+- [ ] **No `effect()`** — use `toObservable()` with RxJS pipes instead (except for simple logging)
+- [ ] **Signals for data** — never subscribe to observables directly; use `toSignal()` or computed
+- [ ] **No bare `.subscribe()`** — always use `takeUntilDestroyed()`, `take(1)`, or another completion operator. Note: `takeUntilDestroyed()` auto-injects `DestroyRef` when called in constructor or field initializer context; it only requires explicit `inject(DestroyRef)` when used outside the injection context (e.g., in `ngOnInit` or event handlers)
+- [ ] **No getters for HTML** — use signals, computed values, or pipes
+- [ ] **Signals can't use RxJS pipes** — they are not observables; use `computed()` or `toSignal()`
+- [ ] **Component structure order** must follow: private injections → public fields → forms → model signals → simple WritableSignals → complex computed/toSignal → constructor → public methods → protected methods → private init functions → private helpers
+- [ ] **Complex computed/toSignal** use private init functions pattern
+- [ ] **Simple WritableSignals** initialized inline
+- [ ] **Model signals** used for two-way binding (`model()` not `signal()` with split binding)
+- [ ] **No `console.log`** — use console.warn/error/info/trace
+- [ ] **Template syntax** — `@if`/`@for` (not `*ngIf`/`*ngFor`)
+- [ ] **`data-testid` attributes** on key elements for test targeting
+- [ ] **`flex + flex-col + gap-*`** — never use `space-y-*`
+- [ ] **No nested ternary expressions**
+- [ ] **Selector prefix** must be `lfx-`
+- [ ] **Direct imports** — no barrel exports for standalone components
+- [ ] **`inject()` for DI** — never constructor-based dependency injection
+
+#### Frontend Service Rules
+
+- [ ] **`@Injectable({ providedIn: 'root' })`** — always tree-shakeable
+- [ ] **`inject(HttpClient)`** — never constructor-based DI
+- [ ] **GET requests** — `catchError(() => of(defaultValue))` for graceful error handling
+- [ ] **POST/PUT/DELETE requests** — `take(1)` and let errors propagate
+- [ ] **Every `HttpClient` call targets a real `/api/...` endpoint** that exists in the backend routes — no mock data or placeholder URLs
+- [ ] **API paths are relative** — `/api/...` format, proxy handles routing
+- [ ] **Interfaces from shared package** — import from `@lfx-one/shared/interfaces`, never define locally
+
+#### SSR Patterns
+
+- [ ] Route resolvers for dynamic content with SEO needs
+- [ ] `first()` and `timeout()` in resolver observables
+- [ ] Meta tags set immediately in `ngOnInit()` with resolved data
+- [ ] `typeof window !== 'undefined'` for client-only code (not `isPlatformServer()`)
+
+---
+
+#### Backend: Three-File Pattern
+
+Every backend endpoint must follow: **service** → **controller** → **route**.
+
+- [ ] **Service** in `src/server/services/<name>.service.ts`
+- [ ] **Controller** in `src/server/controllers/<name>.controller.ts`
+- [ ] **Route** in `src/server/routes/<name>.route.ts`
+
+#### Backend: Service Rules
+
+- [ ] **Uses `MicroserviceProxyService`** for ALL external API calls — never raw `fetch`, `axios`, or `http`
+- [ ] **API reads** use `/query/resources`, **writes** use `/itx/...`
+- [ ] **Uses `logger` service** — never `serverLogger` directly, never `console.log`
+- [ ] **Every `proxyRequest()` call targets a real upstream endpoint** — no fabricated paths
+
+#### Backend: Controller Rules
+
+- [ ] **`logger.startOperation()`** at the beginning of each handler
+- [ ] **`logger.success()`** on success path with startTime
+- [ ] **Bare `next(error)` in catch blocks** — do NOT call `logger.error()` before `next(error)` (`apiErrorHandler` handles centralized error logging with `skipIfLogged: true`)
+- [ ] **Never use `res.status(500).json()`** — always pass errors to `next(error)`
+- [ ] **Operation names in snake_case** matching the HTTP action (e.g., `get_items`, `create_item`)
+
+#### Backend: Logging Patterns (per `.claude/rules/logging-patterns.md`)
+
+- [ ] **Controller/Service separation** — controllers log HTTP lifecycle, services log business logic
+- [ ] **No duplicate logging** — controller and service should not both call `startOperation` for the same operation
+- [ ] **Read endpoints (GET)** — startOperation at DEBUG, success at DEBUG
+- [ ] **Write endpoints (POST/PUT/DELETE)** — startOperation at DEBUG, success at INFO
+- [ ] **Infrastructure operations** — startOperation at INFO, success at INFO
+- [ ] **Services use `logger.debug()`** for step-by-step tracing
+- [ ] **Services use `logger.info()`** for significant business operations (transformations, enrichments, orchestrations)
+- [ ] **Services use `logger.warning()`** for recoverable errors when returning null/empty arrays
+- [ ] **`err` field for errors** — never `{ error: error.message }` (loses stack trace)
+- [ ] **Snake_case operation names** for all logger calls (e.g., `get_meeting_rsvps`)
+
+#### Backend: Authentication & Token Rules
+
+- [ ] **Default to user bearer tokens** (`req.bearerToken`) for ALL authenticated routes
+- [ ] **M2M tokens ONLY for:**
+  - Public-facing endpoints where no user session exists (`/public/api/...`)
+  - Explicit privileged upstream calls where the route has already validated user authorization
+- [ ] **If M2M token is used in an authenticated route:**
+  - User-level authorization is enforced before the M2M call
+  - M2M token scope is minimal (only the specific upstream call)
+  - Original bearer token is restored immediately after the privileged call
+- [ ] **NEVER use M2M tokens to:**
+  - Replace user identity for normal operations
+  - Skip per-user authorization
+  - Build new protected `/api/...` endpoints
+
+#### Backend: Route Rules
+
+- [ ] Route file follows Express Router pattern
+- [ ] `server.ts` registration flagged — it's a protected file requiring code owner approval
+
+---
+
+#### Shared Package Rules
+
+- [ ] **Interfaces** in `packages/shared/src/interfaces/<name>.interface.ts` with `.interface.ts` suffix
+- [ ] **Enums** in `packages/shared/src/enums/<name>.enum.ts`
+- [ ] **Constants** in `packages/shared/src/constants/<name>.constants.ts`
+- [ ] **Barrel exports** — new types exported from `index.ts` in their directory
+- [ ] **`interface` over union types** for shared object shapes
+- [ ] **`as const`** for constant objects
+- [ ] **Never define interfaces locally in components** — always in shared package
+
+---
+
+#### TypeScript Rules
+
+- [ ] **No `as unknown as Type` casts** — find proper type solutions, never route through `unknown`
+- [ ] **camelCase** for variables/functions, **PascalCase** for classes/interfaces
+- [ ] **kebab-case** for file names
+- [ ] **160 character max** line length
+
+#### Tailwind CSS Rules
+
+- [ ] **Prefer standard Tailwind spacing** (e.g., `p-0.5`, `gap-2`) over arbitrary values (e.g., `p-[2px]`, `gap-[3px]`)
+- [ ] **`flex + flex-col + gap-*`** instead of `space-y-*`
+- [ ] **Use `[class.invisible]`** instead of `@if` for small toggle elements to prevent layout shift
+
+#### General Rules
+
+- [ ] **License headers** on ALL source files (`.ts`, `.html`, `.scss`)
+- [ ] **yarn only** — never npx or other package runners
+- [ ] **`docker compose`** not `docker-compose`
+- [ ] **Git commits signed off** with `--signoff`
+- [ ] **No Claude co-author** in commits
+- [ ] **Linting errors fixed** after changes
+
+---
+
+#### Protected Files Check
+
+Flag if any of these protected infrastructure files were modified — they require code owner approval:
+
+- `apps/lfx-one/src/server/server.ts`
+- `apps/lfx-one/src/server/server-logger.ts`
+- `apps/lfx-one/src/server/middleware/*`
+- `apps/lfx-one/src/server/services/logger.service.ts`
+- `apps/lfx-one/src/server/services/microservice-proxy.service.ts`
+- `apps/lfx-one/src/server/services/nats.service.ts`
+- `apps/lfx-one/src/server/services/snowflake.service.ts`
+- `apps/lfx-one/src/server/services/supabase.service.ts`
+- `apps/lfx-one/src/server/services/ai.service.ts`
+- `apps/lfx-one/src/server/services/project.service.ts`
+- `apps/lfx-one/src/server/services/etag.service.ts`
+- `apps/lfx-one/src/server/helpers/error-serializer.ts`
+- `apps/lfx-one/src/app/app.routes.ts`
+- `.husky/*`, `eslint.config.*`, `.prettierrc*`, `turbo.json`, `angular.json`
+- `CLAUDE.md`, `check-headers.sh`, `package.json`, `*/package.json`, `yarn.lock`
+
+### Step 5: Report Findings
+
+For each violation found, report:
+
+1. **File and line number** (or approximate location)
+2. **Rule violated** — cite the specific CLAUDE.md section, rule file, or architecture doc
+3. **What's wrong** — explain the violation clearly
+4. **How to fix** — provide the corrected code snippet
+5. **Severity** — Critical (breaks patterns/contracts), Warning (deviation from conventions), Info (minor style issue)
+
+### Step 6: Summary
+
+After auditing all files, provide:
+
+- Total violations found grouped by severity
+- A pass/fail verdict
+- Top 3 most important fixes to prioritize
+- Confirmation of which rules and documents were checked
+- Whether upstream API contracts were validated (and results)
+
+## Behavior Rules
+
+1. **Be thorough** — check every applicable rule, not just obvious ones
+2. **Be specific** — always cite the exact rule source being violated (CLAUDE.md section, rule file, architecture doc, or feedback memory)
+3. **Be actionable** — always provide corrected code, not just descriptions
+4. **Be fair** — acknowledge when code correctly follows guidelines
+5. **Read referenced docs** — if CLAUDE.md references architecture docs or rule files, read and enforce them
+6. **Focus on recent changes** — don't audit the entire codebase unless explicitly asked
+7. **Validate upstream contracts** — for any backend changes, actually check the upstream OpenAPI spec via `gh api`. If `gh api` fails, log the failure reason and escalate to Warning severity — an unverified contract is not a passing check
+8. **Use context7** — when unsure about a framework API or pattern, use context7 MCP to validate against official documentation
+9. **Run linting** — if possible, run `yarn lint` to catch linting violations the changes may have introduced
+10. **Check feedback memories** — review memory files for learned patterns and rules not yet in CLAUDE.md
+
+## Output Format
+
+```text
+## Code Standards Audit Report
+
+### Documents Referenced
+- [List all CLAUDE.md files, rule files, and architecture docs consulted]
+
+### Files Audited
+- [List of files checked]
+
+### Upstream API Validation
+- [For backend changes: which upstream repos were checked, what was validated, any mismatches found]
+- [For frontend-only changes: "N/A — no backend changes"]
+
+### Protected Files
+- [List any protected files that were modified, or "None modified"]
+
+### Violations Found
+
+#### 🔴 Critical
+[Violations that break core patterns or upstream contracts]
+
+#### 🟡 Warning
+[Deviations from conventions]
+
+#### 🔵 Info
+[Minor style issues]
+
+### ✅ Correctly Followed
+[Notable rules that were correctly followed]
+
+### Verdict: PASS / FAIL
+[Summary and priority fixes]
+```

--- a/.claude/agents/code-standards-enforcer.md
+++ b/.claude/agents/code-standards-enforcer.md
@@ -34,13 +34,13 @@ You must read and internalize the CLAUDE.md file(s) in the project and the user'
 
 ### Step 3: Upstream API Contract Validation (Backend Changes Only)
 
-**Skip this step entirely if the changes are frontend-only (no files under `src/server/`).** Only run upstream validation when backend proxy code was created or modified.
+**Skip this step entirely if the changes are frontend-only (no files under `apps/lfx-one/src/server/`).** Only run upstream validation when backend proxy code was created or modified.
 
 **This is critical for any backend changes.** The LFX One backend is a thin proxy layer to external Go microservices. New or modified proxy endpoints MUST align with the upstream API contract.
 
 #### When to Check
 
-- Any new file in `src/server/services/`, `src/server/controllers/`, or `src/server/routes/`
+- Any new file in `apps/lfx-one/src/server/services/`, `apps/lfx-one/src/server/controllers/`, or `apps/lfx-one/src/server/routes/`
 - Any modified service that calls `MicroserviceProxyService.proxyRequest()`
 - Any new API path or changed request/response shape
 
@@ -147,9 +147,9 @@ For each changed file, check against ALL applicable rules. Categories below:
 
 Every backend endpoint must follow: **service** → **controller** → **route**.
 
-- [ ] **Service** in `src/server/services/<name>.service.ts`
-- [ ] **Controller** in `src/server/controllers/<name>.controller.ts`
-- [ ] **Route** in `src/server/routes/<name>.route.ts`
+- [ ] **Service** in `apps/lfx-one/src/server/services/<name>.service.ts`
+- [ ] **Controller** in `apps/lfx-one/src/server/controllers/<name>.controller.ts`
+- [ ] **Route** in `apps/lfx-one/src/server/routes/<name>.route.ts`
 
 #### Backend: Service Rules
 

--- a/.claude/rules/component-organization.md
+++ b/.claude/rules/component-organization.md
@@ -116,4 +116,4 @@ import { RelativeDateInfo } from '@lfx-one/shared/interfaces';
 ## 6. Do NOT flag these as issues
 
 - **`ChangeDetectionStrategy.OnPush`** is NOT required. With zoneless change detection and signals, OnPush is unnecessary. Do not flag its absence.
-- **`standalone: true`** is NOT required on components, directives, or pipes. Angular 19+ defaults to standalone. Do not flag its absence.
+- **`standalone: true`** is NOT required on components, directives, or pipes. Angular defaults components, directives, and pipes to standalone. Do not flag its absence.

--- a/.claude/rules/component-organization.md
+++ b/.claude/rules/component-organization.md
@@ -112,3 +112,8 @@ interface RelativeDateInfo {
 // Import from shared package
 import { RelativeDateInfo } from '@lfx-one/shared/interfaces';
 ```
+
+## 6. Do NOT flag these as issues
+
+- **`ChangeDetectionStrategy.OnPush`** is NOT required. With zoneless change detection and signals, OnPush is unnecessary. Do not flag its absence.
+- **`standalone: true`** is NOT required on components, directives, or pipes. Angular 19+ defaults to standalone. Do not flag its absence.

--- a/.claude/rules/skill-guidance.md
+++ b/.claude/rules/skill-guidance.md
@@ -38,6 +38,12 @@ This project has guided skills for common workflows. **Proactively suggest the r
 - "Run checks", "Lint and build", "Pre-PR validation"
 - Any indication that development work is finished
 
+**`/lfx-review-pr`** — match any of these intents:
+
+- "Review this PR", "Check PR quality", "Audit code changes"
+- "Review #123", "Is this PR ready to merge?"
+- Any mention of reviewing or auditing a pull request
+
 ## For Cowork Sessions
 
 Non-developer contributors use these skills as guided workflows. Follow these rules:

--- a/.claude/rules/skill-guidance.md
+++ b/.claude/rules/skill-guidance.md
@@ -7,11 +7,12 @@ globs: '*'
 
 This project has guided skills for common workflows. **Proactively suggest the relevant skill** when a user's request matches one of these:
 
-| Skill        | When to Suggest                                                                                                               |
-| ------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| `/setup`     | Getting started, first-time setup, broken environments, install failures, missing env vars, 1Password, how to run the app     |
-| `/develop`   | Add a feature, fix a bug, modify code, create components/services/endpoints/types, refactor, build, implement any code change |
-| `/preflight` | Before submitting a PR, check if code is ready, validate changes, verify a branch, finished development, review readiness     |
+| Skill            | When to Suggest                                                                                                               |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `/setup`         | Getting started, first-time setup, broken environments, install failures, missing env vars, 1Password, how to run the app     |
+| `/develop`       | Add a feature, fix a bug, modify code, create components/services/endpoints/types, refactor, build, implement any code change |
+| `/preflight`     | Before submitting a PR, check if code is ready, validate changes, verify a branch, finished development, review readiness     |
+| `/lfx-review-pr` | Review a PR, audit code changes, check PR quality, validate a PR against standards                                            |
 
 ## Trigger Phrases
 

--- a/.claude/skills/lfx-review-pr/SKILL.md
+++ b/.claude/skills/lfx-review-pr/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: lfx-review-pr
+description: >
+  Review a pull request against LFX architecture standards — fetches PR diff,
+  verifies previous comments are addressed, validates backend code against
+  upstream API contracts, checks code against frontend/backend/shared
+  conventions, and posts inline review comments with suggested fixes. Use when
+  reviewing PRs, checking PR quality, validating code changes, or when the user
+  says "review", "check this PR", "audit code", or mentions /review.
+allowed-tools: Bash, Read, Glob, Grep, Agent, AskUserQuestion
+---
+
+# LFX PR Review
+
+You are reviewing a pull request against the LFX One architecture standards and project conventions. Walk through each phase in order. Do not skip phases, but some phases may be short-circuited when their preconditions are not met (noted inline).
+
+## Phase 1: Input & Context Gathering
+
+### Parse arguments
+
+The args string follows this format: `<PR number> [extra instructions]`.
+
+- First token is the PR number if numeric.
+- Everything after it is extra instructions (e.g., "focus on backend", "check that previous comments were addressed").
+- If no PR number is provided, use **AskUserQuestion** to ask for one. Do not guess.
+
+### Determine repository
+
+```bash
+gh repo view --json nameWithOwner --jq '.nameWithOwner'
+```
+
+Store the result as `{owner}/{repo}` for all subsequent `gh api` calls.
+
+### Fetch PR metadata (parallel)
+
+Run all of the following Bash calls in a single turn:
+
+```bash
+# PR details
+gh pr view <N> --json title,body,headRefName,baseRefName,author,files,additions,deletions,state,number
+
+# Full diff
+gh pr diff <N>
+
+# Inline review comments (previous reviews)
+gh api repos/{owner}/{repo}/pulls/{N}/comments --paginate
+
+# Review summaries (previous reviews)
+gh api repos/{owner}/{repo}/pulls/{N}/reviews --paginate
+
+# Fetch the PR branch
+git fetch origin <headRefName>
+```
+
+If the diff is too large to hold in context, save it to `/tmp/pr-<N>.diff` and read only the key sections (changed `.ts`, `.html`, `.scss` files) with `Read`.
+
+### Read architecture docs (parallel)
+
+Read all of the following in a single turn:
+
+- `docs/architecture/frontend/angular-patterns.md`
+- `docs/architecture/frontend/component-architecture.md`
+- `docs/architecture/frontend/styling-system.md`
+- `docs/architecture/frontend/drawer-pattern.md`
+- `docs/architecture/backend/README.md`
+- `docs/architecture/backend/error-handling-architecture.md`
+- `docs/architecture/backend/logging-monitoring.md`
+
+And these rules files:
+
+- `.claude/rules/component-organization.md`
+- `.claude/rules/logging-patterns.md`
+
+These form your review baseline. Every finding must trace back to a documented rule or architecture decision.
+
+---
+
+## Phase 2: Launch Code Enforcer (background)
+
+Spawn a **code-standards-enforcer** Agent subagent with `run_in_background: true`. Do **not** wait for it to finish — proceed to Phase 3 immediately.
+
+Construct the Agent prompt as follows:
+
+> You are a code-standards enforcer for the LFX One codebase. Your job is to read every changed file on the PR branch and flag violations of project conventions.
+>
+> **Branch:** `origin/<headRefName>`
+> **Changed files:** (include the full list from Phase 1)
+>
+> For each file, read it with `git show origin/<branch>:<path>` and check against:
+>
+> - `.claude/rules/component-organization.md` — signal ordering, class structure, model signals
+> - `.claude/rules/logging-patterns.md` — logger usage, log levels, controller vs service patterns
+> - `.claude/rules/development-rules.md` — license headers, no nested ternaries, flex+gap not space-y, data-testid
+> - `CLAUDE.md` — all project conventions
+>
+> For any backend files under `src/server/` that call upstream microservices, validate against the upstream API contract:
+>
+> ```bash
+> gh api repos/linuxfoundation/<repo>/contents/gen/http/openapi3.yaml --jq '.content' | base64 -d
+> ```
+>
+> Return findings as a JSON array: `[{ "file": "...", "line": N, "severity": "CRITICAL|SHOULD_FIX|NIT", "rule": "...", "message": "...", "suggestion": "..." }]`
+>
+> **Do NOT flag:**
+>
+> - Missing `ChangeDetectionStrategy.OnPush` (not required — app uses zoneless change detection)
+> - Missing `standalone: true` (Angular 20+ defaults to standalone)
+
+---
+
+## Phase 3: Verify Previous Review Comments
+
+This phase checks whether previously raised review comments were actually addressed in code. **Do NOT trust "resolved" status or contributor claims. Read the actual code.**
+
+### Process
+
+1. Gather all inline comments and review bodies from Phase 1.
+2. Skip trivial comments: nits, acknowledgments, "+1", bot auto-comments, and purely informational remarks.
+3. For every **CRITICAL** or **SHOULD FIX** comment:
+   a. Read the file on the PR branch: `git show origin/<headRefName>:<file>`
+   b. Compare the current code against what the comment requested.
+   c. Classify: **FIXED** / **NOT FIXED** / **PARTIALLY FIXED** / **N/A** (comment no longer applies due to file removal or restructuring).
+4. Build a markdown table:
+
+```markdown
+| #   | Comment Summary                            | File                             | Status    | Evidence                          |
+| --- | ------------------------------------------ | -------------------------------- | --------- | --------------------------------- |
+| 1   | Use logger.warning instead of console.warn | src/server/services/foo.ts       | FIXED     | Line 42 now uses logger.warning() |
+| 2   | Missing license header                     | src/app/shared/pipes/bar.pipe.ts | NOT FIXED | File still has no header          |
+```
+
+If there are no previous review comments, note "No previous review comments found" and move on.
+
+---
+
+## Phase 4: Upstream API Contract Validation
+
+**Skip this phase entirely if no files under `src/server/` were changed.**
+
+### Identify upstream calls
+
+For each changed backend service or controller that makes proxy calls to upstream microservices, identify which service is being called using this map:
+
+| Domain        | Repo                        |
+| ------------- | --------------------------- |
+| Queries       | lfx-v2-query-service        |
+| Projects      | lfx-v2-project-service      |
+| Meetings      | lfx-v2-meeting-service      |
+| Mailing Lists | lfx-v2-mailing-list-service |
+| Committees    | lfx-v2-committee-service    |
+| Voting        | lfx-v2-voting-service       |
+| Surveys       | lfx-v2-survey-service       |
+
+### Fetch and validate
+
+```bash
+gh api repos/linuxfoundation/<repo>/contents/gen/http/openapi3.yaml \
+  --jq '.content' | base64 -d
+```
+
+Check each upstream call against the spec:
+
+1. **Endpoint path** — the path exists in the OpenAPI spec.
+2. **HTTP method** — GET/POST/PUT/DELETE matches.
+3. **Request body and query params** — field names and types match the spec schema.
+4. **Response shape** — matches the TypeScript interface used in the service/controller.
+5. **Query Service pagination** — uses `page_size` (NOT `limit`) and `page_token` for cursor pagination.
+
+### Snowflake queries
+
+For Snowflake queries (direct SQL, not proxy calls): verify that every `?` placeholder in the SQL string has a corresponding value in the binds array, in the correct order.
+
+### On failure
+
+If `gh api` fails (404, auth error, network issue), log the failure and include a **WARNING** in the review: "Upstream API contract for {service} could not be verified. Manual validation required."
+
+---
+
+## Phase 5: Compile Context for `/review`
+
+Wait for the code-standards-enforcer Agent from Phase 2 to complete. Then compile all findings from Phases 1–4 and the enforcer into a structured context block that will be passed to `/review`.
+
+### Build the context block
+
+Assemble a single text block containing:
+
+1. **Previous comment verification** — the Phase 3 table (or "No previous review comments found")
+2. **Upstream API validation** — Phase 4 results (or "No backend changes — skipped")
+3. **Code enforcer findings** — the enforcer's results, filtered through the false positive filter below
+4. **Domain checklists to apply** — instruct the reviewer to read and check against:
+   - Frontend files → `references/frontend-checklist.md`
+   - Backend files → `references/backend-checklist.md`
+   - Shared files → `references/shared-and-sql-checklist.md`
+5. **Extra user instructions** — any additional instructions from the args (e.g., "focus on backend")
+
+### Apply false positive filter
+
+Before passing any finding to `/review`, verify it is NOT one of these known false positives:
+
+- **Missing `ChangeDetectionStrategy.OnPush`** — not required. The app uses stable zoneless change detection.
+- **Missing `standalone: true`** — not required. Angular 20+ defaults to standalone.
+- **Suggesting test plans in the PR** — the user's global config explicitly disables this.
+- **Code-enforcer hallucinated rules** — cross-check every enforcer finding against the actual documented rules before including it. If you cannot find the rule in the architecture docs or rules files, drop the finding.
+
+---
+
+## Phase 6: Invoke `/review`
+
+Now hand off to the built-in `/review` command. This gives the review Claude's built-in PR review capabilities while ensuring it has the full LFX-specific context from Phases 1–5.
+
+### Invoke the skill
+
+Use the **Skill** tool to invoke `review` (the built-in `/review` command). Pass the PR number and the compiled context block as args:
+
+```
+<PR number> -- <compiled context from Phase 5>
+```
+
+The args should include:
+
+- The PR number
+- The compiled context block (previous comment verification, upstream validation, enforcer findings, checklist references, extra instructions)
+- A reminder to run the code-standards-enforcer agent as part of the review
+- A note about new contributor status if applicable (see Additional Rules below)
+
+The `/review` command will handle the actual code review, inline comment posting, and summary output. The context you pass ensures it reviews against LFX-specific standards rather than generic best practices.
+
+---
+
+## Additional Rules
+
+### PR size check
+
+If the PR's `additions` exceed 1000 lines, include a note in the review body:
+
+> **Note:** This PR has {additions} additions, which exceeds the recommended 1000-line target per `commit-workflow.md`. Consider splitting into smaller, independently reviewable PRs.
+
+### New contributor awareness
+
+Check the PR author's merge history:
+
+```bash
+gh pr list --author <author> --state merged --limit 5 --json number | jq 'length'
+```
+
+If the author has fewer than 5 merged PRs to this repo, be more thorough and educational in inline comments — explain the "why" behind each rule, not just the "what".
+
+### Extra instructions
+
+If the user passed extra instructions after the PR number (e.g., "focus on backend changes", "check that previous comments were addressed"), prioritize those areas but still execute the full review pipeline. Note in the terminal summary that extra focus was applied.

--- a/.claude/skills/lfx-review-pr/SKILL.md
+++ b/.claude/skills/lfx-review-pr/SKILL.md
@@ -213,7 +213,7 @@ Now hand off to the built-in `/review` command. This gives the review Claude's b
 
 Use the **Skill** tool to invoke `review` (the built-in `/review` command). Pass the PR number and the compiled context block as args:
 
-```
+```text
 <PR number> -- <compiled context from Phase 5>
 ```
 

--- a/.claude/skills/lfx-review-pr/SKILL.md
+++ b/.claude/skills/lfx-review-pr/SKILL.md
@@ -94,7 +94,7 @@ Construct the Agent prompt as follows:
 > - `.claude/rules/development-rules.md` — license headers, no nested ternaries, flex+gap not space-y, data-testid
 > - `CLAUDE.md` — all project conventions
 >
-> For any backend files under `src/server/` that call upstream microservices, validate against the upstream API contract:
+> For any backend files under `apps/lfx-one/src/server/` that call upstream microservices, validate against the upstream API contract:
 >
 > ```bash
 > gh api repos/linuxfoundation/<repo>/contents/gen/http/openapi3.yaml --jq '.content' | base64 -d
@@ -136,7 +136,7 @@ If there are no previous review comments, note "No previous review comments foun
 
 ## Phase 4: Upstream API Contract Validation
 
-**Skip this phase entirely if no files under `src/server/` were changed.**
+**Skip this phase entirely if no files under `apps/lfx-one/src/server/` were changed.**
 
 ### Identify upstream calls
 

--- a/.claude/skills/lfx-review-pr/references/backend-checklist.md
+++ b/.claude/skills/lfx-review-pr/references/backend-checklist.md
@@ -205,7 +205,7 @@ return res.status(400).json({ error: 'Invalid input' });
 **Fix:**
 
 ```typescript
-import { ServiceValidationError } from '../errors/validation.error';
+import { ServiceValidationError } from '../errors/service-validation.error';
 import { AuthenticationError } from '../errors/authentication.error';
 import { MicroserviceError } from '../errors/microservice.error';
 

--- a/.claude/skills/lfx-review-pr/references/backend-checklist.md
+++ b/.claude/skills/lfx-review-pr/references/backend-checklist.md
@@ -1,0 +1,282 @@
+# Backend Review Checklist
+
+Express.js backend review standards. Each item includes severity and a brief violation/fix example.
+
+---
+
+## 1. Three-file pattern (SHOULD FIX)
+
+Every endpoint needs three files: service, controller, route.
+
+- `services/<name>.service.ts` — business logic, API calls, data transformation
+- `controllers/<name>.controller.ts` — HTTP handling (parse req, validate, send res)
+- `routes/<name>.route.ts` — route definitions wiring controllers to paths
+
+**Violation:** Business logic in controller or HTTP handling in service.
+**Fix:** Split into the three-file pattern above.
+
+---
+
+## 2. Controller-Service separation (SHOULD FIX)
+
+Controllers handle HTTP concerns only. Services handle business logic only.
+
+**Violation:**
+
+```typescript
+// In controller — doing business logic
+export const getUser = async (req, res, next) => {
+  const data = await apiClient.get('/users/' + req.params.id);
+  const transformed = { ...data, fullName: data.first + ' ' + data.last };
+  res.json(transformed);
+};
+```
+
+**Fix:**
+
+```typescript
+// Controller — HTTP only
+export const getUser = async (req, res, next) => {
+  const startTime = logger.startOperation(req, 'get_user', { userId: req.params.id });
+  try {
+    const user = await userService.getUserById(req, req.params.id);
+    logger.success(req, 'get_user', startTime, { userId: user.id });
+    return res.json(user);
+  } catch (error) {
+    return next(error);
+  }
+};
+
+// Service — business logic
+public async getUserById(req: Request, userId: string): Promise<User> {
+  logger.debug(req, 'get_user_by_id', 'Fetching user', { userId });
+  const data = await this.microserviceProxy.proxyRequest(...);
+  return { ...data, fullName: data.first + ' ' + data.last };
+}
+```
+
+---
+
+## 3. Logging: bare next(error) (CRITICAL)
+
+Controller catch blocks must use bare `next(error)`. NEVER call `logger.error()` before `next(error)` -- `apiErrorHandler` middleware logs centrally.
+
+**Violation:**
+
+```typescript
+catch (error) {
+  logger.error(req, 'get_user', startTime, error, {});
+  next(error);
+}
+```
+
+**Fix:**
+
+```typescript
+catch (error) {
+  return next(error);
+}
+```
+
+**Exception:** Controllers that handle their own response in the catch block (e.g., SSE streaming with `res.end()`) must log errors themselves since `apiErrorHandler` is never reached.
+
+---
+
+## 4. Logger service usage (SHOULD FIX)
+
+Always use `logger` from `logger.service.ts`. Never import `serverLogger` directly. Never use `console.log`.
+
+**Violation:**
+
+```typescript
+import { serverLogger } from '../server-logger';
+serverLogger.info({ msg: 'something' });
+console.log('debug:', data);
+```
+
+**Fix:**
+
+```typescript
+import { logger } from '../services/logger.service';
+logger.info(req, 'operation', 'Something happened', { data });
+```
+
+---
+
+## 5. Controller logging lifecycle (SHOULD FIX)
+
+Controllers must follow this pattern:
+
+1. `logger.startOperation(req, 'operation_name', metadata)` at start -- returns `startTime`
+2. `logger.success(req, 'operation_name', startTime, metadata)` on success
+3. Operation names in `snake_case` matching HTTP semantics
+
+**Violation:**
+
+```typescript
+export const createMeeting = async (req, res, next) => {
+  try {
+    const result = await meetingService.create(req, req.body);
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+```
+
+**Fix:**
+
+```typescript
+export const createMeeting = async (req, res, next) => {
+  const startTime = logger.startOperation(req, 'create_meeting', {
+    projectId: req.body.projectId,
+  });
+  try {
+    const result = await meetingService.create(req, req.body);
+    logger.success(req, 'create_meeting', startTime, { meetingId: result.id });
+    return res.json(result);
+  } catch (error) {
+    return next(error);
+  }
+};
+```
+
+---
+
+## 6. Service logging (SHOULD FIX)
+
+Services use different log levels for different purposes:
+
+| Method                     | When to use                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------- |
+| `logger.debug(req, ...)`   | Step-by-step tracing, method entry/exit, internal lookups                       |
+| `logger.info(req, ...)`    | Significant operations: transformations, enrichments, multi-step orchestrations |
+| `logger.warning(req, ...)` | Graceful errors: returning null/empty, fallback behavior                        |
+
+**Violation:**
+
+```typescript
+logger.info(req, 'get_meetings', 'Fetching meetings from upstream', {});
+// INFO for a simple fetch is too noisy
+```
+
+**Fix:**
+
+```typescript
+logger.debug(req, 'get_meetings', 'Fetching meetings from upstream', {});
+// DEBUG for tracing, reserve INFO for significant operations
+```
+
+---
+
+## 7. getEffectiveEmail(req) (CRITICAL)
+
+For user identity, always use `getEffectiveEmail(req)` from `auth-helper`. Never access the OIDC user email directly.
+
+**Violation:**
+
+```typescript
+const email = req.oidc?.user?.['email'];
+const email = req.oidc?.user?.email;
+```
+
+**Fix:**
+
+```typescript
+import { getEffectiveEmail } from '../utils/auth-helper';
+const email = getEffectiveEmail(req);
+```
+
+This is required for impersonation support -- `getEffectiveEmail` checks for impersonation context before falling back to the OIDC session email.
+
+---
+
+## 8. Custom error classes (SHOULD FIX)
+
+Use the project's custom error classes from `server/errors/`. No raw `new Error()` or manual `res.status().json()` for errors.
+
+**Violation:**
+
+```typescript
+throw new Error('User not found');
+return res.status(400).json({ error: 'Invalid input' });
+```
+
+**Fix:**
+
+```typescript
+import { ServiceValidationError } from '../errors/validation.error';
+import { AuthenticationError } from '../errors/authentication.error';
+import { MicroserviceError } from '../errors/microservice.error';
+
+throw ServiceValidationError.forField('email', 'Invalid email format');
+throw new AuthenticationError('Token expired');
+throw MicroserviceError.fromMicroserviceResponse(response);
+```
+
+---
+
+## 9. M2M token restrictions (CRITICAL)
+
+M2M tokens only for:
+
+- Public endpoints where no user session exists (e.g., public meeting pages)
+- Explicit privileged upstream calls after user authorization is validated in-app
+
+**Violations:**
+
+- Using M2M token in a protected route to skip user authorization
+- Replacing user bearer token with M2M token for normal API calls
+- Not restoring user auth context after a privileged upstream call
+
+**Fix:** Default to user bearer token (`req.bearerToken`). Only use M2M for the specific upstream call that requires it, and restore user context immediately after.
+
+---
+
+## 10. Upstream API contract validation (CRITICAL)
+
+The LFX One backend is a thin proxy layer. New or modified proxy endpoints MUST match the upstream microservice contract.
+
+**Validate with:**
+
+```bash
+gh api repos/linuxfoundation/<repo>/contents/gen/http/openapi3.yaml --jq '.content' | base64 -d
+```
+
+**Check that:** paths exist, HTTP methods match, request/response shapes match, query params are correct.
+
+**Upstream repo map:**
+
+| Domain        | Repo                        |
+| ------------- | --------------------------- |
+| Queries       | lfx-v2-query-service        |
+| Projects      | lfx-v2-project-service      |
+| Meetings      | lfx-v2-meeting-service      |
+| Mailing Lists | lfx-v2-mailing-list-service |
+| Committees    | lfx-v2-committee-service    |
+| Voting        | lfx-v2-voting-service       |
+| Surveys       | lfx-v2-survey-service       |
+
+---
+
+## 11. Protected files (NIT -- flag for awareness)
+
+Changes to these files should be flagged for extra scrutiny. They are core infrastructure and affect the entire application:
+
+**Server core:**
+
+- `server.ts`, `server-logger.ts`
+- `middleware/*` (auth, error-handler)
+
+**Singleton services:**
+
+- `logger.service.ts`
+- `microservice-proxy.service.ts`
+- `nats.service.ts`
+- `snowflake.service.ts`
+
+**Configuration:**
+
+- `app.routes.ts`
+- `package.json`, `yarn.lock`
+- `CLAUDE.md`

--- a/.claude/skills/lfx-review-pr/references/frontend-checklist.md
+++ b/.claude/skills/lfx-review-pr/references/frontend-checklist.md
@@ -311,5 +311,5 @@ export class MyService {
 The following are **not violations** in this codebase:
 
 - **Missing `ChangeDetectionStrategy.OnPush`** — not required with zoneless change detection
-- **Missing `standalone: true`** — Angular 20+ defaults to standalone
-- **`provideZonelessChangeDetection()`** — this is stable in Angular 20, NOT experimental
+- **Missing `standalone: true`** — Angular defaults components, directives, and pipes to standalone
+- **`provideZonelessChangeDetection()`** — this is stable, NOT experimental

--- a/.claude/skills/lfx-review-pr/references/frontend-checklist.md
+++ b/.claude/skills/lfx-review-pr/references/frontend-checklist.md
@@ -41,7 +41,7 @@ No direct `p-*` components in feature module templates. Must use `lfx-*` wrapper
 <lfx-button label="Save" /> <lfx-table [value]="items()">...</lfx-table>
 ```
 
-Common wrappers: `lfx-button`, `lfx-table`, `lfx-tag`, `lfx-input-text`, `lfx-select`, `lfx-dialog`, `lfx-checkbox`, `lfx-textarea`.
+Common wrappers: `lfx-button`, `lfx-table`, `lfx-tag`, `lfx-input-text`, `lfx-select`, `lfx-checkbox`, `lfx-textarea`.
 
 ---
 
@@ -241,7 +241,9 @@ Required on interactive elements (buttons, inputs, links, dialogs). Convention: 
 
 ## 11. Direct imports (NIT)
 
-Standalone components import directly, no barrel exports.
+Standalone components must be imported directly from their file path, not from barrel index files. However, shared package types ARE imported via subpath entrypoints (`@lfx-one/shared/interfaces`, `@lfx-one/shared/constants`).
+
+Do not import from the root `@lfx-one/shared` barrel; prefer subpath entrypoints.
 
 **Violation:**
 

--- a/.claude/skills/lfx-review-pr/references/frontend-checklist.md
+++ b/.claude/skills/lfx-review-pr/references/frontend-checklist.md
@@ -1,0 +1,313 @@
+# Frontend Review Checklist
+
+Angular 20 frontend review standards. Each item includes severity and a brief violation/fix example.
+
+---
+
+## 1. Component organization order (SHOULD FIX)
+
+Components must follow this 11-section structure:
+
+1. Private injections (with `readonly`)
+2. Public fields from inputs/dialog data (with `readonly`)
+3. Forms
+4. Model signals (`model()`)
+5. Simple WritableSignals (direct initialization)
+6. Complex computed/toSignal signals (via private init functions)
+7. Constructor
+8. Public methods
+9. Protected methods
+10. Private initializer functions (grouped together)
+11. Other private helper methods
+
+**Violation:** WritableSignals declared after constructor, or injections mixed with public fields.
+**Fix:** Reorder to match the structure above.
+
+---
+
+## 2. PrimeNG wrapper strategy (SHOULD FIX)
+
+No direct `p-*` components in feature module templates. Must use `lfx-*` wrappers.
+
+**Violation:**
+
+```html
+<p-button label="Save" /> <p-table [value]="items()">...</p-table>
+```
+
+**Fix:**
+
+```html
+<lfx-button label="Save" /> <lfx-table [value]="items()">...</lfx-table>
+```
+
+Common wrappers: `lfx-button`, `lfx-table`, `lfx-tag`, `lfx-input-text`, `lfx-select`, `lfx-dialog`, `lfx-checkbox`, `lfx-textarea`.
+
+---
+
+## 3. No `<p-dialog>` (CRITICAL)
+
+Must use `DialogService.open()` with dynamic components. Never use `<p-dialog>` in templates.
+
+**Violation:**
+
+```html
+<p-dialog [(visible)]="showDialog" header="Edit Item">
+  <form>...</form>
+</p-dialog>
+```
+
+**Fix:**
+
+```typescript
+private readonly dialogService = inject(DialogService);
+
+openEditDialog(): void {
+  this.dialogService.open(EditItemDialogComponent, {
+    header: 'Edit Item',
+    data: { item: this.selectedItem() },
+  });
+}
+```
+
+---
+
+## 4. No template functions (SHOULD FIX)
+
+Only signal reads `()`, computed values, and pipes allowed in templates. No method calls that execute logic.
+
+**Violation:**
+
+```html
+<span>{{ formatDate(item.date) }}</span>
+<div [class]="getStatusClass(item.status)"></div>
+```
+
+**Fix:**
+
+```html
+<span>{{ item.date | date:'MMM d, y' }}</span>
+<div [class]="item.statusClass"></div>
+```
+
+Use pipes for formatting and computed signals for derived state.
+
+---
+
+## 5. No effect() (SHOULD FIX)
+
+Use `toObservable()` with RxJS pipes instead. Exception: simple logging/debugging only.
+
+**Violation:**
+
+```typescript
+effect(() => {
+  const term = this.searchTerm();
+  this.service.search(term).subscribe((results) => this.results.set(results));
+});
+```
+
+**Fix:**
+
+```typescript
+public results: Signal<Item[]> = this.initResults();
+
+private initResults(): Signal<Item[]> {
+  return toSignal(
+    toObservable(this.searchTerm).pipe(
+      debounceTime(300),
+      switchMap(term => this.service.search(term)),
+      catchError(() => of([] as Item[]))
+    ),
+    { initialValue: [] }
+  );
+}
+```
+
+---
+
+## 6. No bare .subscribe() (SHOULD FIX)
+
+Must use `takeUntilDestroyed()`, `take(1)`, `firstValueFrom`, or similar lifecycle management.
+
+**Violation:**
+
+```typescript
+this.service.getData().subscribe((data) => this.data.set(data));
+```
+
+**Fix:**
+
+```typescript
+// Option 1: takeUntilDestroyed (auto-injects DestroyRef in constructor/field context)
+this.service
+  .getData()
+  .pipe(takeUntilDestroyed())
+  .subscribe((data) => this.data.set(data));
+
+// Option 2: take(1) for one-shot
+this.service
+  .getData()
+  .pipe(take(1))
+  .subscribe((data) => this.data.set(data));
+
+// Option 3: firstValueFrom for async
+const data = await firstValueFrom(this.service.getData());
+```
+
+Note: `takeUntilDestroyed()` auto-injects `DestroyRef` when called in constructor or field initializer context.
+
+---
+
+## 7. Model signals for two-way binding (SHOULD FIX)
+
+Use `model()` not `signal()` for properties needing `[( )]` two-way binding.
+
+**Violation:**
+
+```typescript
+public visible = signal(false);
+// Template: [visible]="visible()" (visibleChange)="visible.set($event)"
+```
+
+**Fix:**
+
+```typescript
+public visible = model(false);
+// Template: [(visible)]="visible"
+```
+
+---
+
+## 8. Tailwind spacing (SHOULD FIX)
+
+Use `flex + flex-col + gap-*` instead of `space-y-*`. Prefer standard Tailwind spacing over arbitrary values. Use `[class.invisible]` instead of `@if` for small toggle elements.
+
+**Violation:**
+
+```html
+<div class="space-y-4">...</div>
+<div class="p-[24px] mt-[13px]">...</div>
+@if (isVisible()) { <span class="badge">New</span> }
+```
+
+**Fix:**
+
+```html
+<div class="flex flex-col gap-4">...</div>
+<div class="p-6 mt-3">...</div>
+<span class="badge" [class.invisible]="!isVisible()">New</span>
+```
+
+---
+
+## 9. License headers (SHOULD FIX)
+
+Required on all `.ts`, `.html`, `.scss` source files.
+
+**TypeScript / SCSS:**
+
+```typescript
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+```
+
+**HTML:**
+
+```html
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+```
+
+---
+
+## 10. data-testid attributes (SHOULD FIX)
+
+Required on interactive elements (buttons, inputs, links, dialogs). Convention: `[section]-[component]-[element]`.
+
+**Violation:**
+
+```html
+<button (click)="save()">Save</button>
+```
+
+**Fix:**
+
+```html
+<button data-testid="settings-form-save-button" (click)="save()">Save</button>
+```
+
+---
+
+## 11. Direct imports (NIT)
+
+Standalone components import directly, no barrel exports.
+
+**Violation:**
+
+```typescript
+import { MeetingInterface, ProjectInterface } from '@lfx-one/shared';
+```
+
+**Fix:**
+
+```typescript
+import { MeetingInterface } from '@lfx-one/shared/interfaces';
+import { ProjectInterface } from '@lfx-one/shared/interfaces';
+```
+
+---
+
+## 12. Additional rules
+
+| Rule                                                             | Severity   |
+| ---------------------------------------------------------------- | ---------- |
+| No `console.log` — use `console.warn` or `console.error`         | SHOULD FIX |
+| No nested ternaries                                              | SHOULD FIX |
+| Selector prefix must be `lfx-`                                   | SHOULD FIX |
+| Use `inject()` for DI — never constructor-based injection        | SHOULD FIX |
+| Use `@if`/`@for` template syntax — not `*ngIf`/`*ngFor`          | SHOULD FIX |
+| Use `ReactiveFormsModule` always — never `[(ngModel)]` for forms | SHOULD FIX |
+
+---
+
+## 13. Frontend service rules (SHOULD FIX)
+
+- Services use `@Injectable({ providedIn: 'root' })`
+- Use `inject(HttpClient)` for HTTP — never constructor injection
+- GET requests use `catchError(() => of(defaultValue))` to prevent error propagation
+- POST/PUT/DELETE use `take(1)` for one-shot subscriptions
+
+**Violation:**
+
+```typescript
+@Injectable()
+export class MyService {
+  constructor(private http: HttpClient) {}
+  getData() {
+    return this.http.get<Data[]>('/api/data');
+  }
+}
+```
+
+**Fix:**
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class MyService {
+  private readonly http = inject(HttpClient);
+  getData(): Observable<Data[]> {
+    return this.http.get<Data[]>('/api/data').pipe(catchError(() => of([] as Data[])));
+  }
+}
+```
+
+---
+
+## DO NOT FLAG
+
+The following are **not violations** in this codebase:
+
+- **Missing `ChangeDetectionStrategy.OnPush`** — not required with zoneless change detection
+- **Missing `standalone: true`** — Angular 20+ defaults to standalone
+- **`provideZonelessChangeDetection()`** — this is stable in Angular 20, NOT experimental

--- a/.claude/skills/lfx-review-pr/references/shared-and-sql-checklist.md
+++ b/.claude/skills/lfx-review-pr/references/shared-and-sql-checklist.md
@@ -8,7 +8,7 @@ Standards for the shared package (`@lfx-one/shared`) and Snowflake SQL queries.
 
 ### 1. Interfaces in shared (SHOULD FIX)
 
-All interfaces belong in `packages/shared/src/interfaces/<name>.interface.ts`. Never define interfaces locally in components.
+Prefer defining reusable interfaces in `packages/shared/src/interfaces/<name>.interface.ts`. Truly local UI-only types with no reuse potential may remain local in a component, but shared or reusable interfaces should not be defined there.
 
 **Violation:**
 

--- a/.claude/skills/lfx-review-pr/references/shared-and-sql-checklist.md
+++ b/.claude/skills/lfx-review-pr/references/shared-and-sql-checklist.md
@@ -1,0 +1,213 @@
+# Shared Package & SQL Review Checklist
+
+Standards for the shared package (`@lfx-one/shared`) and Snowflake SQL queries.
+
+---
+
+## Shared Package
+
+### 1. Interfaces in shared (SHOULD FIX)
+
+All interfaces belong in `packages/shared/src/interfaces/<name>.interface.ts`. Never define interfaces locally in components.
+
+**Violation:**
+
+```typescript
+// In a component file
+interface MeetingDetails {
+  id: string;
+  title: string;
+  date: Date;
+}
+```
+
+**Fix:**
+
+```typescript
+// packages/shared/src/interfaces/meeting.interface.ts
+export interface MeetingDetails {
+  id: string;
+  title: string;
+  date: Date;
+}
+
+// In the component
+import { MeetingDetails } from '@lfx-one/shared/interfaces';
+```
+
+---
+
+### 2. Constants in shared (SHOULD FIX)
+
+All constants belong in `packages/shared/src/constants/<name>.constants.ts`. Use `as const` for constant objects.
+
+**Violation:**
+
+```typescript
+// In a component or service file
+const STATUS_LABELS = { active: 'Active', inactive: 'Inactive' };
+```
+
+**Fix:**
+
+```typescript
+// packages/shared/src/constants/status.constants.ts
+export const STATUS_LABELS = {
+  active: 'Active',
+  inactive: 'Inactive',
+} as const;
+```
+
+---
+
+### 3. Enums in shared (SHOULD FIX)
+
+All enums belong in `packages/shared/src/enums/<name>.enum.ts`.
+
+**Violation:**
+
+```typescript
+// In a component file
+enum MeetingStatus {
+  Scheduled = 'scheduled',
+  Cancelled = 'cancelled',
+}
+```
+
+**Fix:**
+
+```typescript
+// packages/shared/src/enums/meeting.enum.ts
+export enum MeetingStatus {
+  Scheduled = 'scheduled',
+  Cancelled = 'cancelled',
+}
+```
+
+---
+
+### 4. Barrel exports (SHOULD FIX)
+
+New types must be exported from `index.ts` in their directory. Without this, the type cannot be imported via the package path.
+
+**Violation:** Adding `packages/shared/src/interfaces/widget.interface.ts` but not exporting it.
+
+**Fix:** Add to `packages/shared/src/interfaces/index.ts`:
+
+```typescript
+export * from './widget.interface';
+```
+
+---
+
+### 5. No `as unknown as Type` (CRITICAL)
+
+Never cast through `unknown` to fix type mismatches. Find the proper type solution.
+
+**Violation:**
+
+```typescript
+const meeting = response.data as unknown as MeetingInterface;
+const config = rawConfig as unknown as AppConfig;
+```
+
+**Fix:**
+
+```typescript
+// Define proper types that match the actual shape
+const meeting: MeetingInterface = response.data;
+// Or use a type guard
+if (isMeetingInterface(response.data)) {
+  const meeting = response.data;
+}
+```
+
+If the upstream shape truly differs, create a mapping function with explicit types.
+
+---
+
+### 6. TypeScript conventions (NIT)
+
+| Convention                              | Example                              |
+| --------------------------------------- | ------------------------------------ |
+| `camelCase` for variables and functions | `getUserName`, `meetingCount`        |
+| `PascalCase` for classes and interfaces | `MeetingService`, `ProjectInterface` |
+| `kebab-case` for file names             | `meeting-details.component.ts`       |
+| `SCREAMING_SNAKE_CASE` for constants    | `MAX_RETRY_COUNT`, `API_BASE_URL`    |
+
+---
+
+## SQL (Snowflake)
+
+### 7. Bind parameter matching (CRITICAL)
+
+Every `?` placeholder in SQL must have a corresponding value in the binds array. Count the `?` marks and count the bind values -- they must match exactly. This is the most common SQL bug in the codebase.
+
+**Violation:**
+
+```typescript
+const query = `
+  SELECT * FROM meetings
+  WHERE project_id = ? AND status = ? AND created_by = ?
+`;
+const binds = [projectId, status];
+// 3 placeholders, 2 bind values -- WILL FAIL at runtime
+```
+
+**Fix:**
+
+```typescript
+const query = `
+  SELECT * FROM meetings
+  WHERE project_id = ? AND status = ? AND created_by = ?
+`;
+const binds = [projectId, status, createdBy];
+// 3 placeholders, 3 bind values -- correct
+```
+
+---
+
+### 8. No string concatenation (CRITICAL)
+
+Never concatenate user input into SQL strings. Always use parameterized queries with `?` placeholders.
+
+**Violation:**
+
+```typescript
+const query = `SELECT * FROM users WHERE email = '${email}'`;
+const query = "SELECT * FROM users WHERE name = '" + name + "'";
+```
+
+**Fix:**
+
+```typescript
+const query = 'SELECT * FROM users WHERE email = ?';
+const binds = [email];
+```
+
+---
+
+### 9. Query Service conventions (SHOULD FIX)
+
+When calling the query service, use the correct parameter names:
+
+| Parameter    | Purpose                    | Note                                                         |
+| ------------ | -------------------------- | ------------------------------------------------------------ |
+| `page_size`  | Number of results per page | NOT `limit`                                                  |
+| `page_token` | Cursor for pagination      | Opaque string from previous response                         |
+| `name`       | Typeahead search           | Uses `multi_match` with `bool_prefix`                        |
+| `filters`    | Field filtering            | Format: `field:value`, auto-prefixed with `data.`            |
+| `sort`       | Sort order                 | Enum: `name_asc`, `name_desc`, `updated_asc`, `updated_desc` |
+
+**Violation:**
+
+```typescript
+const params = { limit: 50, offset: 0 };
+```
+
+**Fix:**
+
+```typescript
+const params = { page_size: 50 };
+// For next page: { page_size: 50, page_token: previousResponse.nextPageToken }
+```

--- a/docs/architecture/frontend/component-architecture.md
+++ b/docs/architecture/frontend/component-architecture.md
@@ -281,7 +281,7 @@ Before creating a wrapper, **always research the PrimeNG component thoroughly**:
 ng generate component shared/components/[component-name] --skip-tests
 ```
 
-> **Note**: The `--standalone` flag is no longer needed — Angular 19+ defaults all components, directives, and pipes to standalone.
+> **Note**: The `--standalone` flag is no longer needed — Angular defaults components, directives, and pipes to standalone.
 
 #### Step 2: Define Input/Output Signals
 

--- a/docs/architecture/frontend/component-architecture.md
+++ b/docs/architecture/frontend/component-architecture.md
@@ -278,8 +278,10 @@ Before creating a wrapper, **always research the PrimeNG component thoroughly**:
 
 ```bash
 # In the apps/lfx-one directory
-ng generate component shared/components/[component-name] --standalone --skip-tests
+ng generate component shared/components/[component-name] --skip-tests
 ```
+
+> **Note**: The `--standalone` flag is no longer needed — Angular 19+ defaults all components, directives, and pipes to standalone.
 
 #### Step 2: Define Input/Output Signals
 


### PR DESCRIPTION
## Summary

- Adds `/lfx-review-pr` skill that orchestrates PR reviews: gathers architecture docs, verifies previous comments against actual code, validates backend changes against upstream OpenAPI specs, launches code-standards-enforcer in background, then passes all context to `/review`
- Copies `code-standards-enforcer` agent from user-scope to repo-scope (`.claude/agents/`) so all contributors can use it
- Clarifies in `component-organization.md` that `OnPush` and `standalone: true` are not required (prevents false review flags)
- Adds `/lfx-review-pr` to skill routing in `skill-guidance.md`
- Removes stale `--standalone` flag from `ng generate` example in component architecture docs

🤖 Generated with [Claude Code](https://claude.ai/code)