### PR TITLE
feat(ui): standardize empty states across me lens pages

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -4,7 +4,7 @@
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   <div class="flex flex-col gap-6">
     <!-- Page Header -->
-    <div class="mt-3 mb-6">
+    <div class="mt-3">
       <div class="flex justify-between items-center w-full gap-4">
         <h1 class="font-display font-light text-2xl">{{ isMeLens() ? 'My ' + committeeLabel.plural : committeeLabel.plural }}</h1>
         @if (canCreateGroup()) {
@@ -309,16 +309,12 @@
         }
       </div>
     } @else if (isMeLens()) {
-      <lfx-card>
-        <div class="flex items-center justify-center p-16">
-          <div class="text-center max-w-md">
-            <div class="text-gray-400 mb-4">
-              <i class="fa-light fa-users text-[2rem] mb-4"></i>
-              <h3 class="text-gray-600 mt-2">You are not a member of any {{ committeeLabel.plural.toLowerCase() }} yet.</h3>
-            </div>
-          </div>
-        </div>
-      </lfx-card>
+      <lfx-empty-state
+        icon="fa-light fa-users-rectangle"
+        [title]="'No ' + committeeLabel.plural.toLowerCase() + ' yet'"
+        subtitle="Groups you're a member of will appear here."
+        data-testid="committees-empty-state">
+      </lfx-empty-state>
     }
 
     @if (!isMeLens()) {
@@ -353,30 +349,19 @@
       @if (!committeesLoading()) {
         <div class="min-h-[400px]">
           @if (committees().length === 0 && project()?.uid) {
-            <!-- Empty state: No committees exist -->
-            <lfx-card>
-              <div class="flex items-center justify-center p-16">
-                <div class="text-center max-w-md">
-                  <div class="text-gray-400 mb-4">
-                    <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
-                    <h3 class="text-gray-600 mt-2">Your project has no {{ committeeLabel.plural.toLowerCase() }}, yet.</h3>
-                  </div>
-                </div>
-              </div>
-            </lfx-card>
+            <lfx-empty-state
+              icon="fa-light fa-users-rectangle"
+              [title]="'No ' + committeeLabel.plural.toLowerCase() + ' yet'"
+              subtitle="This project has no groups set up yet."
+              data-testid="committees-project-empty-state">
+            </lfx-empty-state>
           } @else if (filteredCommittees().length === 0) {
-            <!-- Empty state: Committees exist but filters returned no results -->
-            <lfx-card>
-              <div class="flex items-center justify-center p-16">
-                <div class="text-center max-w-md">
-                  <div class="text-gray-400 mb-4">
-                    <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
-                  </div>
-                  <h3 class="text-xl font-semibold text-gray-900 mt-4">No {{ committeeLabel.plural.toLowerCase() }} Found</h3>
-                  <p class="text-gray-600 mt-2">Try adjusting your search or filter criteria</p>
-                </div>
-              </div>
-            </lfx-card>
+            <lfx-empty-state
+              icon="fa-light fa-users-rectangle"
+              [title]="'No ' + committeeLabel.plural.toLowerCase() + ' found'"
+              subtitle="Try adjusting your search or filter criteria."
+              data-testid="committees-filtered-empty-state">
+            </lfx-empty-state>
           } @else {
             <lfx-committee-table
               [committees]="filteredCommittees()"

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -125,196 +125,50 @@
       </div>
     }
 
-    <!-- Search & Filters (Me lens only) -->
+    <!-- My Groups Table (Me lens) -->
     @if (isMeLens()) {
-      <div class="bg-white rounded-lg border border-gray-200 p-4 mb-6">
-        <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
-          <div class="flex-1">
-            <lfx-input-text
-              [form]="searchForm"
-              control="search"
-              [placeholder]="'Search ' + committeeLabel.plural.toLowerCase() + '...'"
-              icon="fa-light fa-search"
-              styleClass="w-full"
-              size="small"
-              data-testid="committee-me-search-input"></lfx-input-text>
-          </div>
-          @if (showFoundationFilter()) {
-            <div class="w-full sm:w-48">
-              <lfx-select
-                [form]="searchForm"
-                control="foundationFilter"
-                size="small"
-                [options]="foundationOptions()"
-                styleClass="w-full"
-                (onChange)="onFoundationFilterChange($event.value)"
-                data-testid="committee-foundation-filter"></lfx-select>
-            </div>
-          }
-          @if (showProjectFilter()) {
-            <div class="w-full sm:w-48">
-              <lfx-select
-                [form]="searchForm"
-                control="projectFilter"
-                size="small"
-                [options]="projectOptions()"
-                styleClass="w-full"
-                (onChange)="onProjectFilterChange($event.value)"
-                data-testid="committee-project-filter"></lfx-select>
-            </div>
-          }
-        </div>
-      </div>
-    }
-
-    <!-- My Groups Section -->
-    @if (myCommitteesLoading()) {
-      <div>
-        <div class="flex items-center gap-2 mb-4">
-          <h2 class="text-lg font-semibold text-gray-900">My {{ committeeLabel.plural }}</h2>
-        </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          @for (_ of [1, 2, 3]; track _) {
-            <lfx-card>
-              <div class="flex flex-col gap-3">
-                <div class="flex items-start justify-between gap-2">
-                  <div class="flex flex-col gap-2 flex-1">
-                    <p-skeleton width="60%" height="0.875rem" />
-                    <p-skeleton width="30%" height="0.75rem" />
-                  </div>
-                  <p-skeleton width="4rem" height="1.5rem" borderRadius="1rem" />
-                </div>
-                <div class="flex items-center gap-4 pt-3 border-t border-gray-100">
-                  <p-skeleton width="5rem" height="0.75rem" />
-                  <p-skeleton width="3rem" height="0.75rem" />
-                  <p-skeleton width="1rem" height="0.75rem" borderRadius="2px" />
-                  <p-skeleton width="1rem" height="0.75rem" borderRadius="2px" />
-                </div>
-              </div>
-            </lfx-card>
-          }
-        </div>
-      </div>
-    } @else if (myCommittees().length > 0) {
-      <div>
-        <div class="flex items-center gap-2 mb-4">
-          <h2 class="text-lg font-semibold text-gray-900">My {{ committeeLabel.plural }}</h2>
-          <span class="text-xs font-medium text-gray-500 bg-gray-100 rounded-full px-2 py-0.5">{{ filteredMyCommittees().length }}</span>
-        </div>
-        @if (filteredMyCommittees().length === 0) {
-          <lfx-card>
-            <div class="flex items-center justify-center p-8">
-              <div class="text-center">
-                <i class="fa-light fa-eyes text-2xl text-gray-400 mb-2"></i>
-                <p class="text-sm text-gray-500">No {{ committeeLabel.plural.toLowerCase() }} found matching your filters</p>
-              </div>
-            </div>
-          </lfx-card>
-        } @else {
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            @for (committee of filteredMyCommittees(); track committee.uid) {
-              <div
-                class="block cursor-pointer"
-                tabindex="0"
-                role="link"
-                [attr.aria-label]="'Open ' + (committee.display_name || committee.name)"
-                (click)="onCommitteeClick(committee)"
-                (keydown.enter)="onCommitteeClick(committee)">
-                <lfx-card styleClass="hover:shadow-md transition-shadow cursor-pointer h-full">
-                  <div class="flex flex-col h-full">
-                    <!-- Header: Name + Role Badge -->
-                    <div class="flex items-start justify-between gap-2 mb-3">
-                      <div class="min-w-0 flex-1">
-                        <h3 class="text-sm font-semibold text-gray-900 truncate">{{ committee.display_name || committee.name }}</h3>
-                        <div class="flex items-center gap-2 mt-1">
-                          <span class="text-sm text-gray-500">{{ committee.category }}</span>
-                          @if (!committee.public) {
-                            <i class="fa-light fa-lock w-3 h-3 text-gray-400"></i>
-                          }
-                        </div>
-                      </div>
-                      <!-- Role Badge -->
-                      <span
-                        class="inline-flex items-center text-xs font-medium rounded-full px-2.5 py-1 flex-shrink-0"
-                        [ngClass]="committee.my_role | roleBadgeClass">
-                        {{ committee.my_role }}
-                      </span>
-                    </div>
-
-                    <!-- Meta Row: Members + Voting + Channels -->
-                    <div class="flex items-center gap-4 mt-auto pt-3 border-t border-gray-100">
-                      <div class="flex items-center gap-1.5 text-sm text-gray-500">
-                        <i class="fa-light fa-users w-3.5 h-3.5"></i>
-                        <span>{{ committee.total_members || 0 }} members</span>
-                      </div>
-                      @if (committee.enable_voting) {
-                        <div class="flex items-center gap-1.5 text-xs text-emerald-600">
-                          <i class="fa-light fa-check-to-slot w-3.5 h-3.5"></i>
-                          <span>Voting</span>
-                        </div>
-                      }
-                      <!-- Channels: mailing_list is the direct email string; has_mailing_list is an enriched boolean from query-service association -->
-                      @if (committee.mailing_list) {
-                        <a
-                          [href]="'mailto:' + committee.mailing_list"
-                          (click)="$event.stopPropagation()"
-                          class="flex items-center gap-1 text-sm text-gray-500 hover:text-blue-600 no-underline"
-                          [pTooltip]="committee.mailing_list"
-                          tooltipPosition="top"
-                          aria-label="Mailing list">
-                          <i class="fa-light fa-envelope w-3.5 h-3.5" aria-hidden="true"></i>
-                        </a>
-                      } @else if (committee.has_mailing_list) {
-                        <span
-                          class="flex items-center gap-1 text-sm text-gray-500 cursor-default"
-                          pTooltip="Mailing list associated"
-                          tooltipPosition="top"
-                          tabindex="0"
-                          aria-label="Mailing list associated">
-                          <i class="fa-light fa-envelope w-3.5 h-3.5" aria-hidden="true"></i>
-                        </span>
-                      } @else {
-                        <span
-                          class="flex items-center gap-1 text-gray-300 cursor-default"
-                          pTooltip="No mailing list"
-                          tooltipPosition="top"
-                          tabindex="0"
-                          aria-label="No mailing list">
-                          <i class="fa-light fa-envelope w-3.5 h-3.5" aria-hidden="true"></i>
-                        </span>
-                      }
-                      @if (committee.chat_channel) {
-                        <a
-                          [href]="committee.chat_channel"
-                          target="_blank"
-                          rel="noopener"
-                          (click)="$event.stopPropagation()"
-                          class="flex items-center gap-1 text-sm text-gray-500 hover:text-blue-600 no-underline"
-                          [pTooltip]="committee.chat_channel | platformLabel"
-                          tooltipPosition="top"
-                          [attr.aria-label]="committee.chat_channel | platformLabel">
-                          <i [class]="(committee.chat_channel | platformIcon) + ' w-3.5 h-3.5'" aria-hidden="true"></i>
-                        </a>
-                      } @else {
-                        <span class="flex items-center gap-1 text-gray-300 cursor-default" pTooltip="No chat channel" tooltipPosition="top">
-                          <i class="fa-light fa-comment w-3.5 h-3.5"></i>
-                        </span>
-                      }
-                    </div>
-                  </div>
-                </lfx-card>
+      @if (myCommitteesLoading()) {
+        <lfx-card styleClass="[&_.p-card-body]:!px-5">
+          <div class="flex flex-col gap-4 py-2">
+            @for (_ of [1, 2, 3, 4, 5]; track _) {
+              <div class="flex items-center gap-6">
+                <p-skeleton width="18%" height="0.875rem" />
+                <p-skeleton width="10%" height="0.875rem" />
+                <p-skeleton width="22%" height="0.875rem" />
+                <p-skeleton width="6%" height="0.875rem" />
+                <p-skeleton width="6%" height="0.875rem" />
+                <p-skeleton width="6%" height="0.875rem" />
+                <p-skeleton width="10%" height="0.875rem" />
+                <p-skeleton width="10%" height="0.875rem" />
               </div>
             }
           </div>
-        }
-      </div>
-    } @else if (isMeLens()) {
-      <lfx-empty-state
-        icon="fa-light fa-users-rectangle"
-        [title]="'No ' + committeeLabel.plural.toLowerCase() + ' yet'"
-        subtitle="Groups you're a member of will appear here."
-        data-testid="committees-empty-state">
-      </lfx-empty-state>
+        </lfx-card>
+      } @else if (myCommittees().length === 0) {
+        <lfx-empty-state
+          icon="fa-light fa-users-rectangle"
+          [title]="'No ' + committeeLabel.plural.toLowerCase() + ' yet'"
+          subtitle="Groups you're a member of will appear here."
+          data-testid="committees-empty-state">
+        </lfx-empty-state>
+      } @else {
+        <lfx-committee-table
+          [committees]="filteredMyCommittees()"
+          [myCommitteeUids]="myCommitteeUids()"
+          [searchForm]="searchForm"
+          [categoryOptions]="categories()"
+          [votingStatusOptions]="votingStatusOptions()"
+          [showFoundationFilter]="showFoundationFilter()"
+          [showProjectFilter]="showProjectFilter()"
+          [foundationOptions]="foundationOptions()"
+          [projectOptions]="projectOptions()"
+          (foundationFilterChange)="onFoundationFilterChange($event)"
+          (projectFilterChange)="onProjectFilterChange($event)"
+          (refresh)="refreshCommittees()"
+          (rowClick)="onCommitteeClick($event)"
+          data-testid="committees-me-table">
+        </lfx-committee-table>
+      }
     }
 
     @if (!isMeLens()) {

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -26,6 +26,7 @@ import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize
 
 import { PlatformIconPipe } from '@app/shared/pipes/platform-icon.pipe';
 import { PlatformLabelPipe } from '@app/shared/pipes/platform-label.pipe';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { CommitteeTableComponent } from '../components/committee-table/committee-table.component';
 
 @Component({
@@ -43,6 +44,7 @@ import { CommitteeTableComponent } from '../components/committee-table/committee
     PlatformLabelPipe,
     SkeletonModule,
     TooltipModule,
+    EmptyStateComponent,
   ],
   templateUrl: './committee-dashboard.component.html',
   styleUrl: './committee-dashboard.component.scss',

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -1,49 +1,33 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NgClass } from '@angular/common';
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
-import { InputTextComponent } from '@components/input-text/input-text.component';
-import { SelectComponent } from '@components/select/select.component';
 import { COMMITTEE_LABEL } from '@lfx-one/shared/constants';
 import { Committee, MyCommittee, ProjectContext } from '@lfx-one/shared/interfaces';
-import { RoleBadgeClassPipe } from '@pipes/role-badge-class.pipe';
 import { CommitteeService } from '@services/committee.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
-
 import { SkeletonModule } from 'primeng/skeleton';
-import { TooltipModule } from 'primeng/tooltip';
 import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, of, startWith, switchMap } from 'rxjs';
 
-import { PlatformIconPipe } from '@app/shared/pipes/platform-icon.pipe';
-import { PlatformLabelPipe } from '@app/shared/pipes/platform-label.pipe';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { CommitteeTableComponent } from '../components/committee-table/committee-table.component';
 
 @Component({
   selector: 'lfx-committee-dashboard',
   imports: [
-    NgClass,
-    ReactiveFormsModule,
     ButtonComponent,
     CardComponent,
     CommitteeTableComponent,
-    InputTextComponent,
-    SelectComponent,
-    RoleBadgeClassPipe,
-    PlatformIconPipe,
-    PlatformLabelPipe,
     SkeletonModule,
-    TooltipModule,
     EmptyStateComponent,
   ],
   templateUrl: './committee-dashboard.component.html',
@@ -274,7 +258,7 @@ export class CommitteeDashboardComponent {
 
   private initializeCategories(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const committeesData = this.committees();
+      const committeesData = this.isMeLens() ? this.myCommittees() : this.committees();
 
       // Count committees by category
       const categoryCounts = new Map<string, number>();
@@ -299,7 +283,7 @@ export class CommitteeDashboardComponent {
 
   private initializeVotingStatusOptions(): Signal<{ label: string; value: string | null }[]> {
     return computed(() => {
-      const committeesData = this.committees();
+      const committeesData = this.isMeLens() ? this.myCommittees() : this.committees();
 
       // Count committees by voting status
       const votingEnabledCount = committeesData.filter((c) => c.enable_voting === true).length;
@@ -403,6 +387,20 @@ export class CommitteeDashboardComponent {
             committee.description?.toLowerCase().includes(searchTerm) ||
             committee.category?.toLowerCase().includes(searchTerm)
         );
+      }
+
+      // Apply category filter
+      const category = this.categoryFilter();
+      if (category) {
+        filtered = filtered.filter((c) => c.category === category);
+      }
+
+      // Apply voting status filter
+      const votingStatus = this.votingStatusFilter();
+      if (votingStatus === 'enabled') {
+        filtered = filtered.filter((c) => c.enable_voting === true);
+      } else if (votingStatus === 'disabled') {
+        filtered = filtered.filter((c) => c.enable_voting === false);
       }
 
       return filtered;

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<lfx-card>
+<lfx-card styleClass="[&_.p-card-body]:!px-5">
   <!-- Filter Bar Inside Card -->
   <div class="pb-2 mb-2">
     <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
@@ -17,27 +17,55 @@
           data-testid="committee-search-input"></lfx-input-text>
       </div>
 
+      <!-- Foundation Filter (Me lens) -->
+      @if (showFoundationFilter()) {
+        <div class="w-full sm:w-48">
+          <lfx-select
+            [form]="searchForm()"
+            control="foundationFilter"
+            size="small"
+            [options]="foundationOptions()"
+            styleClass="w-full"
+            (onChange)="foundationFilterChange.emit($event.value)"
+            data-testid="committee-foundation-filter"></lfx-select>
+        </div>
+      }
+
+      <!-- Project Filter (Me lens) -->
+      @if (showProjectFilter()) {
+        <div class="w-full sm:w-48">
+          <lfx-select
+            [form]="searchForm()"
+            control="projectFilter"
+            size="small"
+            [options]="projectOptions()"
+            styleClass="w-full"
+            (onChange)="projectFilterChange.emit($event.value)"
+            data-testid="committee-project-filter"></lfx-select>
+        </div>
+      }
+
       <!-- Category Filter Dropdown -->
-      <div class="w-full sm:w-64">
+      <div class="w-full sm:w-48">
         <lfx-select
           [form]="searchForm()"
           control="category"
           size="small"
           [options]="categoryOptions()"
-          placeholder="Select Type"
+          placeholder="All Types"
           [showClear]="true"
           styleClass="w-full"
           data-testid="committee-type-filter"></lfx-select>
       </div>
 
       <!-- Voting Status Filter Dropdown -->
-      <div class="w-full sm:w-64">
+      <div class="w-full sm:w-48">
         <lfx-select
           [form]="searchForm()"
           control="votingStatus"
           size="small"
           [options]="votingStatusOptions()"
-          placeholder="Select Voting Status"
+          placeholder="All Voting Status"
           [showClear]="true"
           styleClass="w-full"
           data-testid="committee-voting-status-filter"></lfx-select>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
@@ -107,7 +107,7 @@
             @if (isBoardMember()) {
               <span class="text-sm font-medium">{{ committee.name || '-' }}</span>
             } @else {
-              <a [routerLink]="['/groups', committee.uid]" class="text-sm font-medium">
+              <a [routerLink]="['/groups', committee.uid]" class="lfx-table-name-link text-sm">
                 {{ committee.name || '-' }}
               </a>
             }
@@ -121,7 +121,7 @@
           <lfx-tag [value]="category" [severity]="category | committeeCategorySeverity"></lfx-tag>
         </td>
         <td class="min-w-[200px]">
-          <div class="max-w-[300px] line-clamp-2 text-xs">
+          <div class="max-w-[300px] line-clamp-2 text-sm text-gray-700">
             @if (committee.description) {
               {{ committee.description }}
             } @else {
@@ -130,10 +130,7 @@
           </div>
         </td>
         <td>
-          <a [routerLink]="['/groups', committee.uid]">
-            <!-- prettier-ignore -->
-            {{ (committee.total_members ?? 0) | number }}
-          </a>
+          <span class="text-sm text-gray-700">{{ (committee.total_members ?? 0) | number }}</span>
         </td>
         <td>
           <!-- Channels: mailing_list is the direct email string; has_mailing_list is an enriched boolean from query-service association -->
@@ -193,7 +190,7 @@
             <span class="text-gray-400 text-xs" aria-label="Voting disabled">—</span>
           }
         </td>
-        <td>{{ committee.updated_at | date: 'MMM d, y' }}</td>
+        <td><span class="text-sm text-gray-700">{{ committee.updated_at | date: 'MMM d, y' }}</span></td>
         @if (!canManageCommittee()) {
           <td class="whitespace-nowrap">
             @if (myCommitteeUids().has(committee.uid)) {
@@ -223,9 +220,9 @@
                 [attr.data-testid]="'committee-join-' + committee.uid">
               </lfx-button>
             } @else if (committee.public && committee.join_mode === 'invite_only') {
-              <span class="text-sm text-gray-500 italic">Invite only</span>
+              <span class="text-xs text-gray-500 italic">Invite only</span>
             } @else {
-              <span class="text-sm text-gray-400 italic">{{ committee.public ? 'Closed' : 'Private' }}</span>
+              <span class="text-xs text-gray-400 italic">{{ committee.public ? 'Closed' : 'Private' }}</span>
             }
           </td>
         }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
@@ -56,6 +56,10 @@ export class CommitteeTableComponent {
   public searchForm = input.required<FormGroup>();
   public categoryOptions = input.required<{ label: string; value: string | null }[]>();
   public votingStatusOptions = input.required<{ label: string; value: string | null }[]>();
+  public showFoundationFilter = input<boolean>(false);
+  public showProjectFilter = input<boolean>(false);
+  public foundationOptions = input<{ label: string; value: string | null }[]>([]);
+  public projectOptions = input<{ label: string; value: string | null }[]>([]);
 
   // State
   public isBoardMember: Signal<boolean> = computed(() => this.personaService.currentPersona() === 'board-member');
@@ -63,6 +67,8 @@ export class CommitteeTableComponent {
   // Outputs
   public readonly refresh = output<void>();
   public readonly rowClick = output<Committee>();
+  public readonly foundationFilterChange = output<string | null>();
+  public readonly projectFilterChange = output<string | null>();
 
   public joinGroup(committee: Committee): void {
     const joinMode = committee.join_mode || 'closed';

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
@@ -21,9 +21,17 @@
     </lfx-empty-state>
   } @else {
     <!-- Filter Bar + Table -->
-    <lfx-card styleClass="[&_.p-card-body]:!px-5" data-testid="documents-table-card">
+    <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="documents-table-card">
+      <!-- Source Tabs -->
+      <lfx-card-tabs-bar
+        [options]="sourceTabOptions"
+        [selectedFilter]="sourceTab()"
+        (filterChange)="onSourceTabChange($event)"
+        data-testid="documents-source-tabs">
+      </lfx-card-tabs-bar>
+
       <!-- Filters -->
-      <div class="pb-2 mb-2">
+      <div class="px-5 pt-4 pb-3">
         <div class="flex flex-wrap items-center gap-2">
           <!-- Search -->
           <div class="flex-1 min-w-48">
@@ -101,132 +109,120 @@
               data-testid="documents-mailing-list-filter">
             </lfx-select>
           </div>
-
-          <!-- Source filter -->
-          <div class="w-32 shrink-0 overflow-hidden">
-            <lfx-select
-              [form]="filterForm"
-              control="source"
-              size="small"
-              [options]="sourceOptions"
-              placeholder="All Sources"
-              [showClear]="true"
-              styleClass="w-full"
-              data-testid="documents-source-filter">
-            </lfx-select>
-          </div>
         </div>
       </div>
 
-      <!-- Filtered empty state: documents exist but no results match -->
-      @if (!loading() && filteredDocuments().length === 0) {
-        <lfx-empty-state
-          [withCard]="false"
-          icon="fa-light fa-file-lines"
-          title="No documents found"
-          subtitle="Try adjusting your search or filter criteria."
-          data-testid="documents-filtered-empty-state">
-        </lfx-empty-state>
-      } @else {
-        <!-- Table -->
-        <lfx-table
-          [value]="filteredDocuments()"
-          [paginator]="true"
-          [rows]="10"
-          [rowsPerPageOptions]="[10, 25, 50]"
-          [loading]="loading()"
-          [showPageLinks]="false"
-          [showFirstLastIcon]="false"
-          [showCurrentPageReport]="true"
-          currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
-          data-testid="documents-table">
-          <ng-template #header>
-            <tr>
-              <th class="w-[35%]">Name</th>
-              <th class="w-[20%]">Foundation</th>
-              <th class="w-[20%]">Group / Meeting</th>
-              <th class="w-[10%]">Source</th>
-              <th class="w-[10%]">Date</th>
-              <th class="w-[5%]">Actions</th>
-            </tr>
-          </ng-template>
+      <div class="px-5 pb-5">
+        <!-- Filtered empty state: documents exist but no results match -->
+        @if (!loading() && filteredDocuments().length === 0) {
+          <lfx-empty-state
+            [withCard]="false"
+            icon="fa-light fa-file-lines"
+            title="No documents found"
+            subtitle="Try adjusting your search or filter criteria."
+            data-testid="documents-filtered-empty-state">
+          </lfx-empty-state>
+        } @else {
+          <!-- Table -->
+          <lfx-table
+            [value]="filteredDocuments()"
+            [paginator]="true"
+            [rows]="10"
+            [rowsPerPageOptions]="[10, 25, 50]"
+            [loading]="loading()"
+            [showPageLinks]="false"
+            [showFirstLastIcon]="false"
+            [showCurrentPageReport]="true"
+            currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
+            data-testid="documents-table">
+            <ng-template #header>
+              <tr>
+                <th class="w-[35%]">Name</th>
+                <th class="w-[20%]">Foundation</th>
+                <th class="w-[20%]">Group / Meeting</th>
+                <th class="w-[10%]">Source</th>
+                <th class="w-[10%]">Date</th>
+                <th class="w-[5%]">Actions</th>
+              </tr>
+            </ng-template>
 
-          <ng-template #body let-doc let-rowIndex="rowIndex">
-            <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'documents-row-' + doc.id">
-              <!-- Name column -->
-              <td>
-                <div class="flex items-center gap-2">
-                  <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' ' + (doc.source | myDocumentSourceTag: 'iconClass')" class="text-base shrink-0"></i>
-                  @if (doc.url) {
-                    <button
-                      type="button"
-                      class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate"
-                      (click)="openDocument(doc)"
-                      [attr.data-testid]="'documents-name-' + doc.id">
-                      {{ doc.name }}
-                    </button>
-                  } @else {
-                    <span class="text-xs text-gray-900 truncate">{{ doc.name }}</span>
-                  }
-                </div>
-              </td>
+            <ng-template #body let-doc let-rowIndex="rowIndex">
+              <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'documents-row-' + doc.id">
+                <!-- Name column -->
+                <td>
+                  <div class="flex items-center gap-2">
+                    <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' ' + (doc.source | myDocumentSourceTag: 'iconClass')" class="text-base shrink-0"></i>
+                    @if (doc.url) {
+                      <button
+                        type="button"
+                        class="lfx-table-name-link text-sm text-left bg-transparent border-none p-0 truncate"
+                        (click)="openDocument(doc)"
+                        [attr.data-testid]="'documents-name-' + doc.id">
+                        {{ doc.name }}
+                      </button>
+                    } @else {
+                      <span class="text-sm text-gray-900 truncate">{{ doc.name }}</span>
+                    }
+                  </div>
+                </td>
 
-              <!-- Foundation column -->
-              <td>
-                <span class="text-xs text-gray-700">{{ doc.foundationName || '—' }}</span>
-              </td>
+                <!-- Foundation column -->
+                <td>
+                  <span class="text-sm text-gray-700">{{ doc.foundationName || '—' }}</span>
+                </td>
 
-              <!-- Group / Meeting column -->
-              <td>
-                <span class="text-xs text-gray-700">{{ doc.groupOrMeetingName || '—' }}</span>
-              </td>
+                <!-- Group / Meeting column -->
+                <td>
+                  <span class="text-sm text-gray-700">{{ doc.groupOrMeetingName || '—' }}</span>
+                </td>
 
-              <!-- Source column -->
-              <td>
-                <lfx-tag
-                  [value]="doc.source | myDocumentSourceTag: 'label'"
-                  [severity]="doc.source | myDocumentSourceTag: 'severity'"
-                  [attr.data-testid]="'documents-source-tag-' + doc.id">
-                </lfx-tag>
-              </td>
+                <!-- Source column -->
+                <td>
+                  <lfx-tag
+                    [value]="doc.source | myDocumentSourceTag: 'label'"
+                    [severity]="doc.source | myDocumentSourceTag: 'severity'"
+                    [attr.data-testid]="'documents-source-tag-' + doc.id">
+                  </lfx-tag>
+                </td>
 
-              <!-- Date column -->
-              <td>
-                <span class="text-xs text-gray-700">{{ doc.date | date: 'MMM d, y' }}</span>
-              </td>
+                <!-- Date column -->
+                <td>
+                  <span class="text-sm text-gray-700">{{ doc.date | date: 'MMM d, y' }}</span>
+                </td>
 
-              <!-- Actions column -->
-              <td>
-                <div class="flex items-center justify-end gap-1">
-                  @if (doc.source === 'file' && doc.attachmentUid) {
-                    <lfx-button
-                      icon="fa-light fa-arrow-down-to-line"
-                      severity="primary"
-                      size="small"
-                      [text]="true"
-                      (onClick)="openDocument(doc)"
-                      [attr.data-testid]="'documents-download-' + doc.id"
-                      tooltip="Download"
-                      tooltipPosition="top">
-                    </lfx-button>
-                  } @else if (doc.url) {
-                    <lfx-button
-                      [icon]="doc.source === 'recording' ? 'fa-solid fa-circle-play' : 'fa-light fa-arrow-up-right-from-square'"
-                      severity="primary"
-                      size="small"
-                      [text]="true"
-                      (onClick)="openDocument(doc)"
-                      [attr.data-testid]="'documents-open-' + doc.id"
-                      [tooltip]="doc.source === 'recording' ? 'Play recording' : 'Open'"
-                      tooltipPosition="top">
-                    </lfx-button>
-                  }
-                </div>
-              </td>
-            </tr>
-          </ng-template>
-        </lfx-table>
-      }
+                <!-- Actions column -->
+                <td>
+                  <div class="flex items-center justify-end gap-1">
+                    @if (doc.source === 'file' && doc.attachmentUid) {
+                      <lfx-button
+                        icon="fa-light fa-arrow-down-to-line"
+                        severity="primary"
+                        size="small"
+                        [text]="true"
+                        (onClick)="openDocument(doc)"
+                        [attr.data-testid]="'documents-download-' + doc.id"
+                        tooltip="Download"
+                        tooltipPosition="top">
+                      </lfx-button>
+                    } @else if (doc.url) {
+                      <lfx-button
+                        [icon]="doc.source === 'recording' ? 'fa-solid fa-circle-play' : 'fa-light fa-arrow-up-right-from-square'"
+                        severity="primary"
+                        size="small"
+                        [text]="true"
+                        (onClick)="openDocument(doc)"
+                        [attr.data-testid]="'documents-open-' + doc.id"
+                        [tooltip]="doc.source === 'recording' ? 'Play recording' : 'Open'"
+                        tooltipPosition="top">
+                      </lfx-button>
+                    }
+                  </div>
+                </td>
+              </tr>
+            </ng-template>
+          </lfx-table>
+        }
+      </div>
     </lfx-card>
   }
   </div>

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
@@ -2,220 +2,232 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="documents-dashboard">
+  <div class="flex flex-col gap-6">
   <!-- Page Header -->
-  <div class="flex items-start justify-between mb-8">
+  <div class="flex items-start justify-between mt-3">
     <div>
-      <h1 class="font-display font-light text-2xl mb-1" data-testid="documents-dashboard-title">My {{ documentLabel.plural }}</h1>
-      <p class="mt-1 text-gray-500" data-testid="documents-dashboard-description">
-        Documents, links, and attachments from your groups and meetings across all foundations.
-      </p>
+      <h1 class="font-display font-light text-2xl" data-testid="documents-dashboard-title">My {{ documentLabel.plural }}</h1>
+      <p class="mt-1 text-sm text-gray-500" data-testid="documents-dashboard-description">Documents, links, and attachments from your groups and meetings across all foundations.</p>
     </div>
   </div>
 
-  <!-- Filter Bar + Table -->
-  <lfx-card data-testid="documents-table-card">
-    <!-- Filters -->
-    <div class="pb-3 mb-3 border-b border-gray-100">
-      <div class="flex flex-wrap items-center gap-2">
-        <!-- Search -->
-        <div class="flex-1 min-w-48">
-          <lfx-input-text
-            [form]="filterForm"
-            control="search"
-            placeholder="Search documents..."
-            icon="fa-light fa-search"
-            styleClass="w-full"
-            size="small"
-            data-testid="documents-search-input">
-          </lfx-input-text>
-        </div>
+  <!-- Primary empty state: no documents at all -->
+  @if (!loading() && documents().length === 0) {
+    <lfx-empty-state
+      icon="fa-light fa-file-lines"
+      title="No documents yet"
+      subtitle="Documents, links, and attachments from your groups and meetings will appear here."
+      data-testid="documents-empty-state">
+    </lfx-empty-state>
+  } @else {
+    <!-- Filter Bar + Table -->
+    <lfx-card data-testid="documents-table-card">
+      <!-- Filters -->
+      <div class="pb-3 mb-3 border-b border-gray-100">
+        <div class="flex flex-wrap items-center gap-2">
+          <!-- Search -->
+          <div class="flex-1 min-w-48">
+            <lfx-input-text
+              [form]="filterForm"
+              control="search"
+              placeholder="Search documents..."
+              icon="fa-light fa-search"
+              styleClass="w-full"
+              size="small"
+              data-testid="documents-search-input">
+            </lfx-input-text>
+          </div>
 
-        <!-- Foundation filter -->
-        <div class="w-40 shrink-0 overflow-hidden">
-          <lfx-select
-            [form]="filterForm"
-            control="foundation"
-            size="small"
-            [options]="foundationOptions()"
-            placeholder="All Foundations"
-            [showClear]="true"
-            [filter]="true"
-            filterPlaceholder="Search foundations..."
-            styleClass="w-full"
-            data-testid="documents-foundation-filter">
-          </lfx-select>
-        </div>
+          <!-- Foundation filter -->
+          <div class="w-40 shrink-0 overflow-hidden">
+            <lfx-select
+              [form]="filterForm"
+              control="foundation"
+              size="small"
+              [options]="foundationOptions()"
+              placeholder="All Foundations"
+              [showClear]="true"
+              [filter]="true"
+              filterPlaceholder="Search foundations..."
+              styleClass="w-full"
+              data-testid="documents-foundation-filter">
+            </lfx-select>
+          </div>
 
-        <!-- Group filter -->
-        <div class="w-36 shrink-0 overflow-hidden">
-          <lfx-select
-            [form]="filterForm"
-            control="group"
-            size="small"
-            [options]="groupOptions()"
-            placeholder="All Groups"
-            [showClear]="true"
-            [filter]="true"
-            filterPlaceholder="Search groups..."
-            styleClass="w-full"
-            data-testid="documents-group-filter">
-          </lfx-select>
-        </div>
+          <!-- Group filter -->
+          <div class="w-36 shrink-0 overflow-hidden">
+            <lfx-select
+              [form]="filterForm"
+              control="group"
+              size="small"
+              [options]="groupOptions()"
+              placeholder="All Groups"
+              [showClear]="true"
+              [filter]="true"
+              filterPlaceholder="Search groups..."
+              styleClass="w-full"
+              data-testid="documents-group-filter">
+            </lfx-select>
+          </div>
 
-        <!-- Meeting filter -->
-        <div class="w-36 shrink-0 overflow-hidden">
-          <lfx-select
-            [form]="filterForm"
-            control="meeting"
-            size="small"
-            [options]="meetingOptions()"
-            placeholder="All Meetings"
-            [showClear]="true"
-            [filter]="true"
-            filterPlaceholder="Search meetings..."
-            styleClass="w-full"
-            data-testid="documents-meeting-filter">
-          </lfx-select>
-        </div>
+          <!-- Meeting filter -->
+          <div class="w-36 shrink-0 overflow-hidden">
+            <lfx-select
+              [form]="filterForm"
+              control="meeting"
+              size="small"
+              [options]="meetingOptions()"
+              placeholder="All Meetings"
+              [showClear]="true"
+              [filter]="true"
+              filterPlaceholder="Search meetings..."
+              styleClass="w-full"
+              data-testid="documents-meeting-filter">
+            </lfx-select>
+          </div>
 
-        <!-- Mailing list filter -->
-        <div class="w-40 shrink-0 overflow-hidden">
-          <lfx-select
-            [form]="filterForm"
-            control="mailingList"
-            size="small"
-            [options]="mailingListOptions()"
-            placeholder="All Mailing Lists"
-            [showClear]="true"
-            [filter]="true"
-            filterPlaceholder="Search mailing lists..."
-            styleClass="w-full"
-            data-testid="documents-mailing-list-filter">
-          </lfx-select>
-        </div>
+          <!-- Mailing list filter -->
+          <div class="w-40 shrink-0 overflow-hidden">
+            <lfx-select
+              [form]="filterForm"
+              control="mailingList"
+              size="small"
+              [options]="mailingListOptions()"
+              placeholder="All Mailing Lists"
+              [showClear]="true"
+              [filter]="true"
+              filterPlaceholder="Search mailing lists..."
+              styleClass="w-full"
+              data-testid="documents-mailing-list-filter">
+            </lfx-select>
+          </div>
 
-        <!-- Source filter -->
-        <div class="w-32 shrink-0 overflow-hidden">
-          <lfx-select
-            [form]="filterForm"
-            control="source"
-            size="small"
-            [options]="sourceOptions"
-            placeholder="All Sources"
-            [showClear]="true"
-            styleClass="w-full"
-            data-testid="documents-source-filter">
-          </lfx-select>
+          <!-- Source filter -->
+          <div class="w-32 shrink-0 overflow-hidden">
+            <lfx-select
+              [form]="filterForm"
+              control="source"
+              size="small"
+              [options]="sourceOptions"
+              placeholder="All Sources"
+              [showClear]="true"
+              styleClass="w-full"
+              data-testid="documents-source-filter">
+            </lfx-select>
+          </div>
         </div>
       </div>
-    </div>
 
-    <!-- Table -->
-    <lfx-table
-      [value]="filteredDocuments()"
-      [paginator]="true"
-      [rows]="10"
-      [rowsPerPageOptions]="[10, 25, 50]"
-      [loading]="loading()"
-      [showPageLinks]="false"
-      [showFirstLastIcon]="false"
-      [showCurrentPageReport]="true"
-      currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
-      data-testid="documents-table">
-      <ng-template #header>
-        <tr>
-          <th class="w-[35%]">Name</th>
-          <th class="w-[20%]">Foundation</th>
-          <th class="w-[20%]">Group / Meeting</th>
-          <th class="w-[10%]">Source</th>
-          <th class="w-[10%]">Date</th>
-          <th class="w-[5%]">Actions</th>
-        </tr>
-      </ng-template>
+      <!-- Filtered empty state: documents exist but no results match -->
+      @if (!loading() && filteredDocuments().length === 0) {
+        <lfx-empty-state
+          [withCard]="false"
+          icon="fa-light fa-file-lines"
+          title="No documents found"
+          subtitle="Try adjusting your search or filter criteria."
+          data-testid="documents-filtered-empty-state">
+        </lfx-empty-state>
+      } @else {
+        <!-- Table -->
+        <lfx-table
+          [value]="filteredDocuments()"
+          [paginator]="true"
+          [rows]="10"
+          [rowsPerPageOptions]="[10, 25, 50]"
+          [loading]="loading()"
+          [showPageLinks]="false"
+          [showFirstLastIcon]="false"
+          [showCurrentPageReport]="true"
+          currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
+          data-testid="documents-table">
+          <ng-template #header>
+            <tr>
+              <th class="w-[35%]">Name</th>
+              <th class="w-[20%]">Foundation</th>
+              <th class="w-[20%]">Group / Meeting</th>
+              <th class="w-[10%]">Source</th>
+              <th class="w-[10%]">Date</th>
+              <th class="w-[5%]">Actions</th>
+            </tr>
+          </ng-template>
 
-      <ng-template #body let-doc let-rowIndex="rowIndex">
-        <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'documents-row-' + doc.id">
-          <!-- Name column -->
-          <td>
-            <div class="flex items-center gap-2">
-              <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' ' + (doc.source | myDocumentSourceTag: 'iconClass')" class="text-base shrink-0"></i>
-              @if (doc.url) {
-                <button
-                  type="button"
-                  class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate"
-                  (click)="openDocument(doc)"
-                  [attr.data-testid]="'documents-name-' + doc.id">
-                  {{ doc.name }}
-                </button>
-              } @else {
-                <span class="text-xs text-gray-900 truncate">{{ doc.name }}</span>
-              }
-            </div>
-          </td>
+          <ng-template #body let-doc let-rowIndex="rowIndex">
+            <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'documents-row-' + doc.id">
+              <!-- Name column -->
+              <td>
+                <div class="flex items-center gap-2">
+                  <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' ' + (doc.source | myDocumentSourceTag: 'iconClass')" class="text-base shrink-0"></i>
+                  @if (doc.url) {
+                    <button
+                      type="button"
+                      class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate"
+                      (click)="openDocument(doc)"
+                      [attr.data-testid]="'documents-name-' + doc.id">
+                      {{ doc.name }}
+                    </button>
+                  } @else {
+                    <span class="text-xs text-gray-900 truncate">{{ doc.name }}</span>
+                  }
+                </div>
+              </td>
 
-          <!-- Foundation column -->
-          <td>
-            <span class="text-xs text-gray-700">{{ doc.foundationName || '—' }}</span>
-          </td>
+              <!-- Foundation column -->
+              <td>
+                <span class="text-xs text-gray-700">{{ doc.foundationName || '—' }}</span>
+              </td>
 
-          <!-- Group / Meeting column -->
-          <td>
-            <span class="text-xs text-gray-700">{{ doc.groupOrMeetingName || '—' }}</span>
-          </td>
+              <!-- Group / Meeting column -->
+              <td>
+                <span class="text-xs text-gray-700">{{ doc.groupOrMeetingName || '—' }}</span>
+              </td>
 
-          <!-- Source column -->
-          <td>
-            <lfx-tag
-              [value]="doc.source | myDocumentSourceTag: 'label'"
-              [severity]="doc.source | myDocumentSourceTag: 'severity'"
-              [attr.data-testid]="'documents-source-tag-' + doc.id">
-            </lfx-tag>
-          </td>
+              <!-- Source column -->
+              <td>
+                <lfx-tag
+                  [value]="doc.source | myDocumentSourceTag: 'label'"
+                  [severity]="doc.source | myDocumentSourceTag: 'severity'"
+                  [attr.data-testid]="'documents-source-tag-' + doc.id">
+                </lfx-tag>
+              </td>
 
-          <!-- Date column -->
-          <td>
-            <span class="text-xs text-gray-700">{{ doc.date | date: 'MMM d, y' }}</span>
-          </td>
+              <!-- Date column -->
+              <td>
+                <span class="text-xs text-gray-700">{{ doc.date | date: 'MMM d, y' }}</span>
+              </td>
 
-          <!-- Actions column -->
-          <td>
-            <div class="flex items-center justify-end gap-1">
-              @if (doc.source === 'file' && doc.attachmentUid) {
-                <lfx-button
-                  icon="fa-light fa-arrow-down-to-line"
-                  severity="primary"
-                  size="small"
-                  [text]="true"
-                  (onClick)="openDocument(doc)"
-                  [attr.data-testid]="'documents-download-' + doc.id"
-                  tooltip="Download"
-                  tooltipPosition="top">
-                </lfx-button>
-              } @else if (doc.url) {
-                <lfx-button
-                  [icon]="doc.source === 'recording' ? 'fa-solid fa-circle-play' : 'fa-light fa-arrow-up-right-from-square'"
-                  severity="primary"
-                  size="small"
-                  [text]="true"
-                  (onClick)="openDocument(doc)"
-                  [attr.data-testid]="'documents-open-' + doc.id"
-                  [tooltip]="doc.source === 'recording' ? 'Play recording' : 'Open'"
-                  tooltipPosition="top">
-                </lfx-button>
-              }
-            </div>
-          </td>
-        </tr>
-      </ng-template>
-
-      <ng-template #emptymessage>
-        <tr>
-          <td colspan="6" class="text-center py-8">
-            <i class="fa-light fa-file-lines text-3xl text-gray-400 mb-2 block"></i>
-            <p class="text-sm text-gray-500">No documents found</p>
-          </td>
-        </tr>
-      </ng-template>
-    </lfx-table>
-  </lfx-card>
+              <!-- Actions column -->
+              <td>
+                <div class="flex items-center justify-end gap-1">
+                  @if (doc.source === 'file' && doc.attachmentUid) {
+                    <lfx-button
+                      icon="fa-light fa-arrow-down-to-line"
+                      severity="primary"
+                      size="small"
+                      [text]="true"
+                      (onClick)="openDocument(doc)"
+                      [attr.data-testid]="'documents-download-' + doc.id"
+                      tooltip="Download"
+                      tooltipPosition="top">
+                    </lfx-button>
+                  } @else if (doc.url) {
+                    <lfx-button
+                      [icon]="doc.source === 'recording' ? 'fa-solid fa-circle-play' : 'fa-light fa-arrow-up-right-from-square'"
+                      severity="primary"
+                      size="small"
+                      [text]="true"
+                      (onClick)="openDocument(doc)"
+                      [attr.data-testid]="'documents-open-' + doc.id"
+                      [tooltip]="doc.source === 'recording' ? 'Play recording' : 'Open'"
+                      tooltipPosition="top">
+                    </lfx-button>
+                  }
+                </div>
+              </td>
+            </tr>
+          </ng-template>
+        </lfx-table>
+      }
+    </lfx-card>
+  }
+  </div>
 </div>

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
@@ -21,9 +21,9 @@
     </lfx-empty-state>
   } @else {
     <!-- Filter Bar + Table -->
-    <lfx-card data-testid="documents-table-card">
+    <lfx-card styleClass="[&_.p-card-body]:!px-5" data-testid="documents-table-card">
       <!-- Filters -->
-      <div class="pb-3 mb-3 border-b border-gray-100">
+      <div class="pb-2 mb-2">
         <div class="flex flex-wrap items-center gap-2">
           <!-- Search -->
           <div class="flex-1 min-w-48">

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
@@ -7,12 +7,13 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { DOCUMENT_LABEL } from '@lfx-one/shared/constants';
-import { MyDocumentItem, MyDocumentSource } from '@lfx-one/shared/interfaces';
+import { FilterPillOption, MyDocumentItem, MyDocumentSource } from '@lfx-one/shared/interfaces';
 import { DocumentService } from '@services/document.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { catchError, debounceTime, distinctUntilChanged, finalize, map, of, startWith, switchMap } from 'rxjs';
@@ -23,6 +24,7 @@ import { MyDocumentSourceTagPipe } from '@app/shared/pipes/my-document-source-ta
   selector: 'lfx-documents-dashboard',
   imports: [
     CardComponent,
+    CardTabsBarComponent,
     ButtonComponent,
     InputTextComponent,
     SelectComponent,
@@ -43,11 +45,11 @@ export class DocumentsDashboardComponent {
 
   // === Constants ===
   protected readonly documentLabel = DOCUMENT_LABEL;
-  protected readonly sourceOptions: { label: string; value: MyDocumentSource | null }[] = [
-    { label: 'All Sources', value: null },
-    { label: 'Link', value: 'link' as MyDocumentSource },
-    { label: 'Meeting', value: 'meeting' as MyDocumentSource },
-    { label: 'Mailing List', value: 'mailing_list' as MyDocumentSource },
+  protected readonly sourceTabOptions: FilterPillOption[] = [
+    { id: 'all', label: 'All Sources' },
+    { id: 'link', label: 'Links' },
+    { id: 'meeting', label: 'Meetings' },
+    { id: 'mailing_list', label: 'Mailing Lists' },
   ];
 
   // === Forms ===
@@ -57,11 +59,11 @@ export class DocumentsDashboardComponent {
     group: new FormControl<string | null>(null),
     meeting: new FormControl<string | null>(null),
     mailingList: new FormControl<string | null>(null),
-    source: new FormControl<MyDocumentSource | null>(null),
   });
 
   // === Writable Signals ===
   protected readonly loading = signal<boolean>(true);
+  protected readonly sourceTab = signal<string>('all');
 
   // === Computed Signals ===
   protected readonly project = this.projectContextService.activeContext;
@@ -70,7 +72,6 @@ export class DocumentsDashboardComponent {
   protected readonly groupFilter: Signal<string | null> = this.initGroupFilter();
   protected readonly meetingFilter: Signal<string | null> = this.initMeetingFilter();
   protected readonly mailingListFilter: Signal<string | null> = this.initMailingListFilter();
-  protected readonly sourceFilter: Signal<MyDocumentSource | null> = this.initSourceFilter();
   protected readonly documents: Signal<MyDocumentItem[]> = this.initDocuments();
   protected readonly filteredDocuments: Signal<MyDocumentItem[]> = this.initFilteredDocuments();
   protected readonly foundationOptions: Signal<{ label: string; value: string | null }[]> = this.initFoundationOptions();
@@ -79,6 +80,10 @@ export class DocumentsDashboardComponent {
   protected readonly mailingListOptions: Signal<{ label: string; value: string | null }[]> = this.initMailingListOptions();
 
   // === Protected Methods ===
+  protected onSourceTabChange(tab: string): void {
+    this.sourceTab.set(tab);
+  }
+
   protected openDocument(doc: MyDocumentItem): void {
     if (!doc.url) return;
     try {
@@ -120,10 +125,6 @@ export class DocumentsDashboardComponent {
     return toSignal(this.filterForm.controls.mailingList.valueChanges.pipe(startWith<string | null>(null)), { initialValue: null });
   }
 
-  private initSourceFilter(): Signal<MyDocumentSource | null> {
-    return toSignal(this.filterForm.controls.source.valueChanges.pipe(startWith<MyDocumentSource | null>(null)), { initialValue: null });
-  }
-
   private initDocuments(): Signal<MyDocumentItem[]> {
     return toSignal(
       toObservable(this.project).pipe(
@@ -148,7 +149,7 @@ export class DocumentsDashboardComponent {
       const group = this.groupFilter();
       const meeting = this.meetingFilter();
       const mailingList = this.mailingListFilter();
-      const source = this.sourceFilter();
+      const sourceTab = this.sourceTab();
 
       return docs.filter((doc) => {
         if (
@@ -163,8 +164,10 @@ export class DocumentsDashboardComponent {
         if (group && doc.groupOrMeetingUid !== group) return false;
         if (meeting && doc.meetingId !== meeting && doc.pastMeetingId !== meeting) return false;
         if (mailingList && doc.mailingListId !== mailingList) return false;
-        const meetingGroupSources: MyDocumentSource[] = ['file', 'recording', 'transcript', 'summary'];
-        if (source && doc.source !== source && !(source === 'meeting' && meetingGroupSources.includes(doc.source))) return false;
+        if (sourceTab !== 'all') {
+          const meetingGroupSources: MyDocumentSource[] = ['file', 'recording', 'transcript', 'summary'];
+          if (doc.source !== sourceTab && !(sourceTab === 'meeting' && meetingGroupSources.includes(doc.source))) return false;
+        }
         return true;
       });
     });

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
@@ -16,6 +16,7 @@ import { MyDocumentItem, MyDocumentSource } from '@lfx-one/shared/interfaces';
 import { DocumentService } from '@services/document.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { catchError, debounceTime, distinctUntilChanged, finalize, map, of, startWith, switchMap } from 'rxjs';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { MyDocumentSourceTagPipe } from '@app/shared/pipes/my-document-source-tag.pipe';
 
 @Component({
@@ -30,6 +31,7 @@ import { MyDocumentSourceTagPipe } from '@app/shared/pipes/my-document-source-ta
     ReactiveFormsModule,
     DatePipe,
     MyDocumentSourceTagPipe,
+    EmptyStateComponent,
   ],
   templateUrl: './documents-dashboard.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/apps/lfx-one/src/app/modules/events/components/discover-events-button/discover-events-button.component.html
+++ b/apps/lfx-one/src/app/modules/events/components/discover-events-button/discover-events-button.component.html
@@ -6,7 +6,7 @@
   icon="fa-light fa-arrow-up-right-from-square"
   [text]="true"
   severity="primary"
-  [attr.data-testid]="testId()"
+[attr.data-testid]="testId()"
   target="_blank"
   rel="noopener noreferrer"
   [href]="discoverUrl" />

--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.html
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.html
@@ -7,7 +7,7 @@
     <lfx-input-text
       [form]="searchForm"
       control="search"
-      placeholder="Search events..."
+      [placeholder]="searchPlaceholder()"
       icon="fa-light fa-search"
       styleClass="w-full pr-7"
       size="small"

--- a/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/events/components/events-top-bar/events-top-bar.component.ts
@@ -24,6 +24,7 @@ export class EventsTopBarComponent {
   public readonly projectName = input<string | undefined>(undefined);
   /** When true, foundation options are scoped to the user's registered past events */
   public readonly isPast = input<boolean>(false);
+  public readonly searchPlaceholder = input<string>('Search events...');
   public readonly searchQueryChange = output<string>();
 
   public readonly searchForm: FormGroup = new FormGroup({

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.html
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/components/events-table/events-table.component.html
@@ -60,7 +60,7 @@
           [href]="event.url"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline"
+          class="lfx-table-name-link text-sm"
           [attr.data-testid]="'event-name-' + event.id">
           {{ event.name }}
         </a>
@@ -71,24 +71,24 @@
         @if (event.category) {
           <lfx-tag [value]="event.category" severity="secondary" [attr.data-testid]="'event-type-' + event.id" />
         } @else {
-          <span class="text-sm text-gray-400">—</span>
+          <span class="text-xs text-gray-400">—</span>
         }
       </td>
 
       <!-- Date -->
       <td>
-        <span class="text-sm text-gray-700">{{ event.date }}</span>
+        <span class="text-xs text-gray-700">{{ event.date }}</span>
       </td>
 
       <!-- Location -->
       <td>
-        <span class="text-sm text-gray-700">{{ event.location }}</span>
+        <span class="text-xs text-gray-700">{{ event.location }}</span>
       </td>
 
       <!-- Attendees -->
       @if (isPastEvents()) {
         <td>
-          <span class="text-sm text-gray-700" [attr.data-testid]="'event-attendees-' + event.id">
+          <span class="text-xs text-gray-700" [attr.data-testid]="'event-attendees-' + event.id">
             {{ event.attendees !== null ? (event.attendees | number) : '—' }}
           </span>
         </td>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.html
@@ -30,7 +30,7 @@
           scope="col"
           [attr.aria-sort]="sortField() === 'EVENT_NAME' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
           [attr.data-testid]="config().testIdPrefix + '-sort-event-name'">
-          <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('EVENT_NAME')">
+          <button type="button" class="flex cursor-pointer select-none items-center gap-1 text-xs text-gray-500 font-medium" (click)="onHeaderClick('EVENT_NAME')">
             Event Name <i [class]="sortIcons()['EVENT_NAME']"></i>
           </button>
         </th>
@@ -38,7 +38,7 @@
           scope="col"
           [attr.aria-sort]="sortField() === 'EVENT_CITY' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
           [attr.data-testid]="config().testIdPrefix + '-sort-location'">
-          <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('EVENT_CITY')">
+          <button type="button" class="flex cursor-pointer select-none items-center gap-1 text-xs text-gray-500 font-medium" (click)="onHeaderClick('EVENT_CITY')">
             Location <i [class]="sortIcons()['EVENT_CITY']"></i>
           </button>
         </th>
@@ -46,7 +46,7 @@
           scope="col"
           [attr.aria-sort]="sortField() === 'APPLICATION_DATE' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
           [attr.data-testid]="config().testIdPrefix + '-sort-application-date'">
-          <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('APPLICATION_DATE')">
+          <button type="button" class="flex cursor-pointer select-none items-center gap-1 text-xs text-gray-500 font-medium" (click)="onHeaderClick('APPLICATION_DATE')">
             Application Date <i [class]="sortIcons()['APPLICATION_DATE']"></i>
           </button>
         </th>
@@ -67,10 +67,10 @@
           </a>
         </td>
         <td>
-          <span class="text-sm text-gray-700" [attr.data-testid]="config().testIdPrefix + '-location-' + request.id">{{ request.location }}</span>
+          <span class="text-xs text-gray-700" [attr.data-testid]="config().testIdPrefix + '-location-' + request.id">{{ request.location }}</span>
         </td>
         <td>
-          <span class="text-sm text-gray-700" [attr.data-testid]="config().testIdPrefix + '-application-date-' + request.id">{{ request.applicationDate }}</span>
+          <span class="text-xs text-gray-700" [attr.data-testid]="config().testIdPrefix + '-application-date-' + request.id">{{ request.applicationDate }}</span>
         </td>
         <td>
           <lfx-tag

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.html
@@ -50,7 +50,7 @@
             Application Date <i [class]="sortIcons()['APPLICATION_DATE']"></i>
           </button>
         </th>
-        <th scope="col">Status</th>
+        <th scope="col" class="text-right">Status</th>
       </tr>
     </ng-template>
 
@@ -61,22 +61,24 @@
             [href]="request.url"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline"
+            class="lfx-table-name-link text-sm"
             [attr.data-testid]="config().testIdPrefix + '-event-name-' + request.id">
             {{ request.name }}
           </a>
         </td>
         <td>
-          <span class="text-xs text-gray-700" [attr.data-testid]="config().testIdPrefix + '-location-' + request.id">{{ request.location }}</span>
+          <span class="text-sm text-gray-700" [attr.data-testid]="config().testIdPrefix + '-location-' + request.id">{{ request.location }}</span>
         </td>
         <td>
-          <span class="text-xs text-gray-700" [attr.data-testid]="config().testIdPrefix + '-application-date-' + request.id">{{ request.applicationDate }}</span>
+          <span class="text-sm text-gray-700" [attr.data-testid]="config().testIdPrefix + '-application-date-' + request.id">{{ request.applicationDate }}</span>
         </td>
         <td>
-          <lfx-tag
-            [value]="request.status"
-            [severity]="request.status | eventRequestStatusSeverity"
-            [attr.data-testid]="config().testIdPrefix + '-status-' + request.id" />
+          <div class="flex justify-end">
+            <lfx-tag
+              [value]="request.status"
+              [severity]="request.status | eventRequestStatusSeverity"
+              [attr.data-testid]="config().testIdPrefix + '-status-' + request.id" />
+          </div>
         </td>
       </tr>
     </ng-template>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.html
@@ -1,107 +1,84 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex justify-end my-4 pr-4">
-  <lfx-button
-    [label]="config().buttonLabel"
-    [icon]="isSalesforceIdLoading() ? 'fa-light fa-spinner-third fa-spin' : 'fa-light fa-plus'"
-    severity="primary"
-    size="small"
-    [disabled]="!isCreateEnabled()"
-    (onClick)="openApplicationDialog()"
-    [attr.data-testid]="config().testIdPrefix + '-discover-button'" />
-</div>
-<lfx-table
-  [value]="requestsResponse().data"
-  [loading]="loading()"
-  [lazy]="true"
-  [paginator]="requestsResponse().total > 0"
-  [alwaysShowPaginator]="true"
-  [rows]="requestsResponse().pageSize"
-  [first]="requestsResponse().offset"
-  [totalRecords]="requestsResponse().total"
-  [rowsPerPageOptions]="[10, 25, 50]"
-  [showCurrentPageReport]="true"
-  currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
-  paginatorPosition="bottom"
-  (onPage)="onPageChange($event)"
-  [attr.data-testid]="config().testIdPrefix + '-data-table'">
-  <ng-template #header>
-    <tr>
-      <th
-        scope="col"
-        [attr.aria-sort]="sortField() === 'EVENT_NAME' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
-        [attr.data-testid]="config().testIdPrefix + '-sort-event-name'">
-        <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('EVENT_NAME')">
-          Event Name <i [class]="sortIcons()['EVENT_NAME']"></i>
-        </button>
-      </th>
-      <th
-        scope="col"
-        [attr.aria-sort]="sortField() === 'EVENT_CITY' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
-        [attr.data-testid]="config().testIdPrefix + '-sort-location'">
-        <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('EVENT_CITY')">
-          Location <i [class]="sortIcons()['EVENT_CITY']"></i>
-        </button>
-      </th>
-      <th
-        scope="col"
-        [attr.aria-sort]="sortField() === 'APPLICATION_DATE' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
-        [attr.data-testid]="config().testIdPrefix + '-sort-application-date'">
-        <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('APPLICATION_DATE')">
-          Application Date <i [class]="sortIcons()['APPLICATION_DATE']"></i>
-        </button>
-      </th>
-      <th scope="col">Status</th>
-    </tr>
-  </ng-template>
+@if (!loading() && requestsResponse().data.length === 0) {
+  <lfx-empty-state
+    [withCard]="false"
+    [icon]="config().emptyIcon"
+    [title]="config().emptyTitle"
+    [subtitle]="config().emptySubtitle"
+    [attr.data-testid]="config().testIdPrefix + '-empty-state'" />
+} @else {
+  <lfx-table
+    [value]="requestsResponse().data"
+    [loading]="loading()"
+    [lazy]="true"
+    [paginator]="requestsResponse().total > 0"
+    [alwaysShowPaginator]="true"
+    [rows]="requestsResponse().pageSize"
+    [first]="requestsResponse().offset"
+    [totalRecords]="requestsResponse().total"
+    [rowsPerPageOptions]="[10, 25, 50]"
+    [showCurrentPageReport]="true"
+    currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
+    paginatorPosition="bottom"
+    (onPage)="onPageChange($event)"
+    [attr.data-testid]="config().testIdPrefix + '-data-table'">
+    <ng-template #header>
+      <tr>
+        <th
+          scope="col"
+          [attr.aria-sort]="sortField() === 'EVENT_NAME' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
+          [attr.data-testid]="config().testIdPrefix + '-sort-event-name'">
+          <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('EVENT_NAME')">
+            Event Name <i [class]="sortIcons()['EVENT_NAME']"></i>
+          </button>
+        </th>
+        <th
+          scope="col"
+          [attr.aria-sort]="sortField() === 'EVENT_CITY' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
+          [attr.data-testid]="config().testIdPrefix + '-sort-location'">
+          <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('EVENT_CITY')">
+            Location <i [class]="sortIcons()['EVENT_CITY']"></i>
+          </button>
+        </th>
+        <th
+          scope="col"
+          [attr.aria-sort]="sortField() === 'APPLICATION_DATE' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
+          [attr.data-testid]="config().testIdPrefix + '-sort-application-date'">
+          <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('APPLICATION_DATE')">
+            Application Date <i [class]="sortIcons()['APPLICATION_DATE']"></i>
+          </button>
+        </th>
+        <th scope="col">Status</th>
+      </tr>
+    </ng-template>
 
-  <ng-template #body let-request let-rowIndex="rowIndex">
-    <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="config().testIdPrefix + '-row-' + request.id">
-      <!-- Event Name -->
-      <td>
-        <a
-          [href]="request.url"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline"
-          [attr.data-testid]="config().testIdPrefix + '-event-name-' + request.id">
-          {{ request.name }}
-        </a>
-      </td>
-
-      <!-- Location -->
-      <td>
-        <span class="text-sm text-gray-700" [attr.data-testid]="config().testIdPrefix + '-location-' + request.id">{{ request.location }}</span>
-      </td>
-
-      <!-- Application Date -->
-      <td>
-        <span class="text-sm text-gray-700" [attr.data-testid]="config().testIdPrefix + '-application-date-' + request.id">{{ request.applicationDate }}</span>
-      </td>
-
-      <!-- Status -->
-      <td>
-        <lfx-tag
-          [value]="request.status"
-          [severity]="request.status | eventRequestStatusSeverity"
-          [attr.data-testid]="config().testIdPrefix + '-status-' + request.id" />
-      </td>
-    </tr>
-  </ng-template>
-
-  <ng-template #emptymessage>
-    <tr>
-      <td colspan="4" class="text-center py-10">
-        <div class="flex items-center justify-center p-16">
-          <div class="text-center max-w-md">
-            <div class="text-gray-400 mb-4">
-              <i class="fa-light fa-eyes text-3xl mb-4"></i>
-              <h3 class="text-gray-600 mt-2">{{ config().emptyMessage }}</h3>
-            </div>
-          </div>
-        </div>
-      </td>
-    </tr>
-  </ng-template>
-</lfx-table>
+    <ng-template #body let-request let-rowIndex="rowIndex">
+      <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="config().testIdPrefix + '-row-' + request.id">
+        <td>
+          <a
+            [href]="request.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline"
+            [attr.data-testid]="config().testIdPrefix + '-event-name-' + request.id">
+            {{ request.name }}
+          </a>
+        </td>
+        <td>
+          <span class="text-sm text-gray-700" [attr.data-testid]="config().testIdPrefix + '-location-' + request.id">{{ request.location }}</span>
+        </td>
+        <td>
+          <span class="text-sm text-gray-700" [attr.data-testid]="config().testIdPrefix + '-application-date-' + request.id">{{ request.applicationDate }}</span>
+        </td>
+        <td>
+          <lfx-tag
+            [value]="request.status"
+            [severity]="request.status | eventRequestStatusSeverity"
+            [attr.data-testid]="config().testIdPrefix + '-status-' + request.id" />
+        </td>
+      </tr>
+    </ng-template>
+  </lfx-table>
+}

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
@@ -5,7 +5,6 @@ import { ChangeDetectionStrategy, Component, Type, computed, inject, input, Sign
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { EventsService } from '@app/shared/services/events.service';
 import { UserService } from '@app/shared/services/user.service';
-import { ButtonComponent } from '@components/button/button.component';
 import { EventRequestStatusSeverityPipe } from '@app/shared/pipes/event-request-status-severity.pipe';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -19,7 +18,7 @@ import { TravelFundApplicationDialogComponent } from '../travel-fund-application
 import { VisaRequestApplicationDialogComponent } from '../visa-request-application-dialog/visa-request-application-dialog.component';
 @Component({
   selector: 'lfx-event-request-list',
-  imports: [TableComponent, TagComponent, ButtonComponent, DynamicDialogModule, EventRequestStatusSeverityPipe, EmptyStateComponent],
+  imports: [TableComponent, TagComponent, DynamicDialogModule, EventRequestStatusSeverityPipe, EmptyStateComponent],
   providers: [DialogService],
   templateUrl: './event-request-list.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -41,6 +40,9 @@ export class EventRequestListComponent {
   protected readonly isSalesforceIdLoading = signal(false);
   protected readonly requestsResponse: Signal<VisaRequestsResponse> = this.initRequests();
   protected readonly isCreateEnabled: Signal<boolean> = this.initIsCreateEnabled();
+
+  /** True while loading or when at least one result exists — parent uses this to decide whether to show the filter bar. */
+  public readonly hasData = computed(() => this.loading() || this.requestsResponse().data.length > 0);
 
   protected readonly config = computed(() => {
     const isVisa = this.requestType() === 'visa';

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
@@ -14,11 +14,12 @@ import { PageChangeEvent, RequestType, VisaRequestsResponse } from '@lfx-one/sha
 import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
 import { catchError, combineLatest, defer, finalize, map, of, skip, switchMap, tap } from 'rxjs';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { TravelFundApplicationDialogComponent } from '../travel-fund-application-dialog/travel-fund-application-dialog.component';
 import { VisaRequestApplicationDialogComponent } from '../visa-request-application-dialog/visa-request-application-dialog.component';
 @Component({
   selector: 'lfx-event-request-list',
-  imports: [TableComponent, TagComponent, ButtonComponent, DynamicDialogModule, EventRequestStatusSeverityPipe],
+  imports: [TableComponent, TagComponent, ButtonComponent, DynamicDialogModule, EventRequestStatusSeverityPipe, EmptyStateComponent],
   providers: [DialogService],
   templateUrl: './event-request-list.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -47,7 +48,9 @@ export class EventRequestListComponent {
       dialogComponent: (isVisa ? VisaRequestApplicationDialogComponent : TravelFundApplicationDialogComponent) as Type<unknown>,
       dialogHeader: isVisa ? 'Visa Letter Application' : 'Travel Funding Application',
       buttonLabel: isVisa ? 'New Letter Application' : 'New Funding Application',
-      emptyMessage: isVisa ? 'No visa requests found' : 'No travel fund requests found',
+      emptyIcon: isVisa ? 'fa-light fa-passport' : 'fa-light fa-plane',
+      emptyTitle: isVisa ? 'No visa letter requests yet' : 'No travel funding requests yet',
+      emptySubtitle: isVisa ? 'Submit a request to get a visa support letter for an LF event.' : 'Submit an application to get travel funding for an LF event.',
       testIdPrefix: isVisa ? 'visa-request' : 'travel-funding',
     };
   });

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.html
@@ -1,47 +1,45 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="bg-white rounded-lg border border-gray-200" data-testid="events-list">
-  <!-- Tab Navigation -->
-  <div class="flex gap-1 border-b border-gray-200" data-testid="events-tabs">
-    @for (tab of tabs; track tab.id) {
-      <button
-        type="button"
-        (click)="setActiveTab(tab.id)"
-        class="px-4 py-2 text-sm font-medium transition-colors"
-        [ngClass]="{
-          'border-b-2 border-blue-600 text-blue-600': activeTab() === tab.id,
-          'text-gray-500 hover:text-gray-700': activeTab() !== tab.id,
-        }"
-        [attr.data-testid]="'events-tab-' + tab.id">
-        {{ tab.label }}
-        @if (tab.countKey && !upcomingEventsLoading() && !pastEventsLoading()) {
-          <span>({{ tabCounts()[tab.countKey] }})</span>
-        }
-      </button>
-    }
-  </div>
-
+<div data-testid="events-list">
   <!-- Tab Content -->
   @if (activeTab() === 'upcoming') {
-    <lfx-events-table
-      [eventsResponse]="upcomingEvents()"
-      [loading]="upcomingEventsLoading()"
-      [sortField]="upcomingSortField()"
-      [sortOrder]="upcomingSortOrder()"
-      (pageChange)="onUpcomingPageChange($event)"
-      (sortChange)="onUpcomingSortChange($event)"
-      data-testid="events-upcoming-table" />
+    @if (!upcomingEventsLoading() && upcomingEvents().data.length === 0) {
+      <lfx-empty-state
+        [withCard]="false"
+        icon="fa-light fa-calendar"
+        title="No upcoming events"
+        subtitle="Events you're registered for and available to attend will appear here."
+        data-testid="events-upcoming-empty-state" />
+    } @else {
+      <lfx-events-table
+        [eventsResponse]="upcomingEvents()"
+        [loading]="upcomingEventsLoading()"
+        [sortField]="upcomingSortField()"
+        [sortOrder]="upcomingSortOrder()"
+        (pageChange)="onUpcomingPageChange($event)"
+        (sortChange)="onUpcomingSortChange($event)"
+        data-testid="events-upcoming-table" />
+    }
   } @else if (activeTab() === 'past') {
-    <lfx-events-table
-      [eventsResponse]="pastEvents()"
-      [isPastEvents]="true"
-      [loading]="pastEventsLoading()"
-      [sortField]="pastSortField()"
-      [sortOrder]="pastSortOrder()"
-      (pageChange)="onPastPageChange($event)"
-      (sortChange)="onPastSortChange($event)"
-      data-testid="events-past-table" />
+    @if (!pastEventsLoading() && pastEvents().data.length === 0) {
+      <lfx-empty-state
+        [withCard]="false"
+        icon="fa-light fa-calendar"
+        title="No past events"
+        subtitle="Events you've attended will appear here."
+        data-testid="events-past-empty-state" />
+    } @else {
+      <lfx-events-table
+        [eventsResponse]="pastEvents()"
+        [isPastEvents]="true"
+        [loading]="pastEventsLoading()"
+        [sortField]="pastSortField()"
+        [sortOrder]="pastSortOrder()"
+        (pageChange)="onPastPageChange($event)"
+        (sortChange)="onPastSortChange($event)"
+        data-testid="events-past-table" />
+    }
   } @else if (activeTab() === 'visa-letters') {
     <lfx-event-request-list requestType="visa" [searchQuery]="searchQuery()" [status]="status()" data-testid="visa-requests-table" />
   } @else if (activeTab() === 'travel-funding') {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, input, Signal, signal, ViewChild, WritableSignal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, Signal, signal, viewChild, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { EventsService } from '@app/shared/services/events.service';
 import { DEFAULT_EVENTS_PAGE_SIZE, EMPTY_MY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
@@ -19,7 +19,7 @@ import { EventsTableComponent } from '../events-table/events-table.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EventsListComponent {
-  @ViewChild(EventRequestListComponent) private readonly requestListRef?: EventRequestListComponent;
+  private readonly requestListRef = viewChild(EventRequestListComponent);
 
   private readonly eventsService = inject(EventsService);
   private readonly messageService = inject(MessageService);
@@ -56,9 +56,23 @@ export class EventsListComponent {
   public readonly nextEventName = computed(() => this.upcomingEvents().data[0]?.name ?? '');
   public readonly availableToJoinCount = computed(() => this.upcomingEvents().data.filter((e) => !e.isRegistered).length);
 
+  /**
+   * True when the filter/search bar should be visible:
+   * always show when filters are active; hide only on a true empty state (no data + no filters).
+   */
+  public readonly showFiltersBar = computed(() => {
+    const tab = this.activeTab();
+    const hasFilters = !!(this.foundation() || this.searchQuery() || this.role() || this.status());
+    if (hasFilters) return true;
+    if (tab === 'upcoming') return this.upcomingEventsLoading() || this.upcomingEvents().data.length > 0;
+    if (tab === 'past') return this.pastEventsLoading() || this.pastEvents().data.length > 0;
+    // For visa-letters / travel-funding tabs — delegate to the rendered request list
+    return this.requestListRef()?.hasData() ?? true;
+  });
+
   /** Delegates to the currently rendered EventRequestListComponent (visa-letters / travel-funding tabs). */
   public openCurrentRequestDialog(): void {
-    this.requestListRef?.openApplicationDialog();
+    this.requestListRef()?.openApplicationDialog();
   }
 
   public constructor() {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-list/events-list.component.ts
@@ -1,35 +1,34 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NgClass } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, inject, input, output, Signal, signal, WritableSignal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, Signal, signal, ViewChild, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { EventsService } from '@app/shared/services/events.service';
 import { DEFAULT_EVENTS_PAGE_SIZE, EMPTY_MY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
-import { EventTab, EventTabId, MyEventsResponse, PageChangeEvent, SortChangeEvent } from '@lfx-one/shared/interfaces';
+import { EventTabId, MyEventsResponse, PageChangeEvent, SortChangeEvent } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { catchError, combineLatest, debounceTime, finalize, of, skip, switchMap, tap } from 'rxjs';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { EventRequestListComponent } from '../event-request-list/event-request-list.component';
 import { EventsTableComponent } from '../events-table/events-table.component';
 
 @Component({
   selector: 'lfx-events-list',
-  imports: [NgClass, EventsTableComponent, EventRequestListComponent],
+  imports: [EventsTableComponent, EventRequestListComponent, EmptyStateComponent],
   templateUrl: './events-list.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class EventsListComponent {
+  @ViewChild(EventRequestListComponent) private readonly requestListRef?: EventRequestListComponent;
+
   private readonly eventsService = inject(EventsService);
   private readonly messageService = inject(MessageService);
 
+  public readonly activeTab = input<EventTabId>('upcoming');
   public readonly foundation = input<string | null>(null);
   public readonly searchQuery = input<string>('');
   public readonly role = input<string | null>(null);
   public readonly status = input<string | null>(null);
-
-  public readonly activeTabChange = output<EventTabId>();
-
-  protected readonly activeTab = signal<EventTabId>('upcoming');
 
   protected readonly upcomingEventsLoading = signal(true);
   protected readonly pastEventsLoading = signal(true);
@@ -45,13 +44,6 @@ export class EventsListComponent {
   protected readonly upcomingEvents: Signal<MyEventsResponse> = this.initializeUpcomingEvents();
   protected readonly pastEvents: Signal<MyEventsResponse> = this.initializePastEvents();
 
-  protected readonly tabs: EventTab[] = [
-    { id: 'upcoming', label: 'Upcoming', countKey: 'upcoming' },
-    { id: 'past', label: 'Past', countKey: 'past' },
-    { id: 'visa-letters', label: 'Visa Letters' },
-    { id: 'travel-funding', label: 'Travel Funding' },
-  ];
-
   public readonly tabCounts = computed(() => ({
     upcoming: this.upcomingEvents().total,
     past: this.pastEvents().total,
@@ -64,6 +56,11 @@ export class EventsListComponent {
   public readonly nextEventName = computed(() => this.upcomingEvents().data[0]?.name ?? '');
   public readonly availableToJoinCount = computed(() => this.upcomingEvents().data.filter((e) => !e.isRegistered).length);
 
+  /** Delegates to the currently rendered EventRequestListComponent (visa-letters / travel-funding tabs). */
+  public openCurrentRequestDialog(): void {
+    this.requestListRef?.openApplicationDialog();
+  }
+
   public constructor() {
     // Reset both tabs to page 1 when shared filters change
     combineLatest([toObservable(this.foundation), toObservable(this.searchQuery), toObservable(this.role), toObservable(this.status)])
@@ -72,11 +69,6 @@ export class EventsListComponent {
         this.upcomingEventsPage.set({ offset: 0, pageSize: this.upcomingEventsPage().pageSize });
         this.pastEventsPage.set({ offset: 0, pageSize: this.pastEventsPage().pageSize });
       });
-  }
-
-  protected setActiveTab(tab: EventTabId): void {
-    this.activeTab.set(tab);
-    this.activeTabChange.emit(tab);
   }
 
   protected onUpcomingPageChange(event: PageChangeEvent): void {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.html
@@ -69,7 +69,7 @@
           [href]="event.url"
           target="_blank"
           rel="noopener noreferrer"
-          class="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline"
+          class="lfx-table-name-link text-sm"
           [attr.data-testid]="'event-name-' + event.id">
           {{ event.name }}
         </a>
@@ -77,23 +77,17 @@
 
       <!-- Foundation -->
       <td>
-        <div class="max-w-[120px]" [pTooltip]="event.foundation" tooltipPosition="top">
-          <lfx-tag
-            [value]="event.foundation"
-            severity="secondary"
-            styleClass="!block !truncate !max-w-full"
-            [attr.data-testid]="'event-foundation-' + event.id" />
-        </div>
+        <lfx-tag [value]="event.foundation" severity="secondary" [attr.data-testid]="'event-foundation-' + event.id" />
       </td>
 
       <!-- Date -->
       <td>
-        <span class="text-xs text-gray-700">{{ event.date }}</span>
+        <span class="text-sm text-gray-700">{{ event.date }}</span>
       </td>
 
       <!-- Location -->
       <td>
-        <span class="text-xs text-gray-700">{{ event.location }}</span>
+        <span class="text-sm text-gray-700">{{ event.location }}</span>
       </td>
 
       <!-- Role -->
@@ -130,16 +124,25 @@
       @if (!isPastEvents()) {
         <td>
           <div class="flex justify-end">
-            <lfx-button
-              [label]="event.isRegistered ? 'View Event' : 'Register'"
-              severity="primary"
-              [outlined]="true"
-              [href]="event.isRegistered ? event.url : event.registrationUrl"
-              target="_blank"
-              rel="noopener noreferrer"
-              size="small"
-              styleClass="whitespace-nowrap"
-              [attr.data-testid]="'event-view-button-' + event.id" />
+            @if (event.isRegistered) {
+              <lfx-button
+                label="View Event"
+                severity="secondary"
+                [outlined]="true"
+                size="small"
+                styleClass="whitespace-nowrap"
+                (onClick)="openUrl(event.url)"
+                [attr.data-testid]="'event-view-button-' + event.id" />
+            } @else {
+              <lfx-button
+                label="Register"
+                severity="primary"
+                [outlined]="true"
+                size="small"
+                styleClass="whitespace-nowrap"
+                (onClick)="openUrl(event.registrationUrl)"
+                [attr.data-testid]="'event-view-button-' + event.id" />
+            }
           </div>
         </td>
       }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.html
@@ -22,7 +22,7 @@
         scope="col"
         [attr.aria-sort]="sortField() === 'EVENT_NAME' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
         data-testid="sort-event-name">
-        <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('EVENT_NAME')">
+        <button type="button" class="flex cursor-pointer select-none items-center gap-1 text-xs text-gray-500 font-medium" (click)="onHeaderClick('EVENT_NAME')">
           Event Name <i [class]="sortIcons()['EVENT_NAME']"></i>
         </button>
       </th>
@@ -30,7 +30,7 @@
         scope="col"
         [attr.aria-sort]="sortField() === 'PROJECT_NAME' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
         data-testid="sort-foundation">
-        <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('PROJECT_NAME')">
+        <button type="button" class="flex cursor-pointer select-none items-center gap-1 text-xs text-gray-500 font-medium" (click)="onHeaderClick('PROJECT_NAME')">
           Foundation <i [class]="sortIcons()['PROJECT_NAME']"></i>
         </button>
       </th>
@@ -38,7 +38,7 @@
         scope="col"
         [attr.aria-sort]="sortField() === 'EVENT_START_DATE' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
         data-testid="sort-date">
-        <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('EVENT_START_DATE')">
+        <button type="button" class="flex cursor-pointer select-none items-center gap-1 text-xs text-gray-500 font-medium" (click)="onHeaderClick('EVENT_START_DATE')">
           Date <i [class]="sortIcons()['EVENT_START_DATE']"></i>
         </button>
       </th>
@@ -46,17 +46,17 @@
         scope="col"
         [attr.aria-sort]="sortField() === 'EVENT_CITY' ? (sortOrder() === 'ASC' ? 'ascending' : 'descending') : 'none'"
         data-testid="sort-location">
-        <button type="button" class="flex cursor-pointer select-none items-center gap-1" (click)="onHeaderClick('EVENT_CITY')">
+        <button type="button" class="flex cursor-pointer select-none items-center gap-1 text-xs text-gray-500 font-medium" (click)="onHeaderClick('EVENT_CITY')">
           Location <i [class]="sortIcons()['EVENT_CITY']"></i>
         </button>
       </th>
       <th>Role</th>
       <th>Status</th>
       @if (isPastEvents()) {
-        <th>Certificate</th>
+        <th></th>
       }
       @if (!isPastEvents()) {
-        <th>Action</th>
+        <th></th>
       }
     </tr>
   </ng-template>
@@ -88,12 +88,12 @@
 
       <!-- Date -->
       <td>
-        <span class="text-sm text-gray-700">{{ event.date }}</span>
+        <span class="text-xs text-gray-700">{{ event.date }}</span>
       </td>
 
       <!-- Location -->
       <td>
-        <span class="text-sm text-gray-700">{{ event.location }}</span>
+        <span class="text-xs text-gray-700">{{ event.location }}</span>
       </td>
 
       <!-- Role -->
@@ -101,7 +101,7 @@
         @if (event.role) {
           <lfx-tag [value]="event.role" [severity]="roleSeverityMap[event.role] ?? 'secondary'" [attr.data-testid]="'event-role-' + event.id" />
         } @else {
-          <span class="text-sm text-gray-400">—</span>
+          <span class="text-xs text-gray-400">—</span>
         }
       </td>
 
@@ -113,30 +113,34 @@
       <!-- Certificate -->
       @if (isPastEvents()) {
         <td>
-          <lfx-button
-            label="Download Certificate"
-            severity="primary"
-            [outlined]="true"
-            size="small"
-            styleClass="whitespace-nowrap"
-            (click)="downloadCertificate(event.id)"
-            [attr.data-testid]="'event-download-certificate-button-' + event.id" />
+          <div class="flex justify-end">
+            <lfx-button
+              label="Download Certificate"
+              severity="primary"
+              [outlined]="true"
+              size="small"
+              styleClass="whitespace-nowrap"
+              (click)="downloadCertificate(event.id)"
+              [attr.data-testid]="'event-download-certificate-button-' + event.id" />
+          </div>
         </td>
       }
 
       <!-- Action -->
       @if (!isPastEvents()) {
         <td>
-          <lfx-button
-            [label]="event.isRegistered ? 'View Event' : 'Register'"
-            severity="primary"
-            [outlined]="true"
-            [href]="event.isRegistered ? event.url : event.registrationUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            size="small"
-            styleClass="whitespace-nowrap"
-            [attr.data-testid]="'event-view-button-' + event.id" />
+          <div class="flex justify-end">
+            <lfx-button
+              [label]="event.isRegistered ? 'View Event' : 'Register'"
+              severity="primary"
+              [outlined]="true"
+              [href]="event.isRegistered ? event.url : event.registrationUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              size="small"
+              styleClass="whitespace-nowrap"
+              [attr.data-testid]="'event-view-button-' + event.id" />
+          </div>
         </td>
       }
     </tr>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/events-table/events-table.component.ts
@@ -8,12 +8,11 @@ import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { MyEventsResponse, PageChangeEvent, SortChangeEvent, TagSeverity } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
-import { TooltipModule } from 'primeng/tooltip';
 import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'lfx-events-table',
-  imports: [TableComponent, TagComponent, ButtonComponent, TooltipModule],
+  imports: [TableComponent, TagComponent, ButtonComponent],
   templateUrl: './events-table.component.html',
 })
 export class EventsTableComponent {
@@ -64,6 +63,10 @@ export class EventsTableComponent {
 
   protected onHeaderClick(field: string): void {
     this.sortChange.emit({ field });
+  }
+
+  protected openUrl(url: string): void {
+    window.open(url, '_blank', 'noopener,noreferrer');
   }
 
   protected downloadCertificate(eventId: string): void {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -77,25 +77,52 @@
       </lfx-card>
     </div>
 
-    <!-- Search and Filters -->
-    <div class="bg-white rounded-lg border border-gray-200 p-4">
-      <lfx-events-top-bar
-        [isFoundationFilter]="!isRequestTab()"
-        [showRoleFilter]="!isRequestTab()"
-        [isPast]="isPast()"
-        [statusOptions]="currentStatusOptions()"
-        (searchQueryChange)="onSearchQueryChange($event)"
-        (foundationChange)="onFoundationChange($event)"
-        (roleChange)="onRoleChange($event)"
-        (statusChange)="onStatusChange($event)" />
-    </div>
-    <!-- Events List (Tabs + Table) -->
-    <lfx-events-list
-      #eventsList
-      [foundation]="selectedFoundation()"
-      [searchQuery]="selectedSearchQuery()"
-      [role]="selectedRole()"
-      [status]="selectedStatus()"
-      (activeTabChange)="onActiveTabChange($event)" />
+    <!-- Events Card: tabs + search + list all in one -->
+    <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="events-main-card">
+      <!-- Tab Pills -->
+      <div class="flex items-center justify-between px-4 py-4" data-testid="events-tab-pills-wrapper">
+        <lfx-filter-pills
+          [options]="tabOptions"
+          [selectedFilter]="activeTab()"
+          (filterChange)="onActiveTabChange($event)"
+          data-testid="events-tab-pills" />
+        @if (isRequestTab()) {
+          <lfx-button
+            [label]="requestButtonLabel()"
+            icon="fa-light fa-plus"
+            [text]="true"
+            severity="primary"
+            size="small"
+            (onClick)="eventsList.openCurrentRequestDialog()"
+            data-testid="events-new-request-button" />
+        }
+      </div>
+
+      <!-- Divider -->
+      <div class="border-b border-gray-200"></div>
+
+      <!-- Search and Filters -->
+      <div class="p-4 border-b border-gray-200">
+        <lfx-events-top-bar
+          [isFoundationFilter]="!isRequestTab()"
+          [showRoleFilter]="!isRequestTab()"
+          [isPast]="isPast()"
+          [searchPlaceholder]="searchPlaceholder()"
+          [statusOptions]="currentStatusOptions()"
+          (searchQueryChange)="onSearchQueryChange($event)"
+          (foundationChange)="onFoundationChange($event)"
+          (roleChange)="onRoleChange($event)"
+          (statusChange)="onStatusChange($event)" />
+      </div>
+
+      <!-- Events List -->
+      <lfx-events-list
+        #eventsList
+        [activeTab]="activeTab()"
+        [foundation]="selectedFoundation()"
+        [searchQuery]="selectedSearchQuery()"
+        [role]="selectedRole()"
+        [status]="selectedStatus()" />
+    </lfx-card>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -79,30 +79,26 @@
 
     <!-- Events Card: tabs + search + list all in one -->
     <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="events-main-card">
-      <!-- Tab Pills -->
-      <div class="flex items-center justify-between px-4 py-4" data-testid="events-tab-pills-wrapper">
-        <lfx-filter-pills
-          [options]="tabOptions"
-          [selectedFilter]="activeTab()"
-          (filterChange)="onActiveTabChange($event)"
-          data-testid="events-tab-pills" />
+      <!-- Tab Pills Bar -->
+      <lfx-card-tabs-bar
+        [options]="tabOptions"
+        [selectedFilter]="activeTab()"
+        (filterChange)="onActiveTabChange($event)"
+        data-testid="events-tab-pills">
         @if (isRequestTab()) {
           <lfx-button
             [label]="requestButtonLabel()"
             icon="fa-light fa-plus"
-            [text]="true"
             severity="primary"
             size="small"
             (onClick)="eventsList.openCurrentRequestDialog()"
             data-testid="events-new-request-button" />
         }
-      </div>
+      </lfx-card-tabs-bar>
 
-      <!-- Divider -->
-      <div class="border-b border-gray-200"></div>
-
-      <!-- Search and Filters -->
-      <div class="p-4 border-b border-gray-200">
+      <!-- Search and Filters (hidden on true empty state — no data and no active filters) -->
+      @if (showFiltersBar()) {
+      <div class="px-5 pt-4 pb-3">
         <lfx-events-top-bar
           [isFoundationFilter]="!isRequestTab()"
           [showRoleFilter]="!isRequestTab()"
@@ -114,15 +110,18 @@
           (roleChange)="onRoleChange($event)"
           (statusChange)="onStatusChange($event)" />
       </div>
+      }
 
       <!-- Events List -->
-      <lfx-events-list
-        #eventsList
-        [activeTab]="activeTab()"
-        [foundation]="selectedFoundation()"
-        [searchQuery]="selectedSearchQuery()"
-        [role]="selectedRole()"
-        [status]="selectedStatus()" />
+      <div class="px-5 pb-5">
+        <lfx-events-list
+          #eventsList
+          [activeTab]="activeTab()"
+          [foundation]="selectedFoundation()"
+          [searchQuery]="selectedSearchQuery()"
+          [role]="selectedRole()"
+          [status]="selectedStatus()" />
+      </div>
     </lfx-card>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -1,10 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, signal } from '@angular/core';
+import { Component, computed, signal, viewChild } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
-import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
+import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { MY_EVENT_STATUS_OPTIONS, VISA_REQUEST_STATUS_OPTIONS } from '@lfx-one/shared/constants';
 import { EventTabId, FilterOption, FilterPillOption } from '@lfx-one/shared/interfaces';
 import { Tooltip } from 'primeng/tooltip';
@@ -14,10 +14,12 @@ import { EventsListComponent } from './components/events-list/events-list.compon
 
 @Component({
   selector: 'lfx-my-events-dashboard',
-  imports: [ButtonComponent, CardComponent, DiscoverEventsButtonComponent, EventsTopBarComponent, EventsListComponent, Tooltip, FilterPillsComponent],
+  imports: [ButtonComponent, CardComponent, CardTabsBarComponent, DiscoverEventsButtonComponent, EventsTopBarComponent, EventsListComponent, Tooltip],
   templateUrl: './my-events-dashboard.component.html',
 })
 export class MyEventsDashboardComponent {
+  private readonly eventsListRef = viewChild(EventsListComponent);
+
   protected readonly activeTab = signal<EventTabId>('upcoming');
 
   protected readonly tabOptions: FilterPillOption[] = [
@@ -47,6 +49,9 @@ export class MyEventsDashboardComponent {
   protected readonly requestButtonLabel = computed(() =>
     this.activeTab() === 'visa-letters' ? 'New Letter Application' : 'New Funding Application'
   );
+
+  /** Delegates to EventsListComponent — lifted here to avoid template forward-reference issues. */
+  protected readonly showFiltersBar = computed(() => this.eventsListRef()?.showFiltersBar() ?? true);
 
   protected onFoundationChange(value: string | null): void {
     this.selectedFoundation.set(value);

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { MY_EVENT_STATUS_OPTIONS, VISA_REQUEST_STATUS_OPTIONS } from '@lfx-one/shared/constants';
-import { EventTabId, FilterOption } from '@lfx-one/shared/interfaces';
+import { EventTabId, FilterOption, FilterPillOption } from '@lfx-one/shared/interfaces';
 import { Tooltip } from 'primeng/tooltip';
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
 import { EventsTopBarComponent } from '../components/events-top-bar/events-top-bar.component';
@@ -12,11 +14,18 @@ import { EventsListComponent } from './components/events-list/events-list.compon
 
 @Component({
   selector: 'lfx-my-events-dashboard',
-  imports: [CardComponent, DiscoverEventsButtonComponent, EventsTopBarComponent, EventsListComponent, Tooltip],
+  imports: [ButtonComponent, CardComponent, DiscoverEventsButtonComponent, EventsTopBarComponent, EventsListComponent, Tooltip, FilterPillsComponent],
   templateUrl: './my-events-dashboard.component.html',
 })
 export class MyEventsDashboardComponent {
   protected readonly activeTab = signal<EventTabId>('upcoming');
+
+  protected readonly tabOptions: FilterPillOption[] = [
+    { id: 'upcoming', label: 'Upcoming' },
+    { id: 'past', label: 'Past' },
+    { id: 'visa-letters', label: 'Visa Letters' },
+    { id: 'travel-funding', label: 'Travel Funding' },
+  ];
   protected readonly selectedFoundation = signal<string | null>(null);
   protected readonly selectedRole = signal<string | null>(null);
   protected readonly selectedStatus = signal<string | null>(null);
@@ -28,6 +37,16 @@ export class MyEventsDashboardComponent {
   protected readonly isRequestTab = computed(() => this.activeTab() === 'visa-letters' || this.activeTab() === 'travel-funding');
 
   protected readonly currentStatusOptions = computed<FilterOption[]>(() => (this.isRequestTab() ? VISA_REQUEST_STATUS_OPTIONS : MY_EVENT_STATUS_OPTIONS));
+
+  protected readonly searchPlaceholder = computed(() => {
+    if (this.activeTab() === 'visa-letters') return 'Search visa letters...';
+    if (this.activeTab() === 'travel-funding') return 'Search travel fundings...';
+    return 'Search events...';
+  });
+
+  protected readonly requestButtonLabel = computed(() =>
+    this.activeTab() === 'visa-letters' ? 'New Letter Application' : 'New Funding Application'
+  );
 
   protected onFoundationChange(value: string | null): void {
     this.selectedFoundation.set(value);
@@ -45,8 +64,8 @@ export class MyEventsDashboardComponent {
     this.selectedSearchQuery.set(value);
   }
 
-  protected onActiveTabChange(tab: EventTabId): void {
-    this.activeTab.set(tab);
+  protected onActiveTabChange(tab: string): void {
+    this.activeTab.set(tab as EventTabId);
     // Reset all filters when switching tabs — each tab has different filter sets
     this.selectedFoundation.set(null);
     this.selectedRole.set(null);

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<lfx-card>
+<lfx-card styleClass="[&_.p-card-body]:!px-5">
   <!-- Filter Bar Inside Card -->
   <div class="pb-2 mb-2">
     <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
@@ -125,7 +125,7 @@
             } @else {
               <a
                 [routerLink]="['/mailing-lists', mailingList.uid]"
-                class="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline"
+                class="lfx-table-name-link text-sm"
                 [attr.data-testid]="'mailing-list-title-' + mailingList.uid">
                 {{ mailingList.title }}
               </a>
@@ -146,7 +146,7 @@
 
           <!-- Description Column -->
           <td>
-            <div class="line-clamp-2 text-xs">
+            <div class="line-clamp-2 text-sm text-gray-700">
               {{ (mailingList.description | stripHtml) || '-' }}
             </div>
           </td>
@@ -183,7 +183,7 @@
           </td>
 
           <!-- Subscribers Column -->
-          <td>{{ mailingList.subscriber_count }}</td>
+          <td><span class="text-sm text-gray-700">{{ mailingList.subscriber_count }}</span></td>
         } @else {
           <!-- PMO View Row -->
           <!-- Mailing List Column -->
@@ -194,17 +194,17 @@
                   {{ mailingList.title }}
                 </span>
               } @else {
-                <a [routerLink]="['/mailing-lists', mailingList.uid]" class="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline">
+                <a [routerLink]="['/mailing-lists', mailingList.uid]" class="lfx-table-name-link text-sm">
                   {{ mailingList.title }}
                 </a>
               }
-              <span class="text-sm text-gray-500">{{ mailingList | groupEmail }}</span>
+              <span class="text-xs text-gray-500">{{ mailingList | groupEmail }}</span>
             </div>
           </td>
 
           <!-- Description Column -->
           <td>
-            <div class="line-clamp-2 text-xs">
+            <div class="line-clamp-2 text-sm text-gray-700">
               {{ (mailingList.description | stripHtml) || '-' }}
             </div>
           </td>
@@ -232,11 +232,11 @@
 
           <!-- Subscribers Column -->
           <td [attr.data-testid]="'mailing-list-subscribers-' + mailingList.uid">
-            {{ mailingList.subscriber_count }}
+            <span class="text-sm text-gray-700">{{ mailingList.subscriber_count }}</span>
           </td>
 
           <!-- Emails Sent Column -->
-          <td>-</td>
+          <td><span class="text-sm text-gray-700">-</span></td>
 
           <!-- Actions Column - Hidden for board members -->
           @if (!isBoardMember()) {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
@@ -65,17 +65,19 @@
     <!-- Content Area -->
     <div class="min-h-[400px]">
       @if (!isMeLens() && mailingLists().length === 0 && project()?.uid) {
-        <!-- Empty state: No mailing lists exist -->
-        <lfx-card>
-          <div class="flex items-center justify-center p-16">
-            <div class="text-center max-w-md">
-              <div class="text-gray-400 mb-4">
-                <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
-                <h3 class="text-gray-600 mt-2">Your project has no {{ mailingListLabelPlural.toLowerCase() }}, yet.</h3>
-              </div>
-            </div>
-          </div>
-        </lfx-card>
+        <lfx-empty-state
+          icon="fa-light fa-envelope"
+          [title]="'No ' + mailingListLabelPlural.toLowerCase() + ' yet'"
+          subtitle="This project has no mailing lists set up yet."
+          data-testid="mailing-list-project-empty-state">
+        </lfx-empty-state>
+      } @else if (isMeLens() && !myMailingListsLoading() && filteredMailingLists().length === 0) {
+        <lfx-empty-state
+          icon="fa-light fa-envelope"
+          [title]="'No ' + mailingListLabelPlural.toLowerCase() + ' yet'"
+          subtitle="Mailing lists you're subscribed to will appear here."
+          data-testid="mailing-list-me-empty-state">
+        </lfx-empty-state>
       } @else {
         <lfx-mailing-list-table
           [mailingLists]="filteredMailingLists()"

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -17,11 +17,12 @@ import { ProjectService } from '@services/project.service';
 import { MessageService } from 'primeng/api';
 import { BehaviorSubject, catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, of, startWith, switchMap, tap } from 'rxjs';
 
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { MailingListTableComponent } from '../components/mailing-list-table/mailing-list-table.component';
 
 @Component({
   selector: 'lfx-mailing-list-dashboard',
-  imports: [ButtonComponent, CardComponent, MailingListTableComponent, ReactiveFormsModule],
+  imports: [ButtonComponent, CardComponent, MailingListTableComponent, ReactiveFormsModule, EmptyStateComponent],
   templateUrl: './mailing-list-dashboard.component.html',
   styleUrl: './mailing-list-dashboard.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -192,28 +192,19 @@
         }
       </div>
     } @else if (upcomingMeetings().length === 0 && timeFilter() === 'upcoming') {
-      <lfx-card>
-        <div class="flex items-center justify-center p-16">
-          <div class="text-center max-w-md">
-            <div class="text-gray-400 mb-4">
-              <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
-              <h3 class="text-gray-600 mt-2">{{ activeLens() === 'me' ? 'You have no upcoming meetings.' : 'Your project has no meetings, yet.' }}</h3>
-            </div>
-          </div>
-        </div>
-      </lfx-card>
+      <lfx-empty-state
+        icon="fa-light fa-calendar"
+        [title]="activeLens() === 'me' ? 'No upcoming meetings' : 'No meetings yet'"
+        [subtitle]="activeLens() === 'me' ? 'Meetings from your committees and projects will appear here.' : 'Schedule a meeting to get started.'"
+        data-testid="meetings-empty-state">
+      </lfx-empty-state>
     } @else if (filteredMeetings().length === 0 && (project()?.uid || activeLens() === 'me')) {
-      <lfx-card>
-        <div class="flex items-center justify-center p-16">
-          <div class="text-center max-w-md">
-            <div class="text-gray-400 mb-4">
-              <i class="fa-light fa-eyes text-[2rem] mb-4"></i>
-            </div>
-            <h3 class="text-xl font-semibold text-gray-900 mt-4">No Meetings Found</h3>
-            <p class="text-gray-600 mt-2">Try adjusting your search or filter criteria</p>
-          </div>
-        </div>
-      </lfx-card>
+      <lfx-empty-state
+        icon="fa-light fa-calendar"
+        title="No meetings found"
+        subtitle="Try adjusting your search or filter criteria."
+        data-testid="meetings-empty-state-filtered">
+      </lfx-empty-state>
     } @else if (filteredMeetings().length > 0) {
       <div class="flex flex-col gap-4">
         @for (meeting of filteredMeetings(); track meeting.id; let i = $index) {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -37,11 +37,12 @@ import {
   toArray,
 } from 'rxjs';
 
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { MeetingsTopBarComponent } from './components/meetings-top-bar/meetings-top-bar.component';
 
 @Component({
   selector: 'lfx-meetings-dashboard',
-  imports: [MeetingCardComponent, MeetingsTopBarComponent, ButtonComponent, CardComponent, OnRenderDirective],
+  imports: [MeetingCardComponent, MeetingsTopBarComponent, ButtonComponent, CardComponent, OnRenderDirective, EmptyStateComponent],
   templateUrl: './meetings-dashboard.component.html',
   styleUrl: './meetings-dashboard.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/my-activity/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/my-activity/components/surveys-table/surveys-table.component.html
@@ -64,7 +64,7 @@
     <ng-template #body let-survey let-rowIndex="rowIndex">
       <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'my-activity-survey-row-' + survey.survey_id">
         <td>
-          <span class="text-blue-600 font-medium" [attr.data-testid]="'my-activity-survey-name-' + survey.survey_id">
+          <span class="lfx-table-name-link text-xs" [attr.data-testid]="'my-activity-survey-name-' + survey.survey_id">
             {{ survey.survey_title }}
           </span>
         </td>

--- a/apps/lfx-one/src/app/modules/my-activity/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/my-activity/components/votes-table/votes-table.component.html
@@ -63,7 +63,7 @@
     <ng-template #body let-vote let-rowIndex="rowIndex">
       <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'my-activity-vote-row-' + vote.poll_id">
         <td>
-          <span class="text-blue-600 font-medium" [attr.data-testid]="'my-activity-vote-name-' + vote.poll_id">
+          <span class="lfx-table-name-link text-xs" [attr.data-testid]="'my-activity-vote-name-' + vote.poll_id">
             {{ vote.poll_name }}
           </span>
         </td>

--- a/apps/lfx-one/src/app/modules/my-activity/my-activity-dashboard/my-activity-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/my-activity/my-activity-dashboard/my-activity-dashboard.component.html
@@ -14,9 +14,27 @@
   <!-- Content Area - Conditional Tables -->
   <div class="min-h-[400px]">
     @if (isVotesTab()) {
-      <lfx-votes-table [votes]="votes()"></lfx-votes-table>
+      @if (votes().length === 0) {
+        <lfx-empty-state
+          icon="fa-light fa-check-to-slot"
+          title="No vote activity yet"
+          subtitle="Your pending and completed votes will appear here."
+          data-testid="my-activity-votes-empty-state">
+        </lfx-empty-state>
+      } @else {
+        <lfx-votes-table [votes]="votes()"></lfx-votes-table>
+      }
     } @else if (isSurveysTab()) {
-      <lfx-surveys-table [surveys]="surveys()"></lfx-surveys-table>
+      @if (surveys().length === 0) {
+        <lfx-empty-state
+          icon="fa-light fa-clipboard-list"
+          title="No survey activity yet"
+          subtitle="Your pending and completed surveys will appear here."
+          data-testid="my-activity-surveys-empty-state">
+        </lfx-empty-state>
+      } @else {
+        <lfx-surveys-table [surveys]="surveys()"></lfx-surveys-table>
+      }
     }
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/my-activity/my-activity-dashboard/my-activity-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/my-activity/my-activity-dashboard/my-activity-dashboard.component.ts
@@ -15,13 +15,14 @@ import {
 } from '@lfx-one/shared';
 import { MyActivityTab, UserSurvey, UserVote } from '@lfx-one/shared/interfaces';
 
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { ActivityTopBarComponent } from '../components/activity-top-bar/activity-top-bar.component';
 import { SurveysTableComponent } from '../components/surveys-table/surveys-table.component';
 import { VotesTableComponent } from '../components/votes-table/votes-table.component';
 
 @Component({
   selector: 'lfx-my-activity-dashboard',
-  imports: [ActivityTopBarComponent, VotesTableComponent, SurveysTableComponent],
+  imports: [ActivityTopBarComponent, VotesTableComponent, SurveysTableComponent, EmptyStateComponent],
   templateUrl: './my-activity-dashboard.component.html',
 })
 export class MyActivityDashboardComponent {

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -1,8 +1,15 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<lfx-card styleClass="[&_.p-card-body]:!px-5" data-testid="surveys-table-card">
-  <div class="pb-2 mb-2">
+<lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="surveys-table-card">
+  <lfx-card-tabs-bar
+    [options]="statusTabOptions"
+    [selectedFilter]="statusTab()"
+    (filterChange)="onStatusTabChange($event)"
+    data-testid="surveys-status-tabs">
+  </lfx-card-tabs-bar>
+
+  <div class="px-5 pt-4 pb-3">
     <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
       <div class="flex-1 min-w-0">
         <lfx-input-text
@@ -61,20 +68,11 @@
           data-testid="surveys-type-filter"></lfx-select>
       </div>
 
-      <div class="w-full sm:w-auto sm:shrink-0">
-        <lfx-select
-          [form]="searchForm"
-          control="status"
-          size="small"
-          [options]="statusOptions()"
-          (valueChange)="onStatusChange($event)"
-          data-testid="surveys-status-filter"></lfx-select>
-      </div>
-
       <ng-content select="[tableActions]"></ng-content>
     </div>
   </div>
 
+  <div class="px-5 pb-5">
   <lfx-table
     [value]="filteredSurveys()"
     [paginator]="filteredSurveys().length > 10"
@@ -102,7 +100,7 @@
         <td>
           <button
             type="button"
-            class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0"
+            class="lfx-table-name-link text-sm text-left bg-transparent border-none p-0"
             (click)="onViewResults(survey.uid)"
             [attr.data-testid]="'surveys-name-' + survey.uid">
             {{ survey.survey_title }}
@@ -127,7 +125,7 @@
 
         <td>
           <span
-            class="text-xs text-slate-900"
+            class="text-sm text-gray-700"
             [pTooltip]="getResponseTooltip(survey)"
             tooltipPosition="top"
             [attr.data-testid]="'surveys-responses-' + survey.uid">
@@ -135,15 +133,15 @@
           </span>
         </td>
 
-        <td class="text-xs text-slate-900">
+        <td>
           @if (survey.survey_status === SurveyStatus.CLOSED) {
-            <span>{{ survey.survey_cutoff_date | date: 'MMM d, y' }}</span>
+            <span class="text-sm text-gray-700">{{ survey.survey_cutoff_date | date: 'MMM d, y' }}</span>
           } @else if (survey.survey_status === SurveyStatus.DRAFT) {
-            <span class="text-gray-400">&mdash;</span>
+            <span class="text-sm text-gray-700">&mdash;</span>
           } @else if (survey.survey_cutoff_date) {
-            <span>{{ survey.survey_cutoff_date | relativeDueDate }}</span>
+            <span class="text-sm text-gray-700">{{ survey.survey_cutoff_date | relativeDueDate }}</span>
           } @else {
-            <span class="text-gray-400">&mdash;</span>
+            <span class="text-sm text-gray-700">&mdash;</span>
           }
         </td>
 
@@ -193,6 +191,7 @@
       </tr>
     </ng-template>
   </lfx-table>
+  </div>
 </lfx-card>
 
 <p-confirmDialog></p-confirmDialog>

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<lfx-card data-testid="surveys-table-card">
+<lfx-card styleClass="[&_.p-card-body]:!px-5" data-testid="surveys-table-card">
   <div class="pb-2 mb-2">
     <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
       <div class="flex-1 min-w-0">
@@ -98,7 +98,7 @@
     </ng-template>
 
     <ng-template #body let-survey let-rowIndex="rowIndex">
-      <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'surveys-row-' + survey.uid" class="hover:bg-slate-50">
+      <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'surveys-row-' + survey.uid">
         <td>
           <button
             type="button"

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -7,11 +7,13 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { SURVEY_LABEL, SURVEY_STATUS_LABELS, SURVEY_TYPE_LABELS, SurveyStatus } from '@lfx-one/shared';
+import { SURVEY_LABEL, SURVEY_TYPE_LABELS, SurveyStatus } from '@lfx-one/shared';
+import { FilterPillOption } from '@lfx-one/shared/interfaces';
 import { Survey } from '@lfx-one/shared/interfaces';
 import { RelativeDueDatePipe } from '@pipes/relative-due-date.pipe';
 import { SurveyStatusLabelPipe } from '@pipes/survey-status-label.pipe';
@@ -25,6 +27,7 @@ import { debounceTime, distinctUntilChanged, map, startWith } from 'rxjs';
   selector: 'lfx-surveys-table',
   imports: [
     CardComponent,
+    CardTabsBarComponent,
     TableComponent,
     TagComponent,
     ButtonComponent,
@@ -48,6 +51,11 @@ export class SurveysTableComponent {
   // === Constants ===
   protected readonly surveyLabel = SURVEY_LABEL;
   protected readonly SurveyStatus = SurveyStatus;
+  protected readonly statusTabOptions: FilterPillOption[] = [
+    { id: 'all', label: 'All' },
+    { id: 'open', label: 'Open' },
+    { id: 'closed', label: 'Closed' },
+  ];
 
   // === Inputs ===
   public readonly surveys = input.required<Survey[]>();
@@ -71,7 +79,6 @@ export class SurveysTableComponent {
   // === Forms ===
   public searchForm = new FormGroup({
     search: new FormControl<string>(''),
-    status: new FormControl<string | null>(null),
     group: new FormControl<string | null>(null),
     surveyType: new FormControl<string | null>(null),
     foundationFilter: new FormControl<string | null>(null),
@@ -79,13 +86,12 @@ export class SurveysTableComponent {
   });
 
   // === Writable Signals ===
-  private readonly statusFilter = signal<string | null>(null);
+  protected readonly statusTab = signal<string>('all');
   private readonly groupFilter = signal<string | null>(null);
   private readonly typeFilter = signal<string | null>(null);
 
   // === Computed Signals ===
   private readonly searchTerm: Signal<string> = this.initSearchTerm();
-  protected readonly statusOptions: Signal<{ label: string; value: string | null }[]> = this.initStatusOptions();
   protected readonly groupOptions: Signal<{ label: string; value: string | null }[]> = this.initGroupOptions();
   protected readonly typeOptions: Signal<{ label: string; value: string | null }[]> = this.initTypeOptions();
   protected readonly filteredSurveys: Signal<Survey[]> = this.initFilteredSurveys();
@@ -98,8 +104,8 @@ export class SurveysTableComponent {
     this.projectFilterChange.emit(null);
   }
 
-  protected onStatusChange(value: string | null): void {
-    this.statusFilter.set(value);
+  protected onStatusTabChange(tab: string): void {
+    this.statusTab.set(tab);
   }
 
   protected onGroupChange(value: string | null): void {
@@ -158,34 +164,6 @@ export class SurveysTableComponent {
       ),
       { initialValue: '' }
     );
-  }
-
-  private initStatusOptions(): Signal<{ label: string; value: string | null }[]> {
-    return computed(() => {
-      const surveysData = this.surveys();
-      const statusCounts = new Map<string, number>();
-
-      surveysData.forEach((survey) => {
-        statusCounts.set(survey.survey_status, (statusCounts.get(survey.survey_status) || 0) + 1);
-      });
-
-      const options: { label: string; value: string | null }[] = [{ label: 'All Statuses', value: null }];
-
-      const statusOrder: string[] = [SurveyStatus.SENT, SurveyStatus.OPEN, SurveyStatus.DRAFT, SurveyStatus.SCHEDULED, SurveyStatus.CLOSED];
-      statusOrder.forEach((status) => {
-        const count = statusCounts.get(status) || 0;
-        const shouldShowStatus = count > 0 || (status === SurveyStatus.DRAFT && this.hasPMOAccess());
-        if (shouldShowStatus) {
-          const label = SURVEY_STATUS_LABELS[status as SurveyStatus] ?? status;
-          options.push({
-            label: `${label} (${count})`,
-            value: status,
-          });
-        }
-      });
-
-      return options;
-    });
   }
 
   private initGroupOptions(): Signal<{ label: string; value: string | null }[]> {
@@ -250,9 +228,14 @@ export class SurveysTableComponent {
         filtered = filtered.filter((survey) => survey.survey_title.toLowerCase().includes(searchTerm));
       }
 
-      const status = this.statusFilter();
-      if (status) {
-        filtered = filtered.filter((survey) => survey.survey_status === status);
+      const statusTab = this.statusTab();
+      if (statusTab !== 'all') {
+        const openStatuses: SurveyStatus[] = [SurveyStatus.OPEN, SurveyStatus.SENT];
+        if (statusTab === 'open') {
+          filtered = filtered.filter((survey) => openStatuses.includes((survey.survey_status as string).toLowerCase() as SurveyStatus));
+        } else if (statusTab === 'closed') {
+          filtered = filtered.filter((survey) => (survey.survey_status as string).toLowerCase() === SurveyStatus.CLOSED);
+        }
       }
 
       const group = this.groupFilter();

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
@@ -35,20 +35,21 @@
       </div>
     </div>
   } @else if (!isMeLens() && surveys().length === 0) {
-    <!-- Project empty state -->
-    <lfx-card data-testid="surveys-empty-state-card">
-      <div class="p-8 md:p-12">
-        <div class="max-w-2xl mx-auto text-center flex flex-col gap-6">
-          <div class="flex justify-center">
-            <div class="w-20 h-20 rounded-full bg-violet-100 flex items-center justify-center">
-              <i class="fa-light fa-clipboard-list text-4xl text-violet-600"></i>
-            </div>
-          </div>
-          <h2 class="text-xl font-semibold text-gray-900">No {{ surveyLabelPlural | lowercase }} yet</h2>
-          <p class="text-gray-600">Create a {{ surveyLabel | lowercase }} to gather feedback from your project community.</p>
-        </div>
-      </div>
-    </lfx-card>
+    <lfx-empty-state
+      icon="fa-light fa-clipboard-list"
+      [title]="'No ' + (surveyLabelPlural | lowercase) + ' yet'"
+      [subtitle]="'Create a ' + (surveyLabel | lowercase) + ' to gather feedback from your project community.'"
+      [ctaLabel]="hasPMOAccess() ? 'Create ' + surveyLabel : undefined"
+      [ctaRoute]="hasPMOAccess() ? ['/surveys', 'create'] : undefined"
+      data-testid="surveys-empty-state-card">
+    </lfx-empty-state>
+  } @else if (isMeLens() && !mySurveysLoading() && filteredMySurveys().length === 0) {
+    <lfx-empty-state
+      icon="fa-light fa-clipboard-list"
+      [title]="'No ' + (surveyLabelPlural | lowercase) + ' yet'"
+      subtitle="Surveys you've been invited to complete will appear here."
+      data-testid="surveys-me-empty-state">
+    </lfx-empty-state>
   } @else {
     <lfx-surveys-table
       [surveys]="isMeLens() ? filteredMySurveys() : surveys()"

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
@@ -6,7 +6,6 @@ import { Component, computed, inject, Signal, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
-import { CardComponent } from '@components/card/card.component';
 import { SURVEY_LABEL } from '@lfx-one/shared';
 import { ProjectContext, Survey } from '@lfx-one/shared/interfaces';
 import { LensService } from '@services/lens.service';
@@ -15,12 +14,13 @@ import { ProjectContextService } from '@services/project-context.service';
 import { SurveyService } from '@services/survey.service';
 import { BehaviorSubject, catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
 
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { SurveyResultsDrawerComponent } from '../components/survey-results-drawer/survey-results-drawer.component';
 import { SurveysTableComponent } from '../components/surveys-table/surveys-table.component';
 
 @Component({
   selector: 'lfx-surveys-dashboard',
-  imports: [LowerCasePipe, CardComponent, ButtonComponent, SurveysTableComponent, RouterLink, SurveyResultsDrawerComponent],
+  imports: [LowerCasePipe, ButtonComponent, SurveysTableComponent, RouterLink, SurveyResultsDrawerComponent, EmptyStateComponent],
   templateUrl: './surveys-dashboard.component.html',
   styleUrl: './surveys-dashboard.component.scss',
 })

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -1,8 +1,15 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<lfx-card styleClass="[&_.p-card-body]:!px-5" data-testid="votes-table-card">
-  <div class="pb-2 mb-2">
+<lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="votes-table-card">
+  <lfx-card-tabs-bar
+    [options]="statusTabOptions"
+    [selectedFilter]="statusTab()"
+    (filterChange)="onStatusTabChange($event)"
+    data-testid="votes-status-tabs">
+  </lfx-card-tabs-bar>
+
+  <div class="px-5 pt-4 pb-3">
     <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
       <div class="flex-1 min-w-0">
         <lfx-input-text
@@ -57,16 +64,13 @@
           data-testid="votes-group-filter"></lfx-select>
       </div>
 
-      <div class="w-full sm:w-auto sm:shrink-0">
-        <lfx-select [form]="searchForm" control="status" size="small" [options]="statusOptions()" data-testid="votes-status-filter"></lfx-select>
-      </div>
-
       <ng-content select="[tableActions]"></ng-content>
     </div>
   </div>
 
+  <div class="px-5 pb-5">
   <lfx-table
-    [value]="votes()"
+    [value]="displayedVotes()"
     [paginator]="true"
     [rows]="rowsPerPage()"
     [first]="first()"
@@ -100,7 +104,7 @@
         <td>
           <button
             type="button"
-            class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0"
+            class="lfx-table-name-link text-sm text-left bg-transparent border-none p-0"
             (click)="onViewVote(vote.uid)"
             [attr.data-testid]="'votes-name-' + vote.uid">
             {{ vote.name }}
@@ -118,20 +122,20 @@
         </td>
 
         <td>
-          <span class="text-xs text-slate-900" [attr.data-testid]="'votes-responses-' + vote.uid">
+          <span class="text-sm text-gray-700" [attr.data-testid]="'votes-responses-' + vote.uid">
             {{ vote.num_response_received }}
           </span>
         </td>
 
-        <td class="text-xs text-slate-900">
+        <td>
           @if (vote.status === PollStatus.ENDED) {
-            <span>{{ vote.end_time | date: 'MMM d, y' }}</span>
+            <span class="text-sm text-gray-700">{{ vote.end_time | date: 'MMM d, y' }}</span>
           } @else if (vote.status === PollStatus.DISABLED) {
-            <span class="text-gray-500">Draft</span>
+            <span class="text-sm text-gray-700">Draft</span>
           } @else if (vote.end_time) {
-            <span>{{ vote.end_time | relativeDueDate }}</span>
+            <span class="text-sm text-gray-700">{{ vote.end_time | relativeDueDate }}</span>
           } @else {
-            <span>-</span>
+            <span class="text-sm text-gray-700">-</span>
           }
         </td>
 
@@ -208,6 +212,7 @@
       </tr>
     </ng-template>
   </lfx-table>
+  </div>
 </lfx-card>
 
 <p-confirmDialog></p-confirmDialog>

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<lfx-card data-testid="votes-table-card">
+<lfx-card styleClass="[&_.p-card-body]:!px-5" data-testid="votes-table-card">
   <div class="pb-2 mb-2">
     <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
       <div class="flex-1 min-w-0">
@@ -163,9 +163,10 @@
               } @else {
                 <lfx-button
                   label="Results"
-                  severity="primary"
+                  severity="secondary"
+                  [outlined]="true"
                   size="small"
-                  [text]="true"
+                  styleClass="whitespace-nowrap"
                   (onClick)="onViewResults(vote.uid)"
                   [attr.data-testid]="'votes-results-' + vote.uid">
                 </lfx-button>
@@ -175,17 +176,19 @@
                 <lfx-button
                   label="Review"
                   severity="primary"
+                  [outlined]="true"
                   size="small"
-                  [text]="true"
+                  styleClass="whitespace-nowrap"
                   (onClick)="onViewVote(vote.uid)"
                   [attr.data-testid]="'votes-cast-' + vote.uid">
                 </lfx-button>
               } @else if (vote.status === PollStatus.ENDED) {
                 <lfx-button
                   label="Results"
-                  severity="primary"
+                  severity="secondary"
+                  [outlined]="true"
                   size="small"
-                  [text]="true"
+                  styleClass="whitespace-nowrap"
                   (onClick)="onViewResults(vote.uid)"
                   [attr.data-testid]="'votes-results-' + vote.uid">
                 </lfx-button>

--- a/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/components/votes-table/votes-table.component.ts
@@ -3,17 +3,18 @@
 
 import { DatePipe } from '@angular/common';
 import { Component, computed, DestroyRef, inject, input, OnInit, output, signal, Signal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { POLL_STATUS_LABELS, PollStatus, VOTE_LABEL } from '@lfx-one/shared';
-import { Vote, VoteFilterState } from '@lfx-one/shared/interfaces';
+import { PollStatus, VOTE_LABEL } from '@lfx-one/shared';
+import { FilterPillOption, Vote, VoteFilterState } from '@lfx-one/shared/interfaces';
 import { PollStatusLabelPipe } from '@pipes/poll-status-label.pipe';
 import { PollStatusSeverityPipe } from '@pipes/poll-status-severity.pipe';
 import { RelativeDueDatePipe } from '@pipes/relative-due-date.pipe';
@@ -21,12 +22,13 @@ import { VoteService } from '@services/vote.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { TooltipModule } from 'primeng/tooltip';
-import { debounceTime, distinctUntilChanged, map } from 'rxjs';
+import { combineLatest, debounceTime, distinctUntilChanged, map, startWith } from 'rxjs';
 
 @Component({
   selector: 'lfx-votes-table',
   imports: [
     CardComponent,
+    CardTabsBarComponent,
     TableComponent,
     TagComponent,
     ButtonComponent,
@@ -54,6 +56,11 @@ export class VotesTableComponent implements OnInit {
   // === Constants ===
   protected readonly voteLabel = VOTE_LABEL;
   protected readonly PollStatus = PollStatus;
+  protected readonly statusTabOptions: FilterPillOption[] = [
+    { id: 'all', label: 'All' },
+    { id: PollStatus.ACTIVE, label: 'Active' },
+    { id: PollStatus.ENDED, label: 'Ended' },
+  ];
 
   // === Inputs ===
   public readonly votes = input.required<Vote[]>();
@@ -80,18 +87,18 @@ export class VotesTableComponent implements OnInit {
 
   // === Writable Signals ===
   protected readonly isDeleting = signal(false);
+  protected readonly statusTab = signal<string>('all');
 
   // === Forms ===
   public searchForm = new FormGroup({
     search: new FormControl<string>(''),
-    status: new FormControl<PollStatus | null>(null),
     group: new FormControl<string | null>(null),
     foundationFilter: new FormControl<string | null>(null),
     projectFilter: new FormControl<string | null>(null),
   });
 
   // === Computed Signals ===
-  protected readonly statusOptions: Signal<{ label: string; value: PollStatus | null }[]> = this.initStatusOptions();
+  protected readonly displayedVotes: Signal<Vote[]> = this.initDisplayedVotes();
 
   // === Lifecycle ===
   public ngOnInit(): void {
@@ -105,6 +112,10 @@ export class VotesTableComponent implements OnInit {
 
   protected onViewResults(voteId: string): void {
     this.viewResults.emit(voteId);
+  }
+
+  protected onStatusTabChange(tab: string): void {
+    this.statusTab.set(tab);
   }
 
   protected onFoundationFilterChange(value: string | null): void {
@@ -161,36 +172,30 @@ export class VotesTableComponent implements OnInit {
 
   // === Private Initializers ===
   private initFormSubscriptions(): void {
-    this.searchForm.valueChanges
+    combineLatest([
+      this.searchForm.valueChanges.pipe(startWith(this.searchForm.value), debounceTime(300), distinctUntilChanged((a, b) => JSON.stringify(a) === JSON.stringify(b))),
+      toObservable(this.statusTab),
+    ])
       .pipe(
-        debounceTime(300),
-        distinctUntilChanged((prev, curr) => JSON.stringify(prev) === JSON.stringify(curr)),
-        map((value) => ({
-          search: value.search ?? '',
-          status: value.status ?? null,
-          group: value.group ?? null,
+        map(([formValue, statusTab]) => ({
+          search: formValue.search ?? '',
+          status: statusTab !== 'all' ? (statusTab as PollStatus) : null,
+          group: formValue.group ?? null,
         })),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((filters) => this.filtersChange.emit(filters));
   }
 
-  private initStatusOptions(): Signal<{ label: string; value: PollStatus | null }[]> {
+  private initDisplayedVotes(): Signal<Vote[]> {
     return computed(() => {
-      const options: { label: string; value: PollStatus | null }[] = [{ label: 'All Statuses', value: null }];
+      // For lazy (server-side paginated) mode, the server handles status filtering via filtersChange
+      if (this.lazy()) return this.votes();
 
-      const statusOrder: PollStatus[] = [PollStatus.ACTIVE, PollStatus.DISABLED, PollStatus.ENDED];
-      for (const status of statusOrder) {
-        const shouldShowStatus = status !== PollStatus.DISABLED || this.hasPMOAccess();
-        if (shouldShowStatus) {
-          options.push({
-            label: POLL_STATUS_LABELS[status],
-            value: status,
-          });
-        }
-      }
-
-      return options;
+      // For client-side mode (Me lens), filter locally by status tab
+      const tab = this.statusTab();
+      if (tab === 'all') return this.votes();
+      return this.votes().filter((v) => (v.status as string).toLowerCase() === tab);
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -31,20 +31,21 @@
       </div>
     </div>
   } @else if (!isMeLens() && !loading() && votes().length === 0) {
-    <!-- Project empty state -->
-    <lfx-card data-testid="votes-empty-state-card">
-      <div class="p-8 md:p-12">
-        <div class="max-w-2xl mx-auto text-center flex flex-col gap-6">
-          <div class="flex justify-center">
-            <div class="w-20 h-20 rounded-full bg-blue-100 flex items-center justify-center">
-              <i class="fa-light fa-check-to-slot text-4xl text-blue-600"></i>
-            </div>
-          </div>
-          <h2 class="text-xl font-semibold text-gray-900">No {{ voteLabelPlural | lowercase }} yet</h2>
-          <p class="text-gray-600">Create a {{ voteLabel | lowercase }} to gather decisions from project groups.</p>
-        </div>
-      </div>
-    </lfx-card>
+    <lfx-empty-state
+      icon="fa-light fa-check-to-slot"
+      [title]="'No ' + (voteLabelPlural | lowercase) + ' yet'"
+      [subtitle]="'Create a ' + (voteLabel | lowercase) + ' to gather decisions from project groups.'"
+      [ctaLabel]="hasPMOAccess() ? 'Create ' + voteLabel : undefined"
+      [ctaRoute]="hasPMOAccess() ? ['/votes', 'create'] : undefined"
+      data-testid="votes-empty-state-card">
+    </lfx-empty-state>
+  } @else if (isMeLens() && !myVotesLoading() && filteredMyVotes().length === 0) {
+    <lfx-empty-state
+      icon="fa-light fa-check-to-slot"
+      [title]="'No ' + (voteLabelPlural | lowercase) + ' yet'"
+      subtitle="Votes you've been invited to participate in will appear here."
+      data-testid="votes-me-empty-state">
+    </lfx-empty-state>
   } @else {
     <lfx-votes-table
       [votes]="isMeLens() ? filteredMyVotes() : votes()"

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -6,7 +6,6 @@ import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
-import { CardComponent } from '@components/card/card.component';
 import { VOTE_LABEL } from '@lfx-one/shared';
 import { Committee, PaginatedResponse, ProjectContext, Vote, VoteFilterState } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
@@ -16,12 +15,13 @@ import { ProjectContextService } from '@services/project-context.service';
 import { VoteService } from '@services/vote.service';
 import { BehaviorSubject, catchError, combineLatest, finalize, map, of, switchMap, tap } from 'rxjs';
 
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { VoteResultsDrawerComponent } from '../components/vote-results-drawer/vote-results-drawer.component';
 import { VotesTableComponent } from '../components/votes-table/votes-table.component';
 
 @Component({
   selector: 'lfx-votes-dashboard',
-  imports: [LowerCasePipe, CardComponent, ButtonComponent, VotesTableComponent, VoteResultsDrawerComponent, RouterLink],
+  imports: [LowerCasePipe, ButtonComponent, VotesTableComponent, VoteResultsDrawerComponent, RouterLink, EmptyStateComponent],
   templateUrl: './votes-dashboard.component.html',
   styleUrl: './votes-dashboard.component.scss',
 })

--- a/apps/lfx-one/src/app/shared/components/card-tabs-bar/card-tabs-bar.component.html
+++ b/apps/lfx-one/src/app/shared/components/card-tabs-bar/card-tabs-bar.component.html
@@ -1,0 +1,10 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex items-center justify-between px-5 py-4 border-b border-gray-200" data-testid="card-tabs-bar">
+  <lfx-filter-pills
+    [options]="options()"
+    [selectedFilter]="selectedFilter()"
+    (filterChange)="filterChange.emit($event)" />
+  <ng-content />
+</div>

--- a/apps/lfx-one/src/app/shared/components/card-tabs-bar/card-tabs-bar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/card-tabs-bar/card-tabs-bar.component.ts
@@ -1,0 +1,36 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input, output } from '@angular/core';
+import { FilterPillOption } from '@lfx-one/shared/interfaces';
+import { FilterPillsComponent } from '../filter-pills/filter-pills.component';
+
+/**
+ * A standardised top-bar that lives at the top of a `<lfx-card>` with `p-0` body padding.
+ * It renders the tab pills on the left and projects any action elements (buttons, etc.) on the right.
+ * Includes a bottom border separator matching the card's inner divider style.
+ *
+ * Usage:
+ * ```html
+ * <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+ *   <lfx-card-tabs-bar
+ *     [options]="tabOptions"
+ *     [selectedFilter]="activeTab()"
+ *     (filterChange)="onTabChange($event)">
+ *     <!-- optional right-side content -->
+ *     <lfx-button label="New" severity="primary" size="small" />
+ *   </lfx-card-tabs-bar>
+ *   <!-- rest of card content -->
+ * </lfx-card>
+ * ```
+ */
+@Component({
+  selector: 'lfx-card-tabs-bar',
+  imports: [FilterPillsComponent],
+  templateUrl: './card-tabs-bar.component.html',
+})
+export class CardTabsBarComponent {
+  public readonly options = input.required<FilterPillOption[]>();
+  public readonly selectedFilter = input.required<string>();
+  public readonly filterChange = output<string>();
+}

--- a/apps/lfx-one/src/app/shared/components/empty-state/empty-state.component.html
+++ b/apps/lfx-one/src/app/shared/components/empty-state/empty-state.component.html
@@ -1,0 +1,34 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (withCard()) {
+  <lfx-card>
+    <ng-container [ngTemplateOutlet]="content" />
+  </lfx-card>
+} @else {
+  <ng-container [ngTemplateOutlet]="content" />
+}
+
+<ng-template #content>
+  <div class="p-8 md:p-16">
+    <div class="mx-auto text-center flex flex-col gap-4 items-center">
+      <!-- Icon -->
+      <div class="w-20 h-20 rounded-full bg-gray-100 flex items-center justify-center">
+        <i [class]="icon() + ' text-3xl text-gray-500'"></i>
+      </div>
+
+      <!-- Title -->
+      <h3 class="text-lg font-semibold text-gray-900">{{ title() }}</h3>
+
+      <!-- Subtitle -->
+      @if (subtitle()) {
+        <p class="text-sm text-gray-500 whitespace-nowrap">{{ subtitle() }}</p>
+      }
+
+      <!-- CTA -->
+      @if (ctaLabel() && ctaRoute()) {
+        <lfx-button [label]="ctaLabel()!" severity="primary" size="small" [routerLink]="ctaRoute()!"></lfx-button>
+      }
+    </div>
+  </div>
+</ng-template>

--- a/apps/lfx-one/src/app/shared/components/empty-state/empty-state.component.ts
+++ b/apps/lfx-one/src/app/shared/components/empty-state/empty-state.component.ts
@@ -1,0 +1,25 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NgTemplateOutlet } from '@angular/common';
+import { Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+
+@Component({
+  selector: 'lfx-empty-state',
+  imports: [NgTemplateOutlet, CardComponent, ButtonComponent, RouterLink],
+  templateUrl: './empty-state.component.html',
+})
+export class EmptyStateComponent {
+  // === Inputs ===
+  public readonly icon = input.required<string>();
+  public readonly title = input.required<string>();
+  public readonly subtitle = input<string>('');
+  public readonly ctaLabel = input<string | undefined>(undefined);
+  public readonly ctaRoute = input<string[] | undefined>(undefined);
+  /** Set to false when the component is already inside a card-like container */
+  public readonly withCard = input(true);
+}

--- a/apps/lfx-one/src/app/shared/components/table/table.component.scss
+++ b/apps/lfx-one/src/app/shared/components/table/table.component.scss
@@ -30,6 +30,15 @@
           a {
             @apply text-blue-500 hover:text-blue-600 hover:underline cursor-pointer text-sm font-medium;
           }
+
+          // ─── Name-column link pattern ────────────────────────────────────
+          // Apply .lfx-table-name-link to the clickable name/title element in
+          // the first column of any table (works on <a>, <button>, or <span>).
+          // Renders as gray-900 + underline instead of the default blue link.
+          // Nested here so specificity beats the `a` rule above.
+          .lfx-table-name-link {
+            @apply text-gray-900 underline hover:text-gray-700 font-medium cursor-pointer;
+          }
         }
       }
     }

--- a/apps/lfx-one/src/app/shared/components/table/table.component.scss
+++ b/apps/lfx-one/src/app/shared/components/table/table.component.scss
@@ -34,11 +34,15 @@
       }
     }
 
-    // Selectable table rows
+    // Selectable table rows — cursor + hover background to signal clickability
     &.lfx-table-selectable {
       .p-datatable-tbody {
         tr {
-          @apply cursor-pointer;
+          @apply cursor-pointer transition-colors duration-150;
+
+          &:hover {
+            @apply bg-slate-100;
+          }
         }
       }
     }

--- a/apps/lfx-one/src/app/shared/pipes/poll-status-label.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/poll-status-label.pipe.ts
@@ -9,6 +9,7 @@ import { POLL_STATUS_LABELS, PollStatus } from '@lfx-one/shared';
 })
 export class PollStatusLabelPipe implements PipeTransform {
   public transform(status: PollStatus): string {
-    return POLL_STATUS_LABELS[status] ?? status;
+    const normalized = (status as string).toLowerCase() as PollStatus;
+    return POLL_STATUS_LABELS[normalized] ?? status;
   }
 }

--- a/apps/lfx-one/src/app/shared/pipes/poll-status-severity.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/poll-status-severity.pipe.ts
@@ -16,6 +16,7 @@ import { PollStatus, POLL_STATUS_SEVERITY, TagSeverity } from '@lfx-one/shared';
 })
 export class PollStatusSeverityPipe implements PipeTransform {
   public transform(status: PollStatus): TagSeverity {
-    return POLL_STATUS_SEVERITY[status] ?? 'secondary';
+    const normalized = (status as string).toLowerCase() as PollStatus;
+    return POLL_STATUS_SEVERITY[normalized] ?? 'secondary';
   }
 }

--- a/packages/shared/src/utils/survey.utils.ts
+++ b/packages/shared/src/utils/survey.utils.ts
@@ -44,7 +44,8 @@ export function getCombinedSurveyStatus(survey: UserSurvey): CombinedSurveyStatu
  * @returns The computed display status as SurveyStatus
  */
 export function getSurveyDisplayStatus(survey: Pick<Survey, 'survey_status' | 'survey_cutoff_date' | 'response_status'>): SurveyStatus {
-  const status = survey.survey_status as SurveyStatus;
+  // Normalize to lowercase so API values like 'OPEN', 'CLOSED' match enum values
+  const status = (survey.survey_status as string).toLowerCase() as SurveyStatus;
 
   // Explicit response_status from the API takes precedence
   if (survey.response_status === 'closed') {


### PR DESCRIPTION
## Summary

- Add shared `EmptyStateComponent` (icon + gray circle, title, subtitle, optional CTA) reusable across the app with a `withCard` toggle for flexible placement
- Apply consistent empty states to all Me lens pages: Meetings, Mailing Lists, Votes, Surveys, My Activity, My Documents, My Events, My Groups
- Refactor My Events layout: replace custom tab nav with `FilterPillsComponent` placed above search/filters, consolidate everything into a single card (tabs → divider → search → list), move "New Letter/Funding Application" button into the tabs bar, add per-tab search placeholders
- Fix header spacing and subtitle `text-sm` on Documents and Groups dashboards to match other Me lens pages
- Update My Groups empty state icon to `fa-users-rectangle` to match the sidebar navigation entry

## Test plan

- [ ] Verify empty states render correctly on Meetings, Mailing Lists, Votes, Surveys, My Activity, My Documents pages
- [ ] Verify My Events tab switcher (Upcoming / Past / Visa Letters / Travel Funding) works and persists filter resets on tab change
- [ ] Verify "New Letter Application" / "New Funding Application" button appears in the tabs bar on the correct tabs and opens the dialog
- [ ] Verify per-tab search placeholders on My Events ("Search visa letters…", "Search travel fundings…", "Search events…")
- [ ] Verify My Groups empty state uses `fa-users-rectangle` icon
- [ ] Verify header alignment (spacing, subtitle font size) on Documents and Groups pages matches other Me lens pages

🤖 Generated with [Claude Code](https://claude.ai/code)