### PR TITLE
fix(ui): show meetings and pending actions first in me lens dashboard

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -10,6 +10,53 @@
 
   <!-- Dashboard Sections -->
   <div class="flex flex-col gap-6" data-testid="multi-persona-dashboard-sections">
+    <!-- My Meetings -->
+    @defer (on idle) {
+      <lfx-my-meetings />
+    } @placeholder {
+      <section class="flex flex-1 flex-col" data-testid="multi-persona-my-meetings-placeholder">
+        <div class="mb-4 flex h-8 items-center justify-between">
+          <div class="flex items-center gap-2">
+            <p-skeleton width="1.125rem" height="1.125rem" borderRadius="4px" />
+            <p-skeleton width="7rem" height="1rem" />
+          </div>
+          <p-skeleton width="4rem" height="1rem" />
+        </div>
+        <div class="flex flex-col gap-3">
+          <p-skeleton width="100%" height="140px" />
+        </div>
+      </section>
+    }
+
+    <!-- Pending Actions -->
+    @if (pendingActionsLoading()) {
+      <section class="flex flex-1 flex-col" data-testid="multi-persona-pending-actions-loading">
+        <div class="mb-4 flex h-8 items-center gap-2">
+          <p-skeleton width="1.125rem" height="1.125rem" borderRadius="4px" />
+          <p-skeleton width="9rem" height="1rem" />
+        </div>
+        <div class="flex flex-col gap-3">
+          <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
+          <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
+        </div>
+      </section>
+    } @else {
+      @defer (on idle) {
+        <lfx-pending-actions [pendingActions]="pendingActions()" (actionClick)="handleActionClick()" />
+      } @placeholder {
+        <section class="flex flex-1 flex-col" data-testid="multi-persona-pending-actions-placeholder">
+          <div class="mb-4 flex h-8 items-center gap-2">
+            <p-skeleton width="1.125rem" height="1.125rem" borderRadius="4px" />
+            <p-skeleton width="9rem" height="1rem" />
+          </div>
+          <div class="flex flex-col gap-3">
+            <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
+            <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
+          </div>
+        </section>
+      }
+    }
+
     <!-- My Foundations and Projects Section -->
     <section data-testid="multi-persona-projects-section">
       <!-- Section Header -->
@@ -192,52 +239,5 @@
         </table>
       </div>
     </section>
-
-    <!-- My Meetings -->
-    @defer (on idle) {
-      <lfx-my-meetings />
-    } @placeholder {
-      <section class="flex flex-1 flex-col" data-testid="multi-persona-my-meetings-placeholder">
-        <div class="mb-4 flex h-8 items-center justify-between">
-          <div class="flex items-center gap-2">
-            <p-skeleton width="1.125rem" height="1.125rem" borderRadius="4px" />
-            <p-skeleton width="7rem" height="1rem" />
-          </div>
-          <p-skeleton width="4rem" height="1rem" />
-        </div>
-        <div class="flex flex-col gap-3">
-          <p-skeleton width="100%" height="140px" />
-        </div>
-      </section>
-    }
-
-    <!-- Pending Actions -->
-    @if (pendingActionsLoading()) {
-      <section class="flex flex-1 flex-col" data-testid="multi-persona-pending-actions-loading">
-        <div class="mb-4 flex h-8 items-center gap-2">
-          <p-skeleton width="1.125rem" height="1.125rem" borderRadius="4px" />
-          <p-skeleton width="9rem" height="1rem" />
-        </div>
-        <div class="flex flex-col gap-3">
-          <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
-          <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
-        </div>
-      </section>
-    } @else {
-      @defer (on idle) {
-        <lfx-pending-actions [pendingActions]="pendingActions()" (actionClick)="handleActionClick()" />
-      } @placeholder {
-        <section class="flex flex-1 flex-col" data-testid="multi-persona-pending-actions-placeholder">
-          <div class="mb-4 flex h-8 items-center gap-2">
-            <p-skeleton width="1.125rem" height="1.125rem" borderRadius="4px" />
-            <p-skeleton width="9rem" height="1rem" />
-          </div>
-          <div class="flex flex-col gap-3">
-            <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
-            <p-skeleton width="100%" height="4.5rem" borderRadius="8px" />
-          </div>
-        </section>
-      }
-    }
   </div>
 </div>


### PR DESCRIPTION
## What
Reorder sections in the multi-persona dashboard (Me Lens) so **My Meetings** and **My Pending Actions** always appear at the top of the page, before the **My Foundations and Projects** table, regardless of the user's role.

## How
Moved the `<lfx-my-meetings />` and `<lfx-pending-actions />` blocks above the foundations/projects section in `multi-persona-dashboard.component.html`. The single-persona `user-dashboard` already had the correct order, so no changes were needed there.

## Checklist
- [x] No new files — no license headers needed
- [x] Formatting applied (`yarn format`)
- [x] Me Lens only — Foundation and Project lens dashboards are untouched

🤖 Generated with [Claude Code](https://claude.ai/code)