### PR TITLE
feat(meetings): add materials management drawer for organizers

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -457,6 +457,5 @@
 
     <!-- Confirmation Dialog -->
     <p-confirmDialog></p-confirmDialog>
-    <p-toast></p-toast>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -447,11 +447,7 @@
 
     <!-- Meeting Materials Drawer -->
     @if (meeting().organizer && !pastMeeting()) {
-      <lfx-meeting-materials-drawer
-        [(visible)]="materialsDrawerVisible"
-        [meetingId]="meeting().id"
-        (materialsChanged)="onMaterialsChanged()"
-        data-testid="meeting-materials-drawer-card">
+      <lfx-meeting-materials-drawer [(visible)]="materialsDrawerVisible" [meetingId]="meeting().id" data-testid="meeting-materials-drawer-card">
       </lfx-meeting-materials-drawer>
     }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -156,6 +156,15 @@
                   </span>
                 }
               </div>
+              @if (meeting().organizer && !pastMeeting()) {
+                <button
+                  type="button"
+                  (click)="openMaterialsDrawer(); $event.stopPropagation()"
+                  class="text-xs text-blue-600 hover:text-blue-800 font-medium transition-colors"
+                  data-testid="manage-materials-card-btn">
+                  Manage
+                </button>
+              }
             </div>
             @if (attachments().length > 0) {
               <div class="grid grid-cols-4 gap-2">
@@ -436,7 +445,18 @@
       </p-drawer>
     }
 
+    <!-- Meeting Materials Drawer -->
+    @if (meeting().organizer && !pastMeeting()) {
+      <lfx-meeting-materials-drawer
+        [(visible)]="materialsDrawerVisible"
+        [meetingId]="meeting().id"
+        (materialsChanged)="onMaterialsChanged()"
+        data-testid="meeting-materials-drawer-card">
+      </lfx-meeting-materials-drawer>
+    }
+
     <!-- Confirmation Dialog -->
     <p-confirmDialog></p-confirmDialog>
+    <p-toast></p-toast>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -262,7 +262,10 @@ export class MeetingCardComponent implements OnInit {
   }
 
   public onMaterialsChanged(): void {
+    // Immediate refresh + delayed retry to bridge NATS propagation gap between
+    // upload (meeting-service write) and read (query-service indexed via NATS).
     this.loadAttachments();
+    setTimeout(() => this.loadAttachments(), 1000);
   }
 
   public copyMeetingLink(): void {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -3,7 +3,21 @@
 
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
 import { NgClass } from '@angular/common';
-import { Component, computed, effect, inject, Injector, input, OnInit, output, runInInjectionContext, signal, Signal, WritableSignal } from '@angular/core';
+import {
+  Component,
+  computed,
+  effect,
+  inject,
+  Injector,
+  input,
+  OnInit,
+  output,
+  runInInjectionContext,
+  signal,
+  Signal,
+  untracked,
+  WritableSignal,
+} from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import {
@@ -50,10 +64,12 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DrawerModule } from 'primeng/drawer';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, combineLatest, map, Observable, of, switchMap, take, tap } from 'rxjs';
+import { catchError, combineLatest, map, of, switchMap, take, tap } from 'rxjs';
 
 import { CancelOccurrenceConfirmationComponent } from '../../components/cancel-occurrence-confirmation/cancel-occurrence-confirmation.component';
+import { MeetingMaterialsDrawerComponent } from '../meeting-materials-drawer/meeting-materials-drawer.component';
 import { MeetingRsvpDetailsComponent } from '../../components/meeting-rsvp-details/meeting-rsvp-details.component';
 import { PublicRegistrationModalComponent } from '../../components/public-registration-modal/public-registration-modal.component';
 
@@ -75,6 +91,8 @@ import { PublicRegistrationModalComponent } from '../../components/public-regist
     RsvpButtonGroupComponent,
     MeetingRsvpDetailsComponent,
     MeetingRegistrantsDisplayComponent,
+    MeetingMaterialsDrawerComponent,
+    ToastModule,
   ],
   providers: [ConfirmationService],
   templateUrl: './meeting-card.component.html',
