### PR TITLE
feat(dashboards): add multi-persona dashboard and persona fixes

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/dashboard.component.html
@@ -3,7 +3,18 @@
 
 @switch (activeLens()) {
   @case ('me') {
-    <lfx-user-dashboard />
+    @if (!personaLoaded()) {
+      <div class="flex min-h-[60vh] items-center justify-center" data-testid="dashboard-loading">
+        <div class="flex flex-col items-center gap-4">
+          <div class="persona-spinner"></div>
+          <p class="persona-loading-text text-sm text-gray-500">{{ loadingText() }}</p>
+        </div>
+      </div>
+    } @else if (isMultiPersonaView()) {
+      <lfx-multi-persona-dashboard />
+    } @else {
+      <lfx-user-dashboard />
+    }
   }
   @case ('project') {
     <lfx-project-dashboard />

--- a/apps/lfx-one/src/app/modules/dashboards/dashboard.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/dashboard.component.scss
@@ -1,0 +1,30 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+.persona-spinner {
+  @apply h-8 w-8 rounded-full border-[3px] border-gray-200;
+
+  border-top-color: theme('colors.blue.600');
+  animation: spin 0.8s linear infinite;
+}
+
+.persona-loading-text {
+  animation: fade-cycle 2s ease-in-out infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes fade-cycle {
+  0%,
+  100% {
+    opacity: 0.4;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/dashboard.component.ts
@@ -54,6 +54,10 @@ export class DashboardComponent {
     afterNextRender(() => {
       let index = 0;
       const interval = setInterval(() => {
+        if (this.personaLoaded()) {
+          clearInterval(interval);
+          return;
+        }
         index = (index + 1) % LOADING_MESSAGES.length;
         this.loadingText.set(LOADING_MESSAGES[index]);
       }, 2000);

--- a/apps/lfx-one/src/app/modules/dashboards/dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/dashboard.component.ts
@@ -1,29 +1,64 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject } from '@angular/core';
+import { afterNextRender, Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { isBoardScopedPersona } from '@lfx-one/shared/interfaces';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 
 import { BoardMemberDashboardComponent } from './board-member/board-member-dashboard.component';
 import { ExecutiveDirectorDashboardComponent } from './executive-director/executive-director-dashboard.component';
+import { MultiPersonaDashboardComponent } from './multi-persona/multi-persona-dashboard.component';
 import { ProjectDashboardComponent } from './project-dashboard/project-dashboard.component';
 import { UserDashboardComponent } from './user-dashboard/user-dashboard.component';
 
+const LOADING_MESSAGES = [
+  'Loading your dashboard...',
+  'Detecting your roles and projects...',
+  'Fetching your foundation data...',
+  'Preparing your personalized view...',
+  'Almost there...',
+];
+
 @Component({
   selector: 'lfx-dashboard',
-  imports: [UserDashboardComponent, ProjectDashboardComponent, BoardMemberDashboardComponent, ExecutiveDirectorDashboardComponent],
+  imports: [
+    UserDashboardComponent,
+    ProjectDashboardComponent,
+    BoardMemberDashboardComponent,
+    ExecutiveDirectorDashboardComponent,
+    MultiPersonaDashboardComponent,
+  ],
   templateUrl: './dashboard.component.html',
+  styleUrl: './dashboard.component.scss',
 })
 export class DashboardComponent {
   private readonly personaService = inject(PersonaService);
   private readonly lensService = inject(LensService);
+  private readonly destroyRef = inject(DestroyRef);
 
   protected readonly activeLens = this.lensService.activeLens;
+  protected readonly personaLoaded = this.personaService.personaLoaded;
+  protected readonly loadingText = signal(LOADING_MESSAGES[0]);
+
+  protected readonly isMultiPersonaView = computed(() => {
+    return this.personaService.allPersonas().length > 1;
+  });
 
   protected readonly foundationDashboardType = computed(() => {
     const persona = this.personaService.currentPersona();
     return isBoardScopedPersona(persona) ? persona : 'board-member';
   });
+
+  public constructor() {
+    afterNextRender(() => {
+      let index = 0;
+      const interval = setInterval(() => {
+        index = (index + 1) % LOADING_MESSAGES.length;
+        this.loadingText.set(LOADING_MESSAGES[index]);
+      }, 2000);
+
+      this.destroyRef.onDestroy(() => clearInterval(interval));
+    });
+  }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -26,16 +26,7 @@
                   <i class="role-label__dot" [attr.data-role]="group.label"></i>
                   {{ group.label }}
                 </span>
-                <span class="text-gray-500">
-                  @for (name of group.names; track name) {
-                    @if (!$first && $last) {
-                      and
-                    } @else if (!$first) {
-                      ,
-                    }
-                    <strong class="font-medium text-gray-700">{{ name }}</strong>
-                  }
-                </span>
+                <span class="text-gray-500">{{ group.formattedNames }}</span>
               </div>
             }
           </div>
@@ -109,8 +100,11 @@
               <tr
                 class="group cursor-pointer transition-colors hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
                 tabindex="0"
+                role="link"
+                [attr.aria-label]="'Open ' + row.projectName"
                 (click)="openRow(row)"
                 (keydown.enter)="openRow(row)"
+                (keydown.space)="$event.preventDefault(); openRow(row)"
                 [attr.data-testid]="'persona-row-' + row.projectSlug">
                 <!-- Name Column -->
                 <td class="py-4 pr-4">

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -1,0 +1,219 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="multi-persona-dashboard-container">
+  <!-- Page Header -->
+  <div class="mb-6" data-testid="multi-persona-dashboard-header">
+    <h1 class="font-display font-light text-2xl">My Dashboard</h1>
+    <p class="mt-1 text-sm text-gray-500">{{ subtitleText() }}</p>
+  </div>
+
+  <!-- Dashboard Sections -->
+  <div class="flex flex-col gap-6" data-testid="multi-persona-dashboard-sections">
+    <!-- My Foundations and Projects Section -->
+    <section data-testid="multi-persona-projects-section">
+      <!-- Section Header -->
+      <div class="mb-4">
+        <div class="mb-3 flex items-center gap-2">
+          <i class="fa-solid fa-building-columns text-lg text-blue-600"></i>
+          <h2 class="text-lg font-semibold text-gray-900">{{ sectionTitle() }}</h2>
+        </div>
+        @if (roleGroups().length > 0) {
+          <div class="flex flex-col gap-2 text-sm" data-testid="multi-persona-role-groups">
+            @for (group of roleGroups(); track group.label) {
+              <div class="flex items-center gap-3">
+                <span class="role-label" [attr.data-role]="group.label">
+                  <i class="role-label__dot" [attr.data-role]="group.label"></i>
+                  {{ group.label }}
+                </span>
+                <span class="text-gray-500">
+                  @for (name of group.names; track name) {
+                    @if (!$first && $last) {
+                      and
+                    } @else if (!$first) {
+                      ,
+                    }
+                    <strong class="font-medium text-gray-700">{{ name }}</strong>
+                  }
+                </span>
+              </div>
+            }
+          </div>
+          <p class="mt-2 text-xs text-gray-400">Click a row to open the relevant lens.</p>
+        }
+      </div>
+
+      <!-- Summary Pills -->
+      <div
+        class="mb-4 flex flex-wrap items-center rounded-lg border border-blue-200 bg-blue-50 text-sm divide-x divide-blue-200"
+        data-testid="multi-persona-summary-pills">
+        @if (hasFoundations()) {
+          <div class="flex items-center gap-2 px-4 py-2.5">
+            <i class="fa-solid fa-building-columns text-blue-600"></i>
+            <span class="font-semibold text-gray-900">{{ summaryPills().foundationCount }} foundations</span>
+          </div>
+        }
+        @if (hasProjects()) {
+          <div class="flex items-center gap-2 px-4 py-2.5">
+            <i class="fa-solid fa-laptop-code text-blue-600"></i>
+            <span class="font-semibold text-gray-900">{{ summaryPills().projectCount }} projects</span>
+          </div>
+        }
+        <div class="flex items-center gap-2 px-4 py-2.5">
+          <i class="fa-solid fa-square-poll-horizontal text-blue-600"></i>
+          <span class="text-gray-700">{{ summaryPills().openSurveys }} surveys open</span>
+        </div>
+        <div class="flex items-center gap-2 px-4 py-2.5">
+          <i class="fa-solid fa-calendar text-blue-600"></i>
+          <span class="text-gray-700">{{ summaryPills().meetingsThisWeek }} meetings this week</span>
+        </div>
+        <div class="flex items-center gap-2 px-4 py-2.5">
+          <i class="fa-solid fa-circle-check text-blue-600"></i>
+          <span class="text-gray-700">{{ summaryPills().itemsNeedReview }} items need review</span>
+        </div>
+      </div>
+
+      <!-- Projects Table -->
+      <div class="overflow-x-auto" data-testid="multi-persona-table">
+        <table class="w-full">
+          <thead>
+            <tr class="border-b border-gray-200">
+              <th class="pb-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Name</th>
+              @if (showTypeColumn()) {
+                <th class="pb-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Type</th>
+              }
+              <th class="pb-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Your Role</th>
+              @if (hasFoundations()) {
+                <th class="pb-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Health</th>
+              }
+              <th class="pb-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">Voting</th>
+              <th class="pb-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500"></th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100">
+            @for (row of projectRows(); track row.projectUid) {
+              <tr
+                class="group cursor-pointer transition-colors hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
+                tabindex="0"
+                (click)="openRow(row)"
+                (keydown.enter)="openRow(row)"
+                [attr.data-testid]="'persona-row-' + row.projectSlug">
+                <!-- Name Column -->
+                <td class="py-4 pr-4">
+                  <div class="flex items-center gap-3">
+                    @if (row.logoUrl) {
+                      <img [src]="row.logoUrl" [alt]="row.projectName" class="h-10 w-10 rounded-lg bg-gray-100 object-contain p-1" />
+                    } @else if (row.type === 'foundation') {
+                      <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100">
+                        <i class="fa-solid fa-building-columns text-blue-600"></i>
+                      </div>
+                    } @else {
+                      <div class="flex h-10 w-10 items-center justify-center rounded-lg bg-gray-100">
+                        <i class="text-xl fa-solid fa-laptop-code text-gray-600"></i>
+                      </div>
+                    }
+                    <div>
+                      <div class="font-medium text-gray-900">{{ row.projectName }}</div>
+                      @if (row.subtitle) {
+                        <div class="text-xs text-gray-500">{{ row.subtitle }}</div>
+                      }
+                    </div>
+                  </div>
+                </td>
+                <!-- Type Column (conditional) -->
+                @if (showTypeColumn()) {
+                  <td class="py-4 pr-4">
+                    @if (row.type === 'foundation') {
+                      <span class="type-badge type-badge--foundation">Foundation</span>
+                    } @else {
+                      <span class="type-badge type-badge--project">Project</span>
+                    }
+                  </td>
+                }
+                <!-- Role Column -->
+                <td class="py-4 pr-4">
+                  <span class="role-badge" [attr.data-role]="row.role">{{ row.role }}</span>
+                </td>
+                <!-- Health Column (conditional) -->
+                @if (hasFoundations()) {
+                  <td class="py-4 pr-4">
+                    @if (row.healthStatus) {
+                      <div class="flex items-center gap-2">
+                        <span
+                          class="health-dot"
+                          [class.health-dot--on-track]="row.healthStatus === 'on-track'"
+                          [class.health-dot--watch]="row.healthStatus === 'watch'"
+                          [class.health-dot--needs-attention]="row.healthStatus === 'needs-attention'"></span>
+                        <span
+                          class="text-sm"
+                          [class.text-emerald-700]="row.healthStatus === 'on-track'"
+                          [class.text-amber-700]="row.healthStatus === 'watch'"
+                          [class.text-red-700]="row.healthStatus === 'needs-attention'"
+                          >{{ row.healthDetail }}</span
+                        >
+                      </div>
+                    } @else {
+                      <span class="text-sm text-gray-400">&mdash;</span>
+                    }
+                  </td>
+                }
+                <!-- Voting Column -->
+                <td class="py-4 pr-4">
+                  @if (row.votingStatus) {
+                    <span
+                      class="voting-badge"
+                      [class.voting-badge--voting-rep]="row.votingStatus === 'Voting Rep'"
+                      [class.voting-badge--alternate]="row.votingStatus === 'Alternate Voting Rep'"
+                      >{{ row.votingStatus }}</span
+                    >
+                  } @else {
+                    <span class="text-sm text-gray-400">&mdash;</span>
+                  }
+                </td>
+                <!-- Action Column -->
+                <td class="py-4 text-right">
+                  <span class="text-sm font-medium text-blue-600 group-hover:text-blue-700"> Open <i class="fa-solid fa-arrow-right ml-1"></i> </span>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- My Meetings -->
+    @defer (on idle) {
+      <lfx-my-meetings />
+    } @placeholder {
+      <section class="flex flex-1 flex-col" data-testid="multi-persona-my-meetings-placeholder">
+        <div class="mb-4 flex h-8 items-center justify-between">
+          <div class="flex items-center gap-2">
+            <p-skeleton width="1.125rem" height="1.125rem" borderRadius="4px" />
+            <p-skeleton width="7rem" height="1rem" />
+          </div>
+          <p-skeleton width="4rem" height="1rem" />
+        </div>
+        <div class="flex flex-col gap-3">
+          <p-skeleton width="100%" height="140px" />
+        </div>
+      </section>
+    }
+
+    <!-- Pending Actions -->
+    @defer (on idle) {
+      <lfx-pending-actions [pendingActions]="pendingActions()" (actionClick)="handleActionClick()" />
+    } @placeholder {
+      <section class="flex flex-1 flex-col" data-testid="multi-persona-pending-actions-placeholder">
+        <div class="mb-4 flex h-8 items-center justify-between px-2">
+          <div class="flex items-center gap-2">
+            <p-skeleton width="1.125rem" height="1.125rem" borderRadius="4px" />
+            <p-skeleton width="9rem" height="1rem" />
+          </div>
+        </div>
+        <div class="flex flex-col gap-3 px-2">
+          <p-skeleton width="100%" height="140px" />
+        </div>
+      </section>
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -97,15 +97,7 @@
           </thead>
           <tbody class="divide-y divide-gray-100">
             @for (row of projectRows(); track row.projectUid) {
-              <tr
-                class="group cursor-pointer transition-colors hover:bg-gray-50 focus:bg-gray-50 focus:outline-none"
-                tabindex="0"
-                role="link"
-                [attr.aria-label]="'Open ' + row.projectName"
-                (click)="openRow(row)"
-                (keydown.enter)="openRow(row)"
-                (keydown.space)="$event.preventDefault(); openRow(row)"
-                [attr.data-testid]="'persona-row-' + row.projectSlug">
+              <tr class="group transition-colors hover:bg-gray-50" [attr.data-testid]="'persona-row-' + row.projectSlug">
                 <!-- Name Column -->
                 <td class="py-4 pr-4">
                   <div class="flex items-center gap-3">
@@ -180,7 +172,14 @@
                 </td>
                 <!-- Action Column -->
                 <td class="py-4 text-right">
-                  <span class="text-sm font-medium text-blue-600 group-hover:text-blue-700"> Open <i class="fa-solid fa-arrow-right ml-1"></i> </span>
+                  <button
+                    type="button"
+                    class="rounded text-sm font-medium text-blue-600 transition-colors hover:text-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 group-hover:text-blue-700"
+                    [attr.aria-label]="'Open ' + row.projectName"
+                    [attr.data-testid]="'persona-row-open-' + row.projectSlug"
+                    (click)="openRow(row)">
+                    Open <i class="fa-solid fa-arrow-right ml-1"></i>
+                  </button>
                 </td>
               </tr>
             }

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -44,34 +44,48 @@
       </div>
 
       <!-- Summary Pills -->
-      <div
-        class="mb-4 flex flex-wrap items-center rounded-lg border border-blue-200 bg-blue-50 text-sm divide-x divide-blue-200"
-        data-testid="multi-persona-summary-pills">
-        @if (hasFoundations()) {
-          <div class="flex items-center gap-2 px-4 py-2.5">
-            <i class="fa-solid fa-building-columns text-blue-600"></i>
-            <span class="font-semibold text-gray-900">{{ summaryPills().foundationCount }} foundations</span>
+      @if (summaryPillsLoading()) {
+        <div
+          class="mb-4 inline-flex items-center gap-px overflow-hidden rounded-lg border border-blue-200 bg-blue-200"
+          data-testid="multi-persona-summary-pills-loading">
+          @for (i of [1, 2, 3, 4]; track i) {
+            <div class="bg-blue-50 px-4 py-2.5">
+              <p-skeleton width="6rem" height="1rem" />
+            </div>
+          }
+        </div>
+      } @else {
+        <div
+          class="mb-4 inline-flex flex-wrap items-center gap-px overflow-hidden rounded-lg border border-blue-200 bg-blue-200 text-sm"
+          data-testid="multi-persona-summary-pills">
+          @if (hasFoundations()) {
+            <div class="flex items-center gap-2 bg-blue-50 px-4 py-2.5">
+              <i class="fa-solid fa-building-columns text-blue-600"></i>
+              <span class="font-semibold text-gray-900">{{ summaryPills().foundationCount }} foundations</span>
+            </div>
+          }
+          @if (hasProjects()) {
+            <div class="flex items-center gap-2 bg-blue-50 px-4 py-2.5">
+              <i class="fa-solid fa-laptop-code text-blue-600"></i>
+              <span class="font-semibold text-gray-900">{{ summaryPills().projectCount }} projects</span>
+            </div>
+          }
+          <div class="flex items-center gap-2 bg-blue-50 px-4 py-2.5">
+            <i class="fa-solid fa-square-poll-horizontal text-blue-600"></i>
+            <span class="text-gray-700">{{ summaryPills().openSurveys }} surveys open</span>
           </div>
-        }
-        @if (hasProjects()) {
-          <div class="flex items-center gap-2 px-4 py-2.5">
-            <i class="fa-solid fa-laptop-code text-blue-600"></i>
-            <span class="font-semibold text-gray-900">{{ summaryPills().projectCount }} projects</span>
+          <div class="flex items-center gap-2 bg-blue-50 px-4 py-2.5">
+            <i class="fa-solid fa-calendar text-blue-600"></i>
+            <span class="text-gray-700">{{ summaryPills().meetingsThisWeek }} meetings this week</span>
           </div>
-        }
-        <div class="flex items-center gap-2 px-4 py-2.5">
-          <i class="fa-solid fa-square-poll-horizontal text-blue-600"></i>
-          <span class="text-gray-700">{{ summaryPills().openSurveys }} surveys open</span>
+          @if (summaryPills().itemsNeedReview > 0) {
+            <div class="flex items-center gap-2 bg-blue-50 px-4 py-2.5">
+              <i class="fa-solid fa-circle-check text-blue-600"></i>
+              <span class="text-gray-700">{{ summaryPills().itemsNeedReview }} items need review</span>
+            </div>
+          }
         </div>
-        <div class="flex items-center gap-2 px-4 py-2.5">
-          <i class="fa-solid fa-calendar text-blue-600"></i>
-          <span class="text-gray-700">{{ summaryPills().meetingsThisWeek }} meetings this week</span>
-        </div>
-        <div class="flex items-center gap-2 px-4 py-2.5">
-          <i class="fa-solid fa-circle-check text-blue-600"></i>
-          <span class="text-gray-700">{{ summaryPills().itemsNeedReview }} items need review</span>
-        </div>
-      </div>
+      }
 
       <!-- Projects Table -->
       <div class="overflow-x-auto" data-testid="multi-persona-table">
@@ -200,20 +214,32 @@
     }
 
     <!-- Pending Actions -->
-    @defer (on idle) {
-      <lfx-pending-actions [pendingActions]="pendingActions()" (actionClick)="handleActionClick()" />
-    } @placeholder {
-      <section class="flex flex-1 flex-col" data-testid="multi-persona-pending-actions-placeholder">
-        <div class="mb-4 flex h-8 items-center justify-between px-2">
-          <div class="flex items-center gap-2">
+    @if (pendingActionsLoading()) {
+      <section class="flex flex-1 flex-col" data-testid="multi-persona-pending-actions-loading">
+        <div class="mb-4 flex h-8 items-center gap-2">
+          <p-skeleton width="1.125rem" height="1.125rem" borderRadius="4px" />
+          <p-skeleton width="9rem" height="1rem" />
+        </div>
+        <div class="flex flex-col gap-3">
+          <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
+          <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
+        </div>
+      </section>
+    } @else {
+      @defer (on idle) {
+        <lfx-pending-actions [pendingActions]="pendingActions()" (actionClick)="handleActionClick()" />
+      } @placeholder {
+        <section class="flex flex-1 flex-col" data-testid="multi-persona-pending-actions-placeholder">
+          <div class="mb-4 flex h-8 items-center gap-2">
             <p-skeleton width="1.125rem" height="1.125rem" borderRadius="4px" />
             <p-skeleton width="9rem" height="1rem" />
           </div>
-        </div>
-        <div class="flex flex-col gap-3 px-2">
-          <p-skeleton width="100%" height="140px" />
-        </div>
-      </section>
+          <div class="flex flex-col gap-3">
+            <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
+            <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
+          </div>
+        </section>
+      }
     }
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.scss
@@ -1,0 +1,111 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+:host {
+  display: block;
+}
+
+.role-label {
+  @apply inline-flex items-center gap-1.5 whitespace-nowrap text-sm font-semibold text-gray-800;
+
+  &__dot {
+    @apply inline-block h-2 w-2 rounded-full bg-gray-400;
+
+    &[data-role='Executive Director'],
+    &[data-role='Board Member'] {
+      @apply bg-red-500;
+    }
+
+    &[data-role='Chair'] {
+      @apply bg-orange-500;
+    }
+
+    &[data-role='Maintainer'] {
+      @apply bg-blue-500;
+    }
+
+    &[data-role='Contributor'] {
+      @apply bg-gray-400;
+    }
+  }
+}
+
+.type-badge {
+  @apply inline-block rounded-md px-2.5 py-1 text-xs font-medium;
+
+  &--foundation {
+    @apply border border-orange-200 bg-orange-50 text-orange-700;
+  }
+
+  &--project {
+    @apply border border-blue-200 bg-blue-50 text-blue-700;
+  }
+}
+
+.role-badge {
+  @apply inline-block rounded-md border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700;
+
+  &[data-role='Executive Director'] {
+    @apply border-red-200 bg-red-50 text-red-700;
+  }
+
+  &[data-role='Chair'] {
+    @apply border-orange-200 bg-orange-50 text-orange-700;
+  }
+
+  &[data-role='Vice Chair'] {
+    @apply border-orange-200 bg-orange-50 text-orange-600;
+  }
+
+  &[data-role='Treasurer'] {
+    @apply border-emerald-200 bg-emerald-50 text-emerald-700;
+  }
+
+  &[data-role='Secretary'] {
+    @apply border-purple-200 bg-purple-50 text-purple-700;
+  }
+
+  &[data-role='Counsel'] {
+    @apply border-red-200 bg-red-50 text-red-600;
+  }
+
+  &[data-role='Board Member'] {
+    @apply border-red-200 bg-red-50 text-red-700;
+  }
+
+  &[data-role='Maintainer'] {
+    @apply border-blue-200 bg-blue-50 text-blue-700;
+  }
+
+  &[data-role='Contributor'] {
+    @apply border-gray-200 bg-gray-50 text-gray-600;
+  }
+}
+
+.health-dot {
+  @apply inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full;
+
+  &--on-track {
+    @apply bg-emerald-500;
+  }
+
+  &--watch {
+    @apply bg-amber-500;
+  }
+
+  &--needs-attention {
+    @apply bg-red-500;
+  }
+}
+
+.voting-badge {
+  @apply inline-block rounded-md border border-gray-200 bg-gray-50 px-2.5 py-1 text-xs font-medium text-gray-700;
+
+  &--voting-rep {
+    @apply border-blue-200 bg-blue-50 text-blue-700;
+  }
+
+  &--alternate {
+    @apply border-yellow-200 bg-yellow-50 text-yellow-700;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.scss
@@ -16,16 +16,25 @@
       @apply bg-red-500;
     }
 
-    &[data-role='Chair'] {
+    &[data-role='Chair'],
+    &[data-role='Vice Chair'] {
       @apply bg-orange-500;
+    }
+
+    &[data-role='Treasurer'] {
+      @apply bg-emerald-500;
+    }
+
+    &[data-role='Secretary'] {
+      @apply bg-purple-500;
+    }
+
+    &[data-role='Counsel'] {
+      @apply bg-red-400;
     }
 
     &[data-role='Maintainer'] {
       @apply bg-blue-500;
-    }
-
-    &[data-role='Contributor'] {
-      @apply bg-gray-400;
     }
   }
 }
@@ -45,16 +54,14 @@
 .role-badge {
   @apply inline-block rounded-md border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-medium text-blue-700;
 
-  &[data-role='Executive Director'] {
+  &[data-role='Executive Director'],
+  &[data-role='Board Member'] {
     @apply border-red-200 bg-red-50 text-red-700;
   }
 
-  &[data-role='Chair'] {
-    @apply border-orange-200 bg-orange-50 text-orange-700;
-  }
-
+  &[data-role='Chair'],
   &[data-role='Vice Chair'] {
-    @apply border-orange-200 bg-orange-50 text-orange-600;
+    @apply border-orange-200 bg-orange-50 text-orange-700;
   }
 
   &[data-role='Treasurer'] {
@@ -69,15 +76,12 @@
     @apply border-red-200 bg-red-50 text-red-600;
   }
 
-  &[data-role='Board Member'] {
-    @apply border-red-200 bg-red-50 text-red-700;
-  }
-
   &[data-role='Maintainer'] {
     @apply border-blue-200 bg-blue-50 text-blue-700;
   }
 
-  &[data-role='Contributor'] {
+  &[data-role='Contributor'],
+  &[data-role='Member'] {
     @apply border-gray-200 bg-gray-50 text-gray-600;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -1,20 +1,24 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, Signal } from '@angular/core';
+import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import {
   BoardMemberDetectionExtra,
   CommitteeMemberDetectionExtra,
   DashboardSummaryPills,
   EnrichedPersonaProject,
+  FoundationHealthScoreDistributionResponse,
   MultiFoundationSummaryResponse,
   PendingActionItem,
   PerFoundationAnalytics,
   PersonaProjectRow,
   ProjectContext,
+  Meeting,
+  RoleGroup,
 } from '@lfx-one/shared/interfaces';
 import { SurveyStatus } from '@lfx-one/shared/enums';
+import { getActiveOccurrences } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { HiddenActionsService } from '@services/hidden-actions.service';
 import { LensService } from '@services/lens.service';
@@ -24,10 +28,30 @@ import { ProjectService } from '@services/project.service';
 import { SurveyService } from '@services/survey.service';
 import { UserService } from '@services/user.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { BehaviorSubject, catchError, combineLatest, filter, map, of, switchMap, take } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, filter, forkJoin, map, of, switchMap, take } from 'rxjs';
 
 import { MyMeetingsComponent } from '../components/my-meetings/my-meetings.component';
 import { PendingActionsComponent } from '../components/pending-actions/pending-actions.component';
+
+const ROLE_PRIORITY: string[] = [
+  'Executive Director',
+  'Chair',
+  'Vice Chair',
+  'Treasurer',
+  'Secretary',
+  'Counsel',
+  'Director',
+  'Lead',
+  'TAC/TOC Representative',
+  'LF Staff',
+  'Developer Seat',
+  'Maintainer',
+  'Contributor',
+  'Member',
+  'None',
+];
+
+const VOTING_PRIORITY: string[] = ['Voting Rep', 'Alternate Voting Rep', 'Observer', 'Emeritus', 'None'];
 
 @Component({
   selector: 'lfx-multi-persona-dashboard',
@@ -46,26 +70,6 @@ export class MultiPersonaDashboardComponent {
   private readonly hiddenActionsService = inject(HiddenActionsService);
 
   private readonly refresh$ = new BehaviorSubject<void>(undefined);
-
-  private readonly rolePriority: string[] = [
-    'Executive Director',
-    'Chair',
-    'Vice Chair',
-    'Treasurer',
-    'Secretary',
-    'Counsel',
-    'Director',
-    'Lead',
-    'TAC/TOC Representative',
-    'LF Staff',
-    'Developer Seat',
-    'Maintainer',
-    'Contributor',
-    'Member',
-    'None',
-  ];
-
-  private readonly votingPriority: string[] = ['Voting Rep', 'Alternate Voting Rep', 'Observer', 'Emeritus', 'None'];
 
   // All detected projects (foundations + projects)
   protected readonly allProjects: Signal<EnrichedPersonaProject[]> = computed(() => this.personaService.detectedProjects());
@@ -86,10 +90,12 @@ export class MultiPersonaDashboardComponent {
   });
 
   protected readonly subtitleText: Signal<string> = this.initSubtitleText();
-  protected readonly roleGroups: Signal<{ label: string; names: string[] }[]> = this.initRoleGroups();
+  protected readonly roleGroups: Signal<RoleGroup[]> = this.initRoleGroups();
   protected readonly analyticsSummary: Signal<MultiFoundationSummaryResponse | null> = this.initAnalyticsSummary();
   protected readonly projectRows: Signal<PersonaProjectRow[]> = this.initProjectRows();
+  protected readonly summaryPillsLoading = signal(true);
   protected readonly summaryPills: Signal<DashboardSummaryPills> = this.initSummaryPills();
+  protected readonly pendingActionsLoading = signal(true);
   protected readonly pendingActions: Signal<PendingActionItem[]> = this.initPendingActions();
 
   public openRow(row: PersonaProjectRow): void {
@@ -140,10 +146,10 @@ export class MultiPersonaDashboardComponent {
     });
   }
 
-  private initRoleGroups(): Signal<{ label: string; names: string[] }[]> {
+  private initRoleGroups(): Signal<RoleGroup[]> {
     return computed(() => {
       const projects = this.allProjects();
-      const groups: { label: string; names: string[] }[] = [];
+      const groups: RoleGroup[] = [];
 
       const edProjects = projects.filter((p) => p.personas.includes('executive-director'));
       const boardProjects = projects.filter((p) => p.personas.includes('board-member'));
@@ -208,8 +214,8 @@ export class MultiPersonaDashboardComponent {
         if (a.type !== b.type) {
           return a.type === 'foundation' ? -1 : 1;
         }
-        const aRoleIdx = this.rolePriority.indexOf(a.role);
-        const bRoleIdx = this.rolePriority.indexOf(b.role);
+        const aRoleIdx = ROLE_PRIORITY.indexOf(a.role);
+        const bRoleIdx = ROLE_PRIORITY.indexOf(b.role);
         const roleCompare = (aRoleIdx === -1 ? 999 : aRoleIdx) - (bRoleIdx === -1 ? 999 : bRoleIdx);
         if (roleCompare !== 0) return roleCompare;
         return a.projectName.localeCompare(b.projectName);
@@ -225,19 +231,11 @@ export class MultiPersonaDashboardComponent {
         this.userService.getUserMeetings().pipe(catchError(() => of([]))),
       ]).pipe(
         map(([projects, surveys, meetings]) => {
+          this.summaryPillsLoading.set(false);
           const foundationCount = projects.filter((p) => p.isFoundation).length;
           const projectCount = projects.filter((p) => !p.isFoundation).length;
           const openSurveys = surveys.filter((s) => s.survey_status === SurveyStatus.OPEN || s.survey_status === SurveyStatus.SENT).length;
-          const now = new Date();
-          const startOfWeek = new Date(now);
-          startOfWeek.setDate(now.getDate() - now.getDay());
-          startOfWeek.setHours(0, 0, 0, 0);
-          const endOfWeek = new Date(startOfWeek);
-          endOfWeek.setDate(startOfWeek.getDate() + 7);
-          const meetingsThisWeek = meetings.filter((m) => {
-            const meetingDate = new Date(m.start_time || m.created_at);
-            return meetingDate >= startOfWeek && meetingDate < endOfWeek;
-          }).length;
+          const meetingsThisWeek = this.countMeetingsThisWeek(meetings);
 
           return {
             foundationCount,
@@ -255,15 +253,26 @@ export class MultiPersonaDashboardComponent {
   private initPendingActions(): Signal<PendingActionItem[]> {
     return toSignal(
       this.refresh$.pipe(
-        switchMap(() => toObservable(this.userFoundations).pipe(take(1))),
-        switchMap((foundations) => {
-          if (foundations.length === 0) return of([]);
-          const first = foundations[0];
-          return this.projectService
-            .getPendingActions(first.projectSlug, first.projectUid, this.personaService.currentPersona())
-            .pipe(catchError(() => of([])));
+        switchMap(() => {
+          this.pendingActionsLoading.set(true);
+          return toObservable(this.userFoundations).pipe(take(1));
         }),
-        map((actions) => actions.filter((item) => !this.hiddenActionsService.isActionHidden(item)).slice(0, 2))
+        switchMap((foundations) => {
+          if (foundations.length === 0) {
+            this.pendingActionsLoading.set(false);
+            return of([]);
+          }
+          const persona = this.personaService.currentPersona();
+          return forkJoin(
+            foundations.map((f) =>
+              this.projectService.getPendingActions(f.projectSlug, f.projectUid, persona).pipe(catchError(() => of([] as PendingActionItem[])))
+            )
+          ).pipe(map((results) => results.flat()));
+        }),
+        map((actions) => {
+          this.pendingActionsLoading.set(false);
+          return actions.filter((item) => !this.hiddenActionsService.isActionHidden(item)).slice(0, 5);
+        })
       ),
       { initialValue: [] }
     );
@@ -278,7 +287,7 @@ export class MultiPersonaDashboardComponent {
     // For sub-projects, show parent foundation name
     const parentFoundation = this.userFoundations().find((f) => f.projectUid === project.parentProjectUid);
     const parentName = parentFoundation?.projectName || '';
-    return parentName ? `${parentName}` : '';
+    return parentName;
   }
 
   private getRowRole(project: EnrichedPersonaProject): string {
@@ -311,7 +320,7 @@ export class MultiPersonaDashboardComponent {
       roles.push('Executive Director');
     }
     if (roles.length === 0) return 'Member';
-    return this.pickByPriority(roles, this.rolePriority) ?? roles[0];
+    return this.pickByPriority(roles, ROLE_PRIORITY) ?? roles[0];
   }
 
   private getHighestVotingStatus(project: EnrichedPersonaProject): string | null {
@@ -325,7 +334,7 @@ export class MultiPersonaDashboardComponent {
       }
     }
     if (statuses.length === 0) return null;
-    return this.pickByPriority(statuses, this.votingPriority) ?? statuses[0];
+    return this.pickByPriority(statuses, VOTING_PRIORITY) ?? statuses[0];
   }
 
   private pickByPriority(values: string[], priority: string[]): string | null {
@@ -337,24 +346,47 @@ export class MultiPersonaDashboardComponent {
     return null;
   }
 
-  private getHealthStatus(scores?: {
-    excellent: number;
-    healthy: number;
-    stable: number;
-    unsteady: number;
-    critical: number;
-  }): 'on-track' | 'watch' | 'needs-attention' {
+  private getHealthStatus(scores?: FoundationHealthScoreDistributionResponse): 'on-track' | 'watch' | 'needs-attention' {
     if (!scores) return 'on-track';
     if (scores.critical + scores.unsteady > 0) return 'needs-attention';
     if (scores.stable > 0) return 'watch';
     return 'on-track';
   }
 
-  private getHealthDetail(scores?: { excellent: number; healthy: number; stable: number; unsteady: number; critical: number }): string {
+  private getHealthDetail(scores?: FoundationHealthScoreDistributionResponse): string {
     if (!scores) return 'On Track';
     const needsAttention = scores.critical + scores.unsteady;
     if (needsAttention > 0) return `${needsAttention} need attention`;
     if (scores.stable > 0) return `${scores.stable} watch`;
     return 'On Track';
+  }
+
+  private countMeetingsThisWeek(meetings: Meeting[]): number {
+    const now = new Date();
+    const startOfWeek = new Date(now);
+    startOfWeek.setDate(now.getDate() - now.getDay());
+    startOfWeek.setHours(0, 0, 0, 0);
+    const endOfWeek = new Date(startOfWeek);
+    endOfWeek.setDate(startOfWeek.getDate() + 7);
+
+    let count = 0;
+    for (const meeting of meetings) {
+      if (meeting.occurrences?.length > 0) {
+        // Recurring meeting: count active occurrences this week
+        for (const occ of getActiveOccurrences(meeting.occurrences)) {
+          const occDate = new Date(occ.start_time);
+          if (occDate >= startOfWeek && occDate < endOfWeek) {
+            count++;
+          }
+        }
+      } else {
+        // One-off meeting: check series start_time
+        const meetingDate = new Date(meeting.start_time);
+        if (meetingDate >= startOfWeek && meetingDate < endOfWeek) {
+          count++;
+        }
+      }
+    }
+    return count;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -1,0 +1,360 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import {
+  BoardMemberDetectionExtra,
+  CommitteeMemberDetectionExtra,
+  DashboardSummaryPills,
+  EnrichedPersonaProject,
+  MultiFoundationSummaryResponse,
+  PendingActionItem,
+  PerFoundationAnalytics,
+  PersonaProjectRow,
+  ProjectContext,
+} from '@lfx-one/shared/interfaces';
+import { SurveyStatus } from '@lfx-one/shared/enums';
+import { AnalyticsService } from '@services/analytics.service';
+import { HiddenActionsService } from '@services/hidden-actions.service';
+import { LensService } from '@services/lens.service';
+import { PersonaService } from '@services/persona.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
+import { SurveyService } from '@services/survey.service';
+import { UserService } from '@services/user.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { BehaviorSubject, catchError, combineLatest, filter, map, of, switchMap, take } from 'rxjs';
+
+import { MyMeetingsComponent } from '../components/my-meetings/my-meetings.component';
+import { PendingActionsComponent } from '../components/pending-actions/pending-actions.component';
+
+@Component({
+  selector: 'lfx-multi-persona-dashboard',
+  imports: [SkeletonModule, MyMeetingsComponent, PendingActionsComponent],
+  templateUrl: './multi-persona-dashboard.component.html',
+  styleUrl: './multi-persona-dashboard.component.scss',
+})
+export class MultiPersonaDashboardComponent {
+  private readonly personaService = inject(PersonaService);
+  private readonly analyticsService = inject(AnalyticsService);
+  private readonly surveyService = inject(SurveyService);
+  private readonly userService = inject(UserService);
+  private readonly projectService = inject(ProjectService);
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly lensService = inject(LensService);
+  private readonly hiddenActionsService = inject(HiddenActionsService);
+
+  private readonly refresh$ = new BehaviorSubject<void>(undefined);
+
+  private readonly rolePriority: string[] = [
+    'Executive Director',
+    'Chair',
+    'Vice Chair',
+    'Treasurer',
+    'Secretary',
+    'Counsel',
+    'Director',
+    'Lead',
+    'TAC/TOC Representative',
+    'LF Staff',
+    'Developer Seat',
+    'Maintainer',
+    'Contributor',
+    'Member',
+    'None',
+  ];
+
+  private readonly votingPriority: string[] = ['Voting Rep', 'Alternate Voting Rep', 'Observer', 'Emeritus', 'None'];
+
+  // All detected projects (foundations + projects)
+  protected readonly allProjects: Signal<EnrichedPersonaProject[]> = computed(() => this.personaService.detectedProjects());
+
+  // Only foundations (for analytics fetch)
+  protected readonly userFoundations: Signal<EnrichedPersonaProject[]> = computed(() => this.allProjects().filter((p) => p.isFoundation));
+
+  // Visibility flags
+  protected readonly hasFoundations: Signal<boolean> = computed(() => this.allProjects().some((p) => p.isFoundation));
+  protected readonly hasProjects: Signal<boolean> = computed(() => this.allProjects().some((p) => !p.isFoundation));
+  protected readonly showTypeColumn: Signal<boolean> = computed(() => this.hasFoundations() && this.hasProjects());
+
+  // Section title
+  protected readonly sectionTitle: Signal<string> = computed(() => {
+    if (this.hasFoundations() && this.hasProjects()) return 'My Foundations and Projects';
+    if (this.hasFoundations()) return 'My Foundations';
+    return 'My Projects';
+  });
+
+  protected readonly subtitleText: Signal<string> = this.initSubtitleText();
+  protected readonly roleGroups: Signal<{ label: string; names: string[] }[]> = this.initRoleGroups();
+  protected readonly analyticsSummary: Signal<MultiFoundationSummaryResponse | null> = this.initAnalyticsSummary();
+  protected readonly projectRows: Signal<PersonaProjectRow[]> = this.initProjectRows();
+  protected readonly summaryPills: Signal<DashboardSummaryPills> = this.initSummaryPills();
+  protected readonly pendingActions: Signal<PendingActionItem[]> = this.initPendingActions();
+
+  public openRow(row: PersonaProjectRow): void {
+    const context: ProjectContext = {
+      uid: row.projectUid,
+      name: row.projectName,
+      slug: row.projectSlug,
+    };
+    if (row.type === 'foundation') {
+      this.projectContextService.setFoundation(context);
+      this.lensService.setLens('foundation');
+    } else {
+      this.projectContextService.setProject(context);
+      this.lensService.setLens('project');
+    }
+  }
+
+  public handleActionClick(): void {
+    this.refresh$.next();
+  }
+
+  private initSubtitleText(): Signal<string> {
+    return computed(() => {
+      const personas = this.personaService.allPersonas();
+      const roleLabels = personas.map((p) => {
+        switch (p) {
+          case 'executive-director':
+            return 'executive director';
+          case 'board-member':
+            return 'board';
+          case 'maintainer':
+            return 'maintainer';
+          case 'contributor':
+            return 'contributor';
+          default:
+            return p;
+        }
+      });
+      const label = roleLabels.join(' and ');
+
+      if (this.hasFoundations() && this.hasProjects()) {
+        return `Your ${label} activity across all projects and foundations.`;
+      }
+      if (this.hasFoundations()) {
+        return `Your ${label} activity across ${this.userFoundations().length} foundations.`;
+      }
+      return `Your ${label} activity across ${this.allProjects().length} projects.`;
+    });
+  }
+
+  private initRoleGroups(): Signal<{ label: string; names: string[] }[]> {
+    return computed(() => {
+      const projects = this.allProjects();
+      const groups: { label: string; names: string[] }[] = [];
+
+      const edProjects = projects.filter((p) => p.personas.includes('executive-director'));
+      const boardProjects = projects.filter((p) => p.personas.includes('board-member'));
+      const maintainerProjects = projects.filter((p) => p.personas.includes('maintainer'));
+      const contributorProjects = projects.filter((p) => p.personas.includes('contributor') && !p.personas.includes('maintainer'));
+
+      if (edProjects.length > 0) {
+        groups.push({ label: 'Executive Director', names: edProjects.map((p) => p.projectName || p.projectSlug) });
+      }
+      if (boardProjects.length > 0) {
+        groups.push({ label: 'Board Member', names: boardProjects.map((p) => p.projectName || p.projectSlug) });
+      }
+      if (maintainerProjects.length > 0) {
+        groups.push({ label: 'Maintainer', names: maintainerProjects.map((p) => p.projectName || p.projectSlug) });
+      }
+      if (contributorProjects.length > 0) {
+        groups.push({ label: 'Contributor', names: contributorProjects.map((p) => p.projectName || p.projectSlug) });
+      }
+
+      return groups;
+    });
+  }
+
+  private initAnalyticsSummary(): Signal<MultiFoundationSummaryResponse | null> {
+    return toSignal(
+      toObservable(this.userFoundations).pipe(
+        filter((foundations) => foundations.length > 0),
+        switchMap((foundations) => {
+          const slugs = foundations.map((f) => f.projectSlug);
+          return this.analyticsService.getMultiFoundationSummary(slugs).pipe(catchError(() => of(null)));
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initProjectRows(): Signal<PersonaProjectRow[]> {
+    return computed(() => {
+      const projects = this.allProjects();
+      const analytics = this.analyticsSummary();
+
+      const rows = projects.map((project) => {
+        const isFoundation = project.isFoundation;
+        const perFoundation = isFoundation ? analytics?.perFoundation[project.projectSlug] : null;
+
+        return {
+          projectUid: project.projectUid,
+          projectSlug: project.projectSlug,
+          projectName: project.projectName || project.projectSlug,
+          logoUrl: project.logoUrl,
+          type: isFoundation ? ('foundation' as const) : ('project' as const),
+          subtitle: this.getRowSubtitle(project, perFoundation),
+          role: this.getRowRole(project),
+          healthStatus: isFoundation ? this.getHealthStatus(perFoundation?.healthScores) : null,
+          healthDetail: isFoundation ? this.getHealthDetail(perFoundation?.healthScores) : null,
+          votingStatus: this.getHighestVotingStatus(project),
+        };
+      });
+
+      // Sort: foundations first, then by role priority, then alphabetically by name
+      return rows.sort((a, b) => {
+        if (a.type !== b.type) {
+          return a.type === 'foundation' ? -1 : 1;
+        }
+        const aRoleIdx = this.rolePriority.indexOf(a.role);
+        const bRoleIdx = this.rolePriority.indexOf(b.role);
+        const roleCompare = (aRoleIdx === -1 ? 999 : aRoleIdx) - (bRoleIdx === -1 ? 999 : bRoleIdx);
+        if (roleCompare !== 0) return roleCompare;
+        return a.projectName.localeCompare(b.projectName);
+      });
+    });
+  }
+
+  private initSummaryPills(): Signal<DashboardSummaryPills> {
+    return toSignal(
+      combineLatest([
+        toObservable(this.allProjects),
+        this.surveyService.getMySurveys().pipe(catchError(() => of([]))),
+        this.userService.getUserMeetings().pipe(catchError(() => of([]))),
+      ]).pipe(
+        map(([projects, surveys, meetings]) => {
+          const foundationCount = projects.filter((p) => p.isFoundation).length;
+          const projectCount = projects.filter((p) => !p.isFoundation).length;
+          const openSurveys = surveys.filter((s) => s.survey_status === SurveyStatus.OPEN || s.survey_status === SurveyStatus.SENT).length;
+          const now = new Date();
+          const startOfWeek = new Date(now);
+          startOfWeek.setDate(now.getDate() - now.getDay());
+          startOfWeek.setHours(0, 0, 0, 0);
+          const endOfWeek = new Date(startOfWeek);
+          endOfWeek.setDate(startOfWeek.getDate() + 7);
+          const meetingsThisWeek = meetings.filter((m) => {
+            const meetingDate = new Date(m.start_time || m.created_at);
+            return meetingDate >= startOfWeek && meetingDate < endOfWeek;
+          }).length;
+
+          return {
+            foundationCount,
+            projectCount,
+            openSurveys,
+            meetingsThisWeek,
+            itemsNeedReview: 0,
+          };
+        })
+      ),
+      { initialValue: { foundationCount: 0, projectCount: 0, openSurveys: 0, meetingsThisWeek: 0, itemsNeedReview: 0 } }
+    );
+  }
+
+  private initPendingActions(): Signal<PendingActionItem[]> {
+    return toSignal(
+      this.refresh$.pipe(
+        switchMap(() => toObservable(this.userFoundations).pipe(take(1))),
+        switchMap((foundations) => {
+          if (foundations.length === 0) return of([]);
+          const first = foundations[0];
+          return this.projectService
+            .getPendingActions(first.projectSlug, first.projectUid, this.personaService.currentPersona())
+            .pipe(catchError(() => of([])));
+        }),
+        map((actions) => actions.filter((item) => !this.hiddenActionsService.isActionHidden(item)).slice(0, 2))
+      ),
+      { initialValue: [] }
+    );
+  }
+
+  private getRowSubtitle(project: EnrichedPersonaProject, analytics: PerFoundationAnalytics | null | undefined): string {
+    if (project.isFoundation) {
+      const projects = analytics?.totalProjects ?? 0;
+      const members = analytics?.totalMembers ?? 0;
+      return `${projects} projects · ${members.toLocaleString()} members`;
+    }
+    // For sub-projects, show parent foundation name
+    const parentFoundation = this.userFoundations().find((f) => f.projectUid === project.parentProjectUid);
+    const parentName = parentFoundation?.projectName || '';
+    return parentName ? `${parentName}` : '';
+  }
+
+  private getRowRole(project: EnrichedPersonaProject): string {
+    // For foundations, check board_member/committee_member detection extras
+    if (project.isFoundation) {
+      return this.getHighestRole(project);
+    }
+    // For projects, derive from persona type
+    if (project.personas.includes('maintainer')) return 'Maintainer';
+    if (project.personas.includes('contributor')) return 'Contributor';
+    return this.getHighestRole(project);
+  }
+
+  private getHighestRole(project: EnrichedPersonaProject): string {
+    const roles: string[] = [];
+    for (const detection of project.detections) {
+      if (detection.source === 'board_member') {
+        const extra = detection.extra as BoardMemberDetectionExtra | undefined;
+        if (extra?.role) {
+          roles.push(extra.role);
+        }
+      } else if (detection.source === 'committee_member') {
+        const extra = detection.extra as CommitteeMemberDetectionExtra | undefined;
+        if (extra?.role) {
+          roles.push(extra.role);
+        }
+      }
+    }
+    if (project.personas.includes('executive-director')) {
+      roles.push('Executive Director');
+    }
+    if (roles.length === 0) return 'Member';
+    return this.pickByPriority(roles, this.rolePriority) ?? roles[0];
+  }
+
+  private getHighestVotingStatus(project: EnrichedPersonaProject): string | null {
+    const statuses: string[] = [];
+    for (const detection of project.detections) {
+      if (detection.source === 'board_member') {
+        const extra = detection.extra as BoardMemberDetectionExtra | undefined;
+        if (extra?.voting_status) {
+          statuses.push(extra.voting_status);
+        }
+      }
+    }
+    if (statuses.length === 0) return null;
+    return this.pickByPriority(statuses, this.votingPriority) ?? statuses[0];
+  }
+
+  private pickByPriority(values: string[], priority: string[]): string | null {
+    for (const p of priority) {
+      if (values.some((v) => v.toLowerCase() === p.toLowerCase())) {
+        return p;
+      }
+    }
+    return null;
+  }
+
+  private getHealthStatus(scores?: {
+    excellent: number;
+    healthy: number;
+    stable: number;
+    unsteady: number;
+    critical: number;
+  }): 'on-track' | 'watch' | 'needs-attention' {
+    if (!scores) return 'on-track';
+    if (scores.critical + scores.unsteady > 0) return 'needs-attention';
+    if (scores.stable > 0) return 'watch';
+    return 'on-track';
+  }
+
+  private getHealthDetail(scores?: { excellent: number; healthy: number; stable: number; unsteady: number; critical: number }): string {
+    if (!scores) return 'On Track';
+    const needsAttention = scores.critical + scores.unsteady;
+    if (needsAttention > 0) return `${needsAttention} need attention`;
+    if (scores.stable > 0) return `${scores.stable} watch`;
+    return 'On Track';
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -156,18 +156,15 @@ export class MultiPersonaDashboardComponent {
       const maintainerProjects = projects.filter((p) => p.personas.includes('maintainer'));
       const contributorProjects = projects.filter((p) => p.personas.includes('contributor') && !p.personas.includes('maintainer'));
 
-      if (edProjects.length > 0) {
-        groups.push({ label: 'Executive Director', names: edProjects.map((p) => p.projectName || p.projectSlug) });
-      }
-      if (boardProjects.length > 0) {
-        groups.push({ label: 'Board Member', names: boardProjects.map((p) => p.projectName || p.projectSlug) });
-      }
-      if (maintainerProjects.length > 0) {
-        groups.push({ label: 'Maintainer', names: maintainerProjects.map((p) => p.projectName || p.projectSlug) });
-      }
-      if (contributorProjects.length > 0) {
-        groups.push({ label: 'Contributor', names: contributorProjects.map((p) => p.projectName || p.projectSlug) });
-      }
+      const toGroup = (label: string, items: EnrichedPersonaProject[]): RoleGroup => {
+        const names = items.map((p) => p.projectName || p.projectSlug);
+        return { label, names, formattedNames: this.formatNameList(names) };
+      };
+
+      if (edProjects.length > 0) groups.push(toGroup('Executive Director', edProjects));
+      if (boardProjects.length > 0) groups.push(toGroup('Board Member', boardProjects));
+      if (maintainerProjects.length > 0) groups.push(toGroup('Maintainer', maintainerProjects));
+      if (contributorProjects.length > 0) groups.push(toGroup('Contributor', contributorProjects));
 
       return groups;
     });
@@ -388,5 +385,10 @@ export class MultiPersonaDashboardComponent {
       }
     }
     return count;
+  }
+
+  private formatNameList(names: string[]): string {
+    if (names.length <= 1) return names[0] || '';
+    return names.slice(0, -1).join(', ') + ' and ' + names[names.length - 1];
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.html
@@ -4,7 +4,7 @@
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="user-dashboard-container">
   <!-- Page Header -->
   <div class="mb-6" data-testid="user-dashboard-header">
-    <h1>My Dashboard</h1>
+    <h1 class="font-display font-light text-2xl">My Dashboard</h1>
     <p class="mt-1 text-sm text-gray-500">{{ subtitleText() }}</p>
   </div>
 

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -67,6 +67,7 @@ import {
   BrandReachResponse,
   BrandHealthResponse,
   RevenueImpactResponse,
+  MultiFoundationSummaryResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
 
@@ -1248,5 +1249,25 @@ export class AnalyticsService {
         })
       )
     );
+  }
+
+  /**
+   * Get aggregated analytics across multiple foundations
+   * @param slugs - Array of foundation slugs
+   * @returns Observable of multi-foundation summary response
+   */
+  public getMultiFoundationSummary(slugs: string[]): Observable<MultiFoundationSummaryResponse> {
+    return this.http
+      .get<MultiFoundationSummaryResponse>('/api/analytics/multi-foundation-summary', {
+        params: { slugs: slugs.join(',') },
+      })
+      .pipe(
+        catchError(() => {
+          return of({
+            aggregated: { totalValue: 0, totalProjects: 0, totalMembers: 0 },
+            perFoundation: {},
+          });
+        })
+      );
   }
 }

--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -56,7 +56,7 @@ export class PersonaService {
   /** Whether the user holds any project-scoped persona (maintainer, contributor) */
   public readonly hasProjectRole: Signal<boolean>;
 
-  /** Whether persona data has been loaded from the API (or cookie had full data) */
+  /** Whether persona data has been loaded from the API after hydration */
   public readonly personaLoaded: WritableSignal<boolean>;
 
   public constructor() {

--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -56,6 +56,9 @@ export class PersonaService {
   /** Whether the user holds any project-scoped persona (maintainer, contributor) */
   public readonly hasProjectRole: Signal<boolean>;
 
+  /** Whether persona data has been loaded from the API (or cookie had full data) */
+  public readonly personaLoaded: WritableSignal<boolean>;
+
   public constructor() {
     const stored = this.loadFromCookie();
     this.currentPersona = signal<PersonaType>(stored?.primary ?? 'contributor');
@@ -67,6 +70,10 @@ export class PersonaService {
     this.isBoardScoped = computed(() => isBoardScopedPersona(this.currentPersona()));
     this.hasBoardRole = this.initHasBoardRole();
     this.hasProjectRole = this.initHasProjectRole();
+    // Always start as not loaded — SSR renders the loading skeleton, browser hydrates it,
+    // then the API response sets this to true and renders the correct dashboard.
+    // This avoids the flash of stale cookie data (contributor) before the real persona loads.
+    this.personaLoaded = signal(false);
 
     // Always refresh persona data from API after hydration (browser only).
     // Cookie provides initial SSR values; the API is the primary source of truth
@@ -119,6 +126,7 @@ export class PersonaService {
             currentPersona: this.currentPersona(),
             allPersonas: this.allPersonas(),
           });
+          this.personaLoaded.set(true);
           return;
         }
 
@@ -150,6 +158,8 @@ export class PersonaService {
           }
           this.accountContextService.initializeUserOrganizations(response.organizations);
         }
+
+        this.personaLoaded.set(true);
       });
   }
 

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2539,4 +2539,62 @@ export class AnalyticsController {
       return next(error);
     }
   }
+
+  /**
+   * GET /api/analytics/multi-foundation-summary
+   * Aggregate analytics across multiple foundations in a single request
+   * Query params: slugs (required, comma-separated foundation slugs, max 10)
+   */
+  public async getMultiFoundationSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_multi_foundation_summary');
+
+    try {
+      const slugsParam = getStringQueryParam(req, 'slugs');
+
+      if (!slugsParam) {
+        throw ServiceValidationError.forField('slugs', 'slugs query parameter is required', {
+          operation: 'get_multi_foundation_summary',
+        });
+      }
+
+      const slugs = slugsParam
+        .split(',')
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+      if (slugs.length === 0) {
+        throw ServiceValidationError.forField('slugs', 'At least one foundation slug is required', {
+          operation: 'get_multi_foundation_summary',
+        });
+      }
+
+      if (slugs.length > 10) {
+        throw ServiceValidationError.forField('slugs', 'Maximum of 10 foundation slugs allowed per request', {
+          operation: 'get_multi_foundation_summary',
+        });
+      }
+
+      // Validate each slug format
+      for (const slug of slugs) {
+        if (!SLUG_PATTERN.test(slug) || slug.length > NAME_MAX_LENGTH) {
+          throw ServiceValidationError.forField('slugs', `Invalid foundation slug format: ${slug}`, {
+            operation: 'get_multi_foundation_summary',
+          });
+        }
+      }
+
+      const response = await this.projectService.getMultiFoundationSummary(req, slugs);
+
+      logger.success(req, 'get_multi_foundation_summary', startTime, {
+        slug_count: slugs.length,
+        foundations_returned: Object.keys(response.perFoundation).length,
+        aggregated_projects: response.aggregated.totalProjects,
+        aggregated_members: response.aggregated.totalMembers,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
 }

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2549,39 +2549,7 @@ export class AnalyticsController {
     const startTime = logger.startOperation(req, 'get_multi_foundation_summary');
 
     try {
-      const slugsParam = getStringQueryParam(req, 'slugs');
-
-      if (!slugsParam) {
-        throw ServiceValidationError.forField('slugs', 'slugs query parameter is required', {
-          operation: 'get_multi_foundation_summary',
-        });
-      }
-
-      const slugs = slugsParam
-        .split(',')
-        .map((s) => s.trim())
-        .filter((s) => s.length > 0);
-
-      if (slugs.length === 0) {
-        throw ServiceValidationError.forField('slugs', 'At least one foundation slug is required', {
-          operation: 'get_multi_foundation_summary',
-        });
-      }
-
-      if (slugs.length > 10) {
-        throw ServiceValidationError.forField('slugs', 'Maximum of 10 foundation slugs allowed per request', {
-          operation: 'get_multi_foundation_summary',
-        });
-      }
-
-      // Validate each slug format
-      for (const slug of slugs) {
-        if (!SLUG_PATTERN.test(slug) || slug.length > NAME_MAX_LENGTH) {
-          throw ServiceValidationError.forField('slugs', `Invalid foundation slug format: ${slug}`, {
-            operation: 'get_multi_foundation_summary',
-          });
-        }
-      }
+      const slugs = this.parseAndValidateSlugs(req);
 
       const response = await this.projectService.getMultiFoundationSummary(req, slugs);
 
@@ -2596,5 +2564,46 @@ export class AnalyticsController {
     } catch (error) {
       return next(error);
     }
+  }
+
+  /**
+   * Parse and validate a comma-separated slugs query parameter.
+   * @throws ServiceValidationError if the parameter is missing, empty, exceeds max count, or has invalid format
+   */
+  private parseAndValidateSlugs(req: Request, maxCount: number = 10): string[] {
+    const slugsParam = getStringQueryParam(req, 'slugs');
+
+    if (!slugsParam) {
+      throw ServiceValidationError.forField('slugs', 'slugs query parameter is required', {
+        operation: 'get_multi_foundation_summary',
+      });
+    }
+
+    const slugs = slugsParam
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+
+    if (slugs.length === 0) {
+      throw ServiceValidationError.forField('slugs', 'At least one foundation slug is required', {
+        operation: 'get_multi_foundation_summary',
+      });
+    }
+
+    if (slugs.length > maxCount) {
+      throw ServiceValidationError.forField('slugs', `Maximum of ${maxCount} foundation slugs allowed per request`, {
+        operation: 'get_multi_foundation_summary',
+      });
+    }
+
+    for (const slug of slugs) {
+      if (!SLUG_PATTERN.test(slug) || slug.length > NAME_MAX_LENGTH) {
+        throw ServiceValidationError.forField('slugs', `Invalid foundation slug format: ${slug}`, {
+          operation: 'get_multi_foundation_summary',
+        });
+      }
+    }
+
+    return slugs;
   }
 }

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2579,10 +2579,14 @@ export class AnalyticsController {
       });
     }
 
-    const slugs = slugsParam
-      .split(',')
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0);
+    const slugs = [
+      ...new Set(
+        slugsParam
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      ),
+    ];
 
     if (slugs.length === 0) {
       throw ServiceValidationError.forField('slugs', 'At least one foundation slug is required', {

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -176,4 +176,7 @@ router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach
 router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
 router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));
 
+// Multi-foundation summary endpoint (multi-foundation dashboard)
+router.get('/multi-foundation-summary', (req, res, next) => analyticsController.getMultiFoundationSummary(req, res, next));
+
 export default router;

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -404,7 +404,7 @@ export class PersonaDetectionService {
 
       if (detection.source === 'cdp_roles' && detection.extra) {
         const roles = detection.extra['roles'] as { role: string }[] | undefined;
-        if (roles?.some((r) => r.role === 'Maintainer')) {
+        if (roles?.some((r) => r.role.toLowerCase() === 'maintainer')) {
           personas.add('maintainer');
           continue;
         }
@@ -415,6 +415,13 @@ export class PersonaDetectionService {
 
     if (personas.size === 0) {
       personas.add('contributor');
+    }
+
+    // Contributor is implied by any specific role — if a project already has
+    // board-member, executive-director, or maintainer, drop contributor so the
+    // project only appears under the more specific persona(s).
+    if (personas.size > 1 && personas.has('contributor')) {
+      personas.delete('contributor');
     }
 
     return Array.from(personas);

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -404,7 +404,7 @@ export class PersonaDetectionService {
 
       if (detection.source === 'cdp_roles' && detection.extra) {
         const roles = detection.extra['roles'] as { role: string }[] | undefined;
-        if (roles?.some((r) => r.role.toLowerCase() === 'maintainer')) {
+        if (roles?.some((r) => typeof r.role === 'string' && r.role.toLowerCase() === 'maintainer')) {
           personas.add('maintainer');
           continue;
         }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -4261,7 +4261,7 @@ export class ProjectService {
       rejected: results.filter((r) => r.status === 'rejected').length,
     });
 
-    for (const result of results) {
+    results.forEach((result, i) => {
       if (result.status === 'fulfilled') {
         const { slug, totalProjects, totalMembers, totalValue, healthScores } = result.value;
         perFoundation[slug] = { totalProjects, totalMembers, totalValue, healthScores };
@@ -4270,10 +4270,11 @@ export class ProjectService {
         aggregated.totalValue += totalValue;
       } else {
         logger.warning(req, 'get_multi_foundation_summary', 'Failed to fetch analytics for a foundation', {
+          slug: slugs[i],
           error: result.reason instanceof Error ? result.reason.message : String(result.reason),
         });
       }
-    }
+    });
 
     logger.debug(req, 'get_multi_foundation_summary', 'Completed multi-foundation summary', {
       total_slugs: slugs.length,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -87,6 +87,8 @@ import {
   BrandHealthResponse,
   BrandHealthTopProject,
   RevenueImpactResponse,
+  MultiFoundationSummaryResponse,
+  PerFoundationAnalytics,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -4194,9 +4196,7 @@ export class ProjectService {
 
     for (let i = 0; i < projectUids.length; i += batchSize) {
       const batch = projectUids.slice(i, i + batchSize);
-      const results = await Promise.all(
-        batch.map(async (uid) => this.getProjectById(req, uid, false).catch(() => null))
-      );
+      const results = await Promise.all(batch.map(async (uid) => this.getProjectById(req, uid, false).catch(() => null)));
       projects.push(...results);
     }
 
@@ -4219,6 +4219,72 @@ export class ProjectService {
     });
   }
 
+  /**
+   * Get aggregated analytics across multiple foundations in a single request
+   * Fetches total projects, total members, value concentration, and health score
+   * distribution for each slug in parallel, then aggregates.
+   * Individual foundation failures are handled gracefully — they are logged and skipped.
+   * @param req - Express request for logger correlation
+   * @param slugs - Array of foundation slugs (e.g., ['cncf', 'tlf', 'lf-energy'])
+   * @returns Aggregated totals and per-foundation breakdown
+   */
+  public async getMultiFoundationSummary(req: Request, slugs: string[]): Promise<MultiFoundationSummaryResponse> {
+    logger.debug(req, 'get_multi_foundation_summary', 'Fetching analytics for multiple foundations', {
+      slug_count: slugs.length,
+      slugs,
+    });
+
+    const perFoundation: Record<string, PerFoundationAnalytics> = {};
+    const aggregated = { totalValue: 0, totalProjects: 0, totalMembers: 0 };
+
+    const results = await Promise.allSettled(
+      slugs.map(async (slug) => {
+        const [totalProjectsData, totalMembersData, valueConcentrationData, healthScoreData] = await Promise.all([
+          this.getFoundationTotalProjects(slug),
+          this.getFoundationTotalMembers(slug),
+          this.getFoundationValueConcentration(slug),
+          this.getFoundationHealthScoreDistribution(slug),
+        ]);
+
+        return {
+          slug,
+          totalProjects: totalProjectsData.totalProjects,
+          totalMembers: totalMembersData.totalMembers,
+          totalValue: valueConcentrationData.totalValue,
+          healthScores: healthScoreData,
+        };
+      })
+    );
+
+    logger.debug(req, 'get_multi_foundation_summary', 'All foundation queries resolved', {
+      fulfilled: results.filter((r) => r.status === 'fulfilled').length,
+      rejected: results.filter((r) => r.status === 'rejected').length,
+    });
+
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        const { slug, totalProjects, totalMembers, totalValue, healthScores } = result.value;
+        perFoundation[slug] = { totalProjects, totalMembers, totalValue, healthScores };
+        aggregated.totalProjects += totalProjects;
+        aggregated.totalMembers += totalMembers;
+        aggregated.totalValue += totalValue;
+      } else {
+        logger.warning(req, 'get_multi_foundation_summary', 'Failed to fetch analytics for a foundation', {
+          error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        });
+      }
+    }
+
+    logger.debug(req, 'get_multi_foundation_summary', 'Completed multi-foundation summary', {
+      total_slugs: slugs.length,
+      successful: Object.keys(perFoundation).length,
+      aggregated_projects: aggregated.totalProjects,
+      aggregated_members: aggregated.totalMembers,
+    });
+
+    return { aggregated, perFoundation };
+  }
+
   private getRangeSuffix(range: string, convention: string = 'standard'): string {
     const map = ProjectService.rangeSuffixMap[convention];
     return map?.[range] ?? map?.['YTD'] ?? '_ytd';
@@ -4230,5 +4296,4 @@ export class ProjectService {
     const lastUnderscore = full.lastIndexOf('_');
     return { prefix: full.substring(0, lastUnderscore + 1), suffix: full.substring(lastUnderscore + 1) };
   }
-
 }

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -122,3 +122,6 @@ export * from './impersonation.interface';
 
 // Health Metrics interfaces
 export * from './health-metrics.interface';
+
+// Multi-persona dashboard interfaces
+export * from './multi-persona-dashboard.interface';

--- a/packages/shared/src/interfaces/multi-persona-dashboard.interface.ts
+++ b/packages/shared/src/interfaces/multi-persona-dashboard.interface.ts
@@ -11,7 +11,7 @@ export interface PersonaProjectRow {
   logoUrl: string | null;
   /** Whether this row represents a foundation or a sub-project */
   type: 'foundation' | 'project';
-  /** Descriptive subtitle: "N projects · N members" for foundations, "ParentName · N contributors" for projects */
+  /** Descriptive subtitle: "N projects · N members" for foundations, parent foundation name for projects */
   subtitle: string;
   /** Highest-priority role from detections: "Board Member", "Maintainer", "Chair", etc. */
   role: string;
@@ -36,6 +36,8 @@ export interface DashboardSummaryPills {
 export interface RoleGroup {
   label: string;
   names: string[];
+  /** Pre-formatted name list for display (e.g. "CNCF, TLF and OpenSSF") */
+  formattedNames: string;
 }
 
 /** Typed shape of the board_member detection extra payload from persona service */

--- a/packages/shared/src/interfaces/multi-persona-dashboard.interface.ts
+++ b/packages/shared/src/interfaces/multi-persona-dashboard.interface.ts
@@ -1,0 +1,85 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Row in the "My Foundations and Projects" table */
+export interface PersonaProjectRow {
+  projectUid: string;
+  projectSlug: string;
+  projectName: string;
+  logoUrl: string | null;
+  /** Whether this row represents a foundation or a sub-project */
+  type: 'foundation' | 'project';
+  /** Descriptive subtitle: "N projects · N members" for foundations, "ParentName · N contributors" for projects */
+  subtitle: string;
+  /** Highest-priority role from detections: "Board Member", "Maintainer", "Chair", etc. */
+  role: string;
+  /** Health status for foundations (null for projects) */
+  healthStatus: 'on-track' | 'watch' | 'needs-attention' | null;
+  /** Health detail text for foundations (null for projects) */
+  healthDetail: string | null;
+  /** Voting status from board_member detections, null if not applicable */
+  votingStatus: string | null;
+}
+
+/** Aggregated health summary across user foundations */
+export interface FoundationHealthSummaryData {
+  totalValue: number;
+  totalProjects: number;
+  totalMembers: number;
+  metricsTracked: number;
+}
+
+/** Summary pills data */
+export interface DashboardSummaryPills {
+  foundationCount: number;
+  projectCount: number;
+  openSurveys: number;
+  meetingsThisWeek: number;
+  itemsNeedReview: number;
+}
+
+/** Typed shape of the board_member detection extra payload from persona service */
+export interface BoardMemberDetectionExtra {
+  committee_uid: string;
+  committee_name: string;
+  committee_member_uid: string;
+  role: string;
+  voting_status: string;
+  organization: {
+    id: string;
+    name: string;
+    website?: string;
+  };
+}
+
+/** Typed shape of the committee_member detection extra payload from persona service */
+export interface CommitteeMemberDetectionExtra {
+  committee_uid: string;
+  committee_name: string;
+  committee_member_uid: string;
+  role: string;
+}
+
+/** Per-foundation analytics data returned by multi-foundation summary endpoint */
+export interface PerFoundationAnalytics {
+  totalProjects: number;
+  totalMembers: number;
+  totalValue: number;
+  healthScores: {
+    excellent: number;
+    healthy: number;
+    stable: number;
+    unsteady: number;
+    critical: number;
+  };
+}
+
+/** Response from GET /api/analytics/multi-foundation-summary */
+export interface MultiFoundationSummaryResponse {
+  aggregated: {
+    totalValue: number;
+    totalProjects: number;
+    totalMembers: number;
+  };
+  perFoundation: Record<string, PerFoundationAnalytics>;
+}

--- a/packages/shared/src/interfaces/multi-persona-dashboard.interface.ts
+++ b/packages/shared/src/interfaces/multi-persona-dashboard.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { FoundationHealthScoreDistributionResponse } from './analytics-data.interface';
+
 /** Row in the "My Foundations and Projects" table */
 export interface PersonaProjectRow {
   projectUid: string;
@@ -21,14 +23,6 @@ export interface PersonaProjectRow {
   votingStatus: string | null;
 }
 
-/** Aggregated health summary across user foundations */
-export interface FoundationHealthSummaryData {
-  totalValue: number;
-  totalProjects: number;
-  totalMembers: number;
-  metricsTracked: number;
-}
-
 /** Summary pills data */
 export interface DashboardSummaryPills {
   foundationCount: number;
@@ -36,6 +30,12 @@ export interface DashboardSummaryPills {
   openSurveys: number;
   meetingsThisWeek: number;
   itemsNeedReview: number;
+}
+
+/** Role group for dashboard role summary display */
+export interface RoleGroup {
+  label: string;
+  names: string[];
 }
 
 /** Typed shape of the board_member detection extra payload from persona service */
@@ -65,13 +65,7 @@ export interface PerFoundationAnalytics {
   totalProjects: number;
   totalMembers: number;
   totalValue: number;
-  healthScores: {
-    excellent: number;
-    healthy: number;
-    stable: number;
-    unsteady: number;
-    critical: number;
-  };
+  healthScores: FoundationHealthScoreDistributionResponse;
 }
 
 /** Response from GET /api/analytics/multi-foundation-summary */


### PR DESCRIPTION
## Summary
- Add multi-persona dashboard for users with roles across multiple foundations, showing a consolidated view of projects, roles, health status, and pending actions
- Fix persona detection: case-insensitive maintainer role matching (`'maintainer'` vs `'Maintainer'`) — no users were being detected as maintainers via CDP roles
- Deduplicate contributor persona when a more specific role exists (board-member, executive-director, maintainer) on the same project
- Add multi-foundation summary analytics endpoint (`GET /api/analytics/multi-foundation-summary`)
- Standardize dashboard header font styling (`font-display font-light text-2xl`) across My Dashboard, My Meetings, and My Groups
- Fix project name list comma spacing in role groups display
- Use typed `BoardMemberDetectionExtra` and `CommitteeMemberDetectionExtra` interfaces for detection extra casts
- Add intermediate debug logging in `getMultiFoundationSummary` after `Promise.allSettled`

Generated with [Claude Code](https://claude.ai/code)