### PR TITLE
fix(committees): show mailing list indicator from query service data

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -200,7 +200,7 @@
                           <span>Voting</span>
                         </div>
                       }
-                      <!-- Channels: has_mailing_list (boolean) or mailing_list (email string) from upstream -->
+                      <!-- Channels: mailing_list is the direct email string; has_mailing_list is an enriched boolean from query-service association -->
                       @if (committee.mailing_list) {
                         <a
                           [href]="'mailto:' + committee.mailing_list"
@@ -212,12 +212,22 @@
                           <i class="fa-light fa-envelope w-3.5 h-3.5" aria-hidden="true"></i>
                         </a>
                       } @else if (committee.has_mailing_list) {
-                        <span class="flex items-center gap-1 text-sm text-gray-500 cursor-default" pTooltip="Mailing list associated" tooltipPosition="top">
-                          <i class="fa-light fa-envelope w-3.5 h-3.5"></i>
+                        <span
+                          class="flex items-center gap-1 text-sm text-gray-500 cursor-default"
+                          pTooltip="Mailing list associated"
+                          tooltipPosition="top"
+                          tabindex="0"
+                          aria-label="Mailing list associated">
+                          <i class="fa-light fa-envelope w-3.5 h-3.5" aria-hidden="true"></i>
                         </span>
                       } @else {
-                        <span class="flex items-center gap-1 text-gray-300 cursor-default" pTooltip="No mailing list" tooltipPosition="top">
-                          <i class="fa-light fa-envelope w-3.5 h-3.5"></i>
+                        <span
+                          class="flex items-center gap-1 text-gray-300 cursor-default"
+                          pTooltip="No mailing list"
+                          tooltipPosition="top"
+                          tabindex="0"
+                          aria-label="No mailing list">
+                          <i class="fa-light fa-envelope w-3.5 h-3.5" aria-hidden="true"></i>
                         </span>
                       }
                       @if (committee.chat_channel) {

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -200,7 +200,7 @@
                           <span>Voting</span>
                         </div>
                       }
-                      <!-- Channels: mailing_list and chat_channel are plain strings from upstream -->
+                      <!-- Channels: has_mailing_list (boolean) or mailing_list (email string) from upstream -->
                       @if (committee.mailing_list) {
                         <a
                           [href]="'mailto:' + committee.mailing_list"
@@ -211,6 +211,10 @@
                           aria-label="Mailing list">
                           <i class="fa-light fa-envelope w-3.5 h-3.5" aria-hidden="true"></i>
                         </a>
+                      } @else if (committee.has_mailing_list) {
+                        <span class="flex items-center gap-1 text-sm text-gray-500 cursor-default" pTooltip="Mailing list associated" tooltipPosition="top">
+                          <i class="fa-light fa-envelope w-3.5 h-3.5"></i>
+                        </span>
                       } @else {
                         <span class="flex items-center gap-1 text-gray-300 cursor-default" pTooltip="No mailing list" tooltipPosition="top">
                           <i class="fa-light fa-envelope w-3.5 h-3.5"></i>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
@@ -108,7 +108,7 @@
           </a>
         </td>
         <td>
-          <!-- Channels: mailing_list and chat_channel are plain strings from upstream -->
+          <!-- Channels: has_mailing_list (boolean) or mailing_list (email string) from upstream -->
           <div class="flex items-center gap-2">
             @if (committee.mailing_list) {
               <a
@@ -119,6 +119,10 @@
                 aria-label="Mailing list">
                 <i class="fa-light fa-envelope w-4 h-4" aria-hidden="true"></i>
               </a>
+            } @else if (committee.has_mailing_list) {
+              <span class="inline-flex items-center text-gray-500 cursor-default" pTooltip="Mailing list associated" tooltipPosition="top">
+                <i class="fa-light fa-envelope w-4 h-4"></i>
+              </span>
             } @else {
               <span class="inline-flex items-center text-gray-300 cursor-default" pTooltip="No mailing list" tooltipPosition="top">
                 <i class="fa-light fa-envelope w-4 h-4"></i>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
@@ -108,7 +108,7 @@
           </a>
         </td>
         <td>
-          <!-- Channels: has_mailing_list (boolean) or mailing_list (email string) from upstream -->
+          <!-- Channels: mailing_list is the direct email string; has_mailing_list is an enriched boolean from query-service association -->
           <div class="flex items-center gap-2">
             @if (committee.mailing_list) {
               <a
@@ -120,12 +120,22 @@
                 <i class="fa-light fa-envelope w-4 h-4" aria-hidden="true"></i>
               </a>
             } @else if (committee.has_mailing_list) {
-              <span class="inline-flex items-center text-gray-500 cursor-default" pTooltip="Mailing list associated" tooltipPosition="top">
-                <i class="fa-light fa-envelope w-4 h-4"></i>
+              <span
+                class="inline-flex items-center text-gray-500 cursor-default"
+                pTooltip="Mailing list associated"
+                tooltipPosition="top"
+                tabindex="0"
+                aria-label="Mailing list associated">
+                <i class="fa-light fa-envelope w-4 h-4" aria-hidden="true"></i>
               </span>
             } @else {
-              <span class="inline-flex items-center text-gray-300 cursor-default" pTooltip="No mailing list" tooltipPosition="top">
-                <i class="fa-light fa-envelope w-4 h-4"></i>
+              <span
+                class="inline-flex items-center text-gray-300 cursor-default"
+                pTooltip="No mailing list"
+                tooltipPosition="top"
+                tabindex="0"
+                aria-label="No mailing list">
+                <i class="fa-light fa-envelope w-4 h-4" aria-hidden="true"></i>
               </span>
             }
             @if (committee.chat_channel) {

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -789,9 +789,10 @@ export class CommitteeService {
         tags: `committee_uid:${committeeId}`,
       });
       return count;
-    } catch {
+    } catch (error) {
       logger.debug(req, 'get_mailing_list_count_by_committee', 'Failed to fetch mailing list count, defaulting to 0', {
         committee_uid: committeeId,
+        error: error instanceof Error ? error.message : 'Unknown error',
       });
       return 0;
     }

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -90,13 +90,17 @@ export class CommitteeService {
       })
     );
 
