### PR TITLE
feat(meetings): add inline guest management to registrants drawer

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -279,7 +279,7 @@
                 [pastMeeting]="pastMeeting()"
                 [showAddButton]="!pastMeeting()"
                 [additionalRegistrantsCount]="additionalRegistrantsCount()"
-                (addClicked)="onRegistrantsToggle()">
+                (addClicked)="showRegistrants.set(true)">
               </lfx-meeting-rsvp-details>
             }
           } @placeholder {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -278,7 +278,8 @@
                 [currentOccurrence]="currentOccurrence()"
                 [pastMeeting]="pastMeeting()"
                 [showAddButton]="!pastMeeting()"
-                [additionalRegistrantsCount]="additionalRegistrantsCount()">
+                [additionalRegistrantsCount]="additionalRegistrantsCount()"
+                (addClicked)="onRegistrantsToggle()">
               </lfx-meeting-rsvp-details>
             }
           } @placeholder {
@@ -364,7 +365,7 @@
             <lfx-button
               class="w-full"
               icon="fa-light fa-users"
-              [label]="meetingRegistrantCount() > 0 || pastMeeting() ? 'View Guests' : 'Add Guest'"
+              label="Guests"
               size="small"
               severity="secondary"
               styleClass="w-full"

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -19,7 +19,7 @@ import {
   WritableSignal,
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { Router } from '@angular/router';
+
 import {
   MeetingDeleteConfirmationComponent,
   MeetingDeleteResult,
@@ -103,7 +103,7 @@ export class MeetingCardComponent implements OnInit {
   private readonly injector = inject(Injector);
   private readonly clipboard = inject(Clipboard);
   private readonly userService = inject(UserService);
-  private readonly router = inject(Router);
+
   private readonly destroyRef = inject(DestroyRef);
   private readonly refreshAttachments$ = new BehaviorSubject<void>(undefined);
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -238,13 +238,6 @@ export class MeetingCardComponent implements OnInit {
   }
 
   public onRegistrantsToggle(): void {
-    if (this.meetingRegistrantCount() === 0 && !this.pastMeeting()) {
-      this.router.navigate(['/meetings', this.meeting().id, 'edit'], {
-        queryParams: { step: '5' },
-      });
-      return;
-    }
-
     this.showRegistrants.set(!this.showRegistrants());
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -59,20 +59,40 @@
     @if (!registrantsLoading()) {
       <div class="flex flex-col gap-2">
         @if (!pastMeeting() && showAddRegistrant()) {
-          <!-- Add Registrant Option -->
-          <a
-            class="flex items-center gap-2 cursor-pointer hover:bg-blue-50 p-2 rounded-md transition-colors border-2 border-solid border-blue-200 hover:border-blue-400 no-underline"
-            [routerLink]="['/meetings', meeting().id, 'edit']"
-            [queryParams]="{ step: '5' }"
-            data-testid="add-registrant-button">
+          <!-- Add Guest Toggle Button -->
+          <button
+            type="button"
+            class="flex items-center gap-2 cursor-pointer hover:bg-blue-50 p-2 rounded-md transition-colors border-2 border-dashed border-blue-200 hover:border-blue-400 w-full"
+            (click)="toggleAddForm()"
+            data-testid="add-registrant-toggle">
             <div class="w-8 h-8 bg-blue-100 border border-blue-200 rounded-full flex items-center justify-center">
-              <i class="fa-light fa-plus text-blue-500"></i>
+              <i class="fa-light" [class]="showAddForm() ? 'fa-minus' : 'fa-plus'"></i>
             </div>
-            <div class="flex flex-col min-w-0 flex-1">
-              <span class="text-sm text-blue-600 font-medium">Add Guests</span>
-              <span class="text-xs text-blue-500">Click to add new guests</span>
+            <div class="flex flex-col min-w-0 flex-1 text-left">
+              <span class="text-sm text-blue-600 font-medium">{{ showAddForm() ? 'Cancel' : 'Add Guest' }}</span>
             </div>
-          </a>
+          </button>
+
+          <!-- Inline Add Form -->
+          @if (showAddForm()) {
+            <div class="border border-blue-200 rounded-lg p-4 bg-blue-50/30" data-testid="inline-add-registrant-form">
+              <form [formGroup]="addRegistrantForm" (ngSubmit)="onAddRegistrant()" class="flex flex-col gap-3">
+                <lfx-registrant-form [form]="addRegistrantForm" (onUserSelected)="onUserSelectedFromSearch()" data-testid="inline-registrant-form">
+                </lfx-registrant-form>
+                <div class="flex items-center justify-end gap-2 pt-2 border-t border-blue-100">
+                  <lfx-button
+                    label="Add Guest"
+                    size="small"
+                    icon="fa-light fa-user-plus"
+                    [loading]="submitting()"
+                    [disabled]="addRegistrantForm.invalid || submitting()"
+                    type="submit"
+                    data-testid="inline-add-registrant-submit">
+                  </lfx-button>
+                </div>
+              </form>
+            </div>
+          }
         }
 
         @if (pastMeeting()) {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -75,22 +75,21 @@
 
           <!-- Inline Add Form -->
           @if (showAddForm()) {
-            <div class="border border-blue-200 rounded-lg p-4 bg-blue-50/30" data-testid="inline-add-registrant-form">
-              <form [formGroup]="addRegistrantForm" (ngSubmit)="onAddRegistrant()" class="flex flex-col gap-3">
-                <lfx-registrant-form [form]="addRegistrantForm" (onUserSelected)="onUserSelectedFromSearch()" data-testid="inline-registrant-form">
-                </lfx-registrant-form>
-                <div class="flex items-center justify-end gap-2 pt-2 border-t border-blue-100">
-                  <lfx-button
-                    label="Add Guest"
-                    size="small"
-                    icon="fa-light fa-user-plus"
-                    [loading]="submitting()"
-                    [disabled]="addRegistrantForm.invalid || submitting()"
-                    type="submit"
-                    data-testid="inline-add-registrant-submit">
-                  </lfx-button>
-                </div>
-              </form>
+            <div class="border border-blue-200 rounded-lg p-4 bg-blue-50/30 flex flex-col gap-3" data-testid="inline-add-registrant-form">
+              <lfx-registrant-form [form]="addRegistrantForm" (onUserSelected)="onUserSelectedFromSearch()" data-testid="inline-registrant-form">
+              </lfx-registrant-form>
+              <div class="flex items-center justify-end gap-2 pt-2 border-t border-blue-100">
+                <lfx-button
+                  label="Add Guest"
+                  size="small"
+                  icon="fa-light fa-user-plus"
+                  [loading]="submitting()"
+                  [disabled]="addRegistrantForm.invalid || submitting()"
+                  type="button"
+                  (onClick)="onAddRegistrant()"
+                  data-testid="inline-add-registrant-submit">
+                </lfx-button>
+              </div>
             </div>
           }
         }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -82,7 +82,7 @@ export class MeetingRegistrantsDisplayComponent {
   public readonly filteredPastParticipants = this.initFilteredPastParticipants();
 
   public constructor() {
-    this.addRegistrantForm = this.meetingService.createRegistrantFormGroup(true);
+    this.addRegistrantForm = this.meetingService.createRegistrantFormGroup(false);
 
     effect(() => {
       if (this.visible()) {
@@ -129,16 +129,7 @@ export class MeetingRegistrantsDisplayComponent {
               this.additionalRegistrantsCount.update((c) => c + response.summary.successful);
               this.registrantsCountChange.emit(this.additionalRegistrantsCount());
               this.refresh$.next(true);
-
-              const shouldAddMore = this.addRegistrantForm.get('add_more_registrants')?.value;
-              if (shouldAddMore) {
-                const addMoreState = this.addRegistrantForm.get('add_more_registrants')?.value;
-                this.addRegistrantForm.reset();
-                this.addRegistrantForm.get('add_more_registrants')?.setValue(addMoreState);
-              } else {
-                this.addRegistrantForm.reset();
-                this.showAddForm.set(false);
-              }
+              this.addRegistrantForm.reset();
             } else {
               this.messageService.add({
                 severity: 'error',
@@ -180,7 +171,9 @@ export class MeetingRegistrantsDisplayComponent {
                 map((registrants) => registrants.sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as MeetingRegistrant[]),
                 tap((registrants) => {
                   const baseCount = (this.meeting().individual_registrants_count || 0) + (this.meeting().committee_members_count || 0);
-                  const additionalCount = Math.max(0, (registrants?.length || 0) - baseCount);
+                  const fetchedAdditional = Math.max(0, (registrants?.length || 0) - baseCount);
+                  // Never decrease below the current optimistic count (async indexing may lag)
+                  const additionalCount = Math.max(fetchedAdditional, this.additionalRegistrantsCount());
                   this.additionalRegistrantsCount.set(additionalCount);
                   this.registrantsCountChange.emit(additionalCount);
                 }),

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -121,6 +121,9 @@ export class MeetingRegistrantsDisplayComponent {
             this.submitting.set(false);
             if (response.summary.successful > 0) {
               this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Guest added successfully' });
+              // Immediately increment the count for UI feedback (query service indexing is async)
+              this.additionalRegistrantsCount.update((c) => c + response.summary.successful);
+              this.registrantsCountChange.emit(this.additionalRegistrantsCount());
               this.refresh$.next(true);
 
               const shouldAddMore = this.addRegistrantForm.get('add_more_registrants')?.value;

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, effect, inject, input, InputSignal, output, OutputEmitterRef, Signal, signal, WritableSignal } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, input, InputSignal, output, OutputEmitterRef, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
@@ -13,7 +13,7 @@ import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
 import { TooltipModule } from 'primeng/tooltip';
-import { BehaviorSubject, catchError, debounceTime, filter, finalize, map, of, startWith, switchMap, take, tap } from 'rxjs';
+import { BehaviorSubject, catchError, debounceTime, filter, finalize, map, of, pairwise, startWith, switchMap, take, tap } from 'rxjs';
 
 import { RegistrantFormComponent } from '../registrant-form/registrant-form.component';
 
@@ -25,6 +25,7 @@ import { RegistrantFormComponent } from '../registrant-form/registrant-form.comp
 export class MeetingRegistrantsDisplayComponent {
   private readonly meetingService = inject(MeetingService);
   private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
 
   public readonly meeting: InputSignal<Meeting | PastMeeting> = input.required<Meeting | PastMeeting>();
   public readonly pastMeeting: InputSignal<boolean> = input<boolean>(false);
@@ -39,8 +40,8 @@ export class MeetingRegistrantsDisplayComponent {
   public readonly registrants: Signal<MeetingRegistrant[]> = this.initRegistrantsList();
   public readonly pastMeetingParticipants: Signal<PastMeetingParticipant[]> = this.initPastMeetingParticipantsList();
   public readonly additionalRegistrantsCount: WritableSignal<number> = signal(0);
-  public showAddForm = signal(false);
-  public submitting = signal(false);
+  public readonly showAddForm = signal(false);
+  public readonly submitting = signal(false);
 
   // Add registrant form
   public addRegistrantForm: FormGroup;
@@ -88,12 +89,20 @@ export class MeetingRegistrantsDisplayComponent {
       if (this.visible()) {
         this.registrantsLoading.set(true);
         this.refresh$.next(true);
-      } else {
-        // Reset inline add form when drawer closes
-        this.showAddForm.set(false);
-        this.addRegistrantForm.reset();
       }
     });
+
+    // Reset inline add form when drawer closes (open → closed transition)
+    toObservable(this.visible)
+      .pipe(
+        pairwise(),
+        filter(([prev, curr]) => prev && !curr),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe(() => {
+        this.showAddForm.set(false);
+        this.addRegistrantForm.reset();
+      });
   }
 
   // === Public Methods ===

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -88,6 +88,10 @@ export class MeetingRegistrantsDisplayComponent {
       if (this.visible()) {
         this.registrantsLoading.set(true);
         this.refresh$.next(true);
+      } else {
+        // Reset inline add form when drawer closes
+        this.showAddForm.set(false);
+        this.addRegistrantForm.reset();
       }
     });
   }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -5,21 +5,26 @@ import { NgClass } from '@angular/common';
 import { Component, computed, effect, inject, input, InputSignal, output, OutputEmitterRef, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { RouterLink } from '@angular/router';
 import { AvatarComponent } from '@components/avatar/avatar.component';
+import { ButtonComponent } from '@components/button/button.component';
 import { SelectComponent } from '@components/select/select.component';
 import { Meeting, MeetingRegistrant, PastMeeting, PastMeetingParticipant } from '@lfx-one/shared';
+import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
+import { MessageService } from 'primeng/api';
 import { TooltipModule } from 'primeng/tooltip';
-import { BehaviorSubject, catchError, debounceTime, filter, finalize, map, of, startWith, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, debounceTime, filter, finalize, map, of, startWith, switchMap, take, tap } from 'rxjs';
+
+import { RegistrantFormComponent } from '../registrant-form/registrant-form.component';
 
 @Component({
   selector: 'lfx-meeting-registrants-display',
-  imports: [AvatarComponent, TooltipModule, ReactiveFormsModule, SelectComponent, NgClass, RouterLink],
+  imports: [AvatarComponent, ButtonComponent, TooltipModule, ReactiveFormsModule, RegistrantFormComponent, SelectComponent, NgClass],
   templateUrl: './meeting-registrants-display.component.html',
 })
 export class MeetingRegistrantsDisplayComponent {
   private readonly meetingService = inject(MeetingService);
+  private readonly messageService = inject(MessageService);
 
   public readonly meeting: InputSignal<Meeting | PastMeeting> = input.required<Meeting | PastMeeting>();
   public readonly pastMeeting: InputSignal<boolean> = input<boolean>(false);
@@ -34,6 +39,11 @@ export class MeetingRegistrantsDisplayComponent {
   public readonly registrants: Signal<MeetingRegistrant[]> = this.initRegistrantsList();
   public readonly pastMeetingParticipants: Signal<PastMeetingParticipant[]> = this.initPastMeetingParticipantsList();
   public readonly additionalRegistrantsCount: WritableSignal<number> = signal(0);
+  public showAddForm = signal(false);
+  public submitting = signal(false);
+
+  // Add registrant form
+  public addRegistrantForm: FormGroup;
 
   // Search and filter controls
   public readonly searchControl: FormControl<string> = new FormControl<string>('', { nonNullable: true });
@@ -72,6 +82,8 @@ export class MeetingRegistrantsDisplayComponent {
   public readonly filteredPastParticipants = this.initFilteredPastParticipants();
 
   public constructor() {
+    this.addRegistrantForm = this.meetingService.createRegistrantFormGroup(true);
+
     effect(() => {
       if (this.visible()) {
         this.registrantsLoading.set(true);
@@ -80,8 +92,66 @@ export class MeetingRegistrantsDisplayComponent {
     });
   }
 
+  // === Public Methods ===
   public refresh(): void {
     this.refresh$.next(true);
+  }
+
+  public toggleAddForm(): void {
+    const isShowing = this.showAddForm();
+    this.showAddForm.set(!isShowing);
+    if (isShowing) {
+      this.addRegistrantForm.reset();
+    }
+  }
+
+  public onAddRegistrant(): void {
+    if (this.submitting()) return;
+
+    if (this.addRegistrantForm.valid) {
+      this.submitting.set(true);
+      const formValue = this.addRegistrantForm.value;
+      const createData = this.meetingService.stripMetadata(this.meeting().id, formValue);
+
+      this.meetingService
+        .addMeetingRegistrants(this.meeting().id, [createData])
+        .pipe(take(1))
+        .subscribe({
+          next: (response) => {
+            this.submitting.set(false);
+            if (response.summary.successful > 0) {
+              this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Guest added successfully' });
+              this.refresh$.next(true);
+
+              const shouldAddMore = this.addRegistrantForm.get('add_more_registrants')?.value;
+              if (shouldAddMore) {
+                const addMoreState = this.addRegistrantForm.get('add_more_registrants')?.value;
+                this.addRegistrantForm.reset();
+                this.addRegistrantForm.get('add_more_registrants')?.setValue(addMoreState);
+              } else {
+                this.addRegistrantForm.reset();
+                this.showAddForm.set(false);
+              }
+            } else {
+              this.messageService.add({
+                severity: 'error',
+                summary: 'Error',
+                detail: response.failures[0]?.error?.message || 'Failed to add guest',
+              });
+            }
+          },
+          error: () => {
+            this.submitting.set(false);
+            this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to add guest. Please try again.' });
+          },
+        });
+    } else {
+      markFormControlsAsTouched(this.addRegistrantForm);
+    }
+  }
+
+  public onUserSelectedFromSearch(): void {
+    this.onAddRegistrant();
   }
 
   private initRegistrantsList(): Signal<MeetingRegistrant[]> {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.html
@@ -18,8 +18,7 @@
         size="small"
         severity="secondary"
         [attr.data-testid]="'add-participant-button'"
-        [routerLink]="['/meetings', meeting().id, 'edit']"
-        [queryParams]="{ step: '5' }">
+        (onClick)="addClicked.emit()">
       </lfx-button>
     }
   </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, inject, input, InputSignal, signal, Signal, WritableSignal } from '@angular/core';
+import { Component, computed, inject, input, InputSignal, output, signal, Signal, WritableSignal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { calculateRsvpCounts, Meeting, MeetingOccurrence, MeetingRsvp, PastMeeting, Project, RsvpCounts } from '@lfx-one/shared';
@@ -26,6 +26,7 @@ export class MeetingRsvpDetailsComponent {
   public readonly backgroundColor: InputSignal<string | undefined> = input<string | undefined>(undefined);
   public readonly borderColor: InputSignal<string | undefined> = input<string | undefined>(undefined);
   public readonly additionalRegistrantsCount: InputSignal<number> = input<number>(0);
+  public readonly addClicked = output<void>();
   public readonly disabled: InputSignal<boolean> = input<boolean>(false);
   public readonly disabledMessage: InputSignal<string> = input<string>('RSVP not available for this meeting');
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -41,7 +41,6 @@ export class MeetingRsvpDetailsComponent {
   public readonly attendancePercentage: Signal<number> = this.initializeAttendancePercentage();
   public readonly showPoorAttendanceWarning: Signal<boolean> = computed(() => this.pastMeeting() && this.attendancePercentage() < 50);
   public readonly backgroundClasses: Signal<string> = this.initializeBackgroundClasses();
-  public readonly editLink: Signal<string> = this.initializeEditLink();
   public readonly borderClasses: Signal<string> = this.initializeBorderClasses();
   public readonly headerTextClasses: Signal<string> = computed(() => (this.showPoorAttendanceWarning() ? 'text-amber-600' : 'text-gray-600'));
   public readonly summaryTextClasses: Signal<string> = computed(() => (this.showPoorAttendanceWarning() ? 'text-amber-900' : 'text-gray-900'));
@@ -135,16 +134,6 @@ export class MeetingRsvpDetailsComponent {
         return `border ${this.borderColor()}`;
       }
       return '';
-    });
-  }
-
-  private initializeEditLink(): Signal<string> {
-    return computed(() => {
-      const slug = this.project()?.slug;
-      if (slug) {
-        return `/project/${slug}/meetings/${this.meeting().id}/edit`;
-      }
-      return `/meetings/${this.meeting().id}/edit`;
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -356,7 +356,7 @@
                     [currentOccurrence]="currentOccurrence()"
                     [pastMeeting]="isPastMeeting()"
                     [showAddButton]="!!meeting().organizer && !isPastMeeting()"
-                    [additionalRegistrantsCount]="0"
+                    [additionalRegistrantsCount]="additionalRegistrantsCount()"
                     backgroundColor="bg-gray-50"
                     borderColor="border-gray-200"
                     (addClicked)="onRegistrantsToggle()">
@@ -512,7 +512,8 @@
               [pastMeeting]="isPastMeeting()"
               [showAddRegistrant]="!!meeting().organizer && !isPastMeeting()"
               [myMeetingRegistrants]="false"
-              [visible]="showRegistrants()">
+              [visible]="showRegistrants()"
+              (registrantsCountChange)="additionalRegistrantsCount.set($event)">
             </lfx-meeting-registrants-display>
           </p-drawer>
           @if (!(isPastMeeting() && !pastMeetingFullAccess())) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -355,10 +355,11 @@
                     [project]="project()"
                     [currentOccurrence]="currentOccurrence()"
                     [pastMeeting]="isPastMeeting()"
-                    [showAddButton]="false"
+                    [showAddButton]="!!meeting().organizer && !isPastMeeting()"
                     [additionalRegistrantsCount]="0"
                     backgroundColor="bg-gray-50"
-                    borderColor="border-gray-200">
+                    borderColor="border-gray-200"
+                    (addClicked)="onRegistrantsToggle()">
                   </lfx-meeting-rsvp-details>
                 }
                 @if (canToggleRsvpView()) {
@@ -509,7 +510,7 @@
             <lfx-meeting-registrants-display
               [meeting]="meeting()"
               [pastMeeting]="isPastMeeting()"
-              [showAddRegistrant]="false"
+              [showAddRegistrant]="!!meeting().organizer && !isPastMeeting()"
               [myMeetingRegistrants]="false"
               [visible]="showRegistrants()">
             </lfx-meeting-registrants-display>
@@ -749,10 +750,7 @@
 
     <!-- Meeting Materials Drawer -->
     @if (meeting().organizer && !isPastMeeting()) {
-      <lfx-meeting-materials-drawer
-        [(visible)]="materialsDrawerVisible"
-        [meetingId]="meeting().id"
-        (materialsChanged)="onMaterialsChanged()">
+      <lfx-meeting-materials-drawer [(visible)]="materialsDrawerVisible" [meetingId]="meeting().id" (materialsChanged)="onMaterialsChanged()">
       </lfx-meeting-materials-drawer>
     }
   </div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -359,7 +359,7 @@
                     [additionalRegistrantsCount]="additionalRegistrantsCount()"
                     backgroundColor="bg-gray-50"
                     borderColor="border-gray-200"
-                    (addClicked)="onRegistrantsToggle()">
+                    (addClicked)="showRegistrants.set(true)">
                   </lfx-meeting-rsvp-details>
                 }
                 @if (canToggleRsvpView()) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -146,6 +146,7 @@ export class MeetingJoinComponent implements OnInit {
   private hasAutoJoined: WritableSignal<boolean> = signal<boolean>(false);
   public showRegistrants: WritableSignal<boolean> = signal<boolean>(false);
   public showGuestForm: WritableSignal<boolean> = signal<boolean>(false);
+  public additionalRegistrantsCount = signal(0);
   public materialsDrawerVisible = signal(false);
   protected showAllFiles = signal(false);
   protected visibleFiles = computed(() => (this.showAllFiles() ? this.materialFiles() : this.materialFiles().slice(0, 5)));

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -322,7 +322,9 @@ export class MeetingJoinComponent implements OnInit {
     // reads come from query-service indexed asynchronously via NATS, so a single
     // immediate fetch can return stale data before the NATS event propagates.
     this.refreshTrigger$.next();
-    timer(1000).pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.refreshTrigger$.next());
+    timer(1000)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.refreshTrigger$.next());
   }
 
   public downloadAttachment(attachment: MeetingAttachment | PastMeetingAttachment): void {


### PR DESCRIPTION
## Summary
- Replace "navigate to edit page" pattern with inline add capability directly in the registrants drawer
- Organizers can now add guests from both the meeting list card and meeting detail page without leaving the page
- "Add" button in People Invited section now opens the guests drawer instead of navigating to edit flow

## Changes
- **meeting-registrants-display**: Embedded `RegistrantFormComponent` inline with user search + manual entry, auto-refresh on successful add
- **meeting-rsvp-details**: Replaced `routerLink` navigation with `addClicked` output event
- **meeting-card**: Wired `addClicked` to open drawer, removed navigation shortcut, unified button label to "Guests"
- **meeting-join**: Enabled `showAddButton` and `showAddRegistrant` for organizers on detail page

## Test plan
- [ ] Open meeting list → click "Guests" on a meeting card → drawer opens with "Add Guest" toggle
- [ ] Click "Add Guest" → inline form expands with user search
- [ ] Add a guest → success toast, list refreshes, form resets
- [ ] Click "Add" in People Invited header → same drawer opens
- [ ] Open meeting detail page → "Add" button visible for organizers → opens guests drawer
- [ ] Past meetings → no "Add" button shown
- [ ] Non-organizers → no "Add" button shown

🤖 Generated with [Claude Code](https://claude.ai/claude-code)