@@ -102,7 +120,8 @@ export class MeetingCardComponent implements OnInit {
   public recording: WritableSignal<PastMeetingRecording | null> = signal(null);
   public summary: WritableSignal<PastMeetingSummary | null> = signal(null);
   public additionalRegistrantsCount: WritableSignal<number> = signal(0);
-  public attachments: Signal<(MeetingAttachment | PastMeetingAttachment)[]> = signal([]);
+  public attachments = signal<(MeetingAttachment | PastMeetingAttachment)[]>([]);
+  public materialsDrawerVisible = signal(false);
 
   // Computed values for template
   public readonly meetingRegistrantCount: Signal<number> = this.initMeetingRegistrantCount();
@@ -199,10 +218,22 @@ export class MeetingCardComponent implements OnInit {
     );
 
     this.joinUrl = toSignal(joinUrl$, { initialValue: null });
+
+    // Reload attachments when materials drawer closes
+    let drawerWasOpen = false;
+    effect(() => {
+      const open = this.materialsDrawerVisible();
+      if (open) {
+        drawerWasOpen = true;
+      } else if (drawerWasOpen) {
+        drawerWasOpen = false;
+        untracked(() => this.loadAttachments());
+      }
+    });
   }
 
   public ngOnInit(): void {
-    this.attachments = this.initAttachments();
+    this.loadAttachments();
     if (this.pastMeeting()) {
       this.initRecording();
       this.initSummary();
@@ -226,6 +257,14 @@ export class MeetingCardComponent implements OnInit {
 
   public onDrawerHide(): void {
     this.showRegistrants.set(false);
+  }
+
+  public openMaterialsDrawer(): void {
+    this.materialsDrawerVisible.set(true);
+  }
+
+  public onMaterialsChanged(): void {
+    this.loadAttachments();
   }
 
   public copyMeetingLink(): void {
@@ -483,17 +522,16 @@ export class MeetingCardComponent implements OnInit {
       .subscribe();
   }
 
-  private initAttachments(): Signal<(MeetingAttachment | PastMeetingAttachment)[]> {
-    return runInInjectionContext(this.injector, () => {
-      const id = this.meetingInput().id;
-      const attachments$: Observable<(MeetingAttachment | PastMeetingAttachment)[]> = this.pastMeeting()
-        ? this.meetingService.getPastMeetingAttachments(id)
-        : this.meetingService.getMeetingAttachments(id);
+  private loadAttachments(): void {
+    const id = this.meetingInput().id;
+    const attachments$ = this.pastMeeting() ? this.meetingService.getPastMeetingAttachments(id) : this.meetingService.getMeetingAttachments(id);
 
-      return toSignal(attachments$.pipe(catchError(() => of([] as (MeetingAttachment | PastMeetingAttachment)[]))), {
-        initialValue: [],
-      });
-    });
+    attachments$
+      .pipe(
+        take(1),
+        catchError(() => of([] as (MeetingAttachment | PastMeetingAttachment)[]))
+      )
+      .subscribe((data) => this.attachments.set(data));
   }
 
   private initRecording(): void {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -6,6 +6,7 @@ import { NgClass } from '@angular/common';
 import {
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   Injector,
@@ -15,10 +16,9 @@ import {
   runInInjectionContext,
   signal,
   Signal,
-  untracked,
   WritableSignal,
 } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import {
   MeetingDeleteConfirmationComponent,
@@ -65,7 +65,7 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DrawerModule } from 'primeng/drawer';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, combineLatest, map, of, switchMap, take, tap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, filter, map, of, pairwise, switchMap, take, tap } from 'rxjs';
 
 import { CancelOccurrenceConfirmationComponent } from '../../components/cancel-occurrence-confirmation/cancel-occurrence-confirmation.component';
 import { MeetingMaterialsDrawerComponent } from '../meeting-materials-drawer/meeting-materials-drawer.component';
@@ -104,6 +104,8 @@ export class MeetingCardComponent implements OnInit {
   private readonly clipboard = inject(Clipboard);
   private readonly userService = inject(UserService);
   private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly refreshAttachments$ = new BehaviorSubject<void>(undefined);
 
   public readonly meetingInput = input.required<Meeting | PastMeeting>();
   public readonly occurrenceInput = input<MeetingOccurrence | null>(null);
@@ -118,7 +120,7 @@ export class MeetingCardComponent implements OnInit {
   public recording: WritableSignal<PastMeetingRecording | null> = signal(null);
   public summary: WritableSignal<PastMeetingSummary | null> = signal(null);
   public additionalRegistrantsCount: WritableSignal<number> = signal(0);
-  public attachments = signal<(MeetingAttachment | PastMeetingAttachment)[]>([]);
+  public attachments: Signal<(MeetingAttachment | PastMeetingAttachment)[]> = signal([]);
   public materialsDrawerVisible = signal(false);
 
   // Computed values for template
@@ -217,21 +219,18 @@ export class MeetingCardComponent implements OnInit {
 
     this.joinUrl = toSignal(joinUrl$, { initialValue: null });
 
-    // Reload attachments when materials drawer closes
-    let drawerWasOpen = false;
-    effect(() => {
-      const open = this.materialsDrawerVisible();
-      if (open) {
-        drawerWasOpen = true;
-      } else if (drawerWasOpen) {
-        drawerWasOpen = false;
-        untracked(() => this.loadAttachments());
-      }
-    });
+    // Reload attachments when materials drawer closes (true → false transition)
+    toObservable(this.materialsDrawerVisible)
+      .pipe(
+        pairwise(),
+        filter(([prev, curr]) => prev && !curr),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => this.refreshAttachments$.next());
   }
 
   public ngOnInit(): void {
-    this.loadAttachments();
+    this.attachments = this.initAttachments();
     if (this.pastMeeting()) {
       this.initRecording();
       this.initSummary();
@@ -516,16 +515,16 @@ export class MeetingCardComponent implements OnInit {
       .subscribe();
   }
 
-  private loadAttachments(): void {
-    const id = this.meetingInput().id;
-    const attachments$ = this.pastMeeting() ? this.meetingService.getPastMeetingAttachments(id) : this.meetingService.getMeetingAttachments(id);
+  private initAttachments(): Signal<(MeetingAttachment | PastMeetingAttachment)[]> {
+    return runInInjectionContext(this.injector, () => {
+      const id = this.meetingInput().id;
+      const attachments$ = this.pastMeeting() ? this.meetingService.getPastMeetingAttachments(id) : this.meetingService.getMeetingAttachments(id);
 
-    attachments$
-      .pipe(
-        take(1),
-        catchError(() => of([] as (MeetingAttachment | PastMeetingAttachment)[]))
-      )
-      .subscribe((data) => this.attachments.set(data));
+      return toSignal(
+        this.refreshAttachments$.pipe(switchMap(() => attachments$.pipe(catchError(() => of([] as (MeetingAttachment | PastMeetingAttachment)[]))))),
+        { initialValue: [] }
+      );
+    });
   }
 
   private initRecording(): void {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -64,7 +64,6 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DrawerModule } from 'primeng/drawer';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
 import { catchError, combineLatest, map, of, switchMap, take, tap } from 'rxjs';
 
@@ -92,7 +91,6 @@ import { PublicRegistrationModalComponent } from '../../components/public-regist
     MeetingRsvpDetailsComponent,
     MeetingRegistrantsDisplayComponent,
     MeetingMaterialsDrawerComponent,
-    ToastModule,
   ],
   providers: [ConfirmationService],
   templateUrl: './meeting-card.component.html',

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -261,13 +261,6 @@ export class MeetingCardComponent implements OnInit {
     this.materialsDrawerVisible.set(true);
   }
 
-  public onMaterialsChanged(): void {
-    // Immediate refresh + delayed retry to bridge NATS propagation gap between
-    // upload (meeting-service write) and read (query-service indexed via NATS).
-    this.loadAttachments();
-    setTimeout(() => this.loadAttachments(), 1000);
-  }
-
   public copyMeetingLink(): void {
     const meeting = this.meeting();
     const meetingUrl: URL = new URL(environment.urls.home + '/meetings/' + meeting.id);

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.html
@@ -38,7 +38,7 @@
         <lfx-file-upload
           [multiple]="true"
           [accept]="acceptString"
-          [maxFileSize]="10485760"
+          [maxFileSize]="MAX_FILE_SIZE_BYTES"
           (onSelect)="onFileSelect($event)"
           [customUpload]="true"
           dataTest="materials-drawer-upload"

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.html
@@ -1,0 +1,199 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[40%] lg:w-[50%] md:w-[65%] sm:w-[85%] w-full"
+  data-testid="meeting-materials-drawer">
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900">Manage Materials</h2>
+        <p class="text-sm text-gray-500">Upload files and add links for meeting participants</p>
+      </div>
+      <button
+        type="button"
+        (click)="onClose()"
+        class="p-1 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors flex-shrink-0"
+        aria-label="Close panel"
+        data-testid="materials-drawer-close">
+        <i class="fa-light fa-xmark text-xl"></i>
+      </button>
+    </div>
+  </ng-template>
+
+  @if (loading()) {
+    <div class="flex items-center justify-center py-12">
+      <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+    </div>
+  } @else {
+    <div class="flex flex-col gap-6 pb-2">
+      <!-- Upload Files Section -->
+      <div class="flex flex-col gap-4">
+        <h4 class="text-neutral-950 font-medium">Upload Files</h4>
+
+        <lfx-file-upload
+          [multiple]="true"
+          [accept]="acceptString"
+          [maxFileSize]="10485760"
+          (onSelect)="onFileSelect($event)"
+          [customUpload]="true"
+          dataTest="materials-drawer-upload"
+          [showUploadButton]="false"
+          [showCancelButton]="false"
+          chooseLabel="Click to upload files or drag and drop">
+        </lfx-file-upload>
+
+        <!-- Pending Uploads -->
+        @if (pendingAttachments().length > 0) {
+          <div class="flex flex-col gap-2" data-testid="pending-attachments-list">
+            <p class="text-sm text-gray-500 font-medium uppercase tracking-wide">New Files</p>
+            @for (attachment of pendingAttachments(); track attachment.id) {
+              <div class="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border border-blue-200 bg-blue-50" data-testid="pending-attachment-item">
+                <div class="flex items-center gap-2 min-w-0">
+                  <i class="fa-light fa-file-lines text-blue-500 flex-shrink-0"></i>
+                  <span class="text-sm text-gray-700 truncate">{{ attachment.fileName }}</span>
+                </div>
+                <button
+                  type="button"
+                  class="flex-shrink-0 text-gray-400 hover:text-red-500 transition-colors"
+                  (click)="removePendingAttachment(attachment.id)"
+                  [attr.data-testid]="'remove-pending-' + attachment.id">
+                  <i class="fa-light fa-xmark"></i>
+                </button>
+              </div>
+            }
+          </div>
+        }
+
+        <!-- Existing File Attachments -->
+        @if (fileAttachments().length > 0) {
+          <div class="flex flex-col gap-2" data-testid="existing-files-list">
+            <p class="text-sm text-gray-500 font-medium uppercase tracking-wide">Existing Files</p>
+            @for (attachment of fileAttachments(); track attachment.uid) {
+              <div
+                class="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border transition-colors"
+                [class]="pendingDeletions().has(attachment.uid) ? 'border-red-200 bg-red-50' : 'border-gray-200 bg-gray-50'"
+                [attr.data-testid]="'existing-file-' + attachment.uid">
+                <div class="flex items-center gap-2 min-w-0">
+                  <i class="fa-light fa-file-lines flex-shrink-0" [class]="pendingDeletions().has(attachment.uid) ? 'text-red-400' : 'text-gray-500'"></i>
+                  <span class="text-sm truncate" [class]="pendingDeletions().has(attachment.uid) ? 'text-red-600 line-through' : 'text-gray-700'">
+                    {{ attachment.name }}
+                  </span>
+                </div>
+                @if (pendingDeletions().has(attachment.uid)) {
+                  <button
+                    type="button"
+                    class="flex-shrink-0 text-xs text-blue-500 hover:text-blue-700 transition-colors"
+                    (click)="undoDelete(attachment.uid)"
+                    [attr.data-testid]="'undo-delete-' + attachment.uid">
+                    Undo
+                  </button>
+                } @else {
+                  <button
+                    type="button"
+                    class="flex-shrink-0 text-gray-400 hover:text-red-500 transition-colors"
+                    (click)="markForDeletion(attachment.uid)"
+                    [attr.data-testid]="'delete-file-' + attachment.uid">
+                    <i class="fa-light fa-trash"></i>
+                  </button>
+                }
+              </div>
+            }
+          </div>
+        }
+      </div>
+
+      <!-- Add Links Section -->
+      <div class="flex flex-col gap-4">
+        <h4 class="text-neutral-950 font-medium">Add Links</h4>
+
+        <div class="flex flex-col gap-3">
+          <input
+            [value]="newLinkTitle()"
+            (input)="newLinkTitle.set($any($event.target).value)"
+            placeholder="Link title (e.g., Project Repository)"
+            class="w-full h-10 px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-blue-300"
+            data-testid="new-link-title-input" />
+          <div class="flex items-center gap-3">
+            <input
+              [value]="newLinkUrl()"
+              (input)="newLinkUrl.set($any($event.target).value)"
+              placeholder="https://example.com"
+              class="flex-1 h-10 px-3 py-2 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-blue-300"
+              data-testid="new-link-url-input" />
+            <lfx-button
+              icon="fa-light fa-plus"
+              size="small"
+              [disabled]="!newLinkTitle() || !newLinkUrl() || saving()"
+              (onClick)="addLink()"
+              data-testid="add-link-btn">
+            </lfx-button>
+          </div>
+        </div>
+
+        <!-- Existing Links -->
+        @if (linkAttachments().length > 0) {
+          <div class="flex flex-col gap-2" data-testid="existing-links-list">
+            <p class="text-sm text-gray-500 font-medium uppercase tracking-wide">Existing Links</p>
+            @for (attachment of linkAttachments(); track attachment.uid) {
+              <div
+                class="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border transition-colors"
+                [class]="pendingDeletions().has(attachment.uid) ? 'border-red-200 bg-red-50' : 'border-gray-200 bg-gray-50'"
+                [attr.data-testid]="'existing-link-' + attachment.uid">
+                <div class="flex items-center gap-2 min-w-0">
+                  <i class="fa-light fa-link flex-shrink-0" [class]="pendingDeletions().has(attachment.uid) ? 'text-red-400' : 'text-gray-500'"></i>
+                  <div class="flex flex-col gap-0 min-w-0">
+                    <span class="text-sm truncate" [class]="pendingDeletions().has(attachment.uid) ? 'text-red-600 line-through' : 'text-gray-700'">
+                      {{ attachment.name }}
+                    </span>
+                    @if (attachment.link) {
+                      <span class="text-xs text-gray-400 truncate">{{ attachment.link }}</span>
+                    }
+                  </div>
+                </div>
+                @if (pendingDeletions().has(attachment.uid)) {
+                  <button
+                    type="button"
+                    class="flex-shrink-0 text-xs text-blue-500 hover:text-blue-700 transition-colors"
+                    (click)="undoDelete(attachment.uid)"
+                    [attr.data-testid]="'undo-delete-link-' + attachment.uid">
+                    Undo
+                  </button>
+                } @else {
+                  <button
+                    type="button"
+                    class="flex-shrink-0 text-gray-400 hover:text-red-500 transition-colors"
+                    (click)="markForDeletion(attachment.uid)"
+                    [attr.data-testid]="'delete-link-' + attachment.uid">
+                    <i class="fa-light fa-trash"></i>
+                  </button>
+                }
+              </div>
+            }
+          </div>
+        }
+      </div>
+
+      <!-- Save / Cancel Footer -->
+      @if (pendingAttachments().length > 0 || pendingDeletions().size > 0) {
+        <div class="flex items-center justify-end gap-3 pt-4 border-t border-gray-200" data-testid="materials-drawer-footer">
+          <lfx-button label="Cancel" size="small" severity="secondary" [text]="true" (onClick)="onClose()" data-testid="materials-cancel-btn"> </lfx-button>
+          <lfx-button
+            label="Save Changes"
+            size="small"
+            severity="primary"
+            icon="fa-light fa-check"
+            [disabled]="saving()"
+            [loading]="saving()"
+            (onClick)="onSave()"
+            data-testid="materials-save-btn">
+          </lfx-button>
+        </div>
+      }
+    </div>
+  }
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.ts
@@ -20,21 +20,20 @@ import { catchError, from, mergeMap, of, skip, switchMap, take, tap, toArray } f
   styleUrl: './meeting-materials-drawer.component.scss',
 })
 export class MeetingMaterialsDrawerComponent {
-  // 1. Private injections
+  // === Services ===
   private readonly meetingService = inject(MeetingService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
 
-  // 2. Public inputs
   public readonly meetingId = input.required<string>();
-
-  // 4. Model signals
   public visible = model<boolean>(false);
-
-  // Outputs
   public readonly materialsChanged = output<void>();
 
-  // 5. Simple WritableSignals
+  // === Constants ===
+  public readonly acceptString = generateAcceptString();
+  public readonly MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_BYTES;
+
+  // === Writable Signals ===
   public loading = signal(false);
   public saving = signal(false);
   public existingAttachments = signal<MeetingAttachment[]>([]);
@@ -43,11 +42,7 @@ export class MeetingMaterialsDrawerComponent {
   public newLinkTitle = signal('');
   public newLinkUrl = signal('');
 
-  // Constants
-  public readonly acceptString = generateAcceptString();
-  public readonly MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_BYTES;
-
-  // 6. Computed signals
+  // === Computed Signals ===
   public readonly fileAttachments = computed(() => this.existingAttachments().filter((a) => a.type === 'file'));
   public readonly linkAttachments = computed(() => this.existingAttachments().filter((a) => a.type === 'link'));
 
@@ -80,7 +75,7 @@ export class MeetingMaterialsDrawerComponent {
     this.attachments$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
   }
 
-  // 8. Public methods
+  // === Public Methods ===
   public onFileSelect(event: any): void {
     let files: File[] = [];
     if (event.files && Array.isArray(event.files)) {
@@ -216,12 +211,12 @@ export class MeetingMaterialsDrawerComponent {
       });
   }
 
-  // 9. Protected methods
+  // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
   }
 
-  // 11. Private helper methods
+  // === Private Helpers ===
   private validateFile(file: File): string | null {
     if (file.size > MAX_FILE_SIZE_BYTES) {
       return `File "${file.name}" is too large. Maximum size is ${MAX_FILE_SIZE_MB}MB.`;

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.ts
@@ -1,0 +1,250 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, model, output, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { ButtonComponent } from '@components/button/button.component';
+import { FileUploadComponent } from '@components/file-upload/file-upload.component';
+import { ALLOWED_FILE_TYPES, MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_MB } from '@lfx-one/shared/constants';
+import { MeetingAttachment, PendingAttachment } from '@lfx-one/shared/interfaces';
+import { generateAcceptString, getAcceptedFileTypesDisplay, getMimeTypeDisplayName, isFileTypeAllowed } from '@lfx-one/shared/utils';
+import { MeetingService } from '@services/meeting.service';
+import { MessageService } from 'primeng/api';
+import { DrawerModule } from 'primeng/drawer';
+import { catchError, from, mergeMap, of, skip, switchMap, take, tap, toArray } from 'rxjs';
+
+@Component({
+  selector: 'lfx-meeting-materials-drawer',
+  imports: [DrawerModule, FileUploadComponent, ButtonComponent],
+  templateUrl: './meeting-materials-drawer.component.html',
+  styleUrl: './meeting-materials-drawer.component.scss',
+})
+export class MeetingMaterialsDrawerComponent {
+  // 1. Private injections
+  private readonly meetingService = inject(MeetingService);
+  private readonly messageService = inject(MessageService);
+
+  // 2. Public inputs
+  public readonly meetingId = input.required<string>();
+
+  // 4. Model signals
+  public visible = model<boolean>(false);
+
+  // Outputs
+  public readonly materialsChanged = output<void>();
+
+  // 5. Simple WritableSignals
+  public loading = signal(false);
+  public saving = signal(false);
+  public existingAttachments = signal<MeetingAttachment[]>([]);
+  public pendingAttachments = signal<PendingAttachment[]>([]);
+  public pendingDeletions = signal<Set<string>>(new Set());
+  public newLinkTitle = signal('');
+  public newLinkUrl = signal('');
+
+  // Constants
+  public readonly acceptString = generateAcceptString();
+
+  // 6. Computed signals
+  public readonly fileAttachments = computed(() => this.existingAttachments().filter((a) => a.type === 'file'));
+  public readonly linkAttachments = computed(() => this.existingAttachments().filter((a) => a.type === 'link'));
+  public readonly hasChanges = computed(
+    () => this.pendingAttachments().length > 0 || this.pendingDeletions().size > 0 || (this.newLinkTitle().trim() !== '' && this.newLinkUrl().trim() !== '')
+  );
+
+  // Lazy load attachments when drawer opens
+  private readonly attachments$ = toObservable(this.visible).pipe(
+    skip(1),
+    switchMap((isVisible) => {
+      if (!isVisible) {
+        return of([]);
+      }
+      this.loading.set(true);
+      return this.meetingService.getMeetingAttachments(this.meetingId()).pipe(
+        tap(() => this.loading.set(false)),
+        catchError(() => {
+          this.loading.set(false);
+          return of([] as MeetingAttachment[]);
+        })
+      );
+    }),
+    tap((attachments) => {
+      this.existingAttachments.set(attachments);
+      this.pendingAttachments.set([]);
+      this.pendingDeletions.set(new Set());
+      this.newLinkTitle.set('');
+      this.newLinkUrl.set('');
+    })
+  );
+
+  public constructor() {
+    this.attachments$.subscribe();
+  }
+
+  // 8. Public methods
+  public onFileSelect(event: any): void {
+    let files: File[] = [];
+    if (event.files && Array.isArray(event.files)) {
+      files = event.files;
+    } else if (event.currentFiles && Array.isArray(event.currentFiles)) {
+      files = event.currentFiles;
+    } else {
+      return;
+    }
+
+    if (!files || files.length === 0) return;
+
+    const newAttachments = Array.from(files)
+      .map((file) => {
+        const validationError = this.validateFile(file);
+        if (validationError) {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'File Upload Error',
+            detail: validationError,
+            life: 5000,
+          });
+          return null;
+        }
+
+        const pendingAttachment: PendingAttachment = {
+          id: crypto.randomUUID(),
+          fileName: file.name,
+          file: file,
+          fileSize: file.size,
+          mimeType: file.type,
+          uploading: false,
+          uploaded: false,
+        };
+
+        return pendingAttachment;
+      })
+      .filter(Boolean) as PendingAttachment[];
+
+    this.pendingAttachments.update((current) => [...current, ...newAttachments]);
+  }
+
+  public removePendingAttachment(id: string): void {
+    this.pendingAttachments.update((current) => current.filter((f) => f.id !== id));
+  }
+
+  public markForDeletion(uid: string): void {
+    this.pendingDeletions.update((current) => {
+      const next = new Set(current);
+      next.add(uid);
+      return next;
+    });
+  }
+
+  public undoDelete(uid: string): void {
+    this.pendingDeletions.update((current) => {
+      const next = new Set(current);
+      next.delete(uid);
+      return next;
+    });
+  }
+
+  public addLink(): void {
+    const title = this.newLinkTitle().trim();
+    const url = this.newLinkUrl().trim();
+    if (!title || !url) return;
+
+    this.saving.set(true);
+    this.meetingService
+      .createMeetingAttachment(this.meetingId(), { type: 'link', category: 'Other', name: title, link: url })
+      .pipe(take(1))
+      .subscribe({
+        next: (attachment) => {
+          this.existingAttachments.update((current) => [...current, attachment]);
+          this.newLinkTitle.set('');
+          this.newLinkUrl.set('');
+          this.saving.set(false);
+          this.messageService.add({ severity: 'success', summary: 'Link Added', detail: `"${title}" has been added.` });
+          this.materialsChanged.emit();
+        },
+        error: () => {
+          this.saving.set(false);
+          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to add link. Please try again.' });
+        },
+      });
+  }
+
+  public onSave(): void {
+    this.saving.set(true);
+    const meetingId = this.meetingId();
+    const deletions = Array.from(this.pendingDeletions());
+    const uploads = this.pendingAttachments().filter((a) => !a.uploading && !a.uploadError && !a.uploaded && a.file);
+
+    // Sequential: delete → upload
+    const delete$ =
+      deletions.length > 0
+        ? from(deletions).pipe(
+            mergeMap((uid) => this.meetingService.deleteMeetingAttachment(meetingId, uid).pipe(catchError(() => of(null)))),
+            toArray()
+          )
+        : of([]);
+
+    delete$
+      .pipe(
+        switchMap(() => {
+          if (uploads.length === 0) return of([]);
+          return from(uploads).pipe(
+            mergeMap((attachment) =>
+              this.meetingService
+                .uploadMeetingFile(meetingId, attachment.file, {
+                  name: attachment.fileName,
+                  file_size: attachment.fileSize,
+                  file_type: attachment.mimeType,
+                })
+                .pipe(catchError(() => of(null)))
+            ),
+            toArray()
+          );
+        }),
+        take(1)
+      )
+      .subscribe({
+        next: () => {
+          this.saving.set(false);
+          this.messageService.add({ severity: 'success', summary: 'Materials Updated', detail: 'Meeting materials have been saved.' });
+          this.materialsChanged.emit();
+          this.visible.set(false);
+        },
+        error: () => {
+          this.saving.set(false);
+          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to save materials. Please try again.' });
+        },
+      });
+  }
+
+  // 9. Protected methods
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+
+  // 11. Private helper methods
+  private validateFile(file: File): string | null {
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      return `File "${file.name}" is too large. Maximum size is ${MAX_FILE_SIZE_MB}MB.`;
+    }
+
+    if (!isFileTypeAllowed(file.type, file.name, ALLOWED_FILE_TYPES)) {
+      const fileTypeDisplay = getMimeTypeDisplayName(file.type, file.name);
+      const allowedTypes = getAcceptedFileTypesDisplay();
+      return `File type "${fileTypeDisplay}" is not supported. Allowed types: ${allowedTypes}.`;
+    }
+
+    const currentFiles = this.pendingAttachments();
+    const isDuplicate = currentFiles.some((attachment) => attachment.fileName === file.name && !attachment.uploadError);
+
+    if (isDuplicate) {
+      return `A file named "${file.name}" has already been selected for upload.`;
+    }
+
+    if (file.name.includes('..') || file.name.startsWith('.')) {
+      return `Invalid filename "${file.name}". Filename cannot contain path traversal characters or start with a dot.`;
+    }
+
+    return null;
+  }
+}

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.ts
@@ -50,9 +50,6 @@ export class MeetingMaterialsDrawerComponent {
   // 6. Computed signals
   public readonly fileAttachments = computed(() => this.existingAttachments().filter((a) => a.type === 'file'));
   public readonly linkAttachments = computed(() => this.existingAttachments().filter((a) => a.type === 'link'));
-  public readonly hasChanges = computed(
-    () => this.pendingAttachments().length > 0 || this.pendingDeletions().size > 0 || (this.newLinkTitle().trim() !== '' && this.newLinkUrl().trim() !== '')
-  );
 
   // Lazy load attachments when drawer opens
   private readonly attachments$ = toObservable(this.visible).pipe(

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-materials-drawer/meeting-materials-drawer.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, input, model, output, signal } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, input, model, output, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { FileUploadComponent } from '@components/file-upload/file-upload.component';
 import { ALLOWED_FILE_TYPES, MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_MB } from '@lfx-one/shared/constants';
@@ -23,6 +23,7 @@ export class MeetingMaterialsDrawerComponent {
   // 1. Private injections
   private readonly meetingService = inject(MeetingService);
   private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // 2. Public inputs
   public readonly meetingId = input.required<string>();
@@ -44,6 +45,7 @@ export class MeetingMaterialsDrawerComponent {
 
   // Constants
   public readonly acceptString = generateAcceptString();
+  public readonly MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_BYTES;
 
   // 6. Computed signals
   public readonly fileAttachments = computed(() => this.existingAttachments().filter((a) => a.type === 'file'));
@@ -78,7 +80,7 @@ export class MeetingMaterialsDrawerComponent {
   );
 
   public constructor() {
-    this.attachments$.subscribe();
+    this.attachments$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe();
   }
 
   // 8. Public methods
@@ -175,7 +177,7 @@ export class MeetingMaterialsDrawerComponent {
     const deletions = Array.from(this.pendingDeletions());
     const uploads = this.pendingAttachments().filter((a) => !a.uploading && !a.uploadError && !a.uploaded && a.file);
 
-    // Sequential: delete → upload
+    // Delete first (parallel), then upload (parallel)
     const delete$ =
       deletions.length > 0
         ? from(deletions).pipe(

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -747,16 +747,12 @@
       </div>
     </div>
 
-    <!-- Toast Notifications -->
-    <p-toast></p-toast>
-
     <!-- Meeting Materials Drawer -->
     @if (meeting().organizer && !isPastMeeting()) {
       <lfx-meeting-materials-drawer
         [(visible)]="materialsDrawerVisible"
         [meetingId]="meeting().id"
-        (materialsChanged)="onMaterialsChanged()"
-        data-testid="meeting-materials-drawer">
+        (materialsChanged)="onMaterialsChanged()">
       </lfx-meeting-materials-drawer>
     }
   </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -567,7 +567,7 @@
                         <span class="text-xs font-semibold uppercase tracking-wider text-gray-400">Primary Materials</span>
                         <p class="text-xs text-gray-400">Materials intended for review before the meeting.</p>
                         @if (materialFiles().length > 0) {
-                          @for (attachment of materialFiles(); track attachment.uid; let i = $index) {
+                          @for (attachment of visibleFiles(); track attachment.uid; let i = $index) {
                             @let fileType = attachment | fileTypeDisplay;
                             <button
                               type="button"
@@ -587,6 +587,15 @@
                                 </div>
                               </div>
                               <i class="fa-light fa-arrow-up-right-from-square text-gray-400 text-xs flex-shrink-0"></i>
+                            </button>
+                          }
+                          @if (hasMoreFiles()) {
+                            <button
+                              type="button"
+                              (click)="showAllFiles.set(!showAllFiles())"
+                              class="text-xs text-blue-600 hover:text-blue-800 font-medium py-1 transition-colors"
+                              data-testid="toggle-more-files">
+                              {{ showAllFiles() ? 'Show less' : 'Show ' + (materialFiles().length - 5) + ' more' }}
                             </button>
                           }
                         } @else {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -549,7 +549,7 @@
                       @if (hasRecentlyUpdatedMaterials()) {
                         <span class="text-xs font-medium text-emerald-700 bg-emerald-100 px-1.5 py-0.5 rounded-full">Updated</span>
                       }
-                      @if (meeting().organizer) {
+                      @if (meeting().organizer && !isPastMeeting()) {
                         <button
                           type="button"
                           (click)="openMaterialsDrawer()"
@@ -742,7 +742,7 @@
     <p-toast></p-toast>
 
     <!-- Meeting Materials Drawer -->
-    @if (meeting().organizer) {
+    @if (meeting().organizer && !isPastMeeting()) {
       <lfx-meeting-materials-drawer
         [(visible)]="materialsDrawerVisible"
         [meetingId]="meeting().id"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -545,9 +545,18 @@
                     <!-- Header -->
                     <div class="flex items-center gap-2 mb-1">
                       <i class="fa-light fa-folder-open text-gray-500 text-sm"></i>
-                      <h3 class="text-gray-700 text-sm font-medium">Meeting Materials</h3>
+                      <h3 class="text-gray-700 text-sm font-medium flex-1">Meeting Materials</h3>
                       @if (hasRecentlyUpdatedMaterials()) {
                         <span class="text-xs font-medium text-emerald-700 bg-emerald-100 px-1.5 py-0.5 rounded-full">Updated</span>
+                      }
+                      @if (meeting().organizer) {
+                        <button
+                          type="button"
+                          (click)="openMaterialsDrawer()"
+                          class="text-xs text-blue-600 hover:text-blue-800 font-medium transition-colors"
+                          data-testid="manage-materials-btn">
+                          Manage
+                        </button>
                       }
                     </div>
                     <p class="text-xs text-gray-400 mb-3">Documents provided to support meeting preparation, discussion, and governance record.</p>
@@ -731,5 +740,15 @@
 
     <!-- Toast Notifications -->
     <p-toast></p-toast>
+
+    <!-- Meeting Materials Drawer -->
+    @if (meeting().organizer) {
+      <lfx-meeting-materials-drawer
+        [(visible)]="materialsDrawerVisible"
+        [meetingId]="meeting().id"
+        (materialsChanged)="onMaterialsChanged()"
+        data-testid="meeting-materials-drawer">
+      </lfx-meeting-materials-drawer>
+    }
   </div>
 }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -316,7 +316,11 @@ export class MeetingJoinComponent implements OnInit {
   }
 
   public onMaterialsChanged(): void {
+    // Immediate refresh + delayed retry: upload writes to meeting-service via ITX,
+    // reads come from query-service indexed asynchronously via NATS, so a single
+    // immediate fetch can return stale data before the NATS event propagates.
     this.refreshTrigger$.next();
+    setTimeout(() => this.refreshTrigger$.next(), 1000);
   }
 
   public downloadAttachment(attachment: MeetingAttachment | PastMeetingAttachment): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -148,6 +148,9 @@ export class MeetingJoinComponent implements OnInit {
   public showRegistrants: WritableSignal<boolean> = signal<boolean>(false);
   public showGuestForm: WritableSignal<boolean> = signal<boolean>(false);
   public materialsDrawerVisible = signal(false);
+  protected showAllFiles = signal(false);
+  protected visibleFiles = computed(() => (this.showAllFiles() ? this.materialFiles() : this.materialFiles().slice(0, 5)));
+  protected hasMoreFiles = computed(() => this.materialFiles().length > 5);
   // Tracks whether the meeting was loaded via the past-meetings API (occurrence ID in URL).
   // Distinct from isPastMeeting (time-based): isPastMeeting drives UI state (banner, RSVP guards),
   // while loadedViaPastMeetingId gates which API endpoints to call for data (summary, recording, attachments).

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -4,7 +4,7 @@
 import { Clipboard, ClipboardModule } from '@angular/cdk/clipboard';
 import { DatePipe, NgClass } from '@angular/common';
 import { Component, computed, DestroyRef, inject, OnInit, signal, Signal, WritableSignal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MeetingRegistrantsDisplayComponent } from '@app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component';
@@ -50,7 +50,6 @@ import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { DialogService, DynamicDialogModule, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
 import {
   BehaviorSubject,
@@ -67,6 +66,7 @@ import {
   switchMap,
   take,
   tap,
+  timer,
 } from 'rxjs';
 
 import { GuestFormComponent } from '../components/guest-form/guest-form.component';
@@ -88,7 +88,6 @@ import { PublicRegistrationModalComponent } from '../components/public-registrat
     MeetingRsvpDetailsComponent,
     MeetingRegistrantsDisplayComponent,
     GuestFormComponent,
-    ToastModule,
     TooltipModule,
     DrawerModule,
     MeetingTimePipe,
@@ -323,7 +322,7 @@ export class MeetingJoinComponent implements OnInit {
     // reads come from query-service indexed asynchronously via NATS, so a single
     // immediate fetch can return stale data before the NATS event propagates.
     this.refreshTrigger$.next();
-    setTimeout(() => this.refreshTrigger$.next(), 1000);
+    timer(1000).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.refreshTrigger$.next());
   }
 
   public downloadAttachment(attachment: MeetingAttachment | PastMeetingAttachment): void {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -70,6 +70,7 @@ import {
 } from 'rxjs';
 
 import { GuestFormComponent } from '../components/guest-form/guest-form.component';
+import { MeetingMaterialsDrawerComponent } from '../components/meeting-materials-drawer/meeting-materials-drawer.component';
 import { MeetingRsvpDetailsComponent } from '../components/meeting-rsvp-details/meeting-rsvp-details.component';
 import { PublicRegistrationModalComponent } from '../components/public-registration-modal/public-registration-modal.component';
 
@@ -97,6 +98,7 @@ import { PublicRegistrationModalComponent } from '../components/public-registrat
     HeaderComponent,
     FileTypeDisplayPipe,
     DynamicDialogModule,
+    MeetingMaterialsDrawerComponent,
   ],
   providers: [DialogService],
   templateUrl: './meeting-join.component.html',
@@ -145,6 +147,7 @@ export class MeetingJoinComponent implements OnInit {
   private hasAutoJoined: WritableSignal<boolean> = signal<boolean>(false);
   public showRegistrants: WritableSignal<boolean> = signal<boolean>(false);
   public showGuestForm: WritableSignal<boolean> = signal<boolean>(false);
+  public materialsDrawerVisible = signal(false);
   // Tracks whether the meeting was loaded via the past-meetings API (occurrence ID in URL).
   // Distinct from isPastMeeting (time-based): isPastMeeting drives UI state (banner, RSVP guards),
   // while loadedViaPastMeetingId gates which API endpoints to call for data (summary, recording, attachments).
@@ -306,6 +309,14 @@ export class MeetingJoinComponent implements OnInit {
 
   public onRsvpViewToggle(): void {
     this.showMyRsvp.set(!this.showMyRsvp());
+  }
+
+  public openMaterialsDrawer(): void {
+    this.materialsDrawerVisible.set(true);
+  }
+
+  public onMaterialsChanged(): void {
+    this.refreshTrigger$.next();
   }
 
   public downloadAttachment(attachment: MeetingAttachment | PastMeetingAttachment): void {
@@ -763,14 +774,18 @@ export class MeetingJoinComponent implements OnInit {
 
   private initializeAttachments(): Signal<MeetingAttachment[]> {
     return toSignal(
-      toObservable(this.meeting).pipe(
-        filter((meeting) => {
-          if (!meeting?.id) return false;
-          if (meeting.visibility === 'public' && !meeting.restricted) return true;
-          return this.authenticated();
-        }),
-        distinctUntilChanged((a, b) => a.id === b.id),
-        switchMap((meeting) => this.meetingService.getMeetingAttachments(meeting.id)),
+      combineLatest([
+        toObservable(this.meeting).pipe(
+          filter((meeting) => {
+            if (!meeting?.id) return false;
+            if (meeting.visibility === 'public' && !meeting.restricted) return true;
+            return this.authenticated();
+          }),
+          distinctUntilChanged((a, b) => a.id === b.id)
+        ),
+        this.refreshTrigger$,
+      ]).pipe(
+        switchMap(([meeting]) => this.meetingService.getMeetingAttachments(meeting.id)),
         catchError(() => of([] as MeetingAttachment[]))
       ),
       { initialValue: [] }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4274,9 +4274,11 @@ __metadata:
     date-fns-tz: "npm:^3.2.0"
     typescript: "npm:5.8.3"
   peerDependencies:
+    "@angular/core": ^20.3.15
     "@angular/forms": ^20.3.15
     "@fullcalendar/core": ^6.1.19
     chart.js: ^4.5.0
+    rxjs: ^7.8.0
     snowflake-sdk: ^2.3.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary
- Add a **Manage Materials** drawer accessible from both the meeting card (list view) and meeting detail page
- Organizers can upload files and add links directly without navigating the full meeting edit flow
- Resources section auto-refreshes when the drawer closes after changes
- Gated by `meeting().organizer` — only visible to meeting organizers

## What changed
- **New component**: `meeting-materials-drawer` — slide-in drawer with file upload (drag-and-drop), link management, delete/undo, and batch save
- **Meeting card**: Added "Manage" button in resources header, wired drawer with `effect()`-based refresh on close
- **Meeting join page**: Added "Manage" button in materials card header, wired drawer with `refreshTrigger$`-based refresh

## Why
Previously, adding a single file to a meeting required navigating Edit → Step 4 (Resources & Links) → Upload → Save. This drawer reduces that to: click Manage → Upload → Done — similar to how Google Calendar handles event attachments.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)