### PR TITLE
fix(ui): align pending actions empty state with groups page pattern

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -77,9 +77,10 @@
       </div>
     } @else {
       <!-- Empty state - shows when no pending actions -->
-      <div class="text-center py-8" data-testid="dashboard-pending-actions-empty">
-        <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-        <p class="text-sm text-gray-500">No pending actions</p>
+      <div class="flex flex-col items-center py-12" data-testid="dashboard-pending-actions-empty">
+        <i class="fa-light fa-eyes text-3xl text-gray-300 mb-3"></i>
+        <p class="text-sm font-medium text-gray-600">No pending actions</p>
+        <p class="text-xs text-gray-400 mt-1">You're all caught up!</p>
       </div>
     }
   </div>


### PR DESCRIPTION
## Summary
- Updated the "no pending actions" empty state on the dashboard to match the consistent UX pattern used across groups pages (committees, mailing lists, meetings)
- Changes: larger padding, lighter icon, bolder text, added helper text "You're all caught up!"

## Test plan
- [ ] Navigate to foundation overview dashboard with no pending actions
- [ ] Verify empty state shows updated styling matching groups pages
- [ ] Verify pending actions still render correctly when actions exist

🤖 Generated with [Claude Code](https://claude.ai/claude-code)