### PR TITLE
fix(meetings): correct query shapes and foundation classification

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component.ts
@@ -163,7 +163,7 @@ export class RsvpButtonGroupComponent {
           }
           const occurrenceId = this.meeting().recurrence ? this.occurrenceId() : undefined;
           if (authenticated && meeting?.id) {
-            return this.meetingService.getMeetingRsvpByUsername(meeting.id, occurrenceId).pipe(catchError(() => of(null)));
+            return this.meetingService.getMeetingRsvpForCurrentUser(meeting.id, occurrenceId).pipe(catchError(() => of(null)));
           }
           return of(null);
         })

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -541,7 +541,7 @@ export class MeetingService {
     );
   }
 
-  public getMeetingRsvpByUsername(meetingUid: string, occurrenceId?: string): Observable<MeetingRsvp | null> {
+  public getMeetingRsvpForCurrentUser(meetingUid: string, occurrenceId?: string): Observable<MeetingRsvp | null> {
     const options = occurrenceId ? { params: { occurrenceId } } : {};
     return this.http.get<MeetingRsvp | null>(`/api/meetings/${meetingUid}/rsvp/me`, options).pipe(
       catchError((error) => {

--- a/apps/lfx-one/src/app/shared/services/navigation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/navigation.service.ts
@@ -221,11 +221,11 @@ export class NavigationService {
     const firstPage$ = merge(searchTriggered$, reloadTriggered$).pipe(
       switchMap(({ term, selectedUid }) => {
         generation.update((g) => g + 1);
-        return this.fetchSinglePage(lens, term, null, loading, true, generation(), selectedUid);
+        return this.fetchSinglePage(lens, term, null, loading, true, generation(), generation, selectedUid);
       })
     );
 
-    const nextPage$ = loadMore$.pipe(switchMap((token) => this.fetchSinglePage(lens, searchTerm(), token, loading, false, generation(), null)));
+    const nextPage$ = loadMore$.pipe(switchMap((token) => this.fetchSinglePage(lens, searchTerm(), token, loading, false, generation(), generation, null)));
 
     return toSignal(
       merge(firstPage$, nextPage$).pipe(
@@ -260,15 +260,21 @@ export class NavigationService {
     loading: WritableSignal<boolean>,
     reset: boolean,
     generation: number,
+    activeGeneration: Signal<number>,
     selectedUid: string | null
   ): Observable<TaggedLensPage> {
     loading.set(true);
+    // Only this request's generation may clear the loading flag — otherwise a superseded fetch
+    // landing after a new search could drop the spinner while the newer request is still in-flight.
+    const clearLoadingIfActive = (): void => {
+      if (activeGeneration() === generation) loading.set(false);
+    };
     return this.fetchPage(lens, term, pageToken, selectedUid).pipe(
       map((response) => ({ page: this.toLensPage(response, reset), generation })),
-      tap(() => loading.set(false)),
+      tap(clearLoadingIfActive),
       catchError(() => {
         // Reset failures emit an empty page so handleEmptyLensResponse can redirect; scroll-triggered failures stay silent.
-        loading.set(false);
+        clearLoadingIfActive();
         if (reset) {
           return of({
             page: { items: [], nextPageToken: null, bypassActive: false, personaFetchFailed: false, upstreamFailed: true, reset: true },

--- a/apps/lfx-one/src/app/shared/services/navigation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/navigation.service.ts
@@ -209,7 +209,14 @@ export class NavigationService {
       map((term) => ({ term, selectedUid: null as string | null }))
     );
 
-    const reloadTriggered$ = reload$.pipe(map(() => ({ term: searchTerm(), selectedUid: this.getSelectedUidForLens(lens) })));
+    // Only inject the selected uid when no search is active — during search the user's intent is
+    // "filter this list", not "keep my selection pinned", so injection would surface a non-matching row.
+    const reloadTriggered$ = reload$.pipe(
+      map(() => {
+        const term = searchTerm();
+        return { term, selectedUid: term.trim() ? null : this.getSelectedUidForLens(lens) };
+      })
+    );
 
     const firstPage$ = merge(searchTriggered$, reloadTriggered$).pipe(
       switchMap(({ term, selectedUid }) => {
@@ -235,7 +242,12 @@ export class NavigationService {
             this.applyDefaultSelection(lens, page);
           }
         }),
-        scan((acc: LensItem[], page: LensPage) => (page.reset ? page.items : [...acc, ...page.items]), [])
+        // Dedupe by uid when appending next pages — an injected selected item can also appear in a later page.
+        scan((acc: LensItem[], page: LensPage) => {
+          if (page.reset) return page.items;
+          const seen = new Set(acc.map((item) => item.uid));
+          return [...acc, ...page.items.filter((item) => !seen.has(item.uid))];
+        }, [])
       ),
       { initialValue: [] as LensItem[] }
     );

--- a/apps/lfx-one/src/app/shared/services/navigation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/navigation.service.ts
@@ -103,6 +103,12 @@ export class NavigationService {
       return;
     }
 
+    // Preserve an explicit selection (e.g., Me lens → Open) — selected_uid ensures it's in the page.
+    const existing = lens === 'foundation' ? this.projectContextService.selectedFoundation() : this.projectContextService.selectedProject();
+    if (existing?.uid && page.items.some((item) => item.uid === existing.uid)) {
+      return;
+    }
+
     const defaultItem = lens === 'foundation' ? this.pickFoundationByPersonaPriority(page.items) : page.items[0];
     const context = lensItemToProjectContext(defaultItem);
     if (lens === 'foundation') {
@@ -196,18 +202,23 @@ export class NavigationService {
     reload$: Subject<void>
   ): Signal<LensItem[]> {
     // skip(1) drops toObservable's initial replay so fetches only fire on user search input.
-    const searchTriggered$ = toObservable(searchTerm).pipe(skip(1), debounceTime(NAV_SEARCH_DEBOUNCE_MS), distinctUntilChanged());
+    const searchTriggered$ = toObservable(searchTerm).pipe(
+      skip(1),
+      debounceTime(NAV_SEARCH_DEBOUNCE_MS),
+      distinctUntilChanged(),
+      map((term) => ({ term, selectedUid: null as string | null }))
+    );
 
-    const reloadTriggered$ = reload$.pipe(map(() => searchTerm()));
+    const reloadTriggered$ = reload$.pipe(map(() => ({ term: searchTerm(), selectedUid: this.getSelectedUidForLens(lens) })));
 
     const firstPage$ = merge(searchTriggered$, reloadTriggered$).pipe(
-      switchMap((term) => {
+      switchMap(({ term, selectedUid }) => {
         generation.update((g) => g + 1);
-        return this.fetchSinglePage(lens, term, null, loading, true, generation());
+        return this.fetchSinglePage(lens, term, null, loading, true, generation(), selectedUid);
       })
     );
 
-    const nextPage$ = loadMore$.pipe(switchMap((token) => this.fetchSinglePage(lens, searchTerm(), token, loading, false, generation())));
+    const nextPage$ = loadMore$.pipe(switchMap((token) => this.fetchSinglePage(lens, searchTerm(), token, loading, false, generation(), null)));
 
     return toSignal(
       merge(firstPage$, nextPage$).pipe(
@@ -236,10 +247,11 @@ export class NavigationService {
     pageToken: string | null,
     loading: WritableSignal<boolean>,
     reset: boolean,
-    generation: number
+    generation: number,
+    selectedUid: string | null
   ): Observable<TaggedLensPage> {
     loading.set(true);
-    return this.fetchPage(lens, term, pageToken).pipe(
+    return this.fetchPage(lens, term, pageToken, selectedUid).pipe(
       map((response) => ({ page: this.toLensPage(response, reset), generation })),
       tap(() => loading.set(false)),
       catchError(() => {
@@ -256,7 +268,7 @@ export class NavigationService {
     );
   }
 
-  private fetchPage(lens: NavLens, term: string, pageToken: string | null): Observable<LensItemsResponse> {
+  private fetchPage(lens: NavLens, term: string, pageToken: string | null, selectedUid: string | null): Observable<LensItemsResponse> {
     let params = new HttpParams().set('lens', lens);
     if (pageToken) {
       params = params.set('page_token', pageToken);
@@ -264,7 +276,15 @@ export class NavigationService {
     if (term.trim()) {
       params = params.set('name', term.trim());
     }
+    if (selectedUid && !pageToken) {
+      params = params.set('selected_uid', selectedUid);
+    }
     return this.http.get<LensItemsResponse>('/api/nav/lens-items', { params });
+  }
+
+  private getSelectedUidForLens(lens: NavLens): string | null {
+    const context = lens === 'foundation' ? this.projectContextService.selectedFoundation() : this.projectContextService.selectedProject();
+    return context?.uid ?? null;
   }
 
   private toLensPage(response: LensItemsResponse, reset: boolean): LensPage {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -978,11 +978,11 @@ export class MeetingController {
    * GET /meetings/:uid/rsvp/me
    * Gets current user's RSVP via the query service
    */
-  public async getMeetingRsvpByUsername(req: Request, res: Response, next: NextFunction): Promise<void> {
+  public async getMeetingRsvpForCurrentUser(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
     const { occurrenceId } = req.query;
 
-    const startTime = logger.startOperation(req, 'get_meeting_rsvp_by_username', {
+    const startTime = logger.startOperation(req, 'get_meeting_rsvp_for_current_user', {
       meeting_id: uid,
       occurrence_id: occurrenceId,
     });
@@ -991,17 +991,17 @@ export class MeetingController {
       // Validate meeting UID
       if (
         !validateUidParameter(uid, req, next, {
-          operation: 'get_meeting_rsvp_by_username',
+          operation: 'get_meeting_rsvp_for_current_user',
         })
       ) {
         return;
       }
 
       // Get the user's RSVP using direct meeting service call
-      const rsvp = await this.meetingService.getMeetingRsvpByUsername(req, uid, occurrenceId as string | undefined);
+      const rsvp = await this.meetingService.getMeetingRsvpForCurrentUser(req, uid, occurrenceId as string | undefined);
 
       // Log success
-      logger.success(req, 'get_meeting_rsvp_by_username', startTime, {
+      logger.success(req, 'get_meeting_rsvp_for_current_user', startTime, {
         found: !!rsvp,
         rsvp_id: rsvp?.id,
         occurrence_id: occurrenceId,

--- a/apps/lfx-one/src/server/controllers/navigation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/navigation.controller.ts
@@ -37,8 +37,9 @@ export class NavigationController {
 
       const pageToken = getStringQueryParam(req, 'page_token');
       const name = getStringQueryParam(req, 'name');
+      const selectedUid = getStringQueryParam(req, 'selected_uid');
 
-      const result = await this.navigationService.getLensItems(req, { lens, pageToken, name });
+      const result = await this.navigationService.getLensItems(req, { lens, pageToken, name, selectedUid });
 
       logger.success(req, 'get_lens_items', startTime, {
         lens: result.lens,

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -29,13 +29,13 @@ export async function isUserInvitedToMeeting(req: Request, meetingUid: string, e
     return false;
   }
 
-  const token = m2mToken || (await generateM2MToken(req));
   const username = (await getUsernameFromAuth(req)) ?? undefined;
 
   if (!email && !username) {
     return false;
   }
 
+  const token = m2mToken || (await generateM2MToken(req));
   const registrants = await meetingService.getMeetingRegistrantsForUser(req, meetingUid, email || undefined, username, token);
   return registrants.length > 0;
 }

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -30,23 +30,14 @@ export async function isUserInvitedToMeeting(req: Request, meetingUid: string, e
   }
 
   const token = m2mToken || (await generateM2MToken(req));
+  const username = (await getUsernameFromAuth(req)) ?? undefined;
 
-  // Try email first
-  if (email) {
-    const registrants = await meetingService.getMeetingRegistrantsByEmail(req, meetingUid, email, token);
-    if (registrants.length > 0) {
-      return true;
-    }
+  if (!email && !username) {
+    return false;
   }
 
-  // Fall back to username
-  const username = await getUsernameFromAuth(req);
-  if (username) {
-    const registrants = await meetingService.getMeetingRegistrantsByUsername(req, meetingUid, username, token);
-    return registrants.length > 0;
-  }
-
-  return false;
+  const registrants = await meetingService.getMeetingRegistrantsForUser(req, meetingUid, email || undefined, username, token);
+  return registrants.length > 0;
 }
 
 /**

--- a/apps/lfx-one/src/server/routes/meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/meetings.route.ts
@@ -51,7 +51,7 @@ router.post('/:uid/registrants/:registrantId/resend', (req, res, next) => meetin
 // RSVP routes
 router.post('/:uid/rsvp', (req, res, next) => meetingController.createMeetingRsvp(req, res, next));
 router.get('/:uid/rsvp', (req, res, next) => meetingController.getMeetingRsvps(req, res, next));
-router.get('/:uid/rsvp/me', (req, res, next) => meetingController.getMeetingRsvpByUsername(req, res, next));
+router.get('/:uid/rsvp/me', (req, res, next) => meetingController.getMeetingRsvpForCurrentUser(req, res, next));
 
 // Meeting attachment routes
 router.get('/:uid/attachments', (req, res, next) => meetingController.getMeetingAttachments(req, res, next));

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -378,9 +378,11 @@ export class MeetingService {
    * @param includeRsvp - If true, includes RSVP status for each registrant
    */
   public async getMeetingRegistrants(req: Request, meetingUid: string, includeRsvp: boolean = false): Promise<MeetingRegistrant[]> {
+    // Registrant records carry `parent_refs: ['meeting:<uid>']` but no indexed tags — use `parent`
+    // to query parent_refs, matching the working pattern in getMeetingRsvps.
     const params: Record<string, any> = {
       type: 'v1_meeting_registrant',
-      tags: `meeting_id:${meetingUid}`,
+      parent: `meeting:${meetingUid}`,
     };
 
     logger.debug(req, 'get_meeting_registrants', 'Fetching meeting registrants', { meeting_id: meetingUid, params });
@@ -438,13 +440,59 @@ export class MeetingService {
    * Fetches all registrants for a meeting by email
    */
   public async getMeetingRegistrantsByEmail(req: Request, meetingUid: string, email: string, m2mToken?: string): Promise<MeetingRegistrant[]> {
+    // Registrant records carry email/meeting_id as data fields, not indexed tags — use `filters` (field-level AND).
     const params: Record<string, any> = {
       type: 'v1_meeting_registrant',
       parent: '',
-      tags_all: [`email:${email}`, `meeting_id:${meetingUid}`],
+      filters: [`email:${email}`, `meeting_id:${meetingUid}`],
     };
 
     logger.debug(req, 'get_meeting_registrants_by_email', 'Fetching meeting registrants by email params', { meeting_id: meetingUid, email, params });
+
+    const headers = m2mToken ? { Authorization: `Bearer ${m2mToken}` } : undefined;
+
+    return fetchAllQueryResources<MeetingRegistrant>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(
+        req,
+        'LFX_V2_SERVICE',
+        '/query/resources',
+        'GET',
+        { ...params, ...(pageToken && { page_token: pageToken }) },
+        undefined,
+        headers
+      )
+    );
+  }
+
+  /**
+   * Fetches registrants for a meeting that match the caller's email or username in a single query.
+   * Uses `filters=meeting_id:X` (AND) combined with `filters_or=[email:Y, username:Z]` so the
+   * query service resolves the intersection in one call instead of two sequential lookups.
+   */
+  public async getMeetingRegistrantsForUser(
+    req: Request,
+    meetingUid: string,
+    email: string | undefined,
+    username: string | undefined,
+    m2mToken?: string
+  ): Promise<MeetingRegistrant[]> {
+    const orClauses: string[] = [];
+    if (email) orClauses.push(`email:${email.toLowerCase()}`);
+    if (username) orClauses.push(`username:${stripAuthPrefix(username)}`);
+    if (orClauses.length === 0) return [];
+
+    const params: Record<string, any> = {
+      type: 'v1_meeting_registrant',
+      parent: '',
+      filters: [`meeting_id:${meetingUid}`],
+      filters_or: orClauses,
+    };
+
+    logger.debug(req, 'get_meeting_registrants_for_user', 'Fetching registrants for current user', {
+      meeting_id: meetingUid,
+      has_email: !!email,
+      has_username: !!username,
+    });
 
     const headers = m2mToken ? { Authorization: `Bearer ${m2mToken}` } : undefined;
 
@@ -467,10 +515,11 @@ export class MeetingService {
    */
   public async getMeetingRegistrantsByUsername(req: Request, meetingUid: string, username: string, m2mToken?: string): Promise<MeetingRegistrant[]> {
     const plainUsername = stripAuthPrefix(username);
+    // Registrant records carry username/meeting_id as data fields, not indexed tags — use `filters` (field-level AND).
     const params: Record<string, any> = {
       type: 'v1_meeting_registrant',
       parent: '',
-      tags_all: [`username:${plainUsername}`, `meeting_id:${meetingUid}`],
+      filters: [`username:${plainUsername}`, `meeting_id:${meetingUid}`],
     };
 
     logger.debug(req, 'get_meeting_registrants_by_username', 'Fetching meeting registrants by username', { meeting_id: meetingUid, username: plainUsername });
@@ -603,7 +652,10 @@ export class MeetingService {
   }
 
   /**
-   * Checks if a user was a participant in a past meeting by email
+   * Checks if a user was a participant in a past meeting by email or username.
+   * Uses `filters` (AND on meeting id) + `filters_or` (OR across email/username) to resolve the
+   * match in a single query. `tags_all` can't be used here because `username` is not synthesized
+   * into the participant record's indexed tags — username-only matches silently failed before.
    */
   public async isUserPastMeetingParticipant(req: Request, pastMeetingUid: string, email: string, username?: string): Promise<boolean> {
     logger.debug(req, 'is_user_past_meeting_participant', 'Checking if user was a past meeting participant', {
@@ -612,43 +664,34 @@ export class MeetingService {
       username,
     });
 
-    // Try email first
-    if (email) {
-      const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(
-        req,
-        'LFX_V2_SERVICE',
-        '/query/resources',
-        'GET',
-        {
-          type: 'v1_past_meeting_participant',
-          tags_all: [`meeting_and_occurrence_id:${pastMeetingUid}`, `email:${email}`],
-        }
-      );
+    const filtersOr: string[] = [];
+    if (email) filtersOr.push(`email:${email}`);
+    if (username) filtersOr.push(`username:${stripAuthPrefix(username)}`);
 
-      if (resources.length > 0) return true;
+    if (filtersOr.length === 0) {
+      return false;
     }
 
-    // Fall back to username
-    if (username) {
-      const plainUsername = stripAuthPrefix(username);
-      const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(
-        req,
-        'LFX_V2_SERVICE',
-        '/query/resources',
-        'GET',
-        {
-          type: 'v1_past_meeting_participant',
-          tags_all: [`meeting_and_occurrence_id:${pastMeetingUid}`, `username:${plainUsername}`],
-        }
-      );
+    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(
+      req,
+      'LFX_V2_SERVICE',
+      '/query/resources',
+      'GET',
+      {
+        type: 'v1_past_meeting_participant',
+        filters: [`meeting_and_occurrence_id:${pastMeetingUid}`],
+        filters_or: filtersOr,
+      }
+    );
 
-      if (resources.length > 0) return true;
-    }
+    const matched = resources.length > 0;
 
-    logger.debug(req, 'is_user_past_meeting_participant', 'Participant check complete — no match found', {
+    logger.debug(req, 'is_user_past_meeting_participant', 'Participant check complete', {
       past_meeting_id: pastMeetingUid,
+      matched,
     });
-    return false;
+
+    return matched;
   }
 
   /**
@@ -773,23 +816,13 @@ export class MeetingService {
       scope: rsvpData.scope,
     });
 
-    // Resolve registrant_id — try email first, fall back to username
+    // Resolve registrant_id — single query matches email OR username against this meeting.
     const email = getEffectiveEmail(req) ?? undefined;
-    let registrants: MeetingRegistrant[] = [];
-
-    if (email) {
-      registrants = await this.getMeetingRegistrantsByEmail(req, meetingUid, email);
-    }
+    const username = (await getUsernameFromAuth(req)) ?? undefined;
+    const registrants = await this.getMeetingRegistrantsForUser(req, meetingUid, email, username);
 
     if (registrants.length === 0) {
-      const username = await getUsernameFromAuth(req);
-      if (username) {
-        registrants = await this.getMeetingRegistrantsByUsername(req, meetingUid, username);
-      }
-    }
-
-    if (registrants.length === 0) {
-      throw new ResourceNotFoundError('Registrant', email || 'unknown', {
+      throw new ResourceNotFoundError('Registrant', email || username || 'unknown', {
         operation: 'create_meeting_rsvp',
       });
     }
@@ -846,11 +879,12 @@ export class MeetingService {
     });
 
     try {
-      // Get username from authenticated user
+      // Match by email first (always populated on RSVP records); fall back to username for safety.
+      const email = getEffectiveEmail(req);
       const username = await getUsernameFromAuth(req);
 
-      if (!username) {
-        logger.warning(req, 'get_meeting_rsvp_by_username', 'No username found in auth context, returning null', {
+      if (!email && !username) {
+        logger.warning(req, 'get_meeting_rsvp_by_username', 'No email or username in auth context, returning null', {
           meeting_id: meetingUid,
         });
         return null;
@@ -859,8 +893,12 @@ export class MeetingService {
       // Fetch all RSVPs for this meeting via query service
       const allRsvps = await this.getMeetingRsvps(req, meetingUid);
 
-      // Filter RSVPs for current user (match with and without auth provider prefix)
-      const userRsvps = allRsvps.filter((rsvp) => usernameMatches(username, rsvp.username));
+      // Filter RSVPs for current user — RSVP records carry email reliably; username is often absent.
+      const userRsvps = allRsvps.filter((rsvp) => {
+        if (email && rsvp.email?.toLowerCase() === email) return true;
+        if (username && rsvp.username && usernameMatches(username, rsvp.username)) return true;
+        return false;
+      });
 
       if (occurrenceId) {
         // First try to find an occurrence-specific RSVP (takes precedence)

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -877,8 +877,8 @@ export class MeetingService {
    * @param occurrenceId Optional occurrence ID to filter RSVP for specific occurrence
    * @returns Promise resolving to user's RSVP or null
    */
-  public async getMeetingRsvpByUsername(req: Request, meetingUid: string, occurrenceId?: string): Promise<MeetingRsvp | null> {
-    logger.debug(req, 'get_meeting_rsvp_by_username', 'Fetching user RSVP', {
+  public async getMeetingRsvpForCurrentUser(req: Request, meetingUid: string, occurrenceId?: string): Promise<MeetingRsvp | null> {
+    logger.debug(req, 'get_meeting_rsvp_for_current_user', 'Fetching user RSVP', {
       meeting_id: meetingUid,
       occurrence_id: occurrenceId,
     });
@@ -889,7 +889,7 @@ export class MeetingService {
       const username = await getUsernameFromAuth(req);
 
       if (!normalizedEmail && !username) {
-        logger.warning(req, 'get_meeting_rsvp_by_username', 'No email or username in auth context, returning null', {
+        logger.warning(req, 'get_meeting_rsvp_for_current_user', 'No email or username in auth context, returning null', {
           meeting_id: meetingUid,
         });
         return null;
@@ -920,7 +920,7 @@ export class MeetingService {
       // No occurrence specified - return any RSVP for this user
       return userRsvps[0] || null;
     } catch (error) {
-      logger.warning(req, 'get_meeting_rsvp_by_username', 'Failed to fetch user RSVP, returning null', {
+      logger.warning(req, 'get_meeting_rsvp_for_current_user', 'Failed to fetch user RSVP, returning null', {
         meeting_id: meetingUid,
         occurrence_id: occurrenceId,
         error: error instanceof Error ? error.message : 'Unknown error',

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -441,13 +441,18 @@ export class MeetingService {
    */
   public async getMeetingRegistrantsByEmail(req: Request, meetingUid: string, email: string, m2mToken?: string): Promise<MeetingRegistrant[]> {
     // Registrant records carry email/meeting_id as data fields, not indexed tags — use `filters` (field-level AND).
+    const normalizedEmail = email.toLowerCase();
     const params: Record<string, any> = {
       type: 'v1_meeting_registrant',
       parent: '',
-      filters: [`email:${email}`, `meeting_id:${meetingUid}`],
+      filters: [`email:${normalizedEmail}`, `meeting_id:${meetingUid}`],
     };
 
-    logger.debug(req, 'get_meeting_registrants_by_email', 'Fetching meeting registrants by email params', { meeting_id: meetingUid, email, params });
+    logger.debug(req, 'get_meeting_registrants_by_email', 'Fetching meeting registrants by email params', {
+      meeting_id: meetingUid,
+      email: normalizedEmail,
+      params,
+    });
 
     const headers = m2mToken ? { Authorization: `Bearer ${m2mToken}` } : undefined;
 
@@ -665,7 +670,7 @@ export class MeetingService {
     });
 
     const filtersOr: string[] = [];
-    if (email) filtersOr.push(`email:${email}`);
+    if (email) filtersOr.push(`email:${email.toLowerCase()}`);
     if (username) filtersOr.push(`username:${stripAuthPrefix(username)}`);
 
     if (filtersOr.length === 0) {
@@ -880,10 +885,10 @@ export class MeetingService {
 
     try {
       // Match by email first (always populated on RSVP records); fall back to username for safety.
-      const email = getEffectiveEmail(req);
+      const normalizedEmail = getEffectiveEmail(req)?.toLowerCase() ?? null;
       const username = await getUsernameFromAuth(req);
 
-      if (!email && !username) {
+      if (!normalizedEmail && !username) {
         logger.warning(req, 'get_meeting_rsvp_by_username', 'No email or username in auth context, returning null', {
           meeting_id: meetingUid,
         });
@@ -895,7 +900,7 @@ export class MeetingService {
 
       // Filter RSVPs for current user — RSVP records carry email reliably; username is often absent.
       const userRsvps = allRsvps.filter((rsvp) => {
-        if (email && rsvp.email?.toLowerCase() === email) return true;
+        if (normalizedEmail && rsvp.email?.toLowerCase() === normalizedEmail) return true;
         if (username && rsvp.username && usernameMatches(username, rsvp.username)) return true;
         return false;
       });

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -30,7 +30,7 @@ export class NavigationService {
   }
 
   public async getLensItems(req: Request, params: GetLensItemsParams): Promise<LensItemsResponse> {
-    const { lens, pageToken, name } = params;
+    const { lens, pageToken, name, selectedUid } = params;
 
     // Parallel: root-writer check + first upstream page. Deferring persona fetch saves the
     // NATS roundtrip for admins (the hot path).
@@ -96,6 +96,19 @@ export class NavigationService {
       }
     }
 
+    // Ensure the selected project is in the first-page response so navigation from
+    // other lenses (e.g., Me → Open) doesn't get overridden by the default picker.
+    if (selectedUid && !pageToken) {
+      const alreadyIncluded = accumulated.some((item) => item.uid === selectedUid);
+      const allowedByPersona = !eligibleUids || eligibleUids.has(selectedUid);
+      if (!alreadyIncluded && allowedByPersona) {
+        const selectedItem = await this.fetchSelectedItem(req, lens, selectedUid);
+        if (selectedItem) {
+          accumulated.unshift(selectedItem);
+        }
+      }
+    }
+
     logger.debug(req, 'build_lens_items', 'Built lens items', {
       lens,
       item_count: accumulated.length,
@@ -146,6 +159,24 @@ export class NavigationService {
     }
   }
 
+  private async fetchSelectedItem(req: Request, lens: NavLens, uid: string): Promise<LensItem | null> {
+    try {
+      const response = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'project',
+        filters: [`uid:${uid}`],
+      });
+      const project = response?.resources?.[0]?.data;
+      if (!project) return null;
+      // Mirror the main-pipeline contract so an archived selection doesn't get re-injected.
+      if (project.stage !== 'Active') return null;
+      if (lens === 'foundation' && !computeIsFoundation(project)) return null;
+      return this.toLensItem(project);
+    } catch (error) {
+      logger.warning(req, 'fetch_selected_item', 'Failed to fetch selected lens item', { err: error, uid, lens });
+      return null;
+    }
+  }
+
   private filterPageResources(resources: QueryServiceResponse<Project>['resources'], lens: NavLens, eligibleUids: Set<string> | null): Project[] {
     let projects = resources.map((r) => r.data);
     // legal_entity_type negation isn't supported by the filter grammar — re-check locally.
@@ -160,7 +191,7 @@ export class NavigationService {
 
   private buildQuery(lens: NavLens, pageToken: string | undefined, name: string | undefined): LensItemsQuery {
     // legal_entity_type negation is post-filtered (filter grammar has no exclusions).
-    const filters = lens === 'foundation' ? ['stage:Active', 'funding_model:Membership'] : ['stage:Active'];
+    const filters = lens === 'foundation' ? ['stage:Active', 'funding:Funded', 'funding_model:Membership'] : ['stage:Active'];
     const base: LensItemsQuery = { type: 'project', filters, sort: 'name_asc' };
 
     if (pageToken) base.page_token = pageToken;

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { LENS_PERSONA_MAP, NAV_MAX_UPSTREAM_ITERATIONS, NAV_MIN_ITEMS_PER_RESPONSE } from '@lfx-one/shared/constants';
+import { ProjectFunding } from '@lfx-one/shared/enums';
 import {
   EnrichedPersonaProject,
   GetLensItemsParams,
@@ -191,7 +192,7 @@ export class NavigationService {
 
   private buildQuery(lens: NavLens, pageToken: string | undefined, name: string | undefined): LensItemsQuery {
     // legal_entity_type negation is post-filtered (filter grammar has no exclusions).
-    const filters = lens === 'foundation' ? ['stage:Active', 'funding:Funded', 'funding_model:Membership'] : ['stage:Active'];
+    const filters = lens === 'foundation' ? ['stage:Active', `funding:${ProjectFunding.Funded}`, 'funding_model:Membership'] : ['stage:Active'];
     const base: LensItemsQuery = { type: 'project', filters, sort: 'name_asc' };
 
     if (pageToken) base.page_token = pageToken;

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -542,9 +542,9 @@ export class UserService {
 
     // Single participant query matching data.email OR data.username in one round trip.
     // User bearer token works: ACL grants `viewer` on v1_past_meeting to `host`/`invitee`/`attendee`.
-    // failOnPartial: true — partial pagination would silently drop the user's past meetings from
-    // the set, which surfaces as a mysteriously short list. Better to fail loud and let the caller
-    // handle the error than to return a truncated membership set as if it were complete.
+    // failOnPartial: true surfaces truncated membership sets as errors; the outer .catch is
+    // kept as a defensive guard so upstream failures don't 500 the Me lens, but we log at
+    // error level so the gap stays visible in monitoring.
     const participantQuery =
       filtersOr.length > 0
         ? fetchAllQueryResources<PastMeetingParticipant>(
@@ -557,7 +557,7 @@ export class UserService {
               }),
             { failOnPartial: true }
           ).catch((error) => {
-            logger.warning(req, 'get_user_past_meetings', 'Participant query failed, returning empty results', { err: error });
+            logger.error(req, 'get_user_past_meetings', Date.now(), error, { stage: 'participant_query' });
             return [] as PastMeetingParticipant[];
           })
         : Promise.resolve([] as PastMeetingParticipant[]);
@@ -691,7 +691,9 @@ export class UserService {
 
     // Match on data.email OR data.username in a single round trip. Using `filters_or` (field-level)
     // rather than `tags` keeps this resilient to indexer tag-synthesis changes.
-    // failOnPartial: true — truncated membership sets would silently hide meetings from the Me lens.
+    // failOnPartial: true surfaces truncated membership sets as errors; the outer .catch is kept
+    // as a defensive guard so upstream failures don't 500 the Me lens dashboard, but we log at
+    // error level so the gap stays visible in monitoring.
     const registrants = await fetchAllQueryResources<MeetingRegistrant>(
       req,
       (pageToken) =>
@@ -702,7 +704,10 @@ export class UserService {
           ...(pageToken && { page_token: pageToken }),
         }),
       { failOnPartial: true }
-    );
+    ).catch((error) => {
+      logger.error(req, 'get_user_registered_meeting_ids', Date.now(), error, { stage: 'registrant_query' });
+      return [] as MeetingRegistrant[];
+    });
 
     const meetingIds = new Set<string>();
     for (const r of registrants) meetingIds.add(r.meeting_id);

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -509,7 +509,10 @@ export class UserService {
 
     const enriched = await this.meetingService.getMeetingProjectName(req, upcomingMeetings);
 
-    return this.accessCheckService.addAccessToResources(req, enriched, 'v1_meeting', 'organizer');
+    // Every meeting here was found via the user's registrant records, so the user is invited by definition.
+    const invited = enriched.map((m) => ({ ...m, invited: true }));
+
+    return this.accessCheckService.addAccessToResources(req, invited, 'v1_meeting', 'organizer');
   }
 
   /**
@@ -533,46 +536,39 @@ export class UserService {
     const normalizedEmail = email.toLowerCase();
     const username = await getUsernameFromAuth(req);
 
-    // Email + username participant queries are independent — run concurrently.
+    const filtersOr: string[] = [];
+    if (normalizedEmail) filtersOr.push(`email:${normalizedEmail}`);
+    if (username) filtersOr.push(`username:${stripAuthPrefix(username)}`);
+
+    // Single participant query matching data.email OR data.username in one round trip.
     // User bearer token works: ACL grants `viewer` on v1_past_meeting to `host`/`invitee`/`attendee`.
-    const emailQuery = fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        type: 'v1_past_meeting_participant',
-        tags: `email:${normalizedEmail}`,
-        ...(pageToken && { page_token: pageToken }),
-      })
-    ).catch((error) => {
-      logger.warning(req, 'get_user_past_meetings', 'Email participant query failed, returning partial results', { err: error });
-      return [] as PastMeetingParticipant[];
-    });
-
-    const usernameQuery = username
-      ? fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
-          this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-            type: 'v1_past_meeting_participant',
-            tags: `username:${stripAuthPrefix(username)}`,
-            ...(pageToken && { page_token: pageToken }),
+    const participantQuery =
+      filtersOr.length > 0
+        ? fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
+            this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+              type: 'v1_past_meeting_participant',
+              filters_or: filtersOr,
+              ...(pageToken && { page_token: pageToken }),
+            })
+          ).catch((error) => {
+            logger.warning(req, 'get_user_past_meetings', 'Participant query failed, returning empty results', { err: error });
+            return [] as PastMeetingParticipant[];
           })
-        ).catch((error) => {
-          logger.warning(req, 'get_user_past_meetings', 'Username participant query failed, returning partial results', { err: error });
-          return [] as PastMeetingParticipant[];
-        })
-      : Promise.resolve([] as PastMeetingParticipant[]);
+        : Promise.resolve([] as PastMeetingParticipant[]);
 
-    // Participant queries and foundation project UIDs are independent; run concurrently.
+    // Participant and foundation project UID queries are independent; run concurrently.
     const foundationQuery = foundationUid
       ? this.projectService.getFoundationProjectUids(req, foundationUid).then((uids) => new Set(uids))
       : Promise.resolve(undefined);
 
-    const [emailParticipants, usernameParticipants, foundationProjectUids] = await Promise.all([emailQuery, usernameQuery, foundationQuery]);
+    const [participants, foundationProjectUids] = await Promise.all([participantQuery, foundationQuery]);
 
     const pastMeetingIds = new Set<string>();
-    for (const p of emailParticipants) if (p.meeting_and_occurrence_id) pastMeetingIds.add(p.meeting_and_occurrence_id);
-    for (const p of usernameParticipants) if (p.meeting_and_occurrence_id) pastMeetingIds.add(p.meeting_and_occurrence_id);
+    for (const p of participants) if (p.meeting_and_occurrence_id) pastMeetingIds.add(p.meeting_and_occurrence_id);
 
     logger.debug(req, 'get_user_past_meetings', 'Found past meeting participant IDs', {
       total_ids: pastMeetingIds.size,
-      email_matches: emailParticipants.length,
+      participant_matches: participants.length,
     });
 
     if (pastMeetingIds.size === 0) {
@@ -677,37 +673,29 @@ export class UserService {
    */
   public async getUserRegisteredMeetingIds(req: Request, email?: string): Promise<Set<string>> {
     const normalizedEmail = email?.toLowerCase() ?? '';
-
     const username = await getUsernameFromAuth(req);
 
-    const emailQuery = normalizedEmail
-      ? fetchAllQueryResources<MeetingRegistrant>(req, (pageToken) =>
-          this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-            type: 'v1_meeting_registrant',
-            parent: '',
-            tags: `email:${normalizedEmail}`,
-            ...(pageToken && { page_token: pageToken }),
-          })
-        )
-      : Promise.resolve([] as MeetingRegistrant[]);
+    const filtersOr: string[] = [];
+    if (normalizedEmail) filtersOr.push(`email:${normalizedEmail}`);
+    if (username) filtersOr.push(`username:${stripAuthPrefix(username)}`);
 
-    const usernameQuery = username
-      ? fetchAllQueryResources<MeetingRegistrant>(req, (pageToken) =>
-          this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-            type: 'v1_meeting_registrant',
-            parent: '',
-            tags: `username:${stripAuthPrefix(username)}`,
-            ...(pageToken && { page_token: pageToken }),
-          })
-        )
-      : Promise.resolve([] as MeetingRegistrant[]);
+    if (filtersOr.length === 0) {
+      return new Set();
+    }
 
-    // Run both queries concurrently; they're independent lookups that union into one Set.
-    const [emailRegistrants, usernameRegistrants] = await Promise.all([emailQuery, usernameQuery]);
+    // Match on data.email OR data.username in a single round trip. Using `filters_or` (field-level)
+    // rather than `tags` keeps this resilient to indexer tag-synthesis changes.
+    const registrants = await fetchAllQueryResources<MeetingRegistrant>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'v1_meeting_registrant',
+        parent: '',
+        filters_or: filtersOr,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
 
     const meetingIds = new Set<string>();
-    for (const r of emailRegistrants) meetingIds.add(r.meeting_id);
-    for (const r of usernameRegistrants) meetingIds.add(r.meeting_id);
+    for (const r of registrants) meetingIds.add(r.meeting_id);
 
     logger.debug(req, 'get_user_registered_meeting_ids', 'Collected unique meeting IDs', {
       total_unique_meeting_ids: meetingIds.size,

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -542,14 +542,20 @@ export class UserService {
 
     // Single participant query matching data.email OR data.username in one round trip.
     // User bearer token works: ACL grants `viewer` on v1_past_meeting to `host`/`invitee`/`attendee`.
+    // failOnPartial: true — partial pagination would silently drop the user's past meetings from
+    // the set, which surfaces as a mysteriously short list. Better to fail loud and let the caller
+    // handle the error than to return a truncated membership set as if it were complete.
     const participantQuery =
       filtersOr.length > 0
-        ? fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
-            this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-              type: 'v1_past_meeting_participant',
-              filters_or: filtersOr,
-              ...(pageToken && { page_token: pageToken }),
-            })
+        ? fetchAllQueryResources<PastMeetingParticipant>(
+            req,
+            (pageToken) =>
+              this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+                type: 'v1_past_meeting_participant',
+                filters_or: filtersOr,
+                ...(pageToken && { page_token: pageToken }),
+              }),
+            { failOnPartial: true }
           ).catch((error) => {
             logger.warning(req, 'get_user_past_meetings', 'Participant query failed, returning empty results', { err: error });
             return [] as PastMeetingParticipant[];
@@ -685,13 +691,17 @@ export class UserService {
 
     // Match on data.email OR data.username in a single round trip. Using `filters_or` (field-level)
     // rather than `tags` keeps this resilient to indexer tag-synthesis changes.
-    const registrants = await fetchAllQueryResources<MeetingRegistrant>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        type: 'v1_meeting_registrant',
-        parent: '',
-        filters_or: filtersOr,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    // failOnPartial: true — truncated membership sets would silently hide meetings from the Me lens.
+    const registrants = await fetchAllQueryResources<MeetingRegistrant>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'v1_meeting_registrant',
+          parent: '',
+          filters_or: filtersOr,
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      { failOnPartial: true }
     );
 
     const meetingIds = new Set<string>();

--- a/packages/shared/src/enums/index.ts
+++ b/packages/shared/src/enums/index.ts
@@ -11,3 +11,4 @@ export * from './snowflake.enum';
 export * from './poll.enum';
 export * from './survey.enum';
 export * from './event.enum';
+export * from './project-funding.enum';

--- a/packages/shared/src/enums/project-funding.enum.ts
+++ b/packages/shared/src/enums/project-funding.enum.ts
@@ -1,0 +1,13 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Project funding status, synced from SFDC `funding__c` via lfx-v1-sync-helper.
+ * Values mirror the upstream Goa enum declared in `lfx-v2-project-service` at
+ * `api/project/v1/design/types.go` (`ProjectFundingAttribute`).
+ */
+export enum ProjectFunding {
+  Funded = 'Funded',
+  Unfunded = 'Unfunded',
+  SupportedByParent = 'Supported by Parent Project',
+}

--- a/packages/shared/src/interfaces/navigation.interface.ts
+++ b/packages/shared/src/interfaces/navigation.interface.ts
@@ -45,6 +45,8 @@ export interface GetLensItemsParams {
   lens: NavLens;
   pageToken?: string;
   name?: string;
+  /** Ensure this project UID is included in the first-page response even if it would otherwise fall outside it. */
+  selectedUid?: string;
 }
 
 /** Upstream query-service params for lens-item lookups. */

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -12,6 +12,8 @@ export interface Project {
   parent_uid: string;
   stage: string;
   category: string;
+  /** Upstream Goa enum — optional to tolerate records indexed before the attribute was rolled out. */
+  funding?: 'Funded' | 'Unfunded' | 'Supported by Parent Project';
   funding_model: string[];
   charter_url: string;
   legal_entity_type: string;

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { ProjectFunding } from '../enums/project-funding.enum';
+
 export interface Project {
   uid: string;
   slug: string;
@@ -13,7 +15,7 @@ export interface Project {
   stage: string;
   category: string;
   /** Upstream Goa enum — optional to tolerate records indexed before the attribute was rolled out. */
-  funding?: 'Funded' | 'Unfunded' | 'Supported by Parent Project';
+  funding?: ProjectFunding;
   funding_model: string[];
   charter_url: string;
   legal_entity_type: string;

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -31,15 +31,23 @@ export function isFoundationProject(project: EnrichedPersonaProject): boolean {
   return project.isFoundation;
 }
 
-/** Active, membership-funded, not an Internal Allocation. */
+// PCC test-project override (lfx-pcc helper.ts) — kept in sync with hasHealthMetricDashboard.
+const FOUNDATION_NAME_OVERRIDES = new Set(['Test Project Group IT', 'Test Project IT']);
+
+/** Active, membership-funded top-level foundation (Funding === 'Funded'), not an Internal Allocation. PCC test projects also qualify. */
 export function computeIsFoundation(project: Project | null): boolean {
   if (!project) {
     return false;
   }
 
+  if (FOUNDATION_NAME_OVERRIDES.has(project.name)) {
+    return true;
+  }
+
   return (
     project.stage === 'Active' &&
     project.legal_entity_type !== 'Internal Allocation' &&
+    project.funding === 'Funded' &&
     Array.isArray(project.funding_model) &&
     project.funding_model.includes('Membership')
   );

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -34,7 +34,7 @@ export function isFoundationProject(project: EnrichedPersonaProject): boolean {
 // PCC test-project override (lfx-pcc helper.ts) — kept in sync with hasHealthMetricDashboard.
 const FOUNDATION_NAME_OVERRIDES = new Set(['Test Project Group IT', 'Test Project IT']);
 
-/** Active, membership-funded top-level foundation (Funding === 'Funded'), not an Internal Allocation. PCC test projects also qualify. */
+/** Active, membership-funded foundation (Funding === 'Funded'), not an Internal Allocation. PCC test projects also qualify. */
 export function computeIsFoundation(project: Project | null): boolean {
   if (!project) {
     return false;

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { ProjectFunding } from '../enums/project-funding.enum';
 import type { EnrichedPersonaProject, LensItem, Project, ProjectContext } from '../interfaces';
 
 export function toProjectContext(project: EnrichedPersonaProject): ProjectContext {
@@ -47,7 +48,7 @@ export function computeIsFoundation(project: Project | null): boolean {
   return (
     project.stage === 'Active' &&
     project.legal_entity_type !== 'Internal Allocation' &&
-    project.funding === 'Funded' &&
+    project.funding === ProjectFunding.Funded &&
     Array.isArray(project.funding_model) &&
     project.funding_model.includes('Membership')
   );


### PR DESCRIPTION
## Summary
Multi-fix PR. Three independent threads:

### 1. Foundation classification uses upstream `funding`
- Adds the new `funding` enum (`'Funded' | 'Unfunded' | 'Supported by Parent Project'`) to the `Project` interface (upstream Goa enum, now synced end-to-end via lfx-v2-project-service + lfx-v1-sync-helper).
- Tightens `computeIsFoundation` to require `funding === 'Funded'` in addition to the existing checks, so sub-projects with membership funding_model (e.g. "Financial Services Open Source AI Fund") stop being classified as foundations.
- Keeps a name-based override for the two PCC test projects (mirrors `hasHealthMetricDashboard` in lfx-pcc).
- Upstream foundation lens filter now sends `funding:Funded` so the indexer discards non-matching rows instead of the backend filtering them locally.

### 2. Meeting queries use correct query shapes
Several registrant / rsvp / participant queries were using `tags_all` or single-`tags` lookups against records whose indexed tag arrays don't contain those fields. They silently returned empty, breaking RSVP creation and invited/participant checks for anyone not matched by email alone. Switched to `filters` / `filters_or` / `parent` (field-level and parent_refs queries).

| Query | Before | After |
|---|---|---|
| `getMeetingRegistrants` | `tags:meeting_id:X` (empty result) | `parent:meeting:<uid>` |
| `getMeetingRegistrantsByEmail/ByUsername` | `tags_all:[email, meeting_id]` | `filters:[email, meeting_id]` |
| `createMeetingRsvp` / `isUserInvitedToMeeting` | 2 sequential email→username `tags_all` calls | 1 `filters + filters_or` call via new `getMeetingRegistrantsForUser` |
| `getMeetingRsvpByUsername` | `usernameMatches` crashed on RSVPs with no username field | Match by email first, username fallback |
| `isUserPastMeetingParticipant` | 2 sequential `tags_all` calls; username fallback returned 0 (not synthesized as tag) | 1 `filters + filters_or` call |
| `getUserRegisteredMeetingIds` / past participant lookup | 2 parallel `tags` queries | 1 `filters_or` query |
| `getUserMeetings` | `invited` never set | Stamps `invited: true` (every returned meeting is a registration by definition) |

### 3. Nav — preserve selected project across lens switches
When navigating from the Me lens to a specific project's Open view, the selected project could fall outside the first-page slice the nav picker fetches, so the default picker overrode the selection. New `selected_uid` query param threads the current selection from frontend through to the backend so the lens-items response is guaranteed to include it. Also rejects archived projects from the fallback fetch to mirror the main-pipeline `stage:Active` contract.

## Commits
- `feat(shared): use upstream funding attribute for foundation check`
- `fix(meetings): correct query shapes and simplify user lookups`
- `fix(nav): preserve selected project in lens-items first page`

## Validation
- Lint + type-check + build all clean.
- Live-verified each new query shape against prod `lfx-v2-query-service` (registrant, RSVP, past-meeting-participant, nav lens-item fetch).
- Manually exercised RSVP create + "Show Members" + Me-lens RSVP button group in local dev — all working.
- Code-standards-enforcer agent run; SHOULD_FIX findings applied in-branch.

## Upstream dependency
The `funding` field arrives from lfx-v2-project-service v0.6.4 (merged) via lfx-v1-sync-helper (PR open). Prod data is already populated — verified CNCF/TLF/LFN/etc. all carry `funding: 'Funded'`.