### PR TITLE
fix(dashboards): remove projects from persona cookie

### DIFF
--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -66,7 +66,7 @@ export class PersonaService {
     this.multiProject = signal<boolean>(stored?.multiProject ?? false);
     this.multiFoundation = signal<boolean>(stored?.multiFoundation ?? false);
     this.personaProjects = signal<Partial<Record<PersonaType, PersonaProject[]>>>({});
-    this.detectedProjects = signal<EnrichedPersonaProject[]>(stored?.projects ?? []);
+    this.detectedProjects = signal<EnrichedPersonaProject[]>([]);
     this.isBoardScoped = computed(() => isBoardScopedPersona(this.currentPersona()));
     this.hasBoardRole = this.initHasBoardRole();
     this.hasProjectRole = this.initHasProjectRole();
@@ -106,7 +106,7 @@ export class PersonaService {
     if (organizations !== undefined) {
       this.lastKnownOrganizations.set(organizations);
     }
-    this.persistToCookie({ primary, all, multiProject, multiFoundation, organizations: this.lastKnownOrganizations(), projects: this.detectedProjects() });
+    this.persistToCookie({ primary, all, multiProject, multiFoundation, organizations: this.lastKnownOrganizations() });
   }
 
   /**
@@ -147,7 +147,6 @@ export class PersonaService {
             multiProject: this.multiProject(),
             multiFoundation: this.multiFoundation(),
             organizations: response.organizations,
-            projects: this.detectedProjects(),
           });
         }
 

--- a/apps/lfx-one/src/server/utils/persona-helper.ts
+++ b/apps/lfx-one/src/server/utils/persona-helper.ts
@@ -80,6 +80,7 @@ async function resolveFromNats(req: Request, res: Response): Promise<SsrPersonaR
         multiProject: personaResult.multiProject,
         multiFoundation: personaResult.multiFoundation,
         organizations,
+        projects: personaResult.projects,
       };
       res.cookie(PERSONA_COOKIE_KEY, JSON.stringify(cookieState), {
         maxAge: 30 * 24 * 60 * 60 * 1000,

--- a/apps/lfx-one/src/server/utils/persona-helper.ts
+++ b/apps/lfx-one/src/server/utils/persona-helper.ts
@@ -80,7 +80,6 @@ async function resolveFromNats(req: Request, res: Response): Promise<SsrPersonaR
         multiProject: personaResult.multiProject,
         multiFoundation: personaResult.multiFoundation,
         organizations,
-        projects: personaResult.projects,
       };
       res.cookie(PERSONA_COOKIE_KEY, JSON.stringify(cookieState), {
         maxAge: 30 * 24 * 60 * 60 * 1000,

--- a/packages/shared/src/interfaces/persona.interface.ts
+++ b/packages/shared/src/interfaces/persona.interface.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 import type { Account } from './account.interface';
-import type { EnrichedPersonaProject } from './persona-detection.interface';
 
 /**
  * Available persona types for UI customization
@@ -44,8 +43,6 @@ export interface PersistedPersonaState {
   multiFoundation?: boolean;
   /** User's organizations from board member detections */
   organizations?: Account[];
-  /** Enriched projects from persona detection — fallback when API is unavailable */
-  projects?: EnrichedPersonaProject[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Removes `projects` from `PersistedPersonaState` and drops it from both the SSR cookie write (`persona-helper.ts`) and the two client-side `persistToCookie` call sites (`persona.service.ts`)
- Prevents the persona cookie from carrying full `EnrichedPersonaProject` payloads (descriptions, detections, logo URLs), which can exceed the 4KB browser limit and cause the browser to silently drop the cookie

## Context
This branch originally added `projects` to the SSR cookie so impersonation timeouts on `/api/user/personas` wouldn't leave `detectedProjects` empty. Review surfaced that the cookie is the wrong container — the frontend had already been writing full projects to it since PR #451, and extending that to SSR would bloat the cookie for every first-time visitor.

Rather than grow the bloat, this PR removes `projects` from the cookie end-to-end. `detectedProjects` is now initialized to `[]` at construction and populated only from the `/api/user/personas` response after hydration.

## Follow-up
The original impersonation-timeout bug still needs a non-cookie fix. Angular `TransferState` is the canonical SSR one-shot handoff pattern — tracked separately under LFXV2-1468.