### PR TITLE
fix(badges): use auth-service verified emails and lazy load env vars

### DIFF
--- a/apps/lfx-one/src/server/controllers/badges.controller.ts
+++ b/apps/lfx-one/src/server/controllers/badges.controller.ts
@@ -7,18 +7,17 @@ import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError } from '../errors';
 import { CredlyService } from '../services/credly.service';
+import { EmailVerificationService } from '../services/email-verification.service';
 import { logger } from '../services/logger.service';
-import { SupabaseService } from '../services/supabase.service';
-import { getUsernameFromAuth } from '../utils/auth-helper';
 
 export class BadgesController {
   private readonly credlyService = new CredlyService();
-  private readonly supabaseService = new SupabaseService();
+  private readonly emailVerificationService = new EmailVerificationService();
 
   /**
    * GET /api/badges
    * Get badges for the authenticated user from Credly.
-   * Resolves all verified emails from Supabase so badges earned under secondary
+   * Resolves all verified emails from auth-service so badges earned under secondary
    * addresses are included. Falls back to the single OIDC email on failure.
    */
   public async getBadges(req: Request, res: Response, next: NextFunction): Promise<void> {
@@ -46,45 +45,46 @@ export class BadgesController {
 
   /**
    * Resolve all verified email addresses for the authenticated user.
-   * Queries Supabase for the full email list, filters to verified only.
-   * Falls back to the single OIDC session email if Supabase lookup fails.
+   * Queries auth-service via NATS for the full email list, filters to verified only.
+   * Falls back to the single OIDC session email if auth-service lookup fails.
    */
   private async resolveUserEmails(req: Request): Promise<string[]> {
-    const oidcEmail = (req.oidc?.user?.['email'] as string)?.toLowerCase();
+    const oidcEmail = (req.oidc?.user?.['email'] as string | undefined)?.toLowerCase();
+    const userSub = req.oidc?.user?.['sub'] as string | undefined;
 
-    try {
-      const username = await getUsernameFromAuth(req);
-
-      if (!username) {
-        logger.debug(req, 'resolve_user_emails', 'No username from auth, using OIDC email only', {});
-        return oidcEmail ? [oidcEmail] : [];
-      }
-
-      const user = await this.supabaseService.getUser(username);
-
-      if (!user) {
-        logger.debug(req, 'resolve_user_emails', 'User not found in Supabase, using OIDC email only', {
-          username,
-        });
-        return oidcEmail ? [oidcEmail] : [];
-      }
-
-      const userEmails = await this.supabaseService.getUserEmails(user.id);
-      const verifiedEmails = userEmails.filter((e) => e.is_verified && typeof e.email === 'string').map((e) => e.email.toLowerCase());
-
-      logger.debug(req, 'resolve_user_emails', 'Resolved verified emails from Supabase', {
-        total_emails: userEmails.length,
-        verified_count: verifiedEmails.length,
-      });
-
-      // If Supabase returned verified emails, use them; otherwise fall back to OIDC
-      if (verifiedEmails.length > 0) return verifiedEmails;
-      return oidcEmail ? [oidcEmail] : [];
-    } catch (error) {
-      logger.warning(req, 'resolve_user_emails', 'Failed to resolve emails from Supabase, falling back to OIDC email', {
-        err: error instanceof Error ? error : new Error(String(error)),
-      });
+    if (!userSub) {
+      logger.debug(req, 'resolve_user_emails', 'No sub from OIDC, using session email only', {});
       return oidcEmail ? [oidcEmail] : [];
     }
+
+    const emailData = await this.emailVerificationService.getUserEmails(req, userSub);
+
+    if (!emailData) {
+      return oidcEmail ? [oidcEmail] : [];
+    }
+
+    const seen = new Set<string>();
+    const verifiedEmails: string[] = [];
+
+    const add = (email: string): void => {
+      const lower = email.toLowerCase();
+      if (!seen.has(lower)) {
+        seen.add(lower);
+        verifiedEmails.push(lower);
+      }
+    };
+
+    add(emailData.primary_email);
+    for (const alt of emailData.alternate_emails) {
+      if (alt.verified) add(alt.email);
+    }
+
+    logger.debug(req, 'resolve_user_emails', 'Resolved verified emails from auth-service', {
+      alternate_count: emailData.alternate_emails.length,
+      verified_count: verifiedEmails.length,
+    });
+
+    if (verifiedEmails.length > 0) return verifiedEmails;
+    return oidcEmail ? [oidcEmail] : [];
   }
 }

--- a/apps/lfx-one/src/server/controllers/badges.controller.ts
+++ b/apps/lfx-one/src/server/controllers/badges.controller.ts
@@ -44,9 +44,11 @@ export class BadgesController {
   }
 
   /**
-   * Resolve all verified email addresses for the authenticated user.
-   * Queries auth-service via NATS for the full email list, filters to verified only.
-   * Falls back to the single OIDC session email if auth-service lookup fails.
+   * Resolve email addresses for the authenticated user used to look up Credly badges.
+   * Queries auth-service via NATS and returns the primary email plus any alternate
+   * emails flagged verified by auth-service (the primary has no separate verified flag,
+   * so it is always included). Falls back to the single OIDC session email if the
+   * auth-service lookup fails or returns no usable addresses.
    */
   private async resolveUserEmails(req: Request): Promise<string[]> {
     const oidcEmail = (req.oidc?.user?.['email'] as string | undefined)?.toLowerCase();
@@ -67,7 +69,10 @@ export class BadgesController {
     const verifiedEmails: string[] = [];
 
     const add = (email: string): void => {
-      const lower = email.toLowerCase();
+      if (!email) return;
+      const trimmed = email.trim();
+      if (!trimmed) return;
+      const lower = trimmed.toLowerCase();
       if (!seen.has(lower)) {
         seen.add(lower);
         verifiedEmails.push(lower);

--- a/apps/lfx-one/src/server/services/credly.service.ts
+++ b/apps/lfx-one/src/server/services/credly.service.ts
@@ -15,6 +15,8 @@ export class CredlyService {
   private _apiUrl: string | undefined;
   private _orgId: string | undefined;
   private _authToken: string | undefined;
+  private _cacheTtlMs: number | undefined;
+  private _maxCacheSize: number | undefined;
 
   private get apiUrl(): string {
     return (this._apiUrl ??= process.env['CREDLY_API_URL'] || '');
@@ -28,18 +30,26 @@ export class CredlyService {
     return (this._authToken ??= process.env['CREDLY_API_TOKEN'] || '');
   }
 
+  private get cacheTtlMs(): number {
+    if (this._cacheTtlMs === undefined) {
+      const env = parseInt(process.env['CREDLY_CACHE_TTL_MS'] ?? '', 10);
+      this._cacheTtlMs = Number.isNaN(env) ? 30 * 60 * 1_000 : env;
+    }
+    return this._cacheTtlMs;
+  }
+
+  private get maxCacheSize(): number {
+    if (this._maxCacheSize === undefined) {
+      const env = parseInt(process.env['CREDLY_CACHE_MAX_SIZE'] ?? '', 10);
+      this._maxCacheSize = Number.isNaN(env) ? 500 : env;
+    }
+    return this._maxCacheSize;
+  }
+
   private static readonly requestTimeoutMs = 15_000;
   private static readonly maxPaginationPages = 20;
   private static readonly emailBatchSize = 10;
-  private static readonly cacheTtlMs = (() => {
-    const env = parseInt(process.env['CREDLY_CACHE_TTL_MS'] ?? '', 10);
-    return Number.isNaN(env) ? 30 * 60 * 1_000 : env;
-  })();
   private static readonly pendingCacheTtlMs = 5 * 60 * 1_000;
-  private static readonly maxCacheSize = (() => {
-    const env = parseInt(process.env['CREDLY_CACHE_MAX_SIZE'] ?? '', 10);
-    return Number.isNaN(env) ? 500 : env;
-  })();
 
   /** Per-user in-memory badge cache. Key is a sorted, joined email list. */
   private readonly badgeCache = new Map<string, CredlyCachedBadges>();
@@ -99,7 +109,7 @@ export class CredlyService {
     const badges = unique.filter(isValidBadge).map(mapCredlyBadgeToBadge).sort(compareBadgesByIssuedDateDesc);
 
     this.evictExpiredCacheEntries();
-    const ttl = badges.some((b) => b.isPending) ? CredlyService.pendingCacheTtlMs : CredlyService.cacheTtlMs;
+    const ttl = badges.some((b) => b.isPending) ? CredlyService.pendingCacheTtlMs : this.cacheTtlMs;
     this.badgeCache.set(cacheKey, {
       badges,
       expiresAt: Date.now() + ttl,
@@ -212,8 +222,8 @@ export class CredlyService {
       }
     }
     // If still over the limit after expiry eviction, remove oldest entries (insertion order)
-    if (this.badgeCache.size > CredlyService.maxCacheSize) {
-      const overflow = this.badgeCache.size - CredlyService.maxCacheSize;
+    if (this.badgeCache.size > this.maxCacheSize) {
+      const overflow = this.badgeCache.size - this.maxCacheSize;
       let removed = 0;
       for (const key of this.badgeCache.keys()) {
         this.badgeCache.delete(key);

--- a/apps/lfx-one/src/server/services/credly.service.ts
+++ b/apps/lfx-one/src/server/services/credly.service.ts
@@ -10,9 +10,23 @@ import { Request } from 'express';
 import { logger } from './logger.service';
 
 export class CredlyService {
-  private readonly apiUrl = process.env['CREDLY_API_URL'] || '';
-  private readonly orgId = process.env['CREDLY_ORG_ID'] || '';
-  private readonly authToken = process.env['CREDLY_API_TOKEN'] || '';
+  // Resolved lazily on first access so dotenv has finished loading,
+  // then memoized — env is stable after startup.
+  private _apiUrl: string | undefined;
+  private _orgId: string | undefined;
+  private _authToken: string | undefined;
+
+  private get apiUrl(): string {
+    return (this._apiUrl ??= process.env['CREDLY_API_URL'] || '');
+  }
+
+  private get orgId(): string {
+    return (this._orgId ??= process.env['CREDLY_ORG_ID'] || '');
+  }
+
+  private get authToken(): string {
+    return (this._authToken ??= process.env['CREDLY_API_TOKEN'] || '');
+  }
 
   private static readonly requestTimeoutMs = 15_000;
   private static readonly maxPaginationPages = 20;


### PR DESCRIPTION
This pull request updates the badges feature to use the new `auth-service` (via NATS) for resolving user emails instead of Supabase, and refactors the `CredlyService` to lazily load and memoize environment variables. These changes improve reliability, performance, and future maintainability.

**Email resolution service migration:**
* Replaced Supabase-based email resolution with calls to `auth-service` via the new `EmailVerificationService`, ensuring all verified user emails (primary and alternates) are retrieved from a single source of truth. (`apps/lfx-one/src/server/controllers/badges.controller.ts`) [[1]](diffhunk://#diff-1fb64ced55b6fd8d3150f3ea2877ca47973f0bd7f5a78bf22c01d4bf13afb24fR10-R20) [[2]](diffhunk://#diff-1fb64ced55b6fd8d3150f3ea2877ca47973f0bd7f5a78bf22c01d4bf13afb24fL49-L88)

**Environment variable handling improvements:**
* Refactored `CredlyService` to lazily resolve and memoize environment variables (`CREDLY_API_URL`, `CREDLY_ORG_ID`, `CREDLY_API_TOKEN`), preventing issues if environment variables are loaded after service construction and improving performance. (`apps/lfx-one/src/server/services/credly.service.ts`)