### PR TITLE
fix(committees): show my committees section only in me lens view

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -195,7 +195,7 @@
           }
         </div>
       </div>
-    } @else if (myCommittees().length > 0) {
+    } @else if (myCommittees().length > 0 && isMeLens()) {
       <div>
         <div class="flex items-center gap-2 mb-4">
           <h2 class="text-lg font-semibold text-gray-900">My {{ committeeLabel.plural }}</h2>


### PR DESCRIPTION
## Summary
- Add `isMeLens()` guard to the "My Committees" section so it only renders when the user is in the Me Lens view