### PR TITLE
feat(ui): add always-visible KPI descriptions to ED overview cards

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -40,6 +40,7 @@
           <lfx-metric-card
             [title]="card.title"
             [icon]="card.icon"
+            [description]="card.description"
             [testId]="card.testId"
             [chartType]="card.chartType"
             [clickable]="!!card.drawerType"
@@ -86,6 +87,7 @@
           <lfx-metric-card
             [title]="card.title"
             [icon]="card.icon"
+            [description]="card.description"
             [testId]="card.testId"
             [chartType]="card.chartType"
             [clickable]="!!card.drawerType"
@@ -132,6 +134,7 @@
           <lfx-metric-card
             [title]="card.title"
             [icon]="card.icon"
+            [description]="card.description"
             [testId]="card.testId"
             [chartType]="card.chartType"
             [chartData]="card.chartData"

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
@@ -30,6 +30,11 @@
         <h5 class="text-sm font-medium flex-1">{{ title() }}</h5>
       </div>
 
+      <!-- Description -->
+      @if (description()) {
+        <p class="text-[11px] text-gray-400 leading-snug -mt-1 mb-0">{{ description() }}</p>
+      }
+
       <!-- Body: Chart or Custom Content -->
       @if (customContentTemplate) {
         <ng-container [ngTemplateOutlet]="customContentTemplate"></ng-container>

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts
@@ -20,6 +20,7 @@ export class MetricCardComponent {
   // Header inputs
   public readonly title = input.required<string>();
   public readonly icon = input<string>();
+  public readonly description = input<string>();
   public readonly testId = input<string>();
 
   // Chart inputs

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -742,6 +742,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'memberships',
       testId: 'ed-evo-flywheel-conversion',
+      description: 'Event attendees who engage via newsletter, community, working groups, training, code, or web within 90 days.',
       value: `${flywheel.reengagement.reengagementRate.toFixed(1)}%`,
       changePercentage: formatPpMomChange(flywheel.reengagement.reengagementMomChange),
       trend: flywheel.reengagement.reengagementMomChange >= 0 ? 'up' : 'down',
@@ -758,6 +759,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'memberships',
       testId: 'ed-evo-member-growth',
+      description: 'Total paying corporate members with quarterly net new count and associated revenue.',
       value: formatNumber(memberAcquisition.totalMembers),
       changePercentage: formatMomChange(memberAcquisition.changePercentage),
       trend: memberAcquisition.trend,
@@ -773,6 +775,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'memberships',
       testId: 'ed-evo-engaged-community',
+      description: 'Unique individuals active across 7 channels — Slack, Discord, GitHub, mailing lists, training, web, and code — in the last 90 days.',
       value: formatNumber(engagedCommunity.totalMembers),
       changePercentage: formatMomChange(engagedCommunity.changePercentage),
       trend: engagedCommunity.trend,
@@ -788,6 +791,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'memberships',
       testId: 'ed-evo-event-growth',
+      description: 'Year-to-date event count, attendees, and net revenue with YoY comparison.',
       value: formatNumber(eventGrowth.totalRegistrants),
       changePercentage: formatYoyChange(eventGrowth.registrantYoyChange),
       trend: eventGrowth.registrantYoyChange >= 0 ? 'up' : 'down',
@@ -805,6 +809,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'brand',
       testId: 'ed-evo-brand-reach',
+      description: 'Social followers across all platforms and monthly website sessions from GA4.',
       customContentType: 'dual-signal',
       dualSignals: [
         protoDualSignal(
@@ -834,6 +839,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'brand',
       testId: 'ed-evo-brand-health',
+      description: 'Total brand mentions from Octolens social listening with sentiment breakdown.',
       customContentType: 'dual-signal',
       dualSignals: [
         protoDualSignal(
@@ -863,6 +869,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'influence',
       testId: 'ed-evo-revenue-impact',
+      description: 'Revenue attributed to marketing touchpoints (last-touch model) alongside paid media spend.',
       customContentType: 'dual-signal',
       caption: `Last-touch attribution · Last 6 months`,
       dualSignals: [

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -97,6 +97,9 @@ export interface DashboardMetricCard {
   // Status & Metadata
   // ============================================
 
+  /** Always-visible one-liner explaining what this KPI measures */
+  description?: string;
+
   /** Optional tooltip text to display on hover */
   tooltipText?: string;
 


### PR DESCRIPTION
## Summary
- Added a `description` field to the `DashboardMetricCard` interface and `MetricCardComponent` for always-visible one-liner KPI explanations
- Each of the 7 ED overview cards now shows a concise description below the title explaining what the KPI measures
- Descriptions render in all 3 card variants (dual-signal, funnel, standard)

## Changes
| File | Change |
|------|--------|
| `packages/shared/src/interfaces/dashboard-metric.interface.ts` | Added `description?: string` field |
| `packages/shared/src/constants/dashboard-metrics.constants.ts` | Added description text to all 7 ED cards |
| `apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts` | Added `description` input signal |
| `apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html` | Render description between header and body |
| `apps/.../marketing-overview.component.html` | Pass `[description]` in all 3 card template variants |

## Card Descriptions
| Card | Description |
|------|-------------|
| Flywheel Re-engagement | Event attendees who engage via newsletter, community, working groups, training, code, or web within 90 days. |
| Member Growth | Total paying corporate members with quarterly net new count and associated revenue. |
| Engaged Community | Unique individuals active across 7 channels — Slack, Discord, GitHub, mailing lists, training, web, and code — in the last 90 days. |
| Event Growth | Year-to-date event count, attendees, and net revenue with YoY comparison. |
| Brand Reach | Social followers across all platforms and monthly website sessions from GA4. |
| Brand Health | Total brand mentions from Octolens social listening with sentiment breakdown. |
| Attribution | Revenue attributed to marketing touchpoints (last-touch model) alongside paid media spend. |

## Test plan
- [ ] Verify descriptions render below each card title on the ED Marketing Overview dashboard
- [ ] Confirm descriptions appear in all 3 card variants (dual-signal, funnel, standard)
- [ ] Check text is readable at `text-[11px] text-gray-400` styling
- [ ] Verify no layout shifts or overflow on mobile viewport

🤖 Generated with [Claude Code](https://claude.ai/code)