### PR TITLE
feat(transactions): add my transactions page

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -83,6 +83,10 @@ export const routes: Routes = [
         loadChildren: () => import('./modules/trainings/trainings.routes').then((m) => m.TRAINING_ROUTES),
       },
       {
+        path: 'me/transactions',
+        loadChildren: () => import('./modules/transactions/transactions.routes').then((m) => m.TRANSACTION_ROUTES),
+      },
+      {
         path: 'events',
         loadChildren: () => import('./modules/events/events.routes').then((m) => m.EVENTS_ROUTES),
       },

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
@@ -1,0 +1,146 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="transactions-dashboard">
+  <!-- Page Header -->
+  <div class="mt-3 mb-6">
+    <h1 class="font-display font-light text-2xl" data-testid="transactions-title">My Transactions</h1>
+    <p class="mt-1 text-sm text-gray-500" data-testid="transactions-subtitle">{{ subtitle }}</p>
+  </div>
+
+  <!-- Tab switcher -->
+  <div class="mb-6" data-testid="transactions-tabs">
+    <lfx-filter-pills [options]="tabOptions" [selectedFilter]="activeTab()" (filterChange)="onTabChange($event)" />
+  </div>
+
+  <!-- Loading state -->
+  @if (transactions() === undefined) {
+    <div data-testid="transactions-loading">
+      <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden animate-pulse">
+        <div class="grid grid-cols-5 gap-4 px-4 py-3 border-b border-gray-100">
+          @for (i of [1, 2, 3, 4, 5]; track i) {
+            <div class="h-3 bg-gray-200 rounded"></div>
+          }
+        </div>
+        @for (i of [1, 2, 3, 4, 5]; track i) {
+          <div class="grid grid-cols-5 gap-4 px-4 py-4 border-b border-gray-100 last:border-0">
+            <div class="h-3 bg-gray-100 rounded w-3/4"></div>
+            <div class="h-3 bg-gray-100 rounded w-2/3"></div>
+            <div class="h-3 bg-gray-100 rounded w-1/2"></div>
+            <div class="h-3 bg-gray-100 rounded w-1/3"></div>
+            <div class="h-3 bg-gray-100 rounded w-1/4 ml-auto"></div>
+          </div>
+        }
+      </div>
+    </div>
+  } @else if (filteredTransactions().length === 0) {
+    <!-- Empty state -->
+    <div class="flex flex-col items-center justify-center py-20 text-center gap-4" data-testid="transactions-empty-state">
+      <i class="fa-light fa-receipt text-6xl text-gray-300"></i>
+      <div class="flex flex-col gap-2 max-w-md">
+        <h2 class="text-lg font-semibold text-gray-700">No transactions yet</h2>
+        <p class="text-gray-500 text-sm">Your Linux Foundation purchase history will appear here. Recent purchases may take up to 48 hours to be reflected.</p>
+      </div>
+    </div>
+  } @else {
+    <!-- Transactions table -->
+    <lfx-table [value]="paginatedTransactions()" data-testid="transactions-table">
+      <ng-template #header>
+        <tr>
+          <th class="w-[35%]">Name</th>
+          <th class="w-[20%]">Order ID</th>
+          <th class="w-[15%]">Date</th>
+          <th class="w-[15%]">Type</th>
+          <th class="w-[15%] text-right">Amount</th>
+        </tr>
+      </ng-template>
+
+      <ng-template #body let-transaction let-rowIndex="rowIndex">
+        <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'transactions-row-' + transaction.id">
+          <!-- Name column -->
+          <td>
+            <span class="text-xs text-gray-900">{{ transaction.name }}</span>
+          </td>
+
+          <!-- Order ID column -->
+          <td>
+            <span class="text-xs text-gray-500 font-mono">{{ transaction.orderId }}</span>
+          </td>
+
+          <!-- Date column -->
+          <td>
+            <span class="text-xs text-gray-700">{{ transaction.createdDate | date: 'mediumDate' }}</span>
+          </td>
+
+          <!-- Type column -->
+          <td>
+            @if (transaction.transactionType) {
+              <lfx-tag [value]="transaction.transactionType" severity="secondary" [styleClass]="getTypeStyleClass(transaction.transactionType)" />
+            } @else {
+              <span class="text-xs text-gray-400">&mdash;</span>
+            }
+          </td>
+
+          <!-- Amount column -->
+          <td class="text-right">
+            <span class="text-xs font-medium text-gray-900">{{ transaction.netRevenue | currency: 'USD' }}</span>
+          </td>
+        </tr>
+      </ng-template>
+
+      <ng-template #emptymessage>
+        <tr>
+          <td colspan="5" class="text-center py-8">
+            <i class="fa-light fa-receipt text-3xl text-gray-400 mb-2 block"></i>
+            <p class="text-sm text-gray-500">No transactions found</p>
+          </td>
+        </tr>
+      </ng-template>
+    </lfx-table>
+
+    <!-- Pagination row -->
+    @if (totalPages() > 1) {
+      <div class="flex items-center justify-between mt-4" data-testid="transactions-pagination">
+        <span class="text-xs text-gray-400">Showing {{ firstIndex() }}–{{ lastIndex() }} of {{ filteredTransactions().length }}</span>
+        <div class="flex gap-1">
+          <button
+            type="button"
+            class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-700 transition-colors"
+            [class.opacity-50]="currentPage() === 1"
+            [class.cursor-not-allowed]="currentPage() === 1"
+            [class.hover:bg-gray-200]="currentPage() !== 1"
+            [disabled]="currentPage() === 1"
+            (click)="goToPage(currentPage() - 1)"
+            data-testid="pagination-prev">
+            Prev
+          </button>
+          @for (page of pageNumbers(); track page) {
+            <button
+              type="button"
+              class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium transition-colors"
+              [class.bg-blue-500]="currentPage() === page"
+              [class.text-white]="currentPage() === page"
+              [class.bg-gray-100]="currentPage() !== page"
+              [class.text-gray-700]="currentPage() !== page"
+              [class.hover:bg-gray-200]="currentPage() !== page"
+              (click)="goToPage(page)"
+              [attr.data-testid]="'pagination-page-' + page">
+              {{ page }}
+            </button>
+          }
+          <button
+            type="button"
+            class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-700 transition-colors"
+            [class.opacity-50]="currentPage() === totalPages()"
+            [class.cursor-not-allowed]="currentPage() === totalPages()"
+            [class.hover:bg-gray-200]="currentPage() !== totalPages()"
+            [disabled]="currentPage() === totalPages()"
+            (click)="goToPage(currentPage() + 1)"
+            data-testid="pagination-next">
+            Next
+          </button>
+        </div>
+      </div>
+    }
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
@@ -75,7 +75,7 @@
           <!-- Type column -->
           <td>
             @if (transaction.transactionType) {
-              <lfx-tag [value]="transaction.transactionType" severity="secondary" [styleClass]="getTypeStyleClass(transaction.transactionType)" />
+              <lfx-tag [value]="transaction.transactionType" severity="secondary" [styleClass]="transaction.transactionType | transactionTypeStyle" />
             } @else {
               <span class="text-xs text-gray-400">&mdash;</span>
             }

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.scss
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
@@ -1,0 +1,128 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { CurrencyPipe, DatePipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import {
+  TRANSACTION_TYPE_BUNDLE,
+  TRANSACTION_TYPE_CERTIFICATION,
+  TRANSACTION_TYPE_EVENT,
+  TRANSACTION_TYPE_INDIVIDUAL_SUPPORT,
+  TRANSACTION_TYPE_SUBSCRIPTION,
+  TRANSACTION_TYPE_TRAINING,
+} from '@lfx-one/shared/constants';
+import { FilterPillOption, Transaction } from '@lfx-one/shared/interfaces';
+
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
+import { TableComponent } from '@components/table/table.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { TransactionService } from '@services/transaction.service';
+
+const PAGE_SUBTITLE = 'View your Linux Foundation purchase history. Recent purchases may take up to 48 hours to appear.';
+
+const TAB_OPTIONS: FilterPillOption[] = [
+  { id: 'all', label: 'All Transactions' },
+  { id: 'event-tickets', label: 'Event Tickets' },
+  { id: 'training', label: 'Training' },
+  { id: 'certifications', label: 'Certifications' },
+  { id: 'bundle', label: 'Bundles' },
+  { id: 'subscriptions', label: 'Subscriptions' },
+  { id: 'individual-support', label: 'Individual Support' },
+];
+
+const TYPE_STYLE_MAP: Record<string, string> = {
+  [TRANSACTION_TYPE_EVENT]: '!bg-blue-50 !text-blue-700',
+  [TRANSACTION_TYPE_TRAINING]: '!bg-emerald-50 !text-emerald-700',
+  [TRANSACTION_TYPE_CERTIFICATION]: '!bg-violet-50 !text-violet-700',
+  [TRANSACTION_TYPE_SUBSCRIPTION]: '!bg-amber-50 !text-amber-700',
+  [TRANSACTION_TYPE_INDIVIDUAL_SUPPORT]: '!bg-rose-50 !text-rose-700',
+  [TRANSACTION_TYPE_BUNDLE]: '!bg-teal-50 !text-teal-700',
+};
+
+const TAB_TYPE_MAP: Record<string, string> = {
+  'event-tickets': TRANSACTION_TYPE_EVENT,
+  training: TRANSACTION_TYPE_TRAINING,
+  certifications: TRANSACTION_TYPE_CERTIFICATION,
+  subscriptions: TRANSACTION_TYPE_SUBSCRIPTION,
+  'individual-support': TRANSACTION_TYPE_INDIVIDUAL_SUPPORT,
+  bundle: TRANSACTION_TYPE_BUNDLE,
+};
+
+@Component({
+  selector: 'lfx-transactions-dashboard',
+  imports: [FilterPillsComponent, TableComponent, TagComponent, CurrencyPipe, DatePipe],
+  templateUrl: './transactions-dashboard.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TransactionsDashboardComponent {
+  // ─── Private Injections ────────────────────────────────────────────────────
+  private readonly transactionService = inject(TransactionService);
+
+  // ─── Configuration ─────────────────────────────────────────────────────────
+  protected readonly subtitle = PAGE_SUBTITLE;
+  protected readonly tabOptions = TAB_OPTIONS;
+
+  // ─── Writable Signals ──────────────────────────────────────────────────────
+  protected readonly activeTab = signal<string>('all');
+  protected readonly currentPage = signal<number>(1);
+  protected readonly pageSize = 10;
+
+  // ─── Computed Signals ──────────────────────────────────────────────────────
+  protected readonly transactions: Signal<Transaction[] | undefined> = this.initTransactions();
+  protected readonly filteredTransactions: Signal<Transaction[]> = this.initFilteredTransactions();
+  protected readonly totalPages: Signal<number> = computed(() => Math.max(1, Math.ceil(this.filteredTransactions().length / this.pageSize)));
+  protected readonly paginatedTransactions: Signal<Transaction[]> = computed(() => {
+    const start = (this.currentPage() - 1) * this.pageSize;
+    return this.filteredTransactions().slice(start, start + this.pageSize);
+  });
+  protected readonly pageNumbers: Signal<number[]> = computed(() => Array.from({ length: this.totalPages() }, (_, i) => i + 1));
+  protected readonly firstIndex: Signal<number> = computed(() => (this.filteredTransactions().length === 0 ? 0 : (this.currentPage() - 1) * this.pageSize + 1));
+  protected readonly lastIndex: Signal<number> = computed(() => Math.min(this.currentPage() * this.pageSize, this.filteredTransactions().length));
+
+  constructor() {
+    // Reset to page 1 when tab or filtered data changes
+    effect(() => {
+      this.filteredTransactions();
+      this.currentPage.set(1);
+    });
+  }
+
+  // ─── Protected Methods ─────────────────────────────────────────────────────
+  protected onTabChange(tabId: string): void {
+    this.activeTab.set(tabId);
+  }
+
+  protected getTypeStyleClass(transactionType: string | null): string {
+    if (!transactionType) return '';
+    return TYPE_STYLE_MAP[transactionType] ?? '';
+  }
+
+  protected goToPage(page: number): void {
+    if (page >= 1 && page <= this.totalPages()) {
+      this.currentPage.set(page);
+    }
+  }
+
+  // ─── Private Initializers ──────────────────────────────────────────────────
+  private initTransactions(): Signal<Transaction[] | undefined> {
+    return toSignal(this.transactionService.getTransactions());
+  }
+
+  private initFilteredTransactions(): Signal<Transaction[]> {
+    return computed(() => {
+      const all = this.transactions();
+      if (!all) return [];
+
+      const tab = this.activeTab();
+      if (tab === 'all') return all;
+
+      const keyword = TAB_TYPE_MAP[tab];
+      if (!keyword) return all;
+
+      return all.filter((t) => t.transactionType === keyword);
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
@@ -82,7 +82,7 @@ export class TransactionsDashboardComponent {
   protected readonly firstIndex: Signal<number> = computed(() => (this.filteredTransactions().length === 0 ? 0 : (this.currentPage() - 1) * this.pageSize + 1));
   protected readonly lastIndex: Signal<number> = computed(() => Math.min(this.currentPage() * this.pageSize, this.filteredTransactions().length));
 
-  constructor() {
+  public constructor() {
     // Reset to page 1 when tab or filtered data changes
     effect(() => {
       this.filteredTransactions();

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
@@ -64,11 +64,11 @@ export class TransactionsDashboardComponent {
   // ─── Configuration ─────────────────────────────────────────────────────────
   protected readonly subtitle = PAGE_SUBTITLE;
   protected readonly tabOptions = TAB_OPTIONS;
+  protected readonly pageSize = 10;
 
   // ─── Writable Signals ──────────────────────────────────────────────────────
   protected readonly activeTab = signal<string>('all');
   protected readonly currentPage = signal<number>(1);
-  protected readonly pageSize = 10;
 
   // ─── Computed Signals ──────────────────────────────────────────────────────
   protected readonly transactions: Signal<Transaction[] | undefined> = this.initTransactions();

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
@@ -4,7 +4,7 @@
 // Generated with [Claude Code](https://claude.ai/code)
 
 import { CurrencyPipe, DatePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, effect, inject, signal, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import {
   TRANSACTION_TYPE_BUNDLE,
@@ -19,6 +19,7 @@ import { FilterPillOption, Transaction } from '@lfx-one/shared/interfaces';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
+import { TransactionTypeStylePipe } from '@pipes/transaction-type-style.pipe';
 import { TransactionService } from '@services/transaction.service';
 
 const PAGE_SUBTITLE = 'View your Linux Foundation purchase history. Recent purchases may take up to 48 hours to appear.';
@@ -33,15 +34,6 @@ const TAB_OPTIONS: FilterPillOption[] = [
   { id: 'individual-support', label: 'Individual Support' },
 ];
 
-const TYPE_STYLE_MAP: Record<string, string> = {
-  [TRANSACTION_TYPE_EVENT]: '!bg-blue-50 !text-blue-700',
-  [TRANSACTION_TYPE_TRAINING]: '!bg-emerald-50 !text-emerald-700',
-  [TRANSACTION_TYPE_CERTIFICATION]: '!bg-violet-50 !text-violet-700',
-  [TRANSACTION_TYPE_SUBSCRIPTION]: '!bg-amber-50 !text-amber-700',
-  [TRANSACTION_TYPE_INDIVIDUAL_SUPPORT]: '!bg-rose-50 !text-rose-700',
-  [TRANSACTION_TYPE_BUNDLE]: '!bg-teal-50 !text-teal-700',
-};
-
 const TAB_TYPE_MAP: Record<string, string> = {
   'event-tickets': TRANSACTION_TYPE_EVENT,
   training: TRANSACTION_TYPE_TRAINING,
@@ -53,7 +45,7 @@ const TAB_TYPE_MAP: Record<string, string> = {
 
 @Component({
   selector: 'lfx-transactions-dashboard',
-  imports: [FilterPillsComponent, TableComponent, TagComponent, CurrencyPipe, DatePipe],
+  imports: [FilterPillsComponent, TableComponent, TagComponent, CurrencyPipe, DatePipe, TransactionTypeStylePipe],
   templateUrl: './transactions-dashboard.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -82,22 +74,10 @@ export class TransactionsDashboardComponent {
   protected readonly firstIndex: Signal<number> = computed(() => (this.filteredTransactions().length === 0 ? 0 : (this.currentPage() - 1) * this.pageSize + 1));
   protected readonly lastIndex: Signal<number> = computed(() => Math.min(this.currentPage() * this.pageSize, this.filteredTransactions().length));
 
-  public constructor() {
-    // Reset to page 1 when tab or filtered data changes
-    effect(() => {
-      this.filteredTransactions();
-      this.currentPage.set(1);
-    });
-  }
-
   // ─── Protected Methods ─────────────────────────────────────────────────────
   protected onTabChange(tabId: string): void {
     this.activeTab.set(tabId);
-  }
-
-  protected getTypeStyleClass(transactionType: string | null): string {
-    if (!transactionType) return '';
-    return TYPE_STYLE_MAP[transactionType] ?? '';
+    this.currentPage.set(1);
   }
 
   protected goToPage(page: number): void {

--- a/apps/lfx-one/src/app/modules/transactions/transactions.routes.ts
+++ b/apps/lfx-one/src/app/modules/transactions/transactions.routes.ts
@@ -1,0 +1,16 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { Routes } from '@angular/router';
+import { authGuard } from '@shared/guards/auth.guard';
+
+export const TRANSACTION_ROUTES: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./transactions-dashboard/transactions-dashboard.component').then((m) => m.TransactionsDashboardComponent),
+    canActivate: [authGuard],
+    data: { preload: true, preloadDelay: 1500 },
+  },
+];

--- a/apps/lfx-one/src/app/shared/pipes/transaction-type-style.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/transaction-type-style.pipe.ts
@@ -1,0 +1,31 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { Pipe, PipeTransform } from '@angular/core';
+import {
+  TRANSACTION_TYPE_BUNDLE,
+  TRANSACTION_TYPE_CERTIFICATION,
+  TRANSACTION_TYPE_EVENT,
+  TRANSACTION_TYPE_INDIVIDUAL_SUPPORT,
+  TRANSACTION_TYPE_SUBSCRIPTION,
+  TRANSACTION_TYPE_TRAINING,
+} from '@lfx-one/shared/constants';
+import { TransactionType } from '@lfx-one/shared/interfaces';
+
+const TYPE_STYLE_MAP: Record<TransactionType, string> = {
+  [TRANSACTION_TYPE_EVENT]: '!bg-blue-50 !text-blue-700',
+  [TRANSACTION_TYPE_TRAINING]: '!bg-emerald-50 !text-emerald-700',
+  [TRANSACTION_TYPE_CERTIFICATION]: '!bg-violet-50 !text-violet-700',
+  [TRANSACTION_TYPE_SUBSCRIPTION]: '!bg-amber-50 !text-amber-700',
+  [TRANSACTION_TYPE_INDIVIDUAL_SUPPORT]: '!bg-rose-50 !text-rose-700',
+  [TRANSACTION_TYPE_BUNDLE]: '!bg-teal-50 !text-teal-700',
+};
+
+@Pipe({ name: 'transactionTypeStyle' })
+export class TransactionTypeStylePipe implements PipeTransform {
+  public transform(value: TransactionType | null): string {
+    return value ? (TYPE_STYLE_MAP[value] ?? '') : '';
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/transaction.service.ts
+++ b/apps/lfx-one/src/app/shared/services/transaction.service.ts
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Transaction } from '@lfx-one/shared/interfaces';
+import { catchError, Observable, of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class TransactionService {
+  private readonly http = inject(HttpClient);
+
+  public getTransactions(): Observable<Transaction[]> {
+    return this.http.get<Transaction[]>('/api/transactions').pipe(catchError(() => of([])));
+  }
+}

--- a/apps/lfx-one/src/server/controllers/transaction.controller.ts
+++ b/apps/lfx-one/src/server/controllers/transaction.controller.ts
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { NextFunction, Request, Response } from 'express';
+
+import { AuthenticationError } from '../errors';
+import { logger } from '../services/logger.service';
+import { TransactionService } from '../services/transaction.service';
+import { getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
+
+export class TransactionController {
+  private readonly transactionService = new TransactionService();
+
+  /**
+   * GET /api/transactions
+   * Get all transactions for the authenticated user
+   */
+  public async getTransactions(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_transactions');
+
+    try {
+      const rawUsername = await getUsernameFromAuth(req);
+
+      if (!rawUsername) {
+        throw new AuthenticationError('User authentication required', {
+          operation: 'get_transactions',
+        });
+      }
+
+      const username = stripAuthPrefix(rawUsername);
+      const transactions = await this.transactionService.getTransactions(req, username);
+
+      logger.success(req, 'get_transactions', startTime, {
+        result_count: transactions.length,
+      });
+
+      res.json(transactions);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/routes/transaction.route.ts
+++ b/apps/lfx-one/src/server/routes/transaction.route.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { Router } from 'express';
+
+import { TransactionController } from '../controllers/transaction.controller';
+
+const router = Router();
+const transactionController = new TransactionController();
+
+router.get('/', (req, res, next) => transactionController.getTransactions(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -36,6 +36,7 @@ import publicMeetingsRouter from './routes/public-meetings.route';
 import searchRouter from './routes/search.route';
 import surveysRouter from './routes/surveys.route';
 import trainingRouter from './routes/training.route';
+import transactionRouter from './routes/transaction.route';
 import userRouter from './routes/user.route';
 import votesRouter from './routes/votes.route';
 import { reqSerializer, resSerializer, serverLogger } from './server-logger';
@@ -198,6 +199,7 @@ app.use('/api/documents', documentsRouter);
 app.use('/api/events', eventsRouter);
 app.use('/api/impersonate', impersonationRouter);
 app.use('/api/training', trainingRouter);
+app.use('/api/transactions', transactionRouter);
 
 // Add API error handler middleware
 app.use('/api/*', apiErrorHandler);

--- a/apps/lfx-one/src/server/services/transaction.service.ts
+++ b/apps/lfx-one/src/server/services/transaction.service.ts
@@ -1,0 +1,59 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { Transaction, TransactionRow } from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { logger } from './logger.service';
+import { SnowflakeService } from './snowflake.service';
+
+const TRANSACTIONS_QUERY = `
+  SELECT _KEY, ORDER_ID, NAME, NET_REVENUE,
+         CREATED_DATE, TRANSACTION_TYPE, PROJECT_ID, PROJECT_NAME
+  FROM ANALYTICS.PLATINUM_LFX_ONE.USER_TRANSACTIONS
+  WHERE USER_NAME = ?
+  ORDER BY CREATED_DATE DESC
+`;
+
+export class TransactionService {
+  private readonly snowflakeService: SnowflakeService;
+
+  public constructor() {
+    this.snowflakeService = SnowflakeService.getInstance();
+  }
+
+  public async getTransactions(req: Request, username: string): Promise<Transaction[]> {
+    logger.debug(req, 'get_transactions', 'Fetching transactions from Snowflake', { username });
+
+    let result: { rows: TransactionRow[] };
+
+    try {
+      result = await this.snowflakeService.execute<TransactionRow>(TRANSACTIONS_QUERY, [username]);
+    } catch (error) {
+      logger.warning(req, 'get_transactions', 'Snowflake query failed, returning empty transactions', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      return [];
+    }
+
+    logger.debug(req, 'get_transactions', 'Fetched transactions', { count: result.rows.length });
+
+    return result.rows.map((row) => this.mapRowToTransaction(row));
+  }
+
+  private mapRowToTransaction(row: TransactionRow): Transaction {
+    return {
+      id: row._KEY,
+      orderId: row.ORDER_ID,
+      createdDate: row.CREATED_DATE,
+      name: row.NAME ?? '',
+      transactionType: row.TRANSACTION_TYPE,
+      netRevenue: row.NET_REVENUE ?? 0,
+      projectId: row.PROJECT_ID,
+      projectName: row.PROJECT_NAME,
+    };
+  }
+}

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -45,3 +45,4 @@ export * from './committee-documents.constants';
 export * from './lens.constants';
 export * from './training.constants';
 export * from './documents.constants';
+export * from './transaction.constants';

--- a/packages/shared/src/constants/transaction.constants.ts
+++ b/packages/shared/src/constants/transaction.constants.ts
@@ -1,0 +1,12 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+/** TRANSACTION_TYPE values from ANALYTICS.PLATINUM_LFX_ONE.USER_TRANSACTIONS */
+export const TRANSACTION_TYPE_EVENT = 'events' as const;
+export const TRANSACTION_TYPE_TRAINING = 'training' as const;
+export const TRANSACTION_TYPE_CERTIFICATION = 'certifications' as const;
+export const TRANSACTION_TYPE_SUBSCRIPTION = 'subscription' as const;
+export const TRANSACTION_TYPE_INDIVIDUAL_SUPPORT = 'individual' as const;
+export const TRANSACTION_TYPE_BUNDLE = 'bundle' as const;

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -125,3 +125,6 @@ export * from './health-metrics.interface';
 
 // Multi-persona dashboard interfaces
 export * from './multi-persona-dashboard.interface';
+
+// Transaction interfaces
+export * from './transaction.interface';

--- a/packages/shared/src/interfaces/transaction.interface.ts
+++ b/packages/shared/src/interfaces/transaction.interface.ts
@@ -3,6 +3,24 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
+import {
+  TRANSACTION_TYPE_BUNDLE,
+  TRANSACTION_TYPE_CERTIFICATION,
+  TRANSACTION_TYPE_EVENT,
+  TRANSACTION_TYPE_INDIVIDUAL_SUPPORT,
+  TRANSACTION_TYPE_SUBSCRIPTION,
+  TRANSACTION_TYPE_TRAINING,
+} from '../constants/transaction.constants';
+
+/** Union of all known TRANSACTION_TYPE values */
+export type TransactionType =
+  | typeof TRANSACTION_TYPE_EVENT
+  | typeof TRANSACTION_TYPE_TRAINING
+  | typeof TRANSACTION_TYPE_CERTIFICATION
+  | typeof TRANSACTION_TYPE_SUBSCRIPTION
+  | typeof TRANSACTION_TYPE_INDIVIDUAL_SUPPORT
+  | typeof TRANSACTION_TYPE_BUNDLE;
+
 /**
  * A single transaction in the user's purchase history
  */
@@ -16,7 +34,7 @@ export interface Transaction {
   /** Name of the purchased product (NAME) */
   name: string;
   /** Type of transaction: training, certifications, subscription, events, individual (TRANSACTION_TYPE) */
-  transactionType: string | null;
+  transactionType: TransactionType | null;
   /** Net revenue amount paid (NET_REVENUE) */
   netRevenue: number;
   /** Associated project ID (PROJECT_ID) */
@@ -37,7 +55,7 @@ export interface TransactionRow {
   NAME: string | null;
   NET_REVENUE: number | null;
   CREATED_DATE: string;
-  TRANSACTION_TYPE: string | null;
+  TRANSACTION_TYPE: TransactionType | null;
   PROJECT_ID: string | null;
   PROJECT_NAME: string | null;
 }

--- a/packages/shared/src/interfaces/transaction.interface.ts
+++ b/packages/shared/src/interfaces/transaction.interface.ts
@@ -30,9 +30,9 @@ export interface Transaction {
  */
 export interface TransactionRow {
   _KEY: string;
-  USER_NAME: string;
-  USER_EMAIL: string | null;
-  USER_ID: string | null;
+  USER_NAME?: string;
+  USER_EMAIL?: string | null;
+  USER_ID?: string | null;
   ORDER_ID: string;
   NAME: string | null;
   NET_REVENUE: number | null;

--- a/packages/shared/src/interfaces/transaction.interface.ts
+++ b/packages/shared/src/interfaces/transaction.interface.ts
@@ -1,0 +1,43 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+/**
+ * A single transaction in the user's purchase history
+ */
+export interface Transaction {
+  /** Unique record identifier (_KEY) */
+  id: string;
+  /** Source natural key — purchase_id, registration_id, or membership id (ORDER_ID) */
+  orderId: string;
+  /** Transaction date (CREATED_DATE) */
+  createdDate: string;
+  /** Name of the purchased product (NAME) */
+  name: string;
+  /** Type of transaction: training, certifications, subscription, events, individual (TRANSACTION_TYPE) */
+  transactionType: string | null;
+  /** Net revenue amount paid (NET_REVENUE) */
+  netRevenue: number;
+  /** Associated project ID (PROJECT_ID) */
+  projectId: string | null;
+  /** Associated project name (PROJECT_NAME) */
+  projectName: string | null;
+}
+
+/**
+ * Snowflake row shape for ANALYTICS.PLATINUM_LFX_ONE.USER_TRANSACTIONS
+ */
+export interface TransactionRow {
+  _KEY: string;
+  USER_NAME: string;
+  USER_EMAIL: string | null;
+  USER_ID: string | null;
+  ORDER_ID: string;
+  NAME: string | null;
+  NET_REVENUE: number | null;
+  CREATED_DATE: string;
+  TRANSACTION_TYPE: string | null;
+  PROJECT_ID: string | null;
+  PROJECT_NAME: string | null;
+}


### PR DESCRIPTION
## Summary

- Adds the My Transactions page at `/me/transactions` showing a user's Linux Foundation purchase history
- Data sourced from `ANALYTICS.PLATINUM_LFX_ONE.USER_TRANSACTIONS` via Snowflake
- Filter pill tabs: All Transactions, Event Tickets, Training, Certifications, Bundles, Subscriptions, Individual Support
- Color-coded transaction type badges (soft pastel tones per type)
- Pill-style pagination matching the LFX One design system
- Recent purchases may take up to 48 hours to appear (dbt pipeline delay)

## Actual Implementation

<img width="1933" height="942" alt="Screenshot 2026-04-17 at 2 13 47 PM" src="https://github.com/user-attachments/assets/222e0316-84d8-4fcb-b0f7-0cdbf6b097af" />

## Test plan

- [ ] Navigate to `/me/transactions` — page loads with transaction history
- [ ] Filter tabs correctly filter by transaction type
- [ ] Pagination works (Prev/Next and page numbers)
- [ ] Empty state displays when no transactions found
- [ ] Loading skeleton displays while data is fetching
- [ ] Type badges render with correct colors per transaction type

🤖 Generated with [Claude Code](https://claude.ai/code)