### PR TITLE
fix(dashboards): prioritize ed persona over board-member

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -321,9 +321,7 @@ export class CommitteeDashboardComponent {
           seen.set(item.project_uid, item.project_name || item.project_uid);
         }
       }
-      const options = [...seen.entries()]
-        .map(([uid, name]) => ({ label: name, value: uid }))
-        .sort((a, b) => a.label.localeCompare(b.label));
+      const options = [...seen.entries()].map(([uid, name]) => ({ label: name, value: uid })).sort((a, b) => a.label.localeCompare(b.label));
       return [{ label: 'All Foundations', value: null }, ...options];
     });
   }
@@ -341,9 +339,7 @@ export class CommitteeDashboardComponent {
           seen.set(item.project_uid, item.project_name || item.project_uid);
         }
       }
-      const options = [...seen.entries()]
-        .map(([uid, name]) => ({ label: name, value: uid }))
-        .sort((a, b) => a.label.localeCompare(b.label));
+      const options = [...seen.entries()].map(([uid, name]) => ({ label: name, value: uid })).sort((a, b) => a.label.localeCompare(b.label));
       return [{ label: 'All Projects', value: null }, ...options];
     });
   }

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -349,9 +349,7 @@ export class MailingListDashboardComponent {
           seen.set(item.project_uid, item.project_name || item.project_uid);
         }
       }
-      const options = [...seen.entries()]
-        .map(([uid, name]) => ({ label: name, value: uid }))
-        .sort((a, b) => a.label.localeCompare(b.label));
+      const options = [...seen.entries()].map(([uid, name]) => ({ label: name, value: uid })).sort((a, b) => a.label.localeCompare(b.label));
       return [{ label: 'All Foundations', value: null }, ...options];
     });
   }
@@ -369,9 +367,7 @@ export class MailingListDashboardComponent {
           seen.set(item.project_uid, item.project_name || item.project_uid);
         }
       }
-      const options = [...seen.entries()]
-        .map(([uid, name]) => ({ label: name, value: uid }))
-        .sort((a, b) => a.label.localeCompare(b.label));
+      const options = [...seen.entries()].map(([uid, name]) => ({ label: name, value: uid })).sort((a, b) => a.label.localeCompare(b.label));
       return [{ label: 'All Projects', value: null }, ...options];
     });
   }

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -480,9 +480,7 @@ export class MeetingsDashboardComponent {
         }
       }
 
-      const options = [...seen.entries()]
-        .map(([uid, name]) => ({ label: name, value: uid }))
-        .sort((a, b) => a.label.localeCompare(b.label));
+      const options = [...seen.entries()].map(([uid, name]) => ({ label: name, value: uid })).sort((a, b) => a.label.localeCompare(b.label));
 
       return [{ label: 'All Foundations', value: null }, ...options];
     });
@@ -504,9 +502,7 @@ export class MeetingsDashboardComponent {
         }
       }
 
-      const options = [...seen.entries()]
-        .map(([uid, name]) => ({ label: name, value: uid }))
-        .sort((a, b) => a.label.localeCompare(b.label));
+      const options = [...seen.entries()].map(([uid, name]) => ({ label: name, value: uid })).sort((a, b) => a.label.localeCompare(b.label));
 
       return [{ label: 'All Projects', value: null }, ...options];
     });

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
@@ -169,9 +169,7 @@ export class SurveysDashboardComponent {
           seen.set(item.project_uid, item.project_name || item.project_uid);
         }
       }
-      const options = [...seen.entries()]
-        .map(([uid, name]) => ({ label: name, value: uid }))
-        .sort((a, b) => a.label.localeCompare(b.label));
+      const options = [...seen.entries()].map(([uid, name]) => ({ label: name, value: uid })).sort((a, b) => a.label.localeCompare(b.label));
       return [{ label: 'All Foundations', value: null }, ...options];
     });
   }
@@ -187,9 +185,7 @@ export class SurveysDashboardComponent {
           seen.set(item.project_uid, item.project_name || item.project_uid);
         }
       }
