### PR TITLE
fix(documents): add lens awareness and truncate long names

### DIFF
--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
@@ -5,10 +5,8 @@
   <!-- Page Header -->
   <div class="flex items-start justify-between mb-8">
     <div>
-      <h1 class="font-display font-light text-2xl mb-1" data-testid="documents-dashboard-title">My {{ documentLabel.plural }}</h1>
-      <p class="mt-1 text-gray-500" data-testid="documents-dashboard-description">
-        Documents, links, and attachments from your groups and meetings across all foundations.
-      </p>
+      <h1 class="font-display font-light text-2xl mb-1" data-testid="documents-dashboard-title">{{ pageTitle() }}</h1>
+      <p class="mt-1 text-gray-500" data-testid="documents-dashboard-description">{{ pageDescription() }}</p>
     </div>
   </div>
 
@@ -30,21 +28,23 @@
           </lfx-input-text>
         </div>
 
-        <!-- Foundation filter -->
-        <div class="w-40 shrink-0 overflow-hidden">
-          <lfx-select
-            [form]="filterForm"
-            control="foundation"
-            size="small"
-            [options]="foundationOptions()"
-            placeholder="All Foundations"
-            [showClear]="true"
-            [filter]="true"
-            filterPlaceholder="Search foundations..."
-            styleClass="w-full"
-            data-testid="documents-foundation-filter">
-          </lfx-select>
-        </div>
+        <!-- Foundation filter (Me lens only — non-Me lenses are already scoped) -->
+        @if (isMeLens()) {
+          <div class="w-40 shrink-0 overflow-hidden">
+            <lfx-select
+              [form]="filterForm"
+              control="foundation"
+              size="small"
+              [options]="foundationOptions()"
+              placeholder="All Foundations"
+              [showClear]="true"
+              [filter]="true"
+              filterPlaceholder="Search foundations..."
+              styleClass="w-full"
+              data-testid="documents-foundation-filter">
+            </lfx-select>
+          </div>
+        }
 
         <!-- Group filter -->
         <div class="w-36 shrink-0 overflow-hidden">

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, signal, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CardComponent } from '@components/card/card.component';
@@ -11,8 +11,9 @@ import { DocumentsTableComponent } from '@components/documents-table/documents-t
 import { DOCUMENT_LABEL, MEETING_GROUP_SOURCES } from '@lfx-one/shared/constants';
 import { MyDocumentItem, MyDocumentSource } from '@lfx-one/shared/interfaces';
 import { DocumentService } from '@services/document.service';
