### PR TITLE
fix(ui): polish ED overview card trend colors, contrast, and copy

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -54,7 +54,11 @@
                       <div class="flex items-center justify-between">
                         <span class="text-xs text-gray-500">{{ row.label }}</span>
                         @if (row.changePercentage) {
-                          <span class="text-xs font-medium" [class.text-emerald-600]="row.trend === 'up'" [class.text-red-600]="row.trend === 'down'">
+                          <span
+                            class="text-xs font-medium"
+                            [class.text-emerald-600]="row.trend === 'up'"
+                            [class.text-red-600]="row.trend === 'down'"
+                            [class.text-gray-500]="row.trend === 'neutral'">
                             {{ row.changePercentage }}
                           </span>
                         }
@@ -99,7 +103,11 @@
                 <div class="flex items-center gap-2">
                   <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
                   @if (card.changePercentage) {
-                    <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
+                    <span
+                      class="text-xs font-medium"
+                      [class.text-emerald-600]="card.trend === 'up'"
+                      [class.text-red-600]="card.trend === 'down'"
+                      [class.text-gray-500]="card.trend === 'neutral'">
                       {{ card.changePercentage }}
                     </span>
                   }

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
@@ -32,7 +32,7 @@
 
       <!-- Description -->
       @if (description()) {
-        <p class="text-[11px] text-gray-400 leading-snug -mt-1 mb-0">{{ description() }}</p>
+        <p class="text-[11px] text-gray-500 leading-snug -mt-1 mb-0">{{ description() }}</p>
       }
 
       <!-- Body: Chart or Custom Content -->
@@ -63,6 +63,7 @@
                   class="text-xs font-medium"
                   [class.text-emerald-600]="trend() === 'up'"
                   [class.text-red-600]="trend() === 'down'"
