### PR TITLE
feat(permissions): unify CTA visibility with backend writer access

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -7,7 +7,7 @@
     <div class="mt-3 mb-6">
       <div class="flex justify-between items-center w-full gap-4">
         <h1 class="font-display font-light text-2xl">{{ isMeLens() ? 'My ' + committeeLabel.plural : committeeLabel.plural }}</h1>
-        @if (canCreateGroup()) {
+        @if (!isMeLens() && canWrite()) {
           <lfx-button
             [label]="'Create ' + committeeLabel.singular"
             icon="fa-light fa-users mr-1"
@@ -380,7 +380,7 @@
           } @else {
             <lfx-committee-table
               [committees]="filteredCommittees()"
-              [canManageCommittee]="canCreateGroup()"
+              [canManageCommittee]="canWrite()"
               [myCommitteeUids]="myCommitteeUids()"
               [searchForm]="searchForm"
               [categoryOptions]="categories()"

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -14,7 +14,6 @@ import { COMMITTEE_LABEL } from '@lfx-one/shared/constants';
 import { Committee, MyCommittee, ProjectContext } from '@lfx-one/shared/interfaces';
 import { RoleBadgeClassPipe } from '@pipes/role-badge-class.pipe';
 import { CommitteeService } from '@services/committee.service';
-import { FeatureFlagService } from '@services/feature-flag.service';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -52,7 +51,6 @@ export class CommitteeDashboardComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly committeeService = inject(CommitteeService);
   private readonly personaService = inject(PersonaService);
-  private readonly featureFlagService = inject(FeatureFlagService);
   private readonly router = inject(Router);
   private readonly lensService = inject(LensService);
   private readonly messageService = inject(MessageService);
@@ -81,19 +79,13 @@ export class CommitteeDashboardComponent {
   public categoryFilter: Signal<string | null>;
   public votingStatusFilter: Signal<string | null>;
 
-  // Permission signals
-  public isMaintainer: Signal<boolean>;
-  public isBoardMember: Signal<boolean>;
-  public isFoundationContext: Signal<boolean>;
-  public foundationCreateCommitteeFlag: Signal<boolean>;
-  public canCreateGroup: Signal<boolean>;
-
   // Foundation and project filter options (separate dropdowns)
   public foundationOptions: Signal<{ label: string; value: string | null }[]> = this.initializeFoundationOptions();
   public projectOptions: Signal<{ label: string; value: string | null }[]> = this.initializeProjectOptions();
 
-  // Lens
+  // Lens & permissions
   public readonly isMeLens: Signal<boolean> = computed(() => this.lensService.activeLens() === 'me');
+  protected readonly canWrite = this.projectContextService.canWrite;
   public showFoundationFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
   public showProjectFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
 
@@ -113,24 +105,6 @@ export class CommitteeDashboardComponent {
   public constructor() {
     // Initialize project context
     this.project = computed(() => this.projectContextService.activeContext());
-
-    // Initialize permission checks
-    this.isMaintainer = computed(() => this.personaService.currentPersona() === 'maintainer');
-    this.isBoardMember = computed(() => this.personaService.currentPersona() === 'board-member');
-    this.isFoundationContext = computed(() => this.projectContextService.isFoundationContext());
-    this.foundationCreateCommitteeFlag = this.featureFlagService.getBooleanFlag('foundation-create-committee', false);
-    this.canCreateGroup = computed(() => {
-      if (this.isMeLens()) {
-        return false;
-      }
-      // Board members cannot manage committees
-      if (this.isBoardMember()) {
-        return false;
-      }
-      const isMaintainerAndNotFoundation = this.isMaintainer() && !this.isFoundationContext();
-      const hasFeatureFlag = this.foundationCreateCommitteeFlag();
-      return isMaintainerAndNotFoundation || hasFeatureFlag;
-    });
 
     // Initialize data
     this.committees = this.initializeCommittees();

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
@@ -42,7 +42,7 @@
       <!-- Page Title with Add Mailing List Button -->
       <div class="flex justify-between items-center w-full gap-4">
         <h1 class="font-display font-light text-2xl">{{ isMeLens() ? 'My ' + mailingListLabelPlural : mailingListLabelPlural }}</h1>
-        @if (canCreateMailingList()) {
+        @if (!isMeLens() && canWrite()) {
           <lfx-button
             [label]="'Add ' + mailingListLabel"
             icon="fa-light fa-envelope mr-1"
@@ -80,7 +80,7 @@
         <lfx-mailing-list-table
           [mailingLists]="filteredMailingLists()"
           [loading]="isMeLens() && myMailingListsLoading()"
-          [isMaintainer]="isMaintainer()"
+          [isMaintainer]="canWrite()"
           [mailingListLabel]="mailingListLabel"
           [searchForm]="searchForm"
           [committeeFilterOptions]="committeeOptions()"

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -66,9 +66,7 @@ export class MailingListDashboardComponent {
 
   // Complex computed/toSignal signals
   public readonly project: Signal<ProjectContext | null> = this.initProject();
-  public readonly isMaintainer: Signal<boolean> = this.initIsMaintainer();
-  public readonly isFoundationContext: Signal<boolean> = this.initIsFoundationContext();
-  public readonly canCreateMailingList: Signal<boolean> = this.initCanCreateMailingList();
+  protected readonly canWrite = this.projectContextService.canWrite;
   public readonly mailingLists: Signal<GroupsIOMailingList[]> = this.initMailingLists();
   public readonly myMailingLists: Signal<MyMailingList[]> = this.initMyMailingLists();
   public readonly committeeOptions: Signal<FilterOption[]> = this.initCommitteeOptions();
@@ -155,18 +153,6 @@ export class MailingListDashboardComponent {
 
   private initProject(): Signal<ProjectContext | null> {
     return computed(() => this.projectContextService.activeContext());
-  }
-
-  private initIsMaintainer(): Signal<boolean> {
-    return computed(() => this.personaService.currentPersona() === 'maintainer');
-  }
-
-  private initIsFoundationContext(): Signal<boolean> {
-    return computed(() => this.projectContextService.isFoundationContext());
-  }
-
-  private initCanCreateMailingList(): Signal<boolean> {
-    return computed(() => !this.isMeLens() && this.isMaintainer() && !this.isFoundationContext());
   }
 
   private initMailingLists(): Signal<GroupsIOMailingList[]> {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -6,7 +6,7 @@
     <div class="mt-3 mb-6">
       <div class="flex justify-between items-center w-full gap-4">
         <h1 class="font-display font-light text-2xl">{{ activeLens() === 'me' ? 'My Meetings' : 'Meetings' }}</h1>
-        @if (canCreateMeeting()) {
+        @if (activeLens() !== 'me' && canWrite()) {
           <lfx-button
             icon="fa-light fa-calendar"
             severity="info"

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -10,7 +10,6 @@ import { CardComponent } from '@components/card/card.component';
 import { MEETING_TYPE_CONFIGS } from '@lfx-one/shared/constants';
 import { Lens, Meeting, PageResult, PastMeeting, ProjectContext } from '@lfx-one/shared/interfaces';
 import { getCurrentOrNextOccurrence, hasMeetingEnded } from '@lfx-one/shared/utils';
-import { FeatureFlagService } from '@services/feature-flag.service';
 import { LensService } from '@services/lens.service';
 import { MeetingService } from '@services/meeting.service';
 import { PersonaService } from '@services/persona.service';
@@ -49,7 +48,6 @@ export class MeetingsDashboardComponent {
   private readonly meetingService = inject(MeetingService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly personaService = inject(PersonaService);
-  private readonly featureFlagService = inject(FeatureFlagService);
   private readonly lensService = inject(LensService);
   private readonly userService = inject(UserService);
   private readonly router = inject(Router);
@@ -75,10 +73,7 @@ export class MeetingsDashboardComponent {
   public foundationOptions: Signal<{ label: string; value: string | null }[]>;
   public projectOptions: Signal<{ label: string; value: string | null }[]>;
   public project: Signal<ProjectContext | null>;
-  public isMaintainer: Signal<boolean>;
-  public isFoundationContext: Signal<boolean>;
-  public foundationCreateMeetingFlag: Signal<boolean>;
-  public canCreateMeeting: Signal<boolean>;
+  protected readonly canWrite = this.projectContextService.canWrite;
   public loadingMore = signal(false);
   public hasMore: Signal<boolean>;
   public autoLoadTriggerIndex: Signal<number>;
@@ -123,19 +118,6 @@ export class MeetingsDashboardComponent {
   public constructor() {
     // Initialize project context first (needed for reactive data loading)
     this.project = computed(() => this.projectContextService.activeContext());
-
-    // Initialize permission checks
-    this.isMaintainer = computed(() => this.personaService.currentPersona() === 'maintainer');
-    this.isFoundationContext = computed(() => this.projectContextService.isFoundationContext());
-    this.foundationCreateMeetingFlag = this.featureFlagService.getBooleanFlag('foundation-create-meeting', false);
-    this.canCreateMeeting = computed(() => {
-      if (this.activeLens() === 'me') {
-        return false;
-      }
-      const isMaintainerAndNotFoundation = this.isMaintainer() && !this.isFoundationContext();
-      const hasFeatureFlag = this.foundationCreateMeetingFlag();
-      return isMaintainerAndNotFoundation || hasFeatureFlag;
-    });
 
     // Initialize state
     this.meetingsLoading = signal<boolean>(true);

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
@@ -73,7 +73,7 @@
   [(visible)]="resultsDrawerVisible"
   [surveyId]="selectedSurveyId()"
   [listSurvey]="selectedListSurvey()"
-  [hasPMOAccess]="canWrite()"
+  [hasPMOAccess]="!isMeLens() && canWrite()"
   (duplicate)="onDuplicateSurvey($event)"
   (closeSurvey)="onCloseSurvey($event)"
   data-testid="survey-results-drawer">

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
@@ -14,7 +14,7 @@
         }}
       </p>
     </div>
-    @if (!isMeLens() && hasPMOAccess()) {
+    @if (!isMeLens() && canWrite()) {
       <lfx-button
         [label]="'Create ' + surveyLabel"
         size="small"
@@ -52,7 +52,7 @@
   } @else {
     <lfx-surveys-table
       [surveys]="isMeLens() ? filteredMySurveys() : surveys()"
-      [hasPMOAccess]="!isMeLens() && hasPMOAccess()"
+      [hasPMOAccess]="!isMeLens() && canWrite()"
       [loading]="isMeLens() ? mySurveysLoading() : loading()"
       [foundationOptions]="foundationOptions()"
       [projectOptions]="projectOptions()"
@@ -73,7 +73,7 @@
   [(visible)]="resultsDrawerVisible"
   [surveyId]="selectedSurveyId()"
   [listSurvey]="selectedListSurvey()"
-  [hasPMOAccess]="hasPMOAccess()"
+  [hasPMOAccess]="canWrite()"
   (duplicate)="onDuplicateSurvey($event)"
   (closeSurvey)="onCloseSurvey($event)"
   data-testid="survey-results-drawer">

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.ts
@@ -40,7 +40,7 @@ export class SurveysDashboardComponent {
 
   // === Writable Signals ===
   protected readonly loading = signal<boolean>(true);
-  protected readonly hasPMOAccess = signal<boolean>(true);
+  protected readonly canWrite = this.projectContextService.canWrite;
   protected readonly resultsDrawerVisible = signal<boolean>(false);
   protected readonly selectedSurveyId = signal<string | null>(null);
   protected readonly mySurveysLoading = signal<boolean>(true);

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -10,7 +10,7 @@
         {{ isMeLens() ? voteLabelPlural + ' you have been invited to across all foundations and projects.' : 'Make decisions with your project groups.' }}
       </p>
     </div>
-    @if (!isMeLens() && hasPMOAccess()) {
+    @if (!isMeLens() && canWrite()) {
       <lfx-button
         [label]="'Create ' + voteLabel"
         size="small"
@@ -48,7 +48,7 @@
   } @else {
     <lfx-votes-table
       [votes]="isMeLens() ? filteredMyVotes() : votes()"
-      [hasPMOAccess]="!isMeLens() && hasPMOAccess()"
+      [hasPMOAccess]="!isMeLens() && canWrite()"
       [loading]="isMeLens() ? myVotesLoading() : loading()"
       [totalRecords]="isMeLens() ? filteredMyVotes().length : totalRecords()"
       [rowsPerPage]="rowsPerPage()"

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -45,7 +45,7 @@ export class VotesDashboardComponent {
 
   // === Writable Signals ===
   protected readonly loading = signal<boolean>(true);
-  protected readonly hasPMOAccess = signal<boolean>(true);
+  protected readonly canWrite = this.projectContextService.canWrite;
   protected readonly resultsDrawerVisible = signal<boolean>(false);
   protected readonly selectedVoteId = signal<string | null>(null);
   protected readonly rowsPerPage = signal<number>(10);

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -2,13 +2,16 @@
 // SPDX-License-Identifier: MIT
 
 import { computed, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { BOARD_SCOPED_PERSONAS, EnrichedPersonaProject, isBoardScopedPersona, PROJECT_SCOPED_PERSONAS, ProjectContext } from '@lfx-one/shared/interfaces';
 import { isFoundationProject, toProjectContext } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
+import { catchError, map, of, switchMap } from 'rxjs';
 
 import { CookieRegistryService } from './cookie-registry.service';
 import { LensService } from './lens.service';
 import { PersonaService } from './persona.service';
+import { ProjectService } from './project.service';
 
 @Injectable({
   providedIn: 'root',
@@ -18,6 +21,7 @@ export class ProjectContextService {
   private readonly cookieRegistry = inject(CookieRegistryService);
   private readonly lensService = inject(LensService);
   private readonly personaService = inject(PersonaService);
+  private readonly projectService = inject(ProjectService);
 
   private readonly foundationStorageKey = 'lfx-selected-foundation';
   private readonly projectStorageKey = 'lfx-selected-project';
@@ -37,6 +41,9 @@ export class ProjectContextService {
 
   // Available projects filtered for the active lens
   public readonly availableProjects: Signal<ProjectContext[]> = this.initAvailableProjects();
+
+  // Writer permission for the active project (Foundation/Project lens only)
+  public readonly canWrite: Signal<boolean> = this.initCanWrite();
 
   public constructor() {
     this.foundationSelection = signal<ProjectContext | null>(this.loadFromStorage(this.foundationStorageKey));
@@ -178,6 +185,23 @@ export class ProjectContextService {
       }
     }
     return uids;
+  }
+
+  private initCanWrite(): Signal<boolean> {
+    return toSignal(
+      toObservable(this.activeContext).pipe(
+        switchMap((ctx) => {
+          if (!ctx?.slug) {
+            return of(false);
+          }
+          return this.projectService.getProject(ctx.slug, false).pipe(
+            map((project) => project?.writer === true),
+            catchError(() => of(false))
+          );
+        })
+      ),
+      { initialValue: false }
+    );
   }
 
   private persistToStorage(key: string, project: ProjectContext): void {

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -42,7 +42,7 @@ export class ProjectContextService {
   // Available projects filtered for the active lens
   public readonly availableProjects: Signal<ProjectContext[]> = this.initAvailableProjects();
 
-  // Writer permission for the active project (Foundation/Project lens only)
+  // Writer permission for the current active context
   public readonly canWrite: Signal<boolean> = this.initCanWrite();
 
   public constructor() {


### PR DESCRIPTION
## Summary
- Replace inconsistent persona-based Create CTA checks across all 5 dashboard pages with a unified `canWrite` signal backed by the backend AccessCheckService
- Foundation/Project lens: Create button shows only if user has `writer` access to the selected project (resolved via `/access-check` microservice)
- Me lens: Create button always hidden (no project scope)

### Permission model change
**Before** (5 different approaches):
| Page | Condition |
|------|-----------|
| Groups | `!me && !boardMember && (maintainer+!foundation OR feature-flag)` |
| Meetings | `!me && (maintainer+!foundation OR feature-flag)` |
| Mailing Lists | `!me && maintainer && !foundation` (strictest) |
| Votes | `!me && true` (hardcoded — no check) |
| Surveys | `!me && true` (hardcoded — no check) |

**After** (unified):
| Page | Condition |
|------|-----------|
| All 5 | `!isMeLens() && canWrite()` |

`canWrite()` resolves via `ProjectService.getProject(slug)` → `writer: true/false` from the backend `/access-check` microservice. Same pattern already used by the group detail page (`!!committee()?.writer`).

### What was removed
- `FeatureFlagService` from committees + meetings dashboards (only used for CTA flags)
- `isMaintainer`, `isBoardMember`, `isFoundationContext` signals from 3 dashboards
- `foundation-create-committee`, `foundation-create-meeting` feature flag references
- Hardcoded `hasPMOAccess = signal(true)` from votes + surveys

## Test plan
- [ ] Navigate to Groups on **Foundation lens** — Create Group button visible if user has writer access
- [ ] Navigate to Meetings on **Foundation lens** — Create Meeting button visible if user has writer access
- [ ] Navigate to Mailing Lists on **Foundation lens** — Add Mailing List button visible (was previously hidden for all foundation users)
- [ ] Navigate to Votes on **Foundation lens** — Create Vote button visible only with writer access (was previously shown to everyone)
- [ ] Navigate to Surveys on **Foundation lens** — Create Survey button visible only with writer access (was previously shown to everyone)
- [ ] Switch to **Me lens** — all Create buttons hidden on all 5 pages
- [ ] Switch to **Project lens** — Create buttons visible if user has writer access
- [ ] User without writer access — no Create buttons visible on any page

LFXV2-1472

🤖 Generated with [Claude Code](https://claude.ai/code)