### PR TITLE
fix(ui): keep foundation/project selector popovers fixed on page scroll

### DIFF
--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.scss
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.scss
@@ -19,7 +19,12 @@
     @apply p-0;
   }
 
-  // Fixed positioning so the panel stays in place when the page scrolls
+  // Fixed positioning so the panel stays in place when the page scrolls.
+  // `@apply !fixed` is not usable here: Dart Sass compiles SCSS before PostCSS/Tailwind,
+  // so the `!` modifier causes a parse error. `!important` is also load-bearing —
+  // PrimeNG's absolutePosition() sets `position: absolute` as an inline style via JS;
+  // without !important the inline style takes precedence and the fix has no effect.
+  // stylelint-disable-next-line declaration-no-important
   position: fixed !important;
 
   // Force position to the right of the avatar (override absolutePosition)

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.scss
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.scss
@@ -19,6 +19,9 @@
     @apply p-0;
   }
 
+  // Fixed positioning so the panel stays in place when the page scrolls
+  position: fixed !important;
+
   // Force position to the right of the avatar (override absolutePosition)
   left: 72px !important;
   bottom: 16px !important;

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.scss
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.scss
@@ -19,6 +19,9 @@
     display: none !important;
   }
 
+  // Fixed positioning so the panel stays in place when the page scrolls
+  position: fixed !important;
+
   // Force horizontal position to the right of the full sidebar (64px lens + 280px nav = 344px)
   left: 344px !important;
 

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.scss
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.scss
@@ -19,17 +19,26 @@
     display: none !important;
   }
 
-  // Fixed positioning so the panel stays in place when the page scrolls
-  position: fixed !important;
+  // Desktop only — on mobile the sidebar is a drawer with a different layout;
+  // scoping to lg+ avoids anchoring the panel off-screen on narrow viewports
+  @media (min-width: 1024px) {
+    // Fixed positioning so the panel stays in place when the page scrolls.
+    // `@apply !fixed` is not usable here: Dart Sass compiles SCSS before PostCSS/Tailwind,
+    // so the `!` modifier causes a parse error. `!important` is also load-bearing —
+    // PrimeNG's absolutePosition() sets `position: absolute` as an inline style via JS;
+    // without !important the inline style takes precedence and the fix has no effect.
+    // stylelint-disable-next-line declaration-no-important
+    position: fixed !important;
 
-  // Force horizontal position to the right of the full sidebar (64px lens + 280px nav = 344px)
-  left: 344px !important;
+    // Force horizontal position to the right of the full sidebar (64px lens + 280px nav = 344px)
+    left: 344px !important;
 
-  // Align popover top with the trigger top (sidebar top + py-4 padding = 16px)
-  top: 4px !important;
+    // Align popover top with the trigger top (sidebar top + py-4 padding = 16px)
+    top: 4px !important;
 
-  // When dev toolbar is visible, offset by its height (48px)
-  &.project-selector-panel--with-toolbar {
-    top: 52px !important; // 48px toolbar + 4px
+    // When dev toolbar is visible, offset by its height (48px)
+    &.project-selector-panel--with-toolbar {
+      top: 52px !important; // 48px toolbar + 4px
+    }
   }
 }

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.scss
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.scss
@@ -33,7 +33,7 @@
     // Force horizontal position to the right of the full sidebar (64px lens + 280px nav = 344px)
     left: 344px !important;
 
-    // Align popover top with the trigger top (sidebar top + py-4 padding = 16px)
+    // Pin the popover 4px from the top of the viewport
     top: 4px !important;
 
     // When dev toolbar is visible, offset by its height (48px)


### PR DESCRIPTION
## What
When the foundation or project selector dropdown is open and the user scrolls the page behind the backdrop, the PrimeNG `p-popover` panel was moving with the scroll and disappearing off screen.

## How
Override `position` to `fixed` on the popover panels via `::ng-deep` SCSS for both:
- `.project-selector-panel.p-popover` — pinned at `left: 344px` (64px lens rail + 280px sidebar), `top: 4px`
- `.user-menu-popover.p-popover` — pinned at `left: 72px`, `bottom: 16px`

PrimeNG's `absolutePosition()` sets `position: absolute` after each open; the `!important` override keeps the panel viewport-anchored regardless.

## Checklist
- [x] Verified fix: opened dropdown, scrolled underlying page, panel stays in place
- [x] License headers present
- [x] No test changes required (pure CSS fix)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)