### PR TITLE
fix(ui): normalize me lens dashboard header spacing

### DIFF
--- a/apps/lfx-one/src/app/modules/badges/badges-dashboard/badges-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/badges/badges-dashboard/badges-dashboard.component.html
@@ -3,9 +3,9 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   <!-- Page Header -->
-  <div #pageTopAnchor class="mb-8">
-    <h1 data-testid="badges-dashboard-title">{{ badgeLabelPlural }}</h1>
-    <p class="mt-2 text-gray-500" data-testid="badges-dashboard-description">
+  <div #pageTopAnchor class="mb-6">
+    <h1 class="font-display font-light text-2xl" data-testid="badges-dashboard-title">{{ badgeLabelPlural }}</h1>
+    <p class="mt-1 text-sm text-gray-500" data-testid="badges-dashboard-description">
       Discover, recognize achievements in community engagement, event participation, and project contributions.
     </p>
   </div>

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -4,7 +4,7 @@
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   <div class="flex flex-col gap-6">
     <!-- Page Header -->
-    <div class="mt-3 mb-6">
+    <div class="mb-6">
       <div class="flex justify-between items-center w-full gap-4">
         <h1 class="font-display font-light text-2xl">{{ isMeLens() ? 'My ' + committeeLabel.plural : committeeLabel.plural }}</h1>
         @if (!isMeLens() && canWrite()) {

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
@@ -3,11 +3,9 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="documents-dashboard">
   <!-- Page Header -->
-  <div class="flex items-start justify-between mb-8">
-    <div>
-      <h1 class="font-display font-light text-2xl mb-1" data-testid="documents-dashboard-title">{{ pageTitle() }}</h1>
-      <p class="mt-1 text-gray-500" data-testid="documents-dashboard-description">{{ pageDescription() }}</p>
-    </div>
+  <div class="mb-6">
+    <h1 class="font-display font-light text-2xl" data-testid="documents-dashboard-title">{{ pageTitle() }}</h1>
+    <p class="mt-1 text-sm text-gray-500" data-testid="documents-dashboard-description">{{ pageDescription() }}</p>
   </div>
 
   <!-- Filter Bar + Table -->

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
@@ -11,7 +11,7 @@
     </div>
   } @else if (!isMeLens() && hasNoServices()) {
     <!-- No Services Empty State -->
-    <div class="mt-3 mb-6">
+    <div class="mb-6">
       <h1 class="font-display font-light text-2xl">{{ mailingListLabelPlural }}</h1>
       <p class="mt-1 text-sm text-gray-500" data-testid="mailing-list-dashboard-description">Manage communication channels for your project community.</p>
     </div>
@@ -38,7 +38,7 @@
       </div>
     </lfx-card>
   } @else {
-    <div class="mt-3 mb-6">
+    <div class="mb-6">
       <!-- Page Title with Add Mailing List Button -->
       <div class="flex justify-between items-center w-full gap-4">
         <h1 class="font-display font-light text-2xl">{{ isMeLens() ? 'My ' + mailingListLabelPlural : mailingListLabelPlural }}</h1>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -3,7 +3,7 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   <div class="mb-8">
-    <div class="mt-3 mb-6">
+    <div class="mb-6">
       <div class="flex justify-between items-center w-full gap-4">
         <h1 class="font-display font-light text-2xl">{{ activeLens() === 'me' ? 'My Meetings' : 'Meetings' }}</h1>
         @if (activeLens() !== 'me' && canWrite()) {

--- a/apps/lfx-one/src/app/modules/my-activity/my-activity-dashboard/my-activity-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/my-activity/my-activity-dashboard/my-activity-dashboard.component.html
@@ -3,7 +3,7 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="my-activity-dashboard">
   <!-- Page Header -->
-  <div class="mt-3 mb-6">
+  <div class="mb-6">
     <h1 class="font-display font-light text-2xl">{{ activityLabel.singular }}</h1>
     <p class="mt-1 text-sm text-gray-500" data-testid="my-activity-description">{{ activityLabel.description }}</p>
   </div>

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
@@ -2,12 +2,18 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="w-full" data-testid="account-settings">
+  <!-- Page Header -->
+  <div class="mb-6">
+    <h1 class="font-display font-light text-2xl" data-testid="account-settings-title">Account Settings</h1>
+    <p class="mt-1 text-sm text-gray-500">Manage your account preferences, email addresses, and security settings.</p>
+  </div>
+
   <!-- Two Column Layout: TOC + Content -->
   <div class="flex gap-8">
     <!-- LEFT: Table of Contents (outer stretches to row height, inner sticks) -->
     <div class="w-auto shrink-0 pr-10">
       <div class="sticky top-24 flex flex-col gap-3">
-        <h1 class="text-lg font-semibold text-gray-900" data-testid="account-settings-title">Account Settings</h1>
+        <p class="text-xs font-medium text-gray-400 uppercase tracking-wide">On this page</p>
 
         <div class="flex flex-col gap-1">
           <button

--- a/apps/lfx-one/src/app/modules/settings/settings-dashboard/settings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/settings/settings-dashboard/settings-dashboard.component.html
@@ -2,11 +2,11 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 @if (isMe()) {
-  <div class="container mx-auto py-6 px-8">
+  <div class="container mx-auto px-4 sm:px-6 lg:px-8">
     <lfx-account-settings />
   </div>
 } @else {
-  <div class="container mx-auto py-6 px-8">
+  <div class="container mx-auto px-4 sm:px-6 lg:px-8">
     <div class="grid grid-cols-1 lg:grid-cols-4 gap-6">
       <div class="lg:col-span-3">
         <lfx-user-permissions-table [users]="users()" [loading]="loading()" (refresh)="refreshUsers()"></lfx-user-permissions-table>

--- a/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/surveys-dashboard/surveys-dashboard.component.html
@@ -3,7 +3,7 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   <!-- Page Header -->
-  <div class="flex items-center justify-between mt-3 mb-6">
+  <div class="flex items-center justify-between mb-6">
     <div>
       <h1 class="font-display font-light text-2xl" data-testid="surveys-dashboard-title">{{ isMeLens() ? 'My ' + surveyLabelPlural : surveyLabelPlural }}</h1>
       <p class="mt-1 text-sm text-gray-500" data-testid="surveys-dashboard-description">

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
@@ -3,7 +3,7 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="trainings-dashboard">
   <!-- Page Header -->
-  <div class="mt-3 mb-6">
+  <div class="mb-6">
     <h1 class="font-display font-light text-2xl" data-testid="trainings-title">Training &amp; Certifications</h1>
     <p class="mt-1 text-sm text-gray-500" data-testid="trainings-subtitle">{{ subtitle }}</p>
   </div>

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
@@ -3,7 +3,7 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="transactions-dashboard">
   <!-- Page Header -->
-  <div class="mt-3 mb-6">
+  <div class="mb-6">
     <h1 class="font-display font-light text-2xl" data-testid="transactions-title">My Transactions</h1>
     <p class="mt-1 text-sm text-gray-500" data-testid="transactions-subtitle">{{ subtitle }}</p>
   </div>

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.html
@@ -3,7 +3,7 @@
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8">
   <!-- Page Header -->
-  <div class="flex items-center justify-between mt-3 mb-6">
+  <div class="flex items-center justify-between mb-6">
     <div>
       <h1 class="font-display font-light text-2xl" data-testid="votes-dashboard-title">{{ isMeLens() ? 'My ' + voteLabelPlural : voteLabelPlural }}</h1>
       <p class="mt-1 text-sm text-gray-500" data-testid="votes-dashboard-description">


### PR DESCRIPTION
## What
Standardizes the page header position across all Me Lens dashboard pages so every h1 aligns to the same vertical offset (y=21px) as My Dashboard.

## How
- Removed extra `mt-3` / `mb-8` top margins from header wrappers in meetings, my-activity, mailing-lists, votes, surveys, committees, trainings, and transactions dashboards
- Fixed documents header: `mb-8` → `mb-6`, removed stray `mb-1` from h1, added missing `text-sm` to subtitle
- Fixed badges header: added `font-display font-light text-2xl` to h1, normalized subtitle spacing
- Added a proper page-level h1 to account-settings (the page previously had no page header)
- Fixed settings-dashboard container: `px-8` → responsive `px-4 sm:px-6 lg:px-8`

All Me Lens h1 elements now render at y=21px, matching My Dashboard.

## Checklist
- [x] No functional changes — layout/spacing only
- [x] Verified in browser: all h1 elements at y=21 via `getBoundingClientRect()`
- [x] License headers present on all modified files
- [x] Under 1000 lines of diff

Generated with [Claude Code](https://claude.ai/code)