### PR TITLE
feat(events): add search-for-application endpoint for visa and travel fund selection

### DIFF
--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
@@ -129,9 +129,7 @@ export class EventSelectionComponent {
                 this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load events. Please try again.' });
                 return of(emptyResponse);
               }
-              // Load more failed - revert offset so retry fetches the same page
               this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load more events. Please try again.' });
-              this.currentOffset.update((curr) => Math.max(0, curr - EVENT_SELECTION_PAGE_SIZE));
               return EMPTY; // Don't emit to scan, preserving existing data
             }),
             finalize(() => {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
@@ -1,15 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, model, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, model, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { EventsService } from '@app/shared/services/events.service';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
-import { EMPTY_MY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
-import { MyEvent, TimeFilterValue } from '@lfx-one/shared/interfaces';
+import { RequestType, SearchEvent, SearchEventsResponse, TimeFilterValue } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
 import { catchError, combineLatest, debounceTime, EMPTY, finalize, of, scan, skip, switchMap, tap } from 'rxjs';
 import { EVENT_SELECTION_PAGE_SIZE } from '@lfx-one/shared/constants/events.constants';
 @Component({
@@ -22,8 +22,10 @@ import { EVENT_SELECTION_PAGE_SIZE } from '@lfx-one/shared/constants/events.cons
 export class EventSelectionComponent {
   private readonly eventsService = inject(EventsService);
   private readonly fb = inject(NonNullableFormBuilder);
+  private readonly messageService = inject(MessageService);
 
-  public selectedEvent = model<MyEvent | null>(null);
+  public readonly type = input.required<RequestType>();
+  public selectedEvent = model<SearchEvent | null>(null);
 
   // Search via its own form (required by lfx-input-text); debounced separately to avoid extra API calls on each keystroke
   public readonly searchForm = this.fb.group({ searchQuery: '' });
@@ -71,7 +73,7 @@ export class EventSelectionComponent {
 
   // Combine initial events with any "load more" results
   protected readonly allEvents = computed(() => this.initialEventsResponse().data);
-  protected readonly hasMore = computed(() => this.allEvents().length < this.initialEventsResponse().total);
+  protected readonly hasMore = computed(() => this.initialEventsResponse().metadata.hasNextPage);
 
   public constructor() {
     // Reset additional events when filters change (skip initial emission)
@@ -82,7 +84,7 @@ export class EventSelectionComponent {
       });
   }
 
-  public onSelectEvent(event: MyEvent): void {
+  public onSelectEvent(event: SearchEvent): void {
     this.selectedEvent.set(event);
   }
 
@@ -107,8 +109,9 @@ export class EventSelectionComponent {
 
     return {};
   }
-
   private initializeEvents() {
+    const emptyResponse: SearchEventsResponse = { data: [], metadata: { offset: 0, pageSize: 0, totalSize: 0, hasNextPage: false } };
+
     return toSignal(
       combineLatest([toObservable(this.activeFilters), toObservable(this.currentOffset)]).pipe(
         tap(() => {
@@ -119,13 +122,15 @@ export class EventSelectionComponent {
           }
         }),
         switchMap(([filters, offset]) =>
-          this.eventsService.getMyEvents({ isPast: false, pageSize: EVENT_SELECTION_PAGE_SIZE, offset, registeredOnly: true, ...filters }).pipe(
+          this.eventsService.searchEventsForApplication({ type: this.type(), pageSize: EVENT_SELECTION_PAGE_SIZE, offset, ...filters }).pipe(
             catchError(() => {
               if (offset === 0) {
                 // Initial load failed - show empty state
-                return of(EMPTY_MY_EVENTS_RESPONSE);
+                this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load events. Please try again.' });
+                return of(emptyResponse);
               }
               // Load more failed - revert offset so retry fetches the same page
+              this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load more events. Please try again.' });
               this.currentOffset.update((curr) => Math.max(0, curr - EVENT_SELECTION_PAGE_SIZE));
               return EMPTY; // Don't emit to scan, preserving existing data
             }),
@@ -137,13 +142,13 @@ export class EventSelectionComponent {
         ),
         scan((acc, curr) => {
           // Reset when offset is 0 (filter changed), otherwise accumulate
-          if (curr.offset === 0) {
+          if (curr.metadata.offset === 0) {
             return curr;
           }
           return { ...curr, data: [...acc.data, ...curr.data] };
-        }, EMPTY_MY_EVENTS_RESPONSE)
+        }, emptyResponse)
       ),
-      { initialValue: EMPTY_MY_EVENTS_RESPONSE }
+      { initialValue: emptyResponse }
     );
   }
 

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.html
@@ -17,7 +17,7 @@
     <!-- Step content -->
     <div class="scroll-area overflow-y-auto pr-1">
       @if (step() === 'select-event') {
-        <lfx-event-selection [(selectedEvent)]="selectedEvent" />
+        <lfx-event-selection [type]="'travel-fund'" [(selectedEvent)]="selectedEvent" />
       } @else if (step() === 'terms') {
         <lfx-travel-fund-terms />
       } @else if (step() === 'about-me') {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.ts
@@ -6,7 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { EventsService } from '@app/shared/services/events.service';
 import { UserService } from '@app/shared/services/user.service';
 import { ButtonComponent } from '@components/button/button.component';
-import { MyEvent, TravelFundAboutMe, TravelFundApplication, TravelFundExpenses, TravelFundStep } from '@lfx-one/shared/interfaces';
+import { SearchEvent, TravelFundAboutMe, TravelFundApplication, TravelFundExpenses, TravelFundStep } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
 import { ApplicationSuccessComponent } from '../application-success/application-success.component';
@@ -40,7 +40,7 @@ export class TravelFundApplicationDialogComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   protected step = signal<TravelFundStep>('select-event');
-  protected selectedEvent = signal<MyEvent | null>(null);
+  protected selectedEvent = signal<SearchEvent | null>(null);
   protected termsAccepted = signal(false);
   protected aboutMeFormValid = signal(false);
   protected expensesFormValid = signal(true);

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.html
@@ -17,7 +17,7 @@
     <!-- Step content -->
     @if (step() === 'select-event') {
       <div class="scroll-area overflow-y-auto pr-1">
-        <lfx-event-selection [(selectedEvent)]="selectedEvent" />
+        <lfx-event-selection [type]="'visa'" [(selectedEvent)]="selectedEvent" />
       </div>
     } @else if (step() === 'terms') {
       <lfx-visa-request-terms />

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.ts
@@ -6,7 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { EventsService } from '@app/shared/services/events.service';
 import { UserService } from '@app/shared/services/user.service';
 import { ButtonComponent } from '@components/button/button.component';
-import { MyEvent, VisaRequestApplicantInfo, VisaRequestApplication, VisaRequestStep } from '@lfx-one/shared/interfaces';
+import { SearchEvent, VisaRequestApplicantInfo, VisaRequestApplication, VisaRequestStep } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
 import { ApplicationSuccessComponent } from '../application-success/application-success.component';
@@ -38,7 +38,7 @@ export class VisaRequestApplicationDialogComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   protected step = signal<VisaRequestStep>('select-event');
-  protected selectedEvent = signal<MyEvent | null>(null);
+  protected selectedEvent = signal<SearchEvent | null>(null);
   protected termsAccepted = signal(false);
   protected applyFormValid = signal(false);
   protected applicantData = signal<VisaRequestApplicantInfo | null>(null);

--- a/apps/lfx-one/src/app/shared/services/events.service.ts
+++ b/apps/lfx-one/src/app/shared/services/events.service.ts
@@ -16,6 +16,8 @@ import {
   MyEventOrganizationsResponse,
   MyEventsResponse,
   OrgSearchResponse,
+  SearchEventsForApplicationParams,
+  SearchEventsResponse,
   TravelFundApplication,
   TravelFundApplicationResponse,
   TravelFundRequestsResponse,
@@ -32,24 +34,7 @@ export class EventsService {
   private readonly http = inject(HttpClient);
 
   public getMyEvents(params: GetMyEventsParams = {}): Observable<MyEventsResponse> {
-    let httpParams = new HttpParams();
-
-    if (params.isPast !== undefined) httpParams = httpParams.set('isPast', String(params.isPast));
-    if (params.eventId) httpParams = httpParams.set('eventId', params.eventId);
-    if (params.projectName) httpParams = httpParams.set('projectName', params.projectName);
-    if (params.searchQuery) httpParams = httpParams.set('searchQuery', params.searchQuery);
-    if (params.role) httpParams = httpParams.set('role', params.role);
-    if (params.status) httpParams = httpParams.set('status', params.status);
-    if (params.sortField) httpParams = httpParams.set('sortField', params.sortField);
-    if (params.pageSize) httpParams = httpParams.set('pageSize', String(params.pageSize));
-    if (params.offset !== undefined) httpParams = httpParams.set('offset', String(params.offset));
-    if (params.sortOrder) httpParams = httpParams.set('sortOrder', params.sortOrder);
-    if (params.registeredOnly) httpParams = httpParams.set('registeredOnly', 'true');
-    if (params.startDateFrom) httpParams = httpParams.set('startDateFrom', params.startDateFrom);
-    if (params.startDateTo) httpParams = httpParams.set('startDateTo', params.startDateTo);
-    if (params.country) httpParams = httpParams.set('country', params.country);
-
-    return this.http.get<MyEventsResponse>('/api/events', { params: httpParams });
+    return this.http.get<MyEventsResponse>('/api/events', { params: this.buildMyEventsParams(params) });
   }
 
   public getEvents(params: GetEventsParams = {}): Observable<EventsResponse> {
@@ -125,11 +110,38 @@ export class EventsService {
     return this.http.get<OrgSearchResponse>('/api/events/search-organizations', { params });
   }
 
+  public searchEventsForApplication(params: SearchEventsForApplicationParams): Observable<SearchEventsResponse> {
+    const httpParams = this.buildMyEventsParams(params).set('type', params.type);
+
+    return this.http.get<SearchEventsResponse>('/api/events/search-for-application', { params: httpParams });
+  }
+
   public getCertificate(params: GetCertificateParams): Observable<Blob> {
     let httpParams = new HttpParams();
 
     if (params.eventId) httpParams = httpParams.set('eventId', params.eventId);
 
     return this.http.get('/api/events/certificate', { params: httpParams, responseType: 'blob' });
+  }
+
+  private buildMyEventsParams(params: GetMyEventsParams): HttpParams {
+    let httpParams = new HttpParams();
+
+    if (params.isPast !== undefined) httpParams = httpParams.set('isPast', String(params.isPast));
+    if (params.eventId) httpParams = httpParams.set('eventId', params.eventId);
+    if (params.projectName) httpParams = httpParams.set('projectName', params.projectName);
+    if (params.searchQuery) httpParams = httpParams.set('searchQuery', params.searchQuery);
+    if (params.role) httpParams = httpParams.set('role', params.role);
+    if (params.status) httpParams = httpParams.set('status', params.status);
+    if (params.sortField) httpParams = httpParams.set('sortField', params.sortField);
+    if (params.pageSize) httpParams = httpParams.set('pageSize', String(params.pageSize));
+    if (params.offset !== undefined) httpParams = httpParams.set('offset', String(params.offset));
+    if (params.sortOrder) httpParams = httpParams.set('sortOrder', params.sortOrder);
+    if (params.registeredOnly) httpParams = httpParams.set('registeredOnly', 'true');
+    if (params.startDateFrom) httpParams = httpParams.set('startDateFrom', params.startDateFrom);
+    if (params.startDateTo) httpParams = httpParams.set('startDateTo', params.startDateTo);
+    if (params.country) httpParams = httpParams.set('country', params.country);
+
+    return httpParams;
   }
 }

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -408,7 +408,6 @@ export class EventsController {
         startDateFrom: req.query['startDateFrom'] ? String(req.query['startDateFrom']) : undefined,
         startDateTo: req.query['startDateTo'] ? String(req.query['startDateTo']) : undefined,
         country: req.query['country'] ? String(req.query['country']) : undefined,
-        affiliatedProjectSlugs: await this.personaDetectionService.getAffiliatedProjectSlugs(req),
       };
 
       const response: SearchEventsResponse = await this.eventsService.searchEventsForApplication(req, userEmail, options);

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -23,6 +23,9 @@ import {
   GetEventsOptions,
   GetUpcomingCountriesResponse,
   OrgSearchResponse,
+  RequestType,
+  SearchEventsForApplicationOptions,
+  SearchEventsResponse,
   TravelFundApplication,
   TravelFundRequestsResponse,
   VisaRequestApplication,
@@ -344,6 +347,77 @@ export class EventsController {
       const response: OrgSearchResponse = await this.eventsService.searchOrganizations(req, name);
 
       logger.success(req, 'search_organizations', startTime, { result_count: response.data.length });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/events/search-for-application
+   * Returns events eligible for a visa or travel-fund application.
+   * Fetches the authenticated user's upcoming registered events (with optional filters),
+   * looks them up in the API Gateway event-service, and filters by AcceptVisaRequest or AcceptTravelFund.
+   * Query params: type ('visa' | 'travel-fund', required), plus all getMyEvents filter/pagination params
+   */
+  public async searchEventsForApplication(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const rawType = req.query['type'] ? String(req.query['type']) : undefined;
+
+    const startTime = logger.startOperation(req, 'search_events_for_application', {
+      type: rawType,
+      has_query: Object.keys(req.query).length > 0,
+    });
+
+    try {
+      const userEmail = getEffectiveEmail(req);
+
+      if (!userEmail) {
+        throw new AuthenticationError('User authentication required', {
+          operation: 'search_events_for_application',
+        });
+      }
+
+      if (!rawType || (rawType !== 'visa' && rawType !== 'travel-fund')) {
+        throw ServiceValidationError.forField('type', 'type must be "visa" or "travel-fund"', {
+          operation: 'search_events_for_application',
+        });
+      }
+
+      const applicationType = rawType as RequestType;
+
+      const rawPageSize = parseInt(String(req.query['pageSize'] ?? DEFAULT_EVENTS_PAGE_SIZE), 10);
+      const rawOffset = parseInt(String(req.query['offset'] ?? 0), 10);
+      const rawSortOrder = String(req.query['sortOrder'] ?? 'ASC').toUpperCase() as EventSortOrder;
+
+      const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 && rawPageSize <= MAX_EVENTS_PAGE_SIZE ? rawPageSize : DEFAULT_EVENTS_PAGE_SIZE;
+      const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
+      const sortOrder: EventSortOrder = VALID_EVENT_SORT_ORDERS.includes(rawSortOrder) ? rawSortOrder : 'ASC';
+
+      const rawMyEventStatus = req.query['status'] ? String(req.query['status']) : undefined;
+
+      const options: SearchEventsForApplicationOptions = {
+        applicationType,
+        pageSize,
+        offset,
+        sortOrder,
+        sortField: req.query['sortField'] ? String(req.query['sortField']) : undefined,
+        searchQuery: req.query['searchQuery'] ? String(req.query['searchQuery']).trim() : undefined,
+        role: req.query['role'] ? String(req.query['role']) : undefined,
+        status: rawMyEventStatus && VALID_MY_EVENT_STATUS_VALUES.has(rawMyEventStatus) ? rawMyEventStatus : undefined,
+        startDateFrom: req.query['startDateFrom'] ? String(req.query['startDateFrom']) : undefined,
+        startDateTo: req.query['startDateTo'] ? String(req.query['startDateTo']) : undefined,
+        country: req.query['country'] ? String(req.query['country']) : undefined,
+        affiliatedProjectSlugs: await this.personaDetectionService.getAffiliatedProjectSlugs(req),
+      };
+
+      const response: SearchEventsResponse = await this.eventsService.searchEventsForApplication(req, userEmail, options);
+
+      logger.success(req, 'search_events_for_application', startTime, {
+        result_count: response.data.length,
+        total_size: response.metadata.totalSize,
+        application_type: applicationType,
+      });
 
       res.json(response);
     } catch (error) {

--- a/apps/lfx-one/src/server/routes/events.route.ts
+++ b/apps/lfx-one/src/server/routes/events.route.ts
@@ -17,5 +17,6 @@ router.get('/travel-fund-requests', (req, res, next) => eventsController.getTrav
 router.post('/visa-applications', (req, res, next) => eventsController.submitVisaRequestApplication(req, res, next));
 router.post('/travel-fund-applications', (req, res, next) => eventsController.submitTravelFundApplication(req, res, next));
 router.get('/search-organizations', (req, res, next) => eventsController.searchOrganizations(req, res, next));
+router.get('/search-for-application', (req, res, next) => eventsController.searchEventsForApplication(req, res, next));
 router.get('/certificate', (req, res, next) => eventsController.getCertificate(req, res, next));
 export default router;

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -875,17 +875,23 @@ export class EventsService {
         signal: AbortSignal.timeout(10000),
       });
     } catch (err) {
-      logger.warning(req, 'search_events', 'Upstream fetch failed, returning empty', { err });
-      return { data: [], metadata: { offset, pageSize, totalSize: 0, hasNextPage: false } };
+      logger.warning(req, 'search_events', 'Upstream fetch failed', { err });
+      throw new MicroserviceError('Event service fetch failed', 503, 'API_GATEWAY_UNAVAILABLE', {
+        path: targetUrl,
+        originalError: err instanceof Error ? err : new Error(String(err)),
+      });
     }
 
     if (!upstream.ok) {
       const errorText = await upstream.text().catch(() => '');
-      logger.warning(req, 'search_events', 'Upstream returned non-OK status, returning empty', {
+      logger.warning(req, 'search_events', 'Upstream returned non-OK status', {
         status: upstream.status,
         errorBody: errorText.slice(0, 500),
       });
-      return { data: [], metadata: { offset, pageSize, totalSize: 0, hasNextPage: false } };
+      throw new MicroserviceError(`Event service returned ${upstream.status}`, upstream.status, 'API_GATEWAY_ERROR', {
+        path: targetUrl,
+        errorBody: errorText.slice(0, 500),
+      });
     }
 
     let json: { Data?: Record<string, unknown>[]; Metadata?: { Offset?: number; PageSize?: number; TotalSize?: number } } = {};
@@ -893,8 +899,11 @@ export class EventsService {
       const rawBody = await upstream.text();
       json = rawBody ? (JSON.parse(rawBody) as typeof json) : {};
     } catch (err) {
-      logger.warning(req, 'search_events', 'Upstream returned invalid JSON, returning empty', { err });
-      return { data: [], metadata: { offset, pageSize, totalSize: 0, hasNextPage: false } };
+      logger.warning(req, 'search_events', 'Upstream returned invalid JSON', { err });
+      throw new MicroserviceError('Event service returned invalid JSON', 502, 'API_GATEWAY_INVALID_RESPONSE', {
+        path: targetUrl,
+        originalError: err instanceof Error ? err : new Error(String(err)),
+      });
     }
 
     const items = json.Data ?? [];
@@ -903,7 +912,7 @@ export class EventsService {
     const data: SearchEvent[] = items.map((item) => ({
       id: String(item['ID'] ?? ''),
       name: String(item['Name'] ?? ''),
-      projectID: String(item['ProjectID'] ?? ''),
+      projectId: String(item['ProjectID'] ?? ''),
       projectName: String(item['ProjectName'] ?? ''),
       startDate: String(item['StartDate'] ?? ''),
       endDate: String(item['EndDate'] ?? ''),
@@ -916,13 +925,13 @@ export class EventsService {
       locationState: String(item['LocationState'] ?? ''),
       locationZip: String(item['LocationZip'] ?? ''),
       location: this.formatLocation(String(item['Location'] ?? ''), String(item['LocationCity'] ?? ''), String(item['LocationCountry'] ?? '')),
-      eventURL: String(item['EventURL'] ?? ''),
-      registrationURL: String(item['RegistrationURL'] ?? ''),
+      eventUrl: String(item['EventURL'] ?? ''),
+      registrationUrl: String(item['RegistrationURL'] ?? ''),
       description: String(item['Description'] ?? ''),
       acceptTravelFund: String(item['AcceptTravelFund'] ?? ''),
       acceptVisaRequest: String(item['AcceptVisaRequest'] ?? ''),
       embassy: String(item['Embassy'] ?? ''),
-      cventID: String(item['CventID'] ?? ''),
+      cventId: String(item['CventID'] ?? ''),
     }));
 
     const metadata: SearchEventsMetadata = {
@@ -949,8 +958,7 @@ export class EventsService {
    * paginating earlier would produce incorrect totals.
    */
   public async searchEventsForApplication(req: Request, userEmail: string, options: SearchEventsForApplicationOptions): Promise<SearchEventsResponse> {
-    const { applicationType, pageSize, offset, sortOrder, sortField, searchQuery, role, status, startDateFrom, startDateTo, country, affiliatedProjectSlugs } =
-      options;
+    const { applicationType, pageSize, offset, sortOrder, sortField, searchQuery, role, status, startDateFrom, startDateTo, country } = options;
 
     logger.debug(req, 'search_events_for_application', 'Fetching user registered events', {
       application_type: applicationType,
@@ -962,11 +970,15 @@ export class EventsService {
       has_country: !!country,
     });
 
+    // Fetch ALL registered upcoming events — pagination is applied after filtering by application type.
+    // Using a large fetch size because filtering by acceptVisaRequest/acceptTravelFund only happens
+    // in the API Gateway step; paginating here would silently drop eligible events on later pages.
+    const FETCH_ALL_PAGE_SIZE = 500;
     const myEventsResponse = await this.getMyEvents(req, userEmail, {
       isPast: false,
       registeredOnly: true,
-      pageSize,
-      offset,
+      pageSize: FETCH_ALL_PAGE_SIZE,
+      offset: 0,
       sortOrder,
       sortField,
       searchQuery,
@@ -975,7 +987,6 @@ export class EventsService {
       startDateFrom,
       startDateTo,
       country,
-      affiliatedProjectSlugs,
     });
 
     const eventIds = myEventsResponse.data.map((e) => e.id).filter(Boolean);
@@ -1017,14 +1028,16 @@ export class EventsService {
       application_type: applicationType,
     });
 
+    // Step 4: apply client pagination to the filtered list so totalSize and hasNextPage are accurate
+    const page = filtered.slice(offset, offset + pageSize);
+
     return {
-      data: filtered,
+      data: page,
       metadata: {
         offset,
         pageSize,
-        totalSize: myEventsResponse.total,
-        // because of discrepancy between myEventsResponse.total and filtered.length, we need to calculate hasNextPage manually
-        hasNextPage: myEventsResponse.total > offset + pageSize,
+        totalSize: filtered.length,
+        hasNextPage: offset + pageSize < filtered.length,
       },
     };
   }

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -29,6 +29,11 @@ import {
   TravelFundApplicationResponse,
   TravelFundRequestsResponse,
   OrgSearchResponse,
+  SearchEvent,
+  SearchEventsForApplicationOptions,
+  SearchEventsMetadata,
+  SearchEventsOptions,
+  SearchEventsResponse,
   VisaRequest,
   VisaRequestApplication,
   VisaRequestApplicationResponse,
@@ -565,14 +570,7 @@ export class EventsService {
       });
     }
 
-    let eventID = payload.eventId;
-    if (process.env['NODE_ENV'] !== 'production' && process.env['API_GW_DEV_EVENT_ID_OVERRIDE']) {
-      logger.warning(req, 'submit_visa_request_application', 'Using API_GW_DEV_EVENT_ID_OVERRIDE (dev-only)', {
-        override_event_id: process.env['API_GW_DEV_EVENT_ID_OVERRIDE'],
-        original_event_id: payload.eventId,
-      });
-      eventID = process.env['API_GW_DEV_EVENT_ID_OVERRIDE'];
-    }
+    const eventID = payload.eventId;
 
     const body = {
       onBehalfRequest: false, // We're not including this in the form so we just default it
@@ -687,14 +685,7 @@ export class EventsService {
       });
     }
 
-    let eventID = payload.eventId;
-    if (process.env['NODE_ENV'] !== 'production' && process.env['API_GW_DEV_EVENT_ID_OVERRIDE']) {
-      logger.warning(req, 'submit_travel_fund_application', 'Using API_GW_DEV_EVENT_ID_OVERRIDE (dev-only)', {
-        override_event_id: process.env['API_GW_DEV_EVENT_ID_OVERRIDE'],
-        original_event_id: payload.eventId,
-      });
-      eventID = process.env['API_GW_DEV_EVENT_ID_OVERRIDE'];
-    }
+    const eventID = payload.eventId;
 
     const body = {
       accommodationNumberOfNights,
@@ -833,6 +824,209 @@ export class EventsService {
     logger.debug(req, 'search_organizations', 'Organization search complete', { result_count: data.length });
 
     return { data };
+  }
+
+  /**
+   * Search events via the API Gateway event-service /v2/events/search endpoint.
+   */
+  public async searchEvents(req: Request, options: SearchEventsOptions): Promise<SearchEventsResponse> {
+    const { projectName, name, projectID, eventID, pageSize, offset } = options;
+
+    logger.debug(req, 'search_events', 'Searching events via API Gateway', {
+      project_name_count: projectName?.length ?? 0,
+      name_count: name?.length ?? 0,
+      project_id_count: projectID?.length ?? 0,
+      event_id_count: eventID?.length ?? 0,
+      page_size: pageSize,
+      offset,
+    });
+
+    const apiGwAudience = process.env['API_GW_AUDIENCE'];
+
+    if (!apiGwAudience) {
+      throw new MicroserviceError('API_GW_AUDIENCE environment variable is not configured', 503, 'API_GATEWAY_MISCONFIGURED', {
+        operation: 'search_events',
+      });
+    }
+
+    if (!req.apiGatewayToken) {
+      throw new MicroserviceError('API Gateway token not available', 503, 'API_GATEWAY_UNAVAILABLE', {
+        operation: 'search_events',
+      });
+    }
+
+    const params = new URLSearchParams();
+    projectName?.forEach((v) => params.append('projectName', v));
+    name?.forEach((v) => params.append('name', v));
+    projectID?.forEach((v) => params.append('projectID', v));
+    eventID?.forEach((v) => params.append('eventID', v));
+    params.append('pageSize', String(pageSize));
+    params.append('offset', String(offset));
+
+    const targetUrl = `${apiGwAudience.replace(/\/+$/, '')}/event-service/v2/events/search?${params.toString()}`;
+
+    let upstream: globalThis.Response;
+    try {
+      upstream = await fetch(targetUrl, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${req.apiGatewayToken}`,
+        },
+        signal: AbortSignal.timeout(10000),
+      });
+    } catch (err) {
+      logger.warning(req, 'search_events', 'Upstream fetch failed, returning empty', { err });
+      return { data: [], metadata: { offset, pageSize, totalSize: 0, hasNextPage: false } };
+    }
+
+    if (!upstream.ok) {
+      const errorText = await upstream.text().catch(() => '');
+      logger.warning(req, 'search_events', 'Upstream returned non-OK status, returning empty', {
+        status: upstream.status,
+        errorBody: errorText.slice(0, 500),
+      });
+      return { data: [], metadata: { offset, pageSize, totalSize: 0, hasNextPage: false } };
+    }
+
+    let json: { Data?: Record<string, unknown>[]; Metadata?: { Offset?: number; PageSize?: number; TotalSize?: number } } = {};
+    try {
+      const rawBody = await upstream.text();
+      json = rawBody ? (JSON.parse(rawBody) as typeof json) : {};
+    } catch (err) {
+      logger.warning(req, 'search_events', 'Upstream returned invalid JSON, returning empty', { err });
+      return { data: [], metadata: { offset, pageSize, totalSize: 0, hasNextPage: false } };
+    }
+
+    const items = json.Data ?? [];
+    const upstreamMetadata = json.Metadata ?? {};
+
+    const data: SearchEvent[] = items.map((item) => ({
+      id: String(item['ID'] ?? ''),
+      name: String(item['Name'] ?? ''),
+      projectID: String(item['ProjectID'] ?? ''),
+      projectName: String(item['ProjectName'] ?? ''),
+      startDate: String(item['StartDate'] ?? ''),
+      endDate: String(item['EndDate'] ?? ''),
+      date: this.formatDateRange(String(item['StartDate'] ?? ''), String(item['EndDate'] ?? '')),
+      status: String(item['Status'] ?? ''),
+      locationCity: String(item['LocationCity'] ?? ''),
+      locationCountry: String(item['LocationCountry'] ?? ''),
+      locationName: String(item['LocationName'] ?? ''),
+      locationAddress: String(item['LocationAddress'] ?? ''),
+      locationState: String(item['LocationState'] ?? ''),
+      locationZip: String(item['LocationZip'] ?? ''),
+      location: this.formatLocation(String(item['Location'] ?? ''), String(item['LocationCity'] ?? ''), String(item['LocationCountry'] ?? '')),
+      eventURL: String(item['EventURL'] ?? ''),
+      registrationURL: String(item['RegistrationURL'] ?? ''),
+      description: String(item['Description'] ?? ''),
+      acceptTravelFund: String(item['AcceptTravelFund'] ?? ''),
+      acceptVisaRequest: String(item['AcceptVisaRequest'] ?? ''),
+      embassy: String(item['Embassy'] ?? ''),
+      cventID: String(item['CventID'] ?? ''),
+    }));
+
+    const metadata: SearchEventsMetadata = {
+      offset: upstreamMetadata.Offset ?? offset,
+      pageSize: upstreamMetadata.PageSize ?? pageSize,
+      totalSize: upstreamMetadata.TotalSize ?? 0,
+      hasNextPage: upstreamMetadata.TotalSize !== undefined && upstreamMetadata.TotalSize > offset + pageSize,
+    };
+
+    logger.debug(req, 'search_events', 'Event search complete', { result_count: data.length, total_size: metadata.totalSize });
+
+    return { data, metadata };
+  }
+
+  /**
+   * Orchestrates two upstream calls to build a filtered, paginated event list for applications:
+   *   1. Fetch ALL of the user's upcoming registered events that match the provided filters.
+   *   2. Look up those events in the API Gateway event-service via searchEvents.
+   *   3. Filter results by AcceptVisaRequest or AcceptTravelFund depending on applicationType.
+   *   4. Apply offset/pageSize pagination to the filtered result set in memory.
+   *
+   * Pagination is applied after filtering (not at the getMyEvents level) because the
+   * AcceptVisaRequest/AcceptTravelFund filter is only available from the API Gateway —
+   * paginating earlier would produce incorrect totals.
+   */
+  public async searchEventsForApplication(req: Request, userEmail: string, options: SearchEventsForApplicationOptions): Promise<SearchEventsResponse> {
+    const { applicationType, pageSize, offset, sortOrder, sortField, searchQuery, role, status, startDateFrom, startDateTo, country, affiliatedProjectSlugs } =
+      options;
+
+    logger.debug(req, 'search_events_for_application', 'Fetching user registered events', {
+      application_type: applicationType,
+      page_size: pageSize,
+      offset,
+      has_search_query: !!searchQuery,
+      has_role: !!role,
+      has_status: !!status,
+      has_country: !!country,
+    });
+
+    const myEventsResponse = await this.getMyEvents(req, userEmail, {
+      isPast: false,
+      registeredOnly: true,
+      pageSize,
+      offset,
+      sortOrder,
+      sortField,
+      searchQuery,
+      role,
+      status,
+      startDateFrom,
+      startDateTo,
+      country,
+      affiliatedProjectSlugs,
+    });
+
+    const eventIds = myEventsResponse.data.map((e) => e.id).filter(Boolean);
+
+    if (process.env['NODE_ENV'] !== 'production' && process.env['API_GW_DEV_EVENT_ID_OVERRIDE']) {
+      logger.warning(req, 'search_events_for_application', 'Using API_GW_DEV_EVENT_ID_OVERRIDE (dev-only)', {
+        insert_event_id: process.env['API_GW_DEV_EVENT_ID_OVERRIDE'],
+        original_event_id: eventIds,
+      });
+      eventIds.push(process.env['API_GW_DEV_EVENT_ID_OVERRIDE']);
+    }
+
+    if (eventIds.length === 0) {
+      logger.debug(req, 'search_events_for_application', 'No matching registered upcoming events found, returning empty', {
+        application_type: applicationType,
+      });
+      return { data: [], metadata: { offset, pageSize, totalSize: 0, hasNextPage: false } };
+    }
+
+    logger.debug(req, 'search_events_for_application', 'Searching event details via API Gateway', {
+      event_id_count: eventIds.length,
+      application_type: applicationType,
+    });
+
+    // Step 2: fetch full event details for those IDs from the API Gateway event-service
+    const searchResponse = await this.searchEvents(req, {
+      eventID: eventIds,
+      pageSize: eventIds.length,
+      offset: 0,
+    });
+
+    // Step 3: filter by whether the event accepts the requested application type
+    const filterKey = applicationType === 'visa' ? 'acceptVisaRequest' : 'acceptTravelFund';
+    const filtered = searchResponse.data.filter((e) => e[filterKey] === 'Yes');
+
+    logger.debug(req, 'search_events_for_application', 'Filtered events by application type', {
+      total_before_filter: searchResponse.data.length,
+      total_after_filter: filtered.length,
+      application_type: applicationType,
+    });
+
+    return {
+      data: filtered,
+      metadata: {
+        offset,
+        pageSize,
+        totalSize: myEventsResponse.total,
+        // because of discrepancy between myEventsResponse.total and filtered.length, we need to calculate hasNextPage manually
+        hasNextPage: myEventsResponse.total > offset + pageSize,
+      },
+    };
   }
 
   private async executeEventRequestsQuery(

--- a/packages/shared/src/interfaces/events.interface.ts
+++ b/packages/shared/src/interfaces/events.interface.ts
@@ -554,3 +554,84 @@ export interface OrgSearchResponse {
 export interface SalesforceIdResponse {
   id: string;
 }
+
+// ---------------------------------------------------------------------------
+// Event Search (API Gateway event-service)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single event result from the API Gateway event-service /v2/events/search endpoint.
+ */
+export interface SearchEvent {
+  id: string;
+  name: string;
+  projectID: string;
+  projectName: string;
+  startDate: string;
+  endDate: string;
+  date: string;
+  status: string;
+  locationCity: string;
+  locationCountry: string;
+  locationName: string;
+  locationAddress: string;
+  locationState: string;
+  locationZip: string;
+  location: string;
+  eventURL: string;
+  registrationURL: string;
+  description: string;
+  acceptTravelFund: string;
+  acceptVisaRequest: string;
+  embassy: string;
+  cventID: string;
+}
+
+/**
+ * Pagination metadata from the API Gateway event-service search response.
+ */
+export interface SearchEventsMetadata {
+  offset: number;
+  pageSize: number;
+  totalSize: number;
+  hasNextPage: boolean;
+}
+
+/**
+ * Response from the /api/events/search endpoint.
+ */
+export interface SearchEventsResponse {
+  data: SearchEvent[];
+  metadata: SearchEventsMetadata;
+}
+
+/**
+ * Server-side options for searching events via the API Gateway.
+ */
+export interface SearchEventsOptions {
+  projectName?: string[];
+  name?: string[];
+  projectID?: string[];
+  eventID?: string[];
+  pageSize: number;
+  offset: number;
+}
+
+/**
+ * Frontend parameters for the /api/events/search-for-application endpoint.
+ * Extends GetMyEventsParams — all existing filters apply to the underlying getMyEvents call.
+ * isPast and registeredOnly are fixed server-side (always false/true) and are ignored if provided.
+ */
+export interface SearchEventsForApplicationParams extends GetMyEventsParams {
+  /** Determines which events to return — 'visa' filters by AcceptVisaRequest, 'travel-fund' by AcceptTravelFund */
+  type: 'visa' | 'travel-fund';
+}
+
+/**
+ * Server-side options for searchEventsForApplication.
+ * Extends GetMyEventsOptions — all filters are forwarded to the underlying getMyEvents call.
+ * isPast and registeredOnly are always overridden to false/true regardless of what is passed.
+ */
+export interface SearchEventsForApplicationOptions extends GetMyEventsOptions {
+  applicationType: RequestType;
+}

--- a/packages/shared/src/interfaces/events.interface.ts
+++ b/packages/shared/src/interfaces/events.interface.ts
@@ -565,7 +565,7 @@ export interface SalesforceIdResponse {
 export interface SearchEvent {
   id: string;
   name: string;
-  projectID: string;
+  projectId: string;
   projectName: string;
   startDate: string;
   endDate: string;
@@ -578,13 +578,13 @@ export interface SearchEvent {
   locationState: string;
   locationZip: string;
   location: string;
-  eventURL: string;
-  registrationURL: string;
+  eventUrl: string;
+  registrationUrl: string;
   description: string;
   acceptTravelFund: string;
   acceptVisaRequest: string;
   embassy: string;
-  cventID: string;
+  cventId: string;
 }
 
 /**
@@ -598,7 +598,8 @@ export interface SearchEventsMetadata {
 }
 
 /**
- * Response from the /api/events/search endpoint.
+ * Response from the /api/events/search and /api/events/search-for-application endpoints,
+ * and from the upstream API Gateway event-service /v2/events/search endpoint.
  */
 export interface SearchEventsResponse {
   data: SearchEvent[];
@@ -624,7 +625,7 @@ export interface SearchEventsOptions {
  */
 export interface SearchEventsForApplicationParams extends GetMyEventsParams {
   /** Determines which events to return — 'visa' filters by AcceptVisaRequest, 'travel-fund' by AcceptTravelFund */
-  type: 'visa' | 'travel-fund';
+  type: RequestType;
 }
 
 /**


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                      
  - Adds a new `GET /api/events/search-for-application` endpoint that orchestrates two upstream calls: fetches the user's upcoming registered events (Snowflake via `getMyEvents`), then looks them up in the API     
  Gateway `event-service/v2/events/search` and filters by `acceptVisaRequest` or `acceptTravelFund` based on the required `type` param (`visa` | `travel-fund`)                                                       
  - Replaces `getMyEvents` in `EventSelectionComponent` with `searchEventsForApplication`, so the event picker only surfaces events that accept the relevant application type; switches from `MyEvent` (Snowflake) to 
  `SearchEvent` (API Gateway) throughout                                                                                                                                                                              
  - Adds `[type]="'visa'"` and `[type]="'travel-fund'"` inputs to the `<lfx-event-selection>` usages in the respective application dialogs
  - Adds error toasts via `MessageService` on event load failures in `EventSelectionComponent`