+import { LensService } from '@services/lens.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { catchError, debounceTime, distinctUntilChanged, finalize, map, of, startWith, switchMap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, map, of, startWith, switchMap } from 'rxjs';
 
 @Component({
   selector: 'lfx-documents-dashboard',
@@ -23,6 +24,7 @@ import { catchError, debounceTime, distinctUntilChanged, finalize, map, of, star
 export class DocumentsDashboardComponent {
   // === Services ===
   private readonly documentService = inject(DocumentService);
+  private readonly lensService = inject(LensService);
   private readonly projectContextService = inject(ProjectContextService);
 
   // === Constants ===
@@ -48,6 +50,13 @@ export class DocumentsDashboardComponent {
   protected readonly loading = signal<boolean>(true);
 
   // === Computed Signals ===
+  protected readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+  protected readonly pageTitle = computed(() => (this.isMeLens() ? `My ${this.documentLabel.plural}` : this.documentLabel.plural));
+  protected readonly pageDescription = computed(() =>
+    this.isMeLens()
+      ? 'Documents, links, and attachments from your groups and meetings across all foundations.'
+      : 'Documents, links, and attachments for this context.'
+  );
   protected readonly project = this.projectContextService.activeContext;
   protected readonly searchQuery: Signal<string> = this.initSearchQuery();
   protected readonly foundationFilter: Signal<string | null> = this.initFoundationFilter();
@@ -61,6 +70,16 @@ export class DocumentsDashboardComponent {
   protected readonly groupOptions: Signal<{ label: string; value: string | null }[]> = this.initGroupOptions();
   protected readonly meetingOptions: Signal<{ label: string; value: string | null }[]> = this.initMeetingOptions();
   protected readonly mailingListOptions: Signal<{ label: string; value: string | null }[]> = this.initMailingListOptions();
+
+  // === Constructor ===
+  public constructor() {
+    // Reset Me-lens-only filters when switching away from Me lens
+    effect(() => {
+      if (!this.isMeLens()) {
+        this.filterForm.controls.foundation.reset(null);
+      }
+    });
+  }
 
   // === Private Initializers ===
   private initSearchQuery(): Signal<string> {
@@ -96,12 +115,23 @@ export class DocumentsDashboardComponent {
   }
 
   private initDocuments(): Signal<MyDocumentItem[]> {
+    const lens$ = toObservable(this.lensService.activeLens);
+
     return toSignal(
-      toObservable(this.project).pipe(
-        switchMap((project) => {
+      combineLatest([toObservable(this.project), lens$]).pipe(
+        switchMap(([project, lens]) => {
+          // On non-Me lenses, require a project/foundation selection
+          if (lens !== 'me' && !project?.uid) {
+            this.loading.set(false);
+            return of([] as MyDocumentItem[]);
+          }
+
           this.loading.set(true);
 
-          return this.documentService.getMyDocuments(project?.uid).pipe(
+          // Me lens: fetch all documents (no project filter)
+          // Foundation/Project lens: scope to selected project
+          const projectUid = lens === 'me' ? undefined : project?.uid;
+          return this.documentService.getMyDocuments(projectUid).pipe(
             catchError(() => of([] as MyDocumentItem[])),
             finalize(() => this.loading.set(false))
           );
@@ -130,7 +160,7 @@ export class DocumentsDashboardComponent {
         ) {
           return false;
         }
-        if (foundation && doc.foundationUid !== foundation) return false;
+        if (this.isMeLens() && foundation && doc.foundationUid !== foundation) return false;
         if (group && doc.groupOrMeetingUid !== group) return false;
         if (meeting && doc.meetingId !== meeting && doc.pastMeetingId !== meeting) return false;
         if (mailingList && doc.mailingListId !== mailingList) return false;

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
@@ -11,6 +11,7 @@
   [showFirstLastIcon]="false"
   [showCurrentPageReport]="true"
   currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
+  styleClass="[&_table]:table-fixed"
   [attr.data-testid]="testIdPrefix() + '-table'">
   <ng-template #header>
     <tr>
@@ -29,18 +30,20 @@
     <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="testIdPrefix() + '-row-' + doc.id">
       <!-- Name column -->
       <td>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 min-w-0">
           <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' ' + (doc.source | myDocumentSourceTag: 'iconClass')" class="text-base shrink-0"></i>
           @if (doc.url) {
             <button
               type="button"
-              class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate"
+              class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate max-w-full"
               (click)="openDocument(doc)"
+              [pTooltip]="doc.name"
+              tooltipPosition="top"
               [attr.data-testid]="testIdPrefix() + '-name-' + doc.id">
               {{ doc.name }}
             </button>
           } @else {
-            <span class="text-xs text-gray-900 truncate">{{ doc.name }}</span>
+            <span class="text-xs text-gray-900 truncate block max-w-full" [pTooltip]="doc.name" tooltipPosition="top">{{ doc.name }}</span>
           }
         </div>
       </td>

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
@@ -8,10 +8,11 @@ import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { MyDocumentItem } from '@lfx-one/shared/interfaces';
 import { MyDocumentSourceTagPipe } from '@app/shared/pipes/my-document-source-tag.pipe';
+import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   selector: 'lfx-documents-table',
-  imports: [TableComponent, TagComponent, ButtonComponent, DatePipe, MyDocumentSourceTagPipe],
+  imports: [TableComponent, TagComponent, ButtonComponent, DatePipe, MyDocumentSourceTagPipe, TooltipModule],
   templateUrl: './documents-table.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
## Summary
- Documents dashboard now scopes data to the selected foundation/project on non-Me lenses
- On Me lens, all documents across foundations are shown (unchanged behavior)
- Foundation filter dropdown is only shown on Me lens (hidden on all non-Me lenses since data is already scoped by the active context)
- Long document names truncate with tooltip on hover (fixes layout overflow from long URLs)
- Also fixes broken badges build (supabase import removed after service deletion) and badges template formatting

## Test plan
- [ ] Navigate to Documents on **Me lens** — shows "My Documents" with foundation filter, all documents visible
- [ ] Navigate to Documents on **Foundation lens** — shows "Documents" scoped to selected foundation, no foundation filter dropdown
- [ ] Navigate to Documents on **Project lens** — shows "Documents" scoped to selected project, no foundation filter dropdown
- [ ] Hover over a long document name — tooltip shows full name
- [ ] Switch foundations on foundation lens — documents list updates

LFXV2-1537

🤖 Generated with [Claude Code](https://claude.ai/code)