### PR TITLE
fix(api): paginate all query service list endpoints

### DIFF
--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
@@ -9,7 +9,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { EMPTY_MY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
-import { MyEvent, MyEventsResponse, TimeFilterValue } from '@lfx-one/shared/interfaces';
+import { MyEvent, TimeFilterValue } from '@lfx-one/shared/interfaces';
 import { catchError, combineLatest, debounceTime, EMPTY, finalize, of, scan, skip, switchMap, tap } from 'rxjs';
 import { EVENT_SELECTION_PAGE_SIZE } from '@lfx-one/shared/constants/events.constants';
 @Component({

--- a/apps/lfx-one/src/server/controllers/vote.controller.ts
+++ b/apps/lfx-one/src/server/controllers/vote.controller.ts
@@ -23,14 +23,13 @@ export class VoteController {
     });
 
     try {
-      const { data, page_token } = await this.voteService.getVotes(req, req.query as Record<string, any>);
+      const votes = await this.voteService.getVotes(req, req.query as Record<string, any>);
 
       logger.success(req, 'get_votes', startTime, {
-        vote_count: data.length,
-        has_more_pages: !!page_token,
+        vote_count: votes.length,
       });
 
-      res.json({ data, page_token });
+      res.json({ data: votes });
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -78,9 +78,13 @@ export class CommitteeService {
       type: 'committee',
     };
 
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', params);
-
-    let committees = resources.map((resource) => resource.data);
+    let committees = await fetchAllQueryResources<Committee>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        page_size: 100,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
 
     // Get member count for each committee in parallel
     committees = await Promise.all(
@@ -292,15 +296,13 @@ export class CommitteeService {
       tags: `committee_uid:${committeeId}`,
     };
 
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(
-      req,
-      'LFX_V2_SERVICE',
-      `/query/resources`,
-      'GET',
-      params
+    return fetchAllQueryResources<CommitteeMember>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        page_size: 100,
+        ...(pageToken && { page_token: pageToken }),
+      })
     );
-
-    return resources.map((resource) => resource.data);
   }
 
   /**

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -73,8 +73,12 @@ export class CommitteeService {
    * Fetches all committees based on query parameters
    */
   public async getCommittees(req: Request, query: Record<string, any> = {}): Promise<Committee[]> {
+    const queryFilters = { ...query };
+    delete queryFilters['page_token'];
+    delete queryFilters['page_size'];
+
     const params = {
-      ...query,
+      ...queryFilters,
       type: 'committee',
     };
 
@@ -290,8 +294,12 @@ export class CommitteeService {
    * Fetches all members for a specific committee
    */
   public async getCommitteeMembers(req: Request, committeeId: string, query: Record<string, any> = {}): Promise<CommitteeMember[]> {
+    const queryFilters = { ...query };
+    delete queryFilters['page_token'];
+    delete queryFilters['page_size'];
+
     const params = {
-      ...query,
+      ...queryFilters,
       type: 'committee_member',
       tags: `committee_uid:${committeeId}`,
     };
@@ -442,15 +450,13 @@ export class CommitteeService {
       tags_all: [`username:${username}`, `committee_category:${category}`],
     };
 
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(
-      req,
-      'LFX_V2_SERVICE',
-      '/query/resources',
-      'GET',
-      params
+    const userMemberships = await fetchAllQueryResources<CommitteeMember>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        page_size: 100,
+        ...(pageToken && { page_token: pageToken }),
+      })
     );
-
-    const userMemberships = resources.map((resource) => resource.data);
 
     logger.debug(req, 'get_committee_members_by_category', 'Committee memberships retrieved', {
       username,

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -189,15 +189,13 @@ export class MailingListService {
       type: 'groupsio_mailing_list',
     };
 
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<GroupsIOMailingList>>(
-      req,
-      'LFX_V2_SERVICE',
-      '/query/resources',
-      'GET',
-      params
+    let mailingLists = await fetchAllQueryResources<GroupsIOMailingList>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<GroupsIOMailingList>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        page_size: 100,
+        ...(pageToken && { page_token: pageToken }),
+      })
     );
-
-    let mailingLists = resources.map((resource) => resource.data);
 
     // Enrich with service data
     mailingLists = await this.enrichWithServices(req, mailingLists);

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -49,20 +49,22 @@ export class MailingListService {
    * Fetches all Groups.io services based on query parameters
    */
   public async getServices(req: Request, query: Record<string, unknown> = {}): Promise<GroupsIOService[]> {
+    const queryFilters = { ...query };
+    delete queryFilters['page_token'];
+    delete queryFilters['page_size'];
+
     const params = {
-      ...query,
+      ...queryFilters,
       type: 'groupsio_service',
     };
 
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<GroupsIOService>>(
-      req,
-      'LFX_V2_SERVICE',
-      '/query/resources',
-      'GET',
-      params
+    const services = await fetchAllQueryResources<GroupsIOService>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<GroupsIOService>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        page_size: 100,
+        ...(pageToken && { page_token: pageToken }),
+      })
     );
-
-    const services = resources.map((resource) => resource.data);
 
     // Add writer access field to all services
     return await this.accessCheckService.addAccessToResources(req, services, 'groupsio_service');
@@ -184,8 +186,12 @@ export class MailingListService {
    * Fetches all mailing lists based on query parameters
    */
   public async getMailingLists(req: Request, query: Record<string, unknown> = {}): Promise<GroupsIOMailingList[]> {
+    const queryFilters = { ...query };
+    delete queryFilters['page_token'];
+    delete queryFilters['page_size'];
+
     const params = {
-      ...query,
+      ...queryFilters,
       type: 'groupsio_mailing_list',
     };
 
@@ -474,21 +480,23 @@ export class MailingListService {
    * Fetches all members for a mailing list using query service
    */
   public async getMembers(req: Request, mailingListId: string, query: Record<string, unknown> = {}): Promise<MailingListMember[]> {
+    const queryFilters = { ...query };
+    delete queryFilters['page_token'];
+    delete queryFilters['page_size'];
+
     const params = {
-      ...query,
+      ...queryFilters,
       type: 'groupsio_member',
       tags: `mailing_list_uid:${mailingListId}`,
     };
 
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<MailingListMember>>(
-      req,
-      'LFX_V2_SERVICE',
-      '/query/resources',
-      'GET',
-      params
+    const members = await fetchAllQueryResources<MailingListMember>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<MailingListMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        page_size: 100,
+        ...(pageToken && { page_token: pageToken }),
+      })
     );
-
-    const members = resources.map((resource) => resource.data);
 
     // Add writer access field to all members
     return await this.accessCheckService.addAccessToResources(req, members, 'groupsio_member');

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -36,8 +36,12 @@ export class SurveyService {
       query_params: Object.keys(query),
     });
 
+    const queryFilters = { ...query };
+    delete queryFilters['page_token'];
+    delete queryFilters['page_size'];
+
     const params = {
-      ...query,
+      ...queryFilters,
       type: 'survey',
     };
 

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -41,13 +41,13 @@ export class SurveyService {
       type: 'survey',
     };
 
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', params);
-
-    logger.debug(req, 'get_surveys', 'Fetched resources from query service', {
-      count: resources.length,
-    });
-
-    const surveys: Survey[] = resources.map((resource) => resource.data);
+    const surveys = await fetchAllQueryResources<Survey>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        page_size: 100,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
 
     logger.debug(req, 'get_surveys', 'Completed survey fetch', {
       final_count: surveys.length,

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -46,25 +46,19 @@ export class VoteService {
       type: 'vote',
     };
 
-    const { resources, page_token } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote>>(
-      req,
-      'LFX_V2_SERVICE',
-      '/query/resources',
-      'GET',
-      params
+    const votes = await fetchAllQueryResources<Vote>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        page_size: 100,
+        ...(pageToken && { page_token: pageToken }),
+      })
     );
-
-    logger.debug(req, 'get_votes', 'Fetched resources from query service', {
-      count: resources.length,
-    });
-
-    const votes: Vote[] = resources.map((resource) => resource.data);
 
     logger.debug(req, 'get_votes', 'Completed vote fetch', {
       final_count: votes.length,
     });
 
-    return { data: votes, page_token };
+    return { data: votes, page_token: undefined };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -3,7 +3,6 @@
 
 import {
   CreateVoteRequest,
-  PaginatedResponse,
   QueryServiceCountResponse,
   QueryServiceResponse,
   UpdateVoteRequest,
@@ -34,15 +33,18 @@ export class VoteService {
 
   /**
    * Fetches all votes based on query parameters
-   * Uses query service which returns Vote entities with pagination support
    */
-  public async getVotes(req: Request, query: Record<string, any> = {}): Promise<PaginatedResponse<Vote>> {
+  public async getVotes(req: Request, query: Record<string, any> = {}): Promise<Vote[]> {
     logger.debug(req, 'get_votes', 'Starting vote fetch', {
       query_params: Object.keys(query),
     });
 
+    const queryFilters = { ...query };
+    delete queryFilters['page_token'];
+    delete queryFilters['page_size'];
+
     const params = {
-      ...query,
+      ...queryFilters,
       type: 'vote',
     };
 
@@ -58,7 +60,7 @@ export class VoteService {
       final_count: votes.length,
     });
 
-    return { data: votes, page_token: undefined };
+    return votes;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Switch 5 backend service methods (`getCommitteeMembers`, `getCommittees`, `getSurveys`, `getMailingLists`, `getVotes`) from single query service calls to `fetchAllQueryResources` with `page_size: 100`, ensuring all pages are fetched via `page_token` continuation
- **Critical fix**: `getCommitteeMembers` was truncating at the default 50-result limit, causing the `isVisitor` access gate to misclassify legitimate members (member #51+) as visitors — locking them out of the full committee dashboard
- Aligns all list endpoints with the existing pagination pattern used by `getMyCommittees`

Generated with [Claude Code](https://claude.ai/code)