### PR TITLE
fix(ui): fix copy issues across me, foundation, and project lenses

### DIFF
--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -135,7 +135,7 @@ export class MainLayoutComponent {
       expanded: true,
       items: [
         {
-          label: 'My Profile',
+          label: 'Profile',
           icon: 'fa-light fa-user',
           routerLink: '/profile',
         },

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -4,7 +4,7 @@
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="profile-layout">
   <div class="flex flex-col gap-6">
     <!-- Page Title -->
-    <h1 class="font-display font-light text-2xl mt-3" data-testid="profile-page-title">My Profile</h1>
+    <h1 class="font-display font-light text-2xl mt-3" data-testid="profile-page-title">Profile</h1>
 
     <!-- Profile Header Card + Tabs -->
     <div class="relative overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm" data-testid="profile-header-card">

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -50,7 +50,7 @@ const ROLE_PRIORITY: string[] = [
   'Developer Seat',
   'Maintainer',
   'Contributor',
-  'Member',
+  'Group Member',
   'None',
 ];
 
@@ -337,7 +337,7 @@ export class MultiPersonaDashboardComponent {
     if (project.personas.includes('executive-director')) {
       roles.push('Executive Director');
     }
-    if (roles.length === 0) return 'Member';
+    if (roles.length === 0) return 'Group Member';
     return this.pickByPriority(roles, ROLE_PRIORITY) ?? roles[0];
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -325,12 +325,12 @@ export class MultiPersonaDashboardComponent {
       if (detection.source === 'board_member') {
         const extra = detection.extra as BoardMemberDetectionExtra | undefined;
         if (extra?.role) {
-          roles.push(extra.role);
+          roles.push(this.normalizeRole(extra.role));
         }
       } else if (detection.source === 'committee_member') {
         const extra = detection.extra as CommitteeMemberDetectionExtra | undefined;
         if (extra?.role) {
-          roles.push(extra.role);
+          roles.push(this.normalizeRole(extra.role));
         }
       }
     }
@@ -339,6 +339,10 @@ export class MultiPersonaDashboardComponent {
     }
     if (roles.length === 0) return 'Group Member';
     return this.pickByPriority(roles, ROLE_PRIORITY) ?? roles[0];
+  }
+
+  private normalizeRole(role: string): string {
+    return role === 'Member' ? 'Group Member' : role;
   }
 
   private getHighestVotingStatus(project: EnrichedPersonaProject): string | null {

--- a/apps/lfx-one/src/server/services/supabase.service.ts
+++ b/apps/lfx-one/src/server/services/supabase.service.ts
@@ -1,0 +1,22 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export interface SupabaseUser {
+  id: string;
+  username: string;
+}
+
+export interface SupabaseUserEmail {
+  email: string;
+  is_verified: boolean;
+}
+
+export class SupabaseService {
+  public async getUser(_username: string): Promise<SupabaseUser | null> {
+    return null;
+  }
+
+  public async getUserEmails(_userId: string): Promise<SupabaseUserEmail[]> {
+    return [];
+  }
+}

--- a/apps/lfx-one/src/server/services/supabase.service.ts
+++ b/apps/lfx-one/src/server/services/supabase.service.ts
@@ -1,22 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { SupabaseUser, SupabaseUserEmail } from '@lfx-one/shared/interfaces';
 import { logger } from './logger.service';
-
-/** Minimal Supabase user shape used by badge fallback flows. */
-export interface SupabaseUser {
-  id: string;
-  username: string;
-}
-
-/**
- * Supabase email record used by badge email resolution.
- * Fields use snake_case to match the raw Supabase wire format.
- */
-export interface SupabaseUserEmail {
-  email: string;
-  is_verified: boolean;
-}
 
 // TODO: Replace this stub with a real Supabase integration once the service is implemented.
 /** Temporary Supabase service stub — returns null/empty so callers fall back to OIDC email. */
@@ -27,7 +13,7 @@ export class SupabaseService {
    * @returns The user record, or null if not found. Stub always returns null.
    */
   public async getUser(username: string): Promise<SupabaseUser | null> {
-    logger.warning(undefined, 'supabase_get_user', 'SupabaseService is a stub — returning null', { username });
+    logger.debug(undefined, 'supabase_get_user', 'SupabaseService is a stub — returning null', { username });
     return null;
   }
 
@@ -37,7 +23,7 @@ export class SupabaseService {
    * @returns List of email records. Stub always returns an empty list.
    */
   public async getUserEmails(userId: string): Promise<SupabaseUserEmail[]> {
-    logger.warning(undefined, 'supabase_get_user_emails', 'SupabaseService is a stub — returning empty list', { userId });
+    logger.debug(undefined, 'supabase_get_user_emails', 'SupabaseService is a stub — returning empty list', { userId });
     return [];
   }
 }

--- a/apps/lfx-one/src/server/services/supabase.service.ts
+++ b/apps/lfx-one/src/server/services/supabase.service.ts
@@ -1,22 +1,43 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { logger } from './logger.service';
+
+/** Minimal Supabase user shape used by badge fallback flows. */
 export interface SupabaseUser {
   id: string;
   username: string;
 }
 
+/**
+ * Supabase email record used by badge email resolution.
+ * Fields use snake_case to match the raw Supabase wire format.
+ */
 export interface SupabaseUserEmail {
   email: string;
   is_verified: boolean;
 }
 
+// TODO: Replace this stub with a real Supabase integration once the service is implemented.
+/** Temporary Supabase service stub — returns null/empty so callers fall back to OIDC email. */
 export class SupabaseService {
-  public async getUser(_username: string): Promise<SupabaseUser | null> {
+  /**
+   * Look up a Supabase user by username.
+   * @param username - The LFX username to look up.
+   * @returns The user record, or null if not found. Stub always returns null.
+   */
+  public async getUser(username: string): Promise<SupabaseUser | null> {
+    logger.warning(undefined, 'supabase_get_user', 'SupabaseService is a stub — returning null', { username });
     return null;
   }
 
-  public async getUserEmails(_userId: string): Promise<SupabaseUserEmail[]> {
+  /**
+   * Fetch all email addresses associated with a Supabase user ID.
+   * @param userId - The Supabase user ID.
+   * @returns List of email records. Stub always returns an empty list.
+   */
+  public async getUserEmails(userId: string): Promise<SupabaseUserEmail[]> {
+    logger.warning(undefined, 'supabase_get_user_emails', 'SupabaseService is a stub — returning empty list', { userId });
     return [];
   }
 }

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -134,3 +134,6 @@ export * from './multi-persona-dashboard.interface';
 
 // Transaction interfaces
 export * from './transaction.interface';
+
+// Supabase interfaces
+export * from './supabase.interface';

--- a/packages/shared/src/interfaces/supabase.interface.ts
+++ b/packages/shared/src/interfaces/supabase.interface.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Minimal Supabase user shape used by badge fallback flows. */
+export interface SupabaseUser {
+  id: string;
+  username: string;
+}
+
+/**
+ * Supabase email record used by badge email resolution.
+ * Fields use snake_case to match the raw Supabase wire format.
+ */
+export interface SupabaseUserEmail {
+  email: string;
+  is_verified: boolean;
+}


### PR DESCRIPTION
## What
Fixes several copy inconsistencies across lenses:

- **Me lens sidebar**: "My Profile" → "Profile" (avatar dropdown keeps "My profile")
- **Profile page header**: "My Profile" → "Profile"
- **Documents page**: title is now lens-aware — shows "My Documents" in Me lens, "Documents" in Foundation/Project lenses
- **Foundation dashboard**: "Member" → "Group Member" in the Your Role column

Also adds a temporary `SupabaseService` stub to unblock builds caused by the `feat(badges)` merge referencing a service that doesn't yet exist in this repo. The stub returns null/empty so the badges controller gracefully falls back to OIDC email resolution.

## How
- Updated `main-layout.component.ts` sidebar nav label
- Updated `profile-layout.component.html` page header
- Added `pageTitle` and `pageDescription` computed signals to `DocumentsDashboardComponent`; template binds to those signals
- Updated `ROLE_PRIORITY` array and fallback return value in `multi-persona-dashboard.component.ts`
- Added `SupabaseService` stub that logs at DEBUG level (not WARN — stub behaviour is expected)
- Moved `SupabaseUser` / `SupabaseUserEmail` interfaces to `packages/shared/src/interfaces/supabase.interface.ts`

## Checklist
- [x] License headers on new shared interface file
- [x] Interfaces in shared package per dev rules
- [x] Stub logs at DEBUG (not WARN) — fallback is intentional, not an anomaly
- [x] Under 1000 lines of diff

Generated with [Claude Code](https://claude.ai/code)