### PR TITLE
ci: enforce signed-off-by trailer via commitlint

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,1 +1,6 @@
-export default { extends: ["@commitlint/config-angular"] };
+export default {
+  extends: ["@commitlint/config-angular"],
+  rules: {
+    "signed-off-by": [2, "always", "Signed-off-by:"],
+  },
+};


### PR DESCRIPTION
## Summary

- Adds the built-in `signed-off-by` rule to `commitlint.config.mjs` so the existing `commit-msg` Husky hook rejects local commits missing a `Signed-off-by:` trailer.
- Complements server-side DCO enforcement — catches missing sign-offs at the commit moment instead of waiting for the PR check.
- Motivated by PR #502, where a refactor commit reached the PR without a sign-off and required a maintainer to manually approve DCO.

## Context

`@commitlint/config-angular` validates type/scope/header shape but does **not** include `signed-off-by`. Adding `'signed-off-by': [2, 'always', 'Signed-off-by:']` closes that gap with zero new dependencies — the existing `commit-msg` hook already runs commitlint, so the rule takes effect immediately.