### PR TITLE
fix(committees): hide My Groups section on foundation lens

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -195,7 +195,7 @@
           }
         </div>
       </div>
-    } @else if (myCommittees().length > 0) {
+    } @else if (myCommittees().length > 0 && isMeLens()) {
       <div>
         <div class="flex items-center gap-2 mb-4">
           <h2 class="text-lg font-semibold text-gray-900">My {{ committeeLabel.plural }}</h2>

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -167,8 +167,8 @@
       </div>
     }
 
-    <!-- My Groups Section -->
-    @if (myCommitteesLoading()) {
+    <!-- My Groups Section — only visible on Me lens -->
+    @if (isMeLens() && myCommitteesLoading()) {
       <div>
         <div class="flex items-center gap-2 mb-4">
           <h2 class="text-lg font-semibold text-gray-900">My {{ committeeLabel.plural }}</h2>
@@ -195,7 +195,7 @@
           }
         </div>
       </div>
-    } @else if (myCommittees().length > 0 && isMeLens()) {
+    } @else if (isMeLens() && myCommittees().length > 0) {
       <div>
         <div class="flex items-center gap-2 mb-4">
           <h2 class="text-lg font-semibold text-gray-900">My {{ committeeLabel.plural }}</h2>

--- a/apps/lfx-one/src/server/controllers/badges.controller.ts
+++ b/apps/lfx-one/src/server/controllers/badges.controller.ts
@@ -8,18 +8,16 @@ import { NextFunction, Request, Response } from 'express';
 import { AuthenticationError } from '../errors';
 import { CredlyService } from '../services/credly.service';
 import { logger } from '../services/logger.service';
-import { SupabaseService } from '../services/supabase.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
 
 export class BadgesController {
   private readonly credlyService = new CredlyService();
-  private readonly supabaseService = new SupabaseService();
 
   /**
    * GET /api/badges
    * Get badges for the authenticated user from Credly.
-   * Resolves all verified emails from Supabase so badges earned under secondary
-   * addresses are included. Falls back to the single OIDC email on failure.
+   * Currently resolves only the OIDC session email.
+   * TODO: Migrate to email-verification.service to include secondary verified emails.
    */
   public async getBadges(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_badges');
@@ -45,9 +43,9 @@ export class BadgesController {
   }
 
   /**
-   * Resolve all verified email addresses for the authenticated user.
-   * Queries Supabase for the full email list, filters to verified only.
-   * Falls back to the single OIDC session email if Supabase lookup fails.
+   * Resolve verified email addresses for the authenticated user.
+   * TODO: Currently returns OIDC email only; migrate to email-verification.service
+   * to retrieve all verified emails for a user.
    */
   private async resolveUserEmails(req: Request): Promise<string[]> {
     const oidcEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
@@ -60,28 +58,13 @@ export class BadgesController {
         return oidcEmail ? [oidcEmail] : [];
       }
 
-      const user = await this.supabaseService.getUser(username);
-
-      if (!user) {
-        logger.debug(req, 'resolve_user_emails', 'User not found in Supabase, using OIDC email only', {
-          username,
-        });
-        return oidcEmail ? [oidcEmail] : [];
-      }
-
-      const userEmails = await this.supabaseService.getUserEmails(user.id);
-      const verifiedEmails = userEmails.filter((e) => e.is_verified && typeof e.email === 'string').map((e) => e.email.toLowerCase());
-
-      logger.debug(req, 'resolve_user_emails', 'Resolved verified emails from Supabase', {
-        total_emails: userEmails.length,
-        verified_count: verifiedEmails.length,
+      // TODO: Migrate to email-verification.service to resolve all verified emails
+      logger.debug(req, 'resolve_user_emails', 'Using OIDC email only (pending email-verification migration)', {
+        source: 'oidc',
       });
-
-      // If Supabase returned verified emails, use them; otherwise fall back to OIDC
-      if (verifiedEmails.length > 0) return verifiedEmails;
       return oidcEmail ? [oidcEmail] : [];
     } catch (error) {
-      logger.warning(req, 'resolve_user_emails', 'Failed to resolve emails from Supabase, falling back to OIDC email', {
+      logger.warning(req, 'resolve_user_emails', 'Failed to resolve emails, falling back to OIDC email', {
         err: error instanceof Error ? error : new Error(String(error)),
       });
       return oidcEmail ? [oidcEmail] : [];

--- a/apps/lfx-one/src/server/controllers/badges.controller.ts
+++ b/apps/lfx-one/src/server/controllers/badges.controller.ts
@@ -9,7 +9,7 @@ import { AuthenticationError } from '../errors';
 import { CredlyService } from '../services/credly.service';
 import { EmailVerificationService } from '../services/email-verification.service';
 import { logger } from '../services/logger.service';
-import { getUsernameFromAuth } from '../utils/auth-helper';
+import { getEffectiveEmail, getEffectiveSub, getUsernameFromAuth } from '../utils/auth-helper';
 
 export class BadgesController {
   private readonly credlyService = new CredlyService();
@@ -18,8 +18,10 @@ export class BadgesController {
   /**
    * GET /api/badges
    * Get badges for the authenticated user from Credly.
-   * Resolves all verified emails via email-verification.service (NATS) so badges
-   * earned under secondary addresses are included. Falls back to OIDC email on failure.
+   * Resolves primary + alternate verified emails via email-verification.service
+   * (NATS) so badges earned under secondary addresses are included.
+   * The OIDC session email is always included as a safety net.
+   * Falls back to OIDC email only if the service lookup fails.
    */
   public async getBadges(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_badges');
@@ -45,44 +47,46 @@ export class BadgesController {
   }
 
   /**
-   * Resolve all verified email addresses for the authenticated user.
-   * Fetches primary + alternate emails via email-verification.service (NATS).
-   * Falls back to the single OIDC session email if the lookup fails.
+   * Resolve email addresses for the authenticated user.
+   * Fetches primary + verified alternate emails via email-verification.service (NATS).
+   * The OIDC/effective session email is always included to cover cases where the
+   * service response doesn't include it. Falls back to session email only on failure.
+   * Uses impersonation-aware helpers so badges resolve correctly during CTE sessions.
    */
   private async resolveUserEmails(req: Request): Promise<string[]> {
-    const oidcEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+    const sessionEmail = getEffectiveEmail(req);
 
     try {
-      const userSub = req.oidc?.user?.['sub'] as string | undefined;
+      const userSub = getEffectiveSub(req);
 
       if (!userSub) {
-        const username = await getUsernameFromAuth(req);
-        if (!username) {
-          logger.debug(req, 'resolve_user_emails', 'No user identifier from auth, using OIDC email only', {});
-          return oidcEmail ? [oidcEmail] : [];
+        const userIdentifier = await getUsernameFromAuth(req);
+        if (!userIdentifier) {
+          logger.debug(req, 'resolve_user_emails', 'No user identifier from auth, using session email only', {});
+          return sessionEmail ? [sessionEmail] : [];
         }
-        // Fall back to username-based lookup
-        return await this.resolveEmailsFromService(req, username, oidcEmail);
+        return await this.resolveEmailsFromService(req, userIdentifier, sessionEmail);
       }
 
-      return await this.resolveEmailsFromService(req, userSub, oidcEmail);
+      return await this.resolveEmailsFromService(req, userSub, sessionEmail);
     } catch (error) {
-      logger.warning(req, 'resolve_user_emails', 'Failed to resolve emails, falling back to OIDC email', {
+      logger.warning(req, 'resolve_user_emails', 'Failed to resolve emails, falling back to session email', {
         err: error instanceof Error ? error : new Error(String(error)),
       });
-      return oidcEmail ? [oidcEmail] : [];
+      return sessionEmail ? [sessionEmail] : [];
     }
   }
 
   /**
    * Fetch emails from email-verification.service and dedupe into a flat list.
+   * Includes primary email, verified alternates, and the session email as a safety net.
    */
-  private async resolveEmailsFromService(req: Request, userIdentifier: string, oidcEmail: string | undefined): Promise<string[]> {
+  private async resolveEmailsFromService(req: Request, userIdentifier: string, sessionEmail: string | null): Promise<string[]> {
     const emailData = await this.emailVerificationService.getUserEmails(req, userIdentifier);
 
     if (!emailData) {
-      logger.debug(req, 'resolve_user_emails', 'Email service returned no data, using OIDC email only', {});
-      return oidcEmail ? [oidcEmail] : [];
+      logger.debug(req, 'resolve_user_emails', 'Email service returned no data, using session email only', {});
+      return sessionEmail ? [sessionEmail] : [];
     }
 
     // Collect primary + verified alternates, deduped and lowercased
@@ -98,12 +102,12 @@ export class BadgesController {
       }
     }
 
-    // Ensure OIDC email is included even if not in the service response
-    if (oidcEmail) {
-      allEmails.add(oidcEmail);
+    // Always include session email as safety net
+    if (sessionEmail) {
+      allEmails.add(sessionEmail.toLowerCase());
     }
 
-    logger.debug(req, 'resolve_user_emails', 'Resolved verified emails via email-verification.service', {
+    logger.debug(req, 'resolve_user_emails', 'Resolved emails via email-verification.service', {
       resolved_count: allEmails.size,
       source: 'email-verification',
     });

--- a/apps/lfx-one/src/server/controllers/badges.controller.ts
+++ b/apps/lfx-one/src/server/controllers/badges.controller.ts
@@ -7,17 +7,19 @@ import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError } from '../errors';
 import { CredlyService } from '../services/credly.service';
+import { EmailVerificationService } from '../services/email-verification.service';
 import { logger } from '../services/logger.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
 
 export class BadgesController {
   private readonly credlyService = new CredlyService();
+  private readonly emailVerificationService = new EmailVerificationService();
 
   /**
    * GET /api/badges
    * Get badges for the authenticated user from Credly.
-   * Currently resolves only the OIDC session email.
-   * TODO: Migrate to email-verification.service to include secondary verified emails.
+   * Resolves all verified emails via email-verification.service (NATS) so badges
+   * earned under secondary addresses are included. Falls back to OIDC email on failure.
    */
   public async getBadges(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_badges');
@@ -43,31 +45,69 @@ export class BadgesController {
   }
 
   /**
-   * Resolve verified email addresses for the authenticated user.
-   * TODO: Currently returns OIDC email only; migrate to email-verification.service
-   * to retrieve all verified emails for a user.
+   * Resolve all verified email addresses for the authenticated user.
+   * Fetches primary + alternate emails via email-verification.service (NATS).
+   * Falls back to the single OIDC session email if the lookup fails.
    */
   private async resolveUserEmails(req: Request): Promise<string[]> {
     const oidcEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
 
     try {
-      const username = await getUsernameFromAuth(req);
+      const userSub = req.oidc?.user?.['sub'] as string | undefined;
 
-      if (!username) {
-        logger.debug(req, 'resolve_user_emails', 'No username from auth, using OIDC email only', {});
-        return oidcEmail ? [oidcEmail] : [];
+      if (!userSub) {
+        const username = await getUsernameFromAuth(req);
+        if (!username) {
+          logger.debug(req, 'resolve_user_emails', 'No user identifier from auth, using OIDC email only', {});
+          return oidcEmail ? [oidcEmail] : [];
+        }
+        // Fall back to username-based lookup
+        return await this.resolveEmailsFromService(req, username, oidcEmail);
       }
 
-      // TODO: Migrate to email-verification.service to resolve all verified emails
-      logger.debug(req, 'resolve_user_emails', 'Using OIDC email only (pending email-verification migration)', {
-        source: 'oidc',
-      });
-      return oidcEmail ? [oidcEmail] : [];
+      return await this.resolveEmailsFromService(req, userSub, oidcEmail);
     } catch (error) {
       logger.warning(req, 'resolve_user_emails', 'Failed to resolve emails, falling back to OIDC email', {
         err: error instanceof Error ? error : new Error(String(error)),
       });
       return oidcEmail ? [oidcEmail] : [];
     }
+  }
+
+  /**
+   * Fetch emails from email-verification.service and dedupe into a flat list.
+   */
+  private async resolveEmailsFromService(req: Request, userIdentifier: string, oidcEmail: string | undefined): Promise<string[]> {
+    const emailData = await this.emailVerificationService.getUserEmails(req, userIdentifier);
+
+    if (!emailData) {
+      logger.debug(req, 'resolve_user_emails', 'Email service returned no data, using OIDC email only', {});
+      return oidcEmail ? [oidcEmail] : [];
+    }
+
+    // Collect primary + verified alternates, deduped and lowercased
+    const allEmails = new Set<string>();
+
+    if (emailData.primary_email) {
+      allEmails.add(emailData.primary_email.toLowerCase());
+    }
+
+    for (const alt of emailData.alternate_emails ?? []) {
+      if (alt.verified && alt.email) {
+        allEmails.add(alt.email.toLowerCase());
+      }
+    }
+
+    // Ensure OIDC email is included even if not in the service response
+    if (oidcEmail) {
+      allEmails.add(oidcEmail);
+    }
+
+    logger.debug(req, 'resolve_user_emails', 'Resolved verified emails via email-verification.service', {
+      resolved_count: allEmails.size,
+      source: 'email-verification',
+    });
+
+    return Array.from(allEmails);
   }
 }

--- a/apps/lfx-one/src/server/controllers/badges.controller.ts
+++ b/apps/lfx-one/src/server/controllers/badges.controller.ts
@@ -61,11 +61,13 @@ export class BadgesController {
 
       if (!userSub) {
         const userIdentifier = await getUsernameFromAuth(req);
-        if (!userIdentifier) {
-          logger.debug(req, 'resolve_user_emails', 'No user identifier from auth, using session email only', {});
-          return sessionEmail ? [sessionEmail] : [];
+        // Try email-verification service with whatever identifier we have
+        const identifier = userIdentifier ?? sessionEmail;
+        if (!identifier) {
+          logger.debug(req, 'resolve_user_emails', 'No user identifier from auth, returning empty', {});
+          return [];
         }
-        return await this.resolveEmailsFromService(req, userIdentifier, sessionEmail);
+        return await this.resolveEmailsFromService(req, identifier, sessionEmail);
       }
 
       return await this.resolveEmailsFromService(req, userSub, sessionEmail);

--- a/apps/lfx-one/src/server/controllers/badges.controller.ts
+++ b/apps/lfx-one/src/server/controllers/badges.controller.ts
@@ -1,11 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Generated with [Claude Code](https://claude.ai/code)
-
 import { NextFunction, Request, Response } from 'express';
 
-import { AuthenticationError } from '../errors';
 import { CredlyService } from '../services/credly.service';
 import { EmailVerificationService } from '../services/email-verification.service';
 import { logger } from '../services/logger.service';
@@ -30,7 +27,10 @@ export class BadgesController {
       const emails = await this.resolveUserEmails(req);
 
       if (emails.length === 0) {
-        return next(new AuthenticationError('User authentication required', { operation: 'get_badges' }));
+        logger.warning(req, 'get_badges', 'No resolvable email for authenticated user, returning empty badges', {});
+        logger.success(req, 'get_badges', startTime, { email_count: 0, badge_count: 0 });
+        res.json([]);
+        return;
       }
 
       const badges = await this.credlyService.getBadgesForEmails(req, emails);

--- a/apps/lfx-one/src/server/controllers/badges.controller.ts
+++ b/apps/lfx-one/src/server/controllers/badges.controller.ts
@@ -3,6 +3,7 @@
 
 import { NextFunction, Request, Response } from 'express';
 
+import { AuthenticationError } from '../errors';
 import { CredlyService } from '../services/credly.service';
 import { EmailVerificationService } from '../services/email-verification.service';
 import { logger } from '../services/logger.service';
@@ -17,8 +18,8 @@ export class BadgesController {
    * Get badges for the authenticated user from Credly.
    * Resolves primary + alternate verified emails via email-verification.service
    * (NATS) so badges earned under secondary addresses are included.
-   * The OIDC session email is always included as a safety net.
-   * Falls back to OIDC email only if the service lookup fails.
+   * The effective/session email is always included as a safety net.
+   * Falls back to the effective/session email only if the service lookup fails.
    */
   public async getBadges(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_badges');
@@ -27,10 +28,7 @@ export class BadgesController {
       const emails = await this.resolveUserEmails(req);
 
       if (emails.length === 0) {
-        logger.warning(req, 'get_badges', 'No resolvable email for authenticated user, returning empty badges', {});
-        logger.success(req, 'get_badges', startTime, { email_count: 0, badge_count: 0 });
-        res.json([]);
-        return;
+        return next(new AuthenticationError('User authentication required', { operation: 'get_badges' }));
       }
 
       const badges = await this.credlyService.getBadgesForEmails(req, emails);


### PR DESCRIPTION
## Summary
- My Groups cards were rendering on all lenses (foundation, project) when `myCommittees` had data
- Added `isMeLens()` guard to match the pattern used in the meetings dashboard
- Foundation lens now correctly shows only the "All Groups" table

## Test plan
- [ ] Navigate to `/groups` on **Me lens** — My Groups section should display
- [ ] Navigate to `/groups` on **Foundation lens** — My Groups section should be hidden, only "All Groups" table visible
- [ ] Navigate to `/groups` on **Project lens** — My Groups section should be hidden

LFXV2-1518

🤖 Generated with [Claude Code](https://claude.ai/code)