### PR TITLE
feat(ui): improve sidebar project selector and role label display

### DIFF
--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.html
@@ -18,8 +18,8 @@
   </div>
 
   <div class="flex flex-col gap-0.5 grow items-start relative min-w-0 overflow-hidden">
-    <p class="sidebar-project-name">{{ displayName() }}</p>
-    <span class="text-[11px] font-normal text-gray-400 leading-none">{{ lens() === 'foundation' ? 'Foundation' : 'Project' }}</span>
+    <p class="sidebar-project-name" [attr.title]="displayName()">{{ displayName() }}</p>
+    <span class="text-xs font-normal text-gray-400 leading-none">{{ lensTypeLabel() }}</span>
   </div>
 
   <i class="fa-light fa-angles-up-down shrink-0 text-gray-400" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.html
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.html
@@ -7,8 +7,8 @@
   (click)="togglePanel($event, popover)"
   [attr.aria-expanded]="popover.overlayVisible"
   data-testid="project-selector">
-  <div class="bg-gray-100 overflow-clip relative rounded-full shrink-0 size-10">
-    <div class="flex items-center justify-center size-full p-2.5">
+  <div class="bg-gray-100 overflow-clip relative rounded-lg shrink-0 size-11 border border-gray-200">
+    <div class="flex items-center justify-center size-full p-1.5">
       @if (displayLogo()) {
         <img [alt]="displayName()" class="w-full h-full object-contain" [src]="displayLogo()" />
       } @else {
@@ -17,8 +17,9 @@
     </div>
   </div>
 
-  <div class="flex flex-col gap-1 grow items-start relative min-w-0">
+  <div class="flex flex-col gap-0.5 grow items-start relative min-w-0 overflow-hidden">
     <p class="sidebar-project-name">{{ displayName() }}</p>
+    <span class="text-[11px] font-normal text-gray-400 leading-none">{{ lens() === 'foundation' ? 'Foundation' : 'Project' }}</span>
   </div>
 
   <i class="fa-light fa-angles-up-down shrink-0 text-gray-400" aria-hidden="true"></i>
@@ -32,7 +33,7 @@
   (onShow)="onPopoverShow()"
   (onHide)="onPopoverHide()"
   data-testid="project-selector-panel">
-  <div class="p-2">
+  <div class="p-1">
     <div class="relative mb-2">
       <i class="fa-light fa-search absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400"></i>
       <input
@@ -61,8 +62,8 @@
           class="flex items-center gap-3 p-2 w-full text-left hover:bg-gray-100 rounded-lg transition-colors"
           (click)="selectItem(item, popover)"
           [attr.data-testid]="'lens-item-' + item.slug">
-          <div class="bg-gray-100 overflow-clip rounded-full shrink-0 size-8">
-            <div class="flex items-center justify-center size-full p-2">
+          <div class="bg-gray-100 overflow-clip rounded-lg shrink-0 size-9 border border-gray-200">
+            <div class="flex items-center justify-center size-full p-1.5">
               @if (item.logoUrl) {
                 <img [alt]="item.name" class="w-full h-full object-contain" [src]="item.logoUrl" />
               } @else {

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.scss
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.scss
@@ -7,7 +7,7 @@
 }
 
 .sidebar-project-name {
-  @apply font-medium grow leading-5 relative text-base text-gray-900 tracking-tight line-clamp-2;
+  @apply font-medium leading-5 relative text-base text-gray-900 tracking-tight truncate w-full text-left;
 }
 
 // PrimeNG Popover override — hide arrow, force right-of-sidebar positioning

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
@@ -37,6 +37,8 @@ export class ProjectSelectorComponent {
     this.userService.impersonating() ? 'project-selector-panel project-selector-panel--with-banner' : 'project-selector-panel'
   );
 
+  protected readonly lensTypeLabel = computed(() => (this.lens() === 'foundation' ? 'Foundation' : 'Project'));
+
   protected readonly displayName: Signal<string> = this.initializeDisplayName();
   protected readonly displayLogo: Signal<string> = this.initializeDisplayLogo();
   protected readonly items: Signal<LensItem[]> = this.initializeItems();
@@ -76,7 +78,7 @@ export class ProjectSelectorComponent {
   private initializeDisplayName(): Signal<string> {
     return computed(() => {
       const project = this.selectedProject();
-      return project?.name?.trim() || 'Select Project';
+      return project?.name?.trim() || (this.lens() === 'foundation' ? 'Select Foundation' : 'Select Project');
     });
   }
 

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -102,7 +102,7 @@ export class SidebarComponent {
     return computed(() => {
       const persona = this.personaService.currentPersona();
       const option = PERSONA_OPTIONS.find((o) => o.value === persona);
-      return option?.label ?? persona;
+      return option?.label ?? persona.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
     });
   }
 

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -10,7 +10,7 @@ import { ProjectSelectorComponent } from '@components/project-selector/project-s
 import { environment } from '@environments/environment';
 import { PERSONA_OPTIONS } from '@lfx-one/shared/constants';
 import { LensItem, NavLens, ProjectContext, SidebarMenuItem } from '@lfx-one/shared/interfaces';
-import { lensItemToProjectContext } from '@lfx-one/shared/utils';
+import { lensItemToProjectContext, toTitleCase } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
 import { NavigationService } from '@services/navigation.service';
 import { PersonaService } from '@services/persona.service';
@@ -102,7 +102,7 @@ export class SidebarComponent {
     return computed(() => {
       const persona = this.personaService.currentPersona();
       const option = PERSONA_OPTIONS.find((o) => o.value === persona);
-      return option?.label ?? persona.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+      return option?.label ?? toTitleCase(persona);
     });
   }
 

--- a/packages/shared/src/utils/string.utils.ts
+++ b/packages/shared/src/utils/string.utils.ts
@@ -52,3 +52,15 @@ export function parseToInt(value: string | number | undefined | null): number | 
   const parsed = parseInt(value, 10);
   return isNaN(parsed) ? undefined : parsed;
 }
+
+/**
+ * Convert a hyphen- or space-separated string to Title Case.
+ * Example: `toTitleCase('executive-director')` → `'Executive Director'`.
+ */
+export function toTitleCase(value: string): string {
+  return value
+    .split(/[-\s]+/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(' ');
+}


### PR DESCRIPTION
## What
- Selector button now shows a "Foundation" or "Project" label below the name, in regular weight
- Long foundation/project names truncate with ellipsis instead of wrapping to a second line
- Persona labels (e.g. "contributor") that fall outside `PERSONA_OPTIONS` are now title-cased automatically
- Logo avatars in both the selector button and the dropdown list are now square with rounded corners (`rounded-lg`), a subtle gray border, and tighter inner padding (`p-1.5`)

## How
- Added `truncate w-full text-left` to `.sidebar-project-name` and a `font-normal` label span in the project-selector template
- Updated `sidebar.component.ts` persona label fallback to apply title-case word-splitting
- Replaced `rounded-full` with `rounded-lg` + `border border-gray-200` on avatar containers; adjusted sizes (`size-11` selector, `size-9` list)

## Checklist
- [ ] Tests added/updated
- [ ] License headers on new files
- [ ] No mock/debug code included

🤖 Generated with [Claude Code](https://claude.ai/claude-code)