### PR TITLE
feat(dashboards): expand ed dashboard with health and org sections

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.html
@@ -48,6 +48,43 @@
       </section>
     }
 
+    <!-- Foundation Health -->
+    @defer (on idle) {
+      <lfx-foundation-health />
+    } @placeholder {
+      <section data-testid="ed-dashboard-foundation-health-placeholder">
+        <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
+          <div class="flex flex-col gap-3">
+            <p-skeleton width="12rem" height="1.5rem" />
+            <p-skeleton width="16rem" height="1.5rem" />
+          </div>
+          <div class="flex items-center gap-2">
+            <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
+            <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
+          </div>
+        </div>
+        <div class="flex gap-4 overflow-hidden">
+          @for (i of [1, 2, 3, 4]; track i) {
+            <div class="p-4 bg-white border border-gray-200 rounded-lg flex-shrink-0 w-[calc(100vw-3rem)] md:w-80">
+              <div class="flex flex-col gap-2">
+                <div class="flex items-center gap-2">
+                  <p-skeleton width="1rem" height="1rem" borderRadius="4px" />
+                  <p-skeleton width="6rem" height="0.875rem" />
+                </div>
+                <div class="mt-3 w-full h-16">
+                  <p-skeleton width="100%" height="100%" borderRadius="8px" />
+                </div>
+                <div class="flex flex-col gap-1 mt-auto">
+                  <p-skeleton width="3rem" height="1.75rem" />
+                  <p-skeleton width="70%" height="0.75rem" />
+                </div>
+              </div>
+            </div>
+          }
+        </div>
+      </section>
+    }
+
     <!-- Meetings (hidden on org lens) -->
     @if (showMeetings()) {
       @defer (on idle) {
@@ -83,6 +120,45 @@
           <p-skeleton width="100%" height="140px" />
         </div>
       </section>
+    }
+
+    <!-- Organization Involvement (hidden on me lens) -->
+    @if (showOrgInvolvement()) {
+      @defer (on viewport) {
+        <lfx-organization-involvement />
+      } @placeholder {
+        <section data-testid="ed-dashboard-organization-involvement-placeholder">
+          <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
+            <div class="flex flex-col gap-3">
+              <p-skeleton width="14rem" height="1.5rem" />
+              <p-skeleton width="16rem" height="1.5rem" />
+            </div>
+            <div class="flex items-center gap-2">
+              <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
+              <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
+            </div>
+          </div>
+          <div class="flex gap-4 overflow-hidden">
+            @for (i of [1, 2, 3]; track i) {
+              <div class="p-4 bg-white border border-gray-200 rounded-lg flex-shrink-0 w-[calc(100vw-3rem)] md:w-80">
+                <div class="flex flex-col gap-2">
+                  <div class="flex items-center gap-2">
+                    <p-skeleton width="1rem" height="1rem" borderRadius="4px" />
+                    <p-skeleton width="6rem" height="0.875rem" />
+                  </div>
+                  <div class="mt-3 w-full h-16">
+                    <p-skeleton width="100%" height="100%" borderRadius="8px" />
+                  </div>
+                  <div class="flex flex-col gap-1 mt-auto">
+                    <p-skeleton width="3rem" height="1.75rem" />
+                    <p-skeleton width="70%" height="0.75rem" />
+                  </div>
+                </div>
+              </div>
+            }
+          </div>
+        </section>
+      }
     }
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.ts
@@ -11,14 +11,23 @@ import { ProjectService } from '@services/project.service';
 import { SkeletonModule } from 'primeng/skeleton';
 import { BehaviorSubject, catchError, combineLatest, of, switchMap } from 'rxjs';
 
+import { FoundationHealthComponent } from '../components/foundation-health/foundation-health.component';
 import { MyMeetingsComponent } from '../components/my-meetings/my-meetings.component';
+import { OrganizationInvolvementComponent } from '../components/organization-involvement/organization-involvement.component';
 import { PendingActionsComponent } from '../components/pending-actions/pending-actions.component';
 
 import { MarketingOverviewComponent } from './components/marketing-overview/marketing-overview.component';
 
 @Component({
   selector: 'lfx-executive-director-dashboard',
-  imports: [PendingActionsComponent, MyMeetingsComponent, MarketingOverviewComponent, SkeletonModule],
+  imports: [
+    PendingActionsComponent,
+    MyMeetingsComponent,
+    MarketingOverviewComponent,
+    FoundationHealthComponent,
+    OrganizationInvolvementComponent,
+    SkeletonModule,
+  ],
   templateUrl: './executive-director-dashboard.component.html',
 })
 export class ExecutiveDirectorDashboardComponent {
@@ -29,6 +38,7 @@ export class ExecutiveDirectorDashboardComponent {
   private readonly lensService = inject(LensService);
 
   protected readonly showMeetings = computed(() => this.lensService.activeLens() !== 'org');
+  protected readonly showOrgInvolvement = computed(() => this.lensService.activeLens() !== 'me');
 
   // === Configuration ===
   private readonly refresh$ = new BehaviorSubject<void>(undefined);


### PR DESCRIPTION
## Summary
- Render Foundation Health below the Executive Director marketing overview carousel
- Render Organization Involvement after Pending Actions, gated on the active lens (hidden when `me` lens is active)
- Both sections reuse the deferred-loading + skeleton placeholder pattern from the board-member dashboard for consistency