-      const options = [...seen.entries()]
-        .map(([uid, name]) => ({ label: name, value: uid }))
-        .sort((a, b) => a.label.localeCompare(b.label));
+      const options = [...seen.entries()].map(([uid, name]) => ({ label: name, value: uid })).sort((a, b) => a.label.localeCompare(b.label));
       return [{ label: 'All Projects', value: null }, ...options];
     });
   }

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -58,12 +58,7 @@
       </div>
 
       <div class="w-full sm:w-auto sm:shrink-0">
-        <lfx-select
-          [form]="searchForm"
-          control="status"
-          size="small"
-          [options]="statusOptions()"
-          data-testid="votes-status-filter"></lfx-select>
+        <lfx-select [form]="searchForm" control="status" size="small" [options]="statusOptions()" data-testid="votes-status-filter"></lfx-select>
       </div>
 
       <ng-content select="[tableActions]"></ng-content>

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -288,9 +288,7 @@ export class VotesDashboardComponent {
           seen.set(item.project_uid, item.project_name || item.project_uid);
         }
       }
-      const options = [...seen.entries()]
-        .map(([uid, name]) => ({ label: name, value: uid }))
-        .sort((a, b) => a.label.localeCompare(b.label));
+      const options = [...seen.entries()].map(([uid, name]) => ({ label: name, value: uid })).sort((a, b) => a.label.localeCompare(b.label));
       return [{ label: 'All Foundations', value: null }, ...options];
     });
   }
@@ -306,9 +304,7 @@ export class VotesDashboardComponent {
           seen.set(item.project_uid, item.project_name || item.project_uid);
         }
       }
-      const options = [...seen.entries()]
-        .map(([uid, name]) => ({ label: name, value: uid }))
-        .sort((a, b) => a.label.localeCompare(b.label));
+      const options = [...seen.entries()].map(([uid, name]) => ({ label: name, value: uid })).sort((a, b) => a.label.localeCompare(b.label));
       return [{ label: 'All Projects', value: null }, ...options];
     });
   }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1199,5 +1199,4 @@ export class MeetingService {
 
     return nameMap;
   }
-
 }

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -26,7 +26,7 @@ const DETECTION_SOURCE_MAP: Record<string, PersonaType> = {
 };
 
 /** Persona priority order (highest first) for sorting */
-const PERSONA_PRIORITY: PersonaType[] = ['board-member', 'executive-director', 'maintainer', 'contributor'];
+const PERSONA_PRIORITY: PersonaType[] = ['executive-director', 'board-member', 'maintainer', 'contributor'];
 
 /** TTL for the affiliated-project-UIDs cache, in milliseconds */
 const AFFILIATED_PROJECT_UIDS_CACHE_TTL_MS = 15_000;

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1032,5 +1032,4 @@ export class UserService {
       };
     }
   }
-
 }

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -1,14 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import {
-  CreateVoteRequest,
-  QueryServiceCountResponse,
-  QueryServiceResponse,
-  UpdateVoteRequest,
-  Vote,
-  VoteResultsResponse,
-} from '@lfx-one/shared/interfaces';
+import { CreateVoteRequest, QueryServiceCountResponse, QueryServiceResponse, UpdateVoteRequest, Vote, VoteResultsResponse } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';


### PR DESCRIPTION
## Summary
- Swaps persona priority so `executive-director` ranks above `board-member` in `PERSONA_PRIORITY`
- Fixes users with both ED and board-member detections (e.g. `jzemlin`) seeing the board-member dashboard instead of the ED dashboard
- Includes formatting fixes from `yarn format`

## Context
Users detected as both `executive-director` and `board-member` by NATS were getting the board-member dashboard because `board-member` was ranked first in the priority array. Since ED is a superset of board-member, it should take precedence.

LFXV2-1468

## Test plan
- [ ] Impersonate `jzemlin@linuxfoundation.org` → should now show Executive Director Overview instead of Foundation Health
- [ ] Impersonate `mdxit@linuxfoundation.org` → should continue showing Executive Director Overview (no change)
- [ ] Impersonate a board-member-only user → should still show board-member dashboard

🤖 Generated with [Claude Code](https://claude.ai/code)