### PR TITLE
feat(ui): add coming soon state for org lens

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/dashboard.component.html
@@ -43,6 +43,6 @@
     }
   }
   @case ('org') {
-    <lfx-board-member-dashboard />
+    <lfx-org-coming-soon />
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/dashboard.component.ts
@@ -10,6 +10,7 @@ import { PersonaService } from '@services/persona.service';
 import { BoardMemberDashboardComponent } from './board-member/board-member-dashboard.component';
 import { ExecutiveDirectorDashboardComponent } from './executive-director/executive-director-dashboard.component';
 import { MultiPersonaDashboardComponent } from './multi-persona/multi-persona-dashboard.component';
+import { OrgComingSoonComponent } from './org-coming-soon/org-coming-soon.component';
 import { ProjectDashboardComponent } from './project-dashboard/project-dashboard.component';
 import { UserDashboardComponent } from './user-dashboard/user-dashboard.component';
 
@@ -29,6 +30,7 @@ const LOADING_MESSAGES = [
     BoardMemberDashboardComponent,
     ExecutiveDirectorDashboardComponent,
     MultiPersonaDashboardComponent,
+    OrgComingSoonComponent,
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss',

--- a/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.html
@@ -1,9 +1,10 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
+<!-- Generated with [Claude Code](https://claude.ai/code) -->
 
 <div class="flex flex-col items-center justify-center min-h-[60vh] text-center gap-6" data-testid="org-coming-soon">
   <div class="w-20 h-20 rounded-full bg-blue-100 flex items-center justify-center">
-    <i class="fa-light fa-building text-4xl text-blue-500"></i>
+    <i class="fa-light fa-building text-4xl text-blue-500" aria-hidden="true"></i>
   </div>
 
   <div class="flex flex-col items-center gap-3 max-w-lg">

--- a/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.html
@@ -1,0 +1,25 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col items-center justify-center min-h-[60vh] text-center gap-6" data-testid="org-coming-soon">
+  <div class="w-20 h-20 rounded-full bg-blue-100 flex items-center justify-center">
+    <i class="fa-light fa-building text-4xl text-blue-500"></i>
+  </div>
+
+  <div class="flex flex-col items-center gap-3 max-w-lg">
+    <lfx-tag value="Coming soon" severity="contrast" [rounded]="true" />
+    <h1 class="text-2xl font-semibold text-gray-900">Organization Lens</h1>
+
+    <div class="flex flex-wrap justify-center gap-2 mt-2">
+      <lfx-tag
+        value="Central hub for managing your organization open source activities"
+        styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />
+      <lfx-tag
+        value="Benchmark your organization"
+        styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />
+      <lfx-tag
+        value="Identify and drive critical projects and technologies"
+        styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.html
@@ -1,6 +1,5 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
-<!-- Generated with [Claude Code](https://claude.ai/code) -->
 
 <div class="flex flex-col items-center justify-center min-h-[60vh] text-center gap-6" data-testid="org-coming-soon">
   <div class="w-20 h-20 rounded-full bg-blue-100 flex items-center justify-center">
@@ -15,12 +14,8 @@
       <lfx-tag
         value="Central hub for managing your organization open source activities"
         styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />
-      <lfx-tag
-        value="Benchmark your organization"
-        styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />
-      <lfx-tag
-        value="Identify and drive critical projects and technologies"
-        styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />
+      <lfx-tag value="Benchmark your organization" styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />
+      <lfx-tag value="Identify and drive critical projects and technologies" styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />
     </div>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.html
@@ -12,7 +12,7 @@
 
     <div class="flex flex-wrap justify-center gap-2 mt-2">
       <lfx-tag
-        value="Central hub for managing your organization open source activities"
+        value="Central hub for managing your organization's open source activities"
         styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />
       <lfx-tag value="Benchmark your organization" styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />
       <lfx-tag value="Identify and drive critical projects and technologies" styleClass="!bg-white border border-gray-200 !text-gray-600 whitespace-nowrap" />

--- a/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.ts
@@ -1,6 +1,5 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
-// Generated with [Claude Code](https://claude.ai/code)
 
 import { Component } from '@angular/core';
 import { TagComponent } from '@components/tag/tag.component';

--- a/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.ts
@@ -1,5 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
+// Generated with [Claude Code](https://claude.ai/code)
 
 import { Component } from '@angular/core';
 import { TagComponent } from '@components/tag/tag.component';

--- a/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org-coming-soon/org-coming-soon.component.ts
@@ -1,0 +1,12 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component } from '@angular/core';
+import { TagComponent } from '@components/tag/tag.component';
+
+@Component({
+  selector: 'lfx-org-coming-soon',
+  imports: [TagComponent],
+  templateUrl: './org-coming-soon.component.html',
+})
+export class OrgComingSoonComponent {}

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -68,6 +68,45 @@
             }
           }
         </div>
+      } @else if (isOrgLens()) {
+        <div class="flex flex-col gap-2 items-start px-4 w-full" data-testid="sidebar-org-skeleton">
+          <p-skeleton width="100%" height="2rem"></p-skeleton>
+
+          <div class="w-full mt-2">
+            <div class="flex items-center gap-2 px-2 py-1.5">
+              <p-skeleton width="4rem" height="0.6rem"></p-skeleton>
+              <div class="flex-1 h-px bg-gray-100"></div>
+            </div>
+            <div class="flex flex-col gap-1 mt-2">
+              <p-skeleton width="100%" height="2rem"></p-skeleton>
+              <p-skeleton width="100%" height="2rem"></p-skeleton>
+            </div>
+          </div>
+
+          <div class="w-full mt-2">
+            <div class="flex items-center gap-2 px-2 py-1.5">
+              <p-skeleton width="4rem" height="0.6rem"></p-skeleton>
+              <div class="flex-1 h-px bg-gray-100"></div>
+            </div>
+            <div class="flex flex-col gap-1 mt-2">
+              <p-skeleton width="100%" height="2rem"></p-skeleton>
+              <p-skeleton width="100%" height="2rem"></p-skeleton>
+            </div>
+          </div>
+
+          <div class="w-full mt-2">
+            <div class="flex items-center gap-2 px-2 py-1.5">
+              <p-skeleton width="4rem" height="0.6rem"></p-skeleton>
+              <div class="flex-1 h-px bg-gray-100"></div>
+            </div>
+            <div class="flex flex-col gap-1 mt-2">
+              <p-skeleton width="100%" height="2rem"></p-skeleton>
+              <p-skeleton width="100%" height="2rem"></p-skeleton>
+              <p-skeleton width="100%" height="2rem"></p-skeleton>
+              <p-skeleton width="100%" height="2rem"></p-skeleton>
+            </div>
+          </div>
+        </div>
       } @else {
         <div class="flex flex-col gap-2 items-start px-4 w-full" data-testid="sidebar-menu-loading">
           <p-skeleton width="100%" height="2rem"></p-skeleton>

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -41,6 +41,7 @@ export class SidebarComponent {
   public readonly selectorPanelOpen = model<boolean>(false);
 
   protected readonly activeLens = this.lensService.activeLens;
+  protected readonly isOrgLens = computed(() => this.activeLens() === 'org');
   protected readonly selectedProject: Signal<ProjectContext | null> = computed(() => this.projectContextService.activeContext());
   protected readonly navLens: Signal<NavLens | null> = this.initNavLens();
   protected readonly lensLoaded: Signal<boolean> = this.initLensLoaded();
@@ -90,6 +91,7 @@ export class SidebarComponent {
 
   private initLensLoaded(): Signal<boolean> {
     return computed(() => {
+      if (this.activeLens() === 'org') return false;
       const lens = this.navLens();
       if (!lens) return true;
       return this.navigationService.loaded(lens)();

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -91,7 +91,7 @@ export class SidebarComponent {
 
   private initLensLoaded(): Signal<boolean> {
     return computed(() => {
-      if (this.activeLens() === 'org') return false;
+      if (this.isOrgLens()) return false;
       const lens = this.navLens();
       if (!lens) return true;
       return this.navigationService.loaded(lens)();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4274,11 +4274,9 @@ __metadata:
     date-fns-tz: "npm:^3.2.0"
     typescript: "npm:5.8.3"
   peerDependencies:
-    "@angular/core": ^20.3.15
     "@angular/forms": ^20.3.15
     "@fullcalendar/core": ^6.1.19
     chart.js: ^4.5.0
-    rxjs: ^7.8.0
     snowflake-sdk: ^2.3.1
   languageName: unknown
   linkType: soft

--- a/yarn.lock
+++ b/yarn.lock
@@ -4274,9 +4274,11 @@ __metadata:
     date-fns-tz: "npm:^3.2.0"
     typescript: "npm:5.8.3"
   peerDependencies:
+    "@angular/core": ^20.3.15
     "@angular/forms": ^20.3.15
     "@fullcalendar/core": ^6.1.19
     chart.js: ^4.5.0
+    rxjs: ^7.8.0
     snowflake-sdk: ^2.3.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## What
Adds a coming soon placeholder state for the Organization lens, which is still work in progress.

## How
- **Sidebar**: Modified `SidebarComponent` to permanently show a structural skeleton when the org lens is active — mimics the menu shape (1 overview row + 3 sections) with no text
- **Page**: New `OrgComingSoonComponent` replaces the org dashboard with a centered empty state: building icon in a blue circle, dark "Coming soon" tag, "Organization Lens" title, and 3 feature bullet tags

## Checklist
- [x] License headers on new files
- [x] No unrelated changes bundled