### PR TITLE
fix(ui): safari summary card stacking and selector display fallback

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -31,7 +31,7 @@
     @if (!isMeLens()) {
       <div data-testid="committees-foundation-stats">
         <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+          <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
             <div class="flex items-center gap-3 p-4">
               <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
                 <i class="fa-light fa-users-rectangle text-xl"></i>
@@ -80,7 +80,7 @@
     @if (isMeLens()) {
       <div data-testid="committees-me-stats">
         <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+          <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
             <div class="flex items-center gap-3 p-4">
               <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
                 <i class="fa-light fa-users-rectangle text-xl"></i>

--- a/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/foundation-event-dashboard/foundation-event-dashboard.component.html
@@ -14,7 +14,7 @@
     <!-- Summary Stat Cards -->
     <div data-testid="foundation-events-stats">
       <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-        <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+        <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
           <div class="flex items-center gap-3 p-4">
             <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
               <i class="fa-light fa-ticket text-xl"></i>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -27,7 +27,7 @@
     <!-- Me lens stat cards -->
     <div class="mb-0" data-testid="events-me-stats">
       <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-        <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+        <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
           <div class="flex items-center gap-3 p-4">
             <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
               <i class="fa-light fa-ticket text-xl"></i>
@@ -57,7 +57,6 @@
                 <p class="text-xl font-medium text-gray-900">{{ eventsList.attendedCount() }}</p>
               }
               <p class="text-sm font-normal text-gray-900">Attended Events</p>
-              <p class="text-xs text-gray-400">All past events</p>
             </div>
           </div>
           <div class="flex items-center gap-3 p-4">
@@ -71,7 +70,6 @@
                 <p class="text-xl font-medium text-gray-900">{{ eventsList.tabCounts().upcoming }}</p>
               }
               <p class="text-sm font-normal text-gray-900">Upcoming Events</p>
-              <p class="text-xs text-gray-400">All upcoming events</p>
             </div>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -23,7 +23,7 @@
     @if (activeLens() === 'me') {
       <div class="mb-6" data-testid="meetings-me-stats">
         <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 divide-y sm:divide-y-0 lg:divide-y-0 lg:divide-x divide-gray-200">
+          <div class="grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 divide-y sm:divide-y-0 lg:divide-y-0 lg:divide-x divide-gray-200">
             <div class="flex items-center gap-3 p-4">
               <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
                 <i class="fa-light fa-calendar text-xl"></i>
@@ -96,7 +96,7 @@
     @if (activeLens() !== 'me') {
       <div class="mb-6" data-testid="meetings-foundation-stats">
         <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 divide-y sm:divide-y-0 lg:divide-y-0 lg:divide-x divide-gray-200">
+          <div class="grid w-full grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 divide-y sm:divide-y-0 lg:divide-y-0 lg:divide-x divide-gray-200">
             <div class="flex items-center gap-3 p-4">
               <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
                 <i class="fa-light fa-calendar text-xl"></i>

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
@@ -15,7 +15,7 @@
       <!-- Summary Stat Cards -->
       <div class="mb-6" data-testid="trainings-stats">
         <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+          <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
             <div class="flex items-center gap-3 p-4">
               <div class="flex items-center justify-center w-11 h-11 rounded-full bg-purple-100 text-purple-600 flex-shrink-0">
                 <i class="fa-light fa-award text-xl"></i>

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
@@ -78,7 +78,7 @@ export class ProjectSelectorComponent {
   private initializeDisplayName(): Signal<string> {
     return computed(() => {
       const project = this.selectedProject();
-      return project?.name?.trim() || (this.lens() === 'foundation' ? 'Select Foundation' : 'Select Project');
+      return project?.name?.trim() || `Select ${this.lensTypeLabel()}`;
     });
   }
 


### PR DESCRIPTION
## What

- **Safari stacking fix**: Summary stat cards stacking vertically in Safari on large viewports across all dashboard pages (My Events, Foundation Events, My Meetings, My Groups/Committees, Trainings). Also removed the "All past events" / "All upcoming events" description labels from My Events attended/upcoming summary cards.
- **Selector display DRY-up** *(follow-up to #503)*: `initializeDisplayName()` now reuses the `lensTypeLabel()` computed instead of duplicating the foundation/project mapping inline.

## How

- **Safari fix**: Added `w-full` to all stat card grid containers. Root cause — PrimeNG's `p-card` uses `flex-direction: column` internally, and Safari has a bug where a CSS grid inside a flex-column container doesn't inherit the parent's width, collapsing it to 1 column regardless of viewport. Chrome handles width inheritance automatically, so the issue was Safari-only.
- **Selector refactor**: Single source of truth for the lens label — `initializeDisplayName()` returns `` project?.name?.trim() || `Select ${this.lensTypeLabel()}` ``.