### PR TITLE
fix(documents): render meeting summary content as preview

### DIFF
--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
@@ -42,7 +42,13 @@
               {{ doc.name }}
             </button>
           } @else if (doc.source === 'summary') {
-            <span class="text-xs text-gray-900 truncate min-w-0" [pTooltip]="doc.name" tooltipPosition="top" [attr.data-testid]="testIdPrefix() + '-name-' + doc.id">{{ doc.name }}</span>
+            <span
+              class="text-xs text-gray-900 truncate min-w-0"
+              [pTooltip]="doc.name"
+              tooltipPosition="top"
+              [attr.data-testid]="testIdPrefix() + '-name-' + doc.id"
+              >{{ doc.name }}</span
+            >
           } @else if (doc.url) {
             <button
               type="button"
@@ -111,17 +117,17 @@
               tooltipPosition="top">
             </lfx-button>
           } @else if (doc.source === 'summary') {
-            <lfx-button
-              icon="fa-solid fa-eye"
-              severity="primary"
-              size="small"
-              [text]="true"
-              [disabled]="!doc.summaryContent"
-              (onClick)="previewSummary(doc)"
-              [attr.data-testid]="testIdPrefix() + '-preview-' + doc.id"
-              [tooltip]="doc.summaryContent ? 'Preview' : 'Summary not available'"
-              tooltipPosition="top">
-            </lfx-button>
+            <span [pTooltip]="doc.summaryContent ? 'Preview' : 'Summary not available'" tooltipPosition="top" class="inline-flex">
+              <lfx-button
+                icon="fa-solid fa-eye"
+                severity="primary"
+                size="small"
+                [text]="true"
+                [disabled]="!doc.summaryContent"
+                (onClick)="previewSummary(doc)"
+                [attr.data-testid]="testIdPrefix() + '-preview-' + doc.id">
+              </lfx-button>
+            </span>
           } @else if (doc.source === 'transcript' && doc.url) {
             <lfx-button
               icon="fa-solid fa-arrow-up-right-from-square"

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
@@ -11,7 +11,6 @@
   [showFirstLastIcon]="false"
   [showCurrentPageReport]="true"
   currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
-  styleClass="[&_table]:table-fixed"
   [attr.data-testid]="testIdPrefix() + '-table'">
   <ng-template #header>
     <tr>
@@ -30,20 +29,26 @@
     <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="testIdPrefix() + '-row-' + doc.id">
       <!-- Name column -->
       <td>
-        <div class="flex items-center gap-2 min-w-0">
+        <div class="flex items-center gap-2">
           <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' ' + (doc.source | myDocumentSourceTag: 'iconClass')" class="text-base shrink-0"></i>
-          @if (doc.url) {
+          @if (doc.source === 'summary' && doc.summaryContent) {
             <button
               type="button"
-              class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate max-w-full"
+              class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate"
+              (click)="previewSummary(doc)"
+              [attr.data-testid]="testIdPrefix() + '-name-' + doc.id">
+              {{ doc.name }}
+            </button>
+          } @else if (doc.url) {
+            <button
+              type="button"
+              class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate"
               (click)="openDocument(doc)"
-              [pTooltip]="doc.name"
-              tooltipPosition="top"
               [attr.data-testid]="testIdPrefix() + '-name-' + doc.id">
               {{ doc.name }}
             </button>
           } @else {
-            <span class="text-xs text-gray-900 truncate block max-w-full" [pTooltip]="doc.name" tooltipPosition="top">{{ doc.name }}</span>
+            <span class="text-xs text-gray-900 truncate">{{ doc.name }}</span>
           }
         </div>
       </td>
@@ -99,7 +104,18 @@
               tooltip="Play recording"
               tooltipPosition="top">
             </lfx-button>
-          } @else if ((doc.source === 'transcript' || doc.source === 'summary') && doc.url) {
+          } @else if (doc.source === 'summary' && doc.summaryContent) {
+            <lfx-button
+              icon="fa-solid fa-eye"
+              severity="primary"
+              size="small"
+              [text]="true"
+              (onClick)="previewSummary(doc)"
+              [attr.data-testid]="testIdPrefix() + '-preview-' + doc.id"
+              tooltip="Preview"
+              tooltipPosition="top">
+            </lfx-button>
+          } @else if (doc.source === 'transcript' && doc.url) {
             <lfx-button
               icon="fa-solid fa-arrow-up-right-from-square"
               severity="primary"

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
@@ -31,7 +31,7 @@
       <td>
         <div class="flex items-center gap-2">
           <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' ' + (doc.source | myDocumentSourceTag: 'iconClass')" class="text-base shrink-0"></i>
-          @if (doc.source === 'summary') {
+          @if (doc.source === 'summary' && doc.summaryContent) {
             <button
               type="button"
               class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate"
@@ -39,6 +39,8 @@
               [attr.data-testid]="testIdPrefix() + '-name-' + doc.id">
               {{ doc.name }}
             </button>
+          } @else if (doc.source === 'summary') {
+            <span class="text-xs text-gray-900 truncate" [attr.data-testid]="testIdPrefix() + '-name-' + doc.id">{{ doc.name }}</span>
           } @else if (doc.url) {
             <button
               type="button"
@@ -110,9 +112,10 @@
               severity="primary"
               size="small"
               [text]="true"
+              [disabled]="!doc.summaryContent"
               (onClick)="previewSummary(doc)"
               [attr.data-testid]="testIdPrefix() + '-preview-' + doc.id"
-              tooltip="Preview"
+              [tooltip]="doc.summaryContent ? 'Preview' : 'Summary not available'"
               tooltipPosition="top">
             </lfx-button>
           } @else if (doc.source === 'transcript' && doc.url) {

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
@@ -11,6 +11,7 @@
   [showFirstLastIcon]="false"
   [showCurrentPageReport]="true"
   currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
+  styleClass="[&_table]:table-fixed"
   [attr.data-testid]="testIdPrefix() + '-table'">
   <ng-template #header>
     <tr>
@@ -60,7 +61,13 @@
               {{ doc.name }}
             </button>
           } @else {
-            <span class="text-xs text-gray-900 truncate min-w-0" [pTooltip]="doc.name" tooltipPosition="top">{{ doc.name }}</span>
+            <span
+              class="text-xs text-gray-900 truncate min-w-0"
+              [pTooltip]="doc.name"
+              tooltipPosition="top"
+              [attr.data-testid]="testIdPrefix() + '-name-' + doc.id"
+              >{{ doc.name }}</span
+            >
           }
         </div>
       </td>

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
@@ -31,7 +31,7 @@
       <td>
         <div class="flex items-center gap-2">
           <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' ' + (doc.source | myDocumentSourceTag: 'iconClass')" class="text-base shrink-0"></i>
-          @if (doc.source === 'summary' && doc.summaryContent) {
+          @if (doc.source === 'summary') {
             <button
               type="button"
               class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate"
@@ -104,7 +104,7 @@
               tooltip="Play recording"
               tooltipPosition="top">
             </lfx-button>
-          } @else if (doc.source === 'summary' && doc.summaryContent) {
+          } @else if (doc.source === 'summary') {
             <lfx-button
               icon="fa-solid fa-eye"
               severity="primary"

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
@@ -29,28 +29,32 @@
     <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="testIdPrefix() + '-row-' + doc.id">
       <!-- Name column -->
       <td>
-        <div class="flex items-center gap-2">
+        <div class="flex items-center gap-2 min-w-0">
           <i [class]="(doc.source | myDocumentSourceTag: 'icon') + ' ' + (doc.source | myDocumentSourceTag: 'iconClass')" class="text-base shrink-0"></i>
           @if (doc.source === 'summary' && doc.summaryContent) {
             <button
               type="button"
-              class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate"
+              class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate min-w-0"
               (click)="previewSummary(doc)"
+              [pTooltip]="doc.name"
+              tooltipPosition="top"
               [attr.data-testid]="testIdPrefix() + '-name-' + doc.id">
               {{ doc.name }}
             </button>
           } @else if (doc.source === 'summary') {
-            <span class="text-xs text-gray-900 truncate" [attr.data-testid]="testIdPrefix() + '-name-' + doc.id">{{ doc.name }}</span>
+            <span class="text-xs text-gray-900 truncate min-w-0" [pTooltip]="doc.name" tooltipPosition="top" [attr.data-testid]="testIdPrefix() + '-name-' + doc.id">{{ doc.name }}</span>
           } @else if (doc.url) {
             <button
               type="button"
-              class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate"
+              class="text-blue-600 hover:text-blue-700 hover:underline font-medium text-xs text-left bg-transparent border-none cursor-pointer p-0 truncate min-w-0"
               (click)="openDocument(doc)"
+              [pTooltip]="doc.name"
+              tooltipPosition="top"
               [attr.data-testid]="testIdPrefix() + '-name-' + doc.id">
               {{ doc.name }}
             </button>
           } @else {
-            <span class="text-xs text-gray-900 truncate">{{ doc.name }}</span>
+            <span class="text-xs text-gray-900 truncate min-w-0" [pTooltip]="doc.name" tooltipPosition="top">{{ doc.name }}</span>
           }
         </div>
       </td>

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
@@ -49,7 +49,7 @@ export class DocumentsTableComponent {
       draggable: false,
       resizable: false,
       data: {
-        summaryUid: doc.summaryUid ?? doc.id.replace('past_meeting_summary:', ''),
+        summaryUid: doc.summaryUid,
         pastMeetingUid: doc.groupOrMeetingUid,
         meetingTitle: doc.groupOrMeetingName,
         summaryContent: doc.summaryContent ?? '',

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
@@ -2,21 +2,26 @@
 // SPDX-License-Identifier: MIT
 
 import { DatePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
+import { SummaryModalComponent } from '@components/summary-modal/summary-modal.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { MyDocumentItem } from '@lfx-one/shared/interfaces';
 import { MyDocumentSourceTagPipe } from '@app/shared/pipes/my-document-source-tag.pipe';
+import { DialogService } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
   selector: 'lfx-documents-table',
   imports: [TableComponent, TagComponent, ButtonComponent, DatePipe, MyDocumentSourceTagPipe, TooltipModule],
+  providers: [DialogService],
   templateUrl: './documents-table.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DocumentsTableComponent {
+  private readonly dialogService = inject(DialogService);
+
   public readonly documents = input<MyDocumentItem[]>([]);
   public readonly loading = input<boolean>(false);
   public readonly showFoundation = input<boolean>(true);
@@ -35,6 +40,23 @@ export class DocumentsTableComponent {
     } catch {
       // Invalid URL — silently ignore
     }
+  }
+
+  protected previewSummary(doc: MyDocumentItem): void {
+    this.dialogService.open(SummaryModalComponent, {
+      header: doc.name,
+      width: '700px',
+      modal: true,
+      draggable: false,
+      resizable: false,
+      data: {
+        summaryUid: doc.summaryUid ?? doc.id.replace('past_meeting_summary:', ''),
+        pastMeetingUid: doc.groupOrMeetingUid,
+        meetingTitle: doc.name,
+        summaryContent: doc.summaryContent ?? '',
+        approved: false,
+      },
+    });
   }
 
   protected downloadDocument(doc: MyDocumentItem): void {

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
@@ -44,7 +44,6 @@ export class DocumentsTableComponent {
 
   protected previewSummary(doc: MyDocumentItem): void {
     this.dialogService.open(SummaryModalComponent, {
-      header: doc.name,
       width: '700px',
       modal: true,
       draggable: false,

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
@@ -51,7 +51,7 @@ export class DocumentsTableComponent {
       data: {
         summaryUid: doc.summaryUid ?? doc.id.replace('past_meeting_summary:', ''),
         pastMeetingUid: doc.groupOrMeetingUid,
-        meetingTitle: doc.name,
+        meetingTitle: doc.groupOrMeetingName,
         summaryContent: doc.summaryContent ?? '',
         approved: false,
       },

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
@@ -54,6 +54,7 @@ export class DocumentsTableComponent {
         meetingTitle: doc.groupOrMeetingName,
         summaryContent: doc.summaryContent ?? '',
         approved: false,
+        readOnly: true,
       },
     });
   }

--- a/apps/lfx-one/src/app/shared/components/summary-modal/summary-modal.component.html
+++ b/apps/lfx-one/src/app/shared/components/summary-modal/summary-modal.component.html
@@ -39,27 +39,31 @@
       </div>
       <lfx-button label="Save" size="small" severity="info" [loading]="isSaving()" data-testid="save-edit-button" (click)="saveEdit()"></lfx-button>
     } @else {
-      <div class="flex gap-2">
-        <lfx-button label="Edit" icon="fa-light fa-pen" size="small" severity="secondary" data-testid="edit-button" (click)="enterEditMode()"></lfx-button>
-        @if (!isApproved()) {
-          <lfx-button
-            label="Approve"
-            icon="fa-light fa-check"
-            size="small"
-            severity="success"
-            [loading]="isApproving()"
-            data-testid="approve-button"
-            (click)="approve()"></lfx-button>
-        } @else {
-          <lfx-button
-            label="Approved"
-            icon="fa-light fa-check-circle"
-            size="small"
-            severity="success"
-            [disabled]="true"
-            data-testid="approved-badge"></lfx-button>
-        }
-      </div>
+      @if (!readOnly()) {
+        <div class="flex gap-2">
+          <lfx-button label="Edit" icon="fa-light fa-pen" size="small" severity="secondary" data-testid="edit-button" (click)="enterEditMode()"></lfx-button>
+          @if (!isApproved()) {
+            <lfx-button
+              label="Approve"
+              icon="fa-light fa-check"
+              size="small"
+              severity="success"
+              [loading]="isApproving()"
+              data-testid="approve-button"
+              (click)="approve()"></lfx-button>
+          } @else {
+            <lfx-button
+              label="Approved"
+              icon="fa-light fa-check-circle"
+              size="small"
+              severity="success"
+              [disabled]="true"
+              data-testid="approved-badge"></lfx-button>
+          }
+        </div>
+      } @else {
+        <span></span>
+      }
       <lfx-button label="Close" size="small" severity="secondary" data-testid="close-button" (click)="onClose()"></lfx-button>
     }
   </div>

--- a/apps/lfx-one/src/app/shared/components/summary-modal/summary-modal.component.html
+++ b/apps/lfx-one/src/app/shared/components/summary-modal/summary-modal.component.html
@@ -3,9 +3,9 @@
 
 <div class="flex flex-col gap-4" data-testid="summary-modal-container">
   <!-- Meeting Title -->
-  <div class="mb-4">
-    <h4 class="text-lg font-semibold text-gray-900 mb-1">{{ meetingTitle }}</h4>
-    <p class="text-sm text-gray-600">AI-generated meeting summary</p>
+  <div>
+    <h4 class="text-lg font-semibold text-gray-900">{{ meetingTitle }}</h4>
+    <p class="text-sm text-gray-500">AI-generated meeting summary</p>
   </div>
 
   <!-- Summary Content Display -->
@@ -23,12 +23,16 @@
     </div>
   } @else {
     <div class="bg-gray-50 rounded-lg p-6 border border-gray-200 max-h-[500px] overflow-y-auto" data-testid="summary-content-container">
-      <div class="prose prose-sm max-w-none text-gray-900 whitespace-pre-wrap" [innerHTML]="summaryContent()" data-testid="summary-content"></div>
+      @if (summaryContent()) {
+        <lfx-markdown-renderer [content]="summaryContent()" data-testid="summary-content" />
+      } @else {
+        <p class="text-sm text-gray-500 text-center py-4">No summary content available.</p>
+      }
     </div>
   }
 
   <!-- Action Buttons -->
-  <div class="flex justify-between gap-2 mt-6">
+  <div class="flex justify-between gap-2 mt-2">
     @if (isEditMode()) {
       <div class="flex gap-2">
         <lfx-button label="Cancel" size="small" severity="secondary" data-testid="cancel-edit-button" (click)="cancelEdit()"></lfx-button>

--- a/apps/lfx-one/src/app/shared/components/summary-modal/summary-modal.component.ts
+++ b/apps/lfx-one/src/app/shared/components/summary-modal/summary-modal.component.ts
@@ -27,6 +27,7 @@ export class SummaryModalComponent {
   private readonly summaryUid = this.dialogConfig.data.summaryUid as string;
   private readonly pastMeetingUid = this.dialogConfig.data.pastMeetingUid as string;
   public readonly meetingTitle = this.dialogConfig.data.meetingTitle as string;
+  public readonly readOnly = signal(!!(this.dialogConfig.data.readOnly as boolean | undefined));
 
   // Edit mode state
   public readonly isEditMode: WritableSignal<boolean> = signal(false);

--- a/apps/lfx-one/src/app/shared/components/summary-modal/summary-modal.component.ts
+++ b/apps/lfx-one/src/app/shared/components/summary-modal/summary-modal.component.ts
@@ -1,10 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, Signal, signal, WritableSignal } from '@angular/core';
+import { Component, inject, Signal, signal, WritableSignal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ButtonComponent } from '@components/button/button.component';
+import { MarkdownRendererComponent } from '@components/markdown-renderer/markdown-renderer.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
@@ -13,14 +13,13 @@ import { take } from 'rxjs';
 
 @Component({
   selector: 'lfx-summary-modal',
-  imports: [ButtonComponent, ReactiveFormsModule, TextareaComponent],
+  imports: [ButtonComponent, ReactiveFormsModule, TextareaComponent, MarkdownRendererComponent],
   templateUrl: './summary-modal.component.html',
 })
 export class SummaryModalComponent {
   // Injected services
   private readonly dialogRef = inject(DynamicDialogRef);
   private readonly dialogConfig = inject(DynamicDialogConfig);
-  private readonly sanitizer = inject(DomSanitizer);
   private readonly meetingService = inject(MeetingService);
   private readonly messageService = inject(MessageService);
 
@@ -42,11 +41,8 @@ export class SummaryModalComponent {
     content: new FormControl(this.dialogConfig.data.summaryContent as string),
   });
 
-  // Sanitized HTML content for display
-  public readonly summaryContent: Signal<SafeHtml> = computed(() => {
-    const content = this.isEditMode() ? this.editForm.get('content')?.value : this.originalContent();
-    return this.sanitizer.bypassSecurityTrustHtml(content || '');
-  });
+  // Raw content for display — rendered as markdown by MarkdownRendererComponent
+  public readonly summaryContent: Signal<string> = this.originalContent;
 
   // Public methods
   public enterEditMode(): void {
@@ -73,12 +69,10 @@ export class SummaryModalComponent {
             summary: 'Success',
             detail: 'Summary updated successfully',
           });
-          // Update the original content with the saved changes
           this.originalContent.set(editedContent);
           this.wasUpdated.set(true);
           this.isSaving.set(false);
           this.isEditMode.set(false);
-          // Keep modal open to show updated content
         },
         error: (error: unknown) => {
           this.messageService.add({
@@ -122,7 +116,6 @@ export class SummaryModalComponent {
   }
 
   public onClose(): void {
-    // Return updated content if changes were saved
     if (this.wasUpdated()) {
       this.dialogRef.close({ updated: true, content: this.originalContent(), approved: this.isApproved() });
     } else {

--- a/apps/lfx-one/src/server/services/document.service.ts
+++ b/apps/lfx-one/src/server/services/document.service.ts
@@ -642,10 +642,7 @@ export class DocumentService {
   private mapPastMeetingSummaries(summaries: PastMeetingSummaryQueryResult[], meetingDetails: MeetingDetails): MyDocumentItem[] {
     return summaries.map((s): MyDocumentItem => {
       const meeting = meetingDetails.get(s.meeting_id);
-      // Prefer edited content; fall back to original. Encode as a data URL so
-      // the "Open" action opens the raw markdown text directly in a browser tab.
-      const rawContent = s.edited_content || s.content;
-      const url = rawContent ? `data:text/plain;charset=utf-8,${encodeURIComponent(rawContent)}` : undefined;
+      const summaryContent = s.edited_content || s.content;
       return {
         id: `past_meeting_summary:${s.id}`,
         name: s.summary_title || s.zoom_meeting_topic || 'Meeting Summary',
@@ -656,7 +653,8 @@ export class DocumentService {
         groupOrMeetingUid: s.meeting_and_occurrence_id,
         date: s.summary_start_time || s.created_at,
         pastMeetingId: s.meeting_and_occurrence_id,
-        url,
+        summaryUid: s.id,
+        summaryContent,
       };
     });
   }

--- a/apps/lfx-one/src/server/services/document.service.ts
+++ b/apps/lfx-one/src/server/services/document.service.ts
@@ -642,6 +642,10 @@ export class DocumentService {
   private mapPastMeetingSummaries(summaries: PastMeetingSummaryQueryResult[], meetingDetails: MeetingDetails): MyDocumentItem[] {
     return summaries.map((s): MyDocumentItem => {
       const meeting = meetingDetails.get(s.meeting_id);
+      // Prefer edited content; fall back to original. Encode as a data URL so
+      // the "Open" action opens the raw markdown text directly in a browser tab.
+      const rawContent = s.edited_content || s.content;
+      const url = rawContent ? `data:text/plain;charset=utf-8,${encodeURIComponent(rawContent)}` : undefined;
       return {
         id: `past_meeting_summary:${s.id}`,
         name: s.summary_title || s.zoom_meeting_topic || 'Meeting Summary',
@@ -652,6 +656,7 @@ export class DocumentService {
         groupOrMeetingUid: s.meeting_and_occurrence_id,
         date: s.summary_start_time || s.created_at,
         pastMeetingId: s.meeting_and_occurrence_id,
+        url,
       };
     });
   }

--- a/apps/lfx-one/src/server/services/document.service.ts
+++ b/apps/lfx-one/src/server/services/document.service.ts
@@ -642,7 +642,7 @@ export class DocumentService {
   private mapPastMeetingSummaries(summaries: PastMeetingSummaryQueryResult[], meetingDetails: MeetingDetails): MyDocumentItem[] {
     return summaries.map((s): MyDocumentItem => {
       const meeting = meetingDetails.get(s.meeting_id);
-      const summaryContent = s.edited_content || s.content;
+      const summaryContent = s.edited_content ?? s.content;
       return {
         id: `past_meeting_summary:${s.id}`,
         name: s.summary_title || s.zoom_meeting_topic || 'Meeting Summary',

--- a/packages/shared/src/interfaces/my-document.interface.ts
+++ b/packages/shared/src/interfaces/my-document.interface.ts
@@ -60,6 +60,8 @@ export interface PastMeetingSummaryQueryResult {
   zoom_meeting_topic?: string;
   summary_start_time?: string;
   created_at: string;
+  content?: string;
+  edited_content?: string;
 }
 
 /** Raw shape returned by query service for `v1_meeting` resource type (minimal fields for ID extraction) */

--- a/packages/shared/src/interfaces/my-document.interface.ts
+++ b/packages/shared/src/interfaces/my-document.interface.ts
@@ -60,7 +60,9 @@ export interface PastMeetingSummaryQueryResult {
   zoom_meeting_topic?: string;
   summary_start_time?: string;
   created_at: string;
+  /** Consolidated markdown of the summary (indexer contract field) */
   content?: string;
+  /** Edited markdown content, takes precedence over content when present */
   edited_content?: string;
 }
 
@@ -120,4 +122,8 @@ export interface MyDocumentItem {
   mailingListId?: string;
   /** File extension or MIME type for icon display (e.g., 'pdf', 'pptx') */
   fileType?: string;
+  /** Raw markdown content for summary-type documents — used by the preview dialog */
+  summaryContent?: string;
+  /** Summary record UID — used by the preview dialog to support edit/approve actions */
+  summaryUid?: string;
 }


### PR DESCRIPTION
## Summary

- Add `content` and `edited_content` fields to `PastMeetingSummaryQueryResult` interface so the indexer contract fields are captured
- Add `summaryContent` (raw markdown) and `summaryUid` fields to `MyDocumentItem`
- In `mapPastMeetingSummaries`, populate both using `edited_content ?? content` (nullish coalescing so an intentionally cleared edit is preserved)
- `DocumentsTableComponent` injects `DialogService` and opens `SummaryModalComponent` for summary-type documents — the same dialog used in the meetings module
- Summary name is a clickable link when content is present; plain text otherwise
- Preview eye icon is disabled with tooltip "Summary not available" when no content is present
- `SummaryModalComponent` updated to use `MarkdownRendererComponent` so markdown syntax renders as formatted HTML

## Root Cause

`PastMeetingSummaryQueryResult` was missing the `content` and `edited_content` fields from the [indexer contract](https://github.com/linuxfoundation/lfx-v2-meeting-service/blob/main/docs/indexer-contract.md#v1-past-meeting-summary). The fields were never mapped, leaving `url` and content fields unset on every `MyDocumentItem` of source `summary`, so no action was rendered.

## Test plan

- [ ] Navigate to My Documents or the committee Documents tab
- [ ] Confirm that summary-type documents with content show a clickable name and enabled eye icon
- [ ] Clicking either the name or the eye icon opens the summary preview dialog
- [ ] Dialog header shows the summary title; content renders as formatted markdown (not raw `##` symbols)
- [ ] Summary documents without content show plain text name and a disabled eye icon with tooltip "Summary not available"

🤖 Generated with [Claude Code](https://claude.ai/code)