-    // Get member count for each committee in parallel
+    // Get member count and mailing list association for each committee in parallel
     committees = await Promise.all(
       committees.map(async (committee) => {
-        const memberCount = await this.getCommitteeMembersCount(req, committee.uid);
+        const [memberCount, mlCount] = await Promise.all([
+          this.getCommitteeMembersCount(req, committee.uid),
+          this.getMailingListCountByCommittee(req, committee.uid),
+        ]);
         return {
           ...committee,
           total_members: memberCount,
+          has_mailing_list: mlCount > 0,
         };
       })
     );
@@ -510,17 +514,21 @@ export class CommitteeService {
       });
     }
 
-    // Fetch committee details for each membership in parallel
+    // Fetch committee details, member count, and mailing list association in parallel
     const committeeUids = Array.from(membershipMap.keys());
     const committees = await Promise.all(
       committeeUids.map(async (uid) => {
         try {
-          const committee = await this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${uid}`, 'GET');
-          const memberCount = await this.getCommitteeMembersCount(req, uid);
+          const [committee, memberCount, mlCount] = await Promise.all([
+            this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${uid}`, 'GET'),
+            this.getCommitteeMembersCount(req, uid),
+            this.getMailingListCountByCommittee(req, uid),
+          ]);
           const membership = membershipMap.get(uid)!;
           return {
             ...committee,
             total_members: memberCount,
+            has_mailing_list: mlCount > 0,
             my_role: membership.role,
             my_member_uid: membership.member_uid,
           } as MyCommittee;
@@ -768,5 +776,24 @@ export class CommitteeService {
       committee_uid: committeeId,
       settings_data: settingsData,
     });
+  }
+
+  /**
+   * Fetches count of mailing lists associated with a specific committee.
+   * Used to determine the has_mailing_list flag for committee list views.
+   */
+  private async getMailingListCountByCommittee(req: Request, committeeId: string): Promise<number> {
+    try {
+      const { count } = await this.microserviceProxy.proxyRequest<QueryServiceCountResponse>(req, 'LFX_V2_SERVICE', '/query/resources/count', 'GET', {
+        type: 'groupsio_mailing_list',
+        tags: `committee_uid:${committeeId}`,
+      });
+      return count;
+    } catch {
+      logger.debug(req, 'get_mailing_list_count_by_committee', 'Failed to fetch mailing list count, defaulting to 0', {
+        committee_uid: committeeId,
+      });
+      return 0;
+    }
   }
 }

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -189,6 +189,8 @@ export interface Committee {
   join_mode?: JoinMode;
 
   // ── Communication Channels ──
+  /** Whether the committee has any associated mailing lists (computed by upstream) */
+  has_mailing_list?: boolean;
   /** Mailing list email address associated with the group (plain string from upstream). Set to null to clear. */
   mailing_list?: string | null;
   /** Chat channel URL or identifier associated with the group (plain string from upstream). Set to null to clear. */

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -189,7 +189,7 @@ export interface Committee {
   join_mode?: JoinMode;
 
   // ── Communication Channels ──
-  /** Whether the committee has any associated mailing lists (computed by upstream) */
+  /** Whether the committee has any associated mailing lists (enriched by BFF via query-service association counts) */
   has_mailing_list?: boolean;
   /** Mailing list email address associated with the group (plain string from upstream). Set to null to clear. */
   mailing_list?: string | null;


### PR DESCRIPTION
## Summary
- Committee cards and table always showed "No mailing list" because they checked `committee.mailing_list` (a plain email string field) instead of actual GroupsIO mailing list associations
- The upstream `has_mailing_list` flag is unreliable — it's updated via async NATS events that can be lost or were never emitted for historical data
- Added `has_mailing_list` to the `Committee` interface and populate it by querying the query service for associated `groupsio_mailing_list` resources per committee
- Both `getCommittees` (project lens) and `getMyCommittees` (me lens) now enrich committees with the mailing list association flag
- Also parallelized the previously sequential calls in `getMyCommittees` (committee GET + member count + ML count now run in `Promise.all`)

Generated with [Claude Code](https://claude.ai/code)