+                  [class.text-gray-500]="trend() === 'neutral'"
                   data-testid="metric-card-change-percentage">
                   {{ changePercentage() }}
                 </span>

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts
@@ -32,7 +32,7 @@ export class MetricCardComponent {
   public readonly value = input<string>();
   public readonly subtitle = input<string>();
   public readonly valueTooltip = input<string>();
-  public readonly trend = input<'up' | 'down'>();
+  public readonly trend = input<'up' | 'down' | 'neutral'>();
   public readonly changePercentage = input<string>();
 
   // Styling

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -640,7 +640,7 @@ function protoSparkline(data: number[], color: string) {
 }
 
 /** Helper to build a dual-signal row with sparkline */
-function protoDualSignal(label: string, value: string, data: number[], color: string, change?: string, trend?: 'up' | 'down'): DualSignalRow {
+function protoDualSignal(label: string, value: string, data: number[], color: string, change?: string, trend?: 'up' | 'down' | 'neutral'): DualSignalRow {
   return {
     label,
     value,
@@ -688,11 +688,11 @@ function paidMediaMomChange(trend: { spend: number }[]): string | undefined {
 }
 
 /** Compute trend direction from a paid media monthly trend series */
-function paidMediaTrend(trend: { spend: number }[]): 'up' | 'down' | undefined {
+function paidMediaTrend(trend: { spend: number }[]): 'up' | 'down' | 'neutral' | undefined {
   if (trend.length < 2) return undefined;
   const prev = trend[trend.length - 2].spend;
   const curr = trend[trend.length - 1].spend;
-  return curr >= prev ? 'up' : 'down';
+  return curr === prev ? 'neutral' : curr > prev ? 'up' : 'down';
 }
 
 /** Extract values from NorthStarMonthlyDataPoint[] */
@@ -721,9 +721,11 @@ function eventAttrMomChange(series: number[]): string | undefined {
 }
 
 /** Compute trend direction from event-attribution monthly revenue series */
-function eventAttrTrendDirection(series: number[]): 'up' | 'down' | undefined {
+function eventAttrTrendDirection(series: number[]): 'up' | 'down' | 'neutral' | undefined {
   if (series.length < 2) return undefined;
-  return series[series.length - 1] >= series[series.length - 2] ? 'up' : 'down';
+  const curr = series[series.length - 1];
+  const prev = series[series.length - 2];
+  return curr === prev ? 'neutral' : curr > prev ? 'up' : 'down';
 }
 
 /**
@@ -745,8 +747,8 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Event attendees who engage via newsletter, community, working groups, training, code, or web within 90 days.',
       value: `${flywheel.reengagement.reengagementRate.toFixed(1)}%`,
       changePercentage: formatPpMomChange(flywheel.reengagement.reengagementMomChange),
-      trend: flywheel.reengagement.reengagementMomChange >= 0 ? 'up' : 'down',
-      subtitle: 'Re-engagement within 90 days · Sparkline: monthly re-engaged count',
+      trend: flywheel.reengagement.reengagementMomChange === 0 ? 'neutral' : flywheel.reengagement.reengagementMomChange > 0 ? 'up' : 'down',
+      subtitle: 'Re-engagement within 90 days',
       chartData: flywheel.monthlyData.length > 0 ? protoSparkline(monthlyValues(flywheel.monthlyData), lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText:
@@ -779,7 +781,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       value: formatNumber(engagedCommunity.totalMembers),
       changePercentage: formatMomChange(engagedCommunity.changePercentage),
       trend: engagedCommunity.trend,
-      subtitle: `${Object.values(engagedCommunity.breakdown).filter((v) => v > 0).length} channels · Last 6 months`,
+      subtitle: 'Last 6 months',
       chartData: protoSparkline(engagedCommunity.monthlyData.length > 0 ? monthlyValues(engagedCommunity.monthlyData) : [0], lfxColors.blue[500]),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Unique individuals active across Slack, Discord, GitHub, and mailing lists in the last 90 days.',
@@ -794,8 +796,8 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Year-to-date event count, attendees, and net revenue with YoY comparison.',
       value: formatNumber(eventGrowth.totalRegistrants),
       changePercentage: formatYoyChange(eventGrowth.registrantYoyChange),
-      trend: eventGrowth.registrantYoyChange >= 0 ? 'up' : 'down',
-      subtitle: `${formatNumber(eventGrowth.totalEvents)} events · YTD registrants`,
+      trend: eventGrowth.registrantYoyChange === 0 ? 'neutral' : eventGrowth.registrantYoyChange > 0 ? 'up' : 'down',
+      subtitle: `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD registrants`,
       chartData: eventGrowth.monthlyData.length > 0 ? protoSparkline(monthlyValues(eventGrowth.monthlyData), lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Year-to-date event attendees and YoY change. Source: Event registrations.',
@@ -854,7 +856,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           [],
           lfxColors.emerald[500],
           formatPpMomChange(brandHealth.sentimentMomChangePp),
-          brandHealth.sentimentMomChangePp >= 0 ? 'up' : 'down'
+          brandHealth.sentimentMomChangePp === 0 ? 'neutral' : brandHealth.sentimentMomChangePp > 0 ? 'up' : 'down'
         ),
       ],
       caption: `${formatNumber(brandHealth.totalMentions)} mentions · Last 6 months`,

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -56,7 +56,7 @@ export interface DashboardMetricCard {
   icon?: string;
 
   /** Trend direction indicator */
-  trend?: 'up' | 'down';
+  trend?: 'up' | 'down' | 'neutral';
 
   /** Percentage change value (e.g., '+12.4%') */
   changePercentage?: string;
@@ -318,7 +318,7 @@ export interface DualSignalRow {
   /** Change percentage display (e.g., "+8.2% MoM") */
   changePercentage?: string;
   /** Trend direction */
-  trend?: 'up' | 'down';
+  trend?: 'up' | 'down' | 'neutral';
   /** Sparkline chart data for this signal */
   chartData?: ChartData<ChartType>;
 }


### PR DESCRIPTION
## Summary
- Add `neutral` trend state so zero-change deltas render in gray instead of misleading green
- Bump KPI description contrast from `text-gray-400` to `text-gray-500` for WCAG AA compliance
- Fix "1 events" → "1 event" pluralization on Event Growth card
- Remove misleading channel count from Engaged Community subtitle (was "2 channels" but description says "7 channels")
- Clean up Flywheel subtitle — remove sparkline reference that reads as broken when data is empty

LFXV2-1468

## Test plan
- [ ] Verify zero-change deltas (e.g., +0.0pp MoM) show gray text, not green
- [ ] Verify description text below card titles is readable (text-gray-500)
- [ ] Verify Event Growth card says "1 event" when count is 1
- [ ] Verify Engaged Community subtitle says "Last 6 months" without channel count
- [ ] Verify Flywheel subtitle says "Re-engagement within 90 days" without sparkline reference
- [ ] Verify up/down trends still show green/red correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)