### PR TITLE
fix(ui): polish ED dashboard cards and reorder sections

### DIFF
--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -72,12 +72,30 @@ test.describe('Marketing Overview Section', () => {
     await expect(subtitle).toContainText('North Star KPIs');
   });
 
-  test('renders carousel with navigation controls', async ({ page }) => {
+  test('renders Foundation Health before Marketing Metrics', async ({ page }) => {
+    const healthSection = page.locator('[data-testid="foundation-health-section"]');
+    const edSection = page.locator('[data-testid="ed-evolution-section"]');
+
+    // Both sections should be visible
+    await expect(healthSection).toBeVisible();
+    await expect(edSection).toBeVisible();
+
+    // Foundation Health should appear before Marketing Metrics in the DOM
+    const healthBox = await healthSection.boundingBox();
+    const edBox = await edSection.boundingBox();
+    expect(healthBox!.y).toBeLessThan(edBox!.y);
+  });
+
+  test('renders carousel with navigation controls and count', async ({ page }) => {
     const carousel = page.locator('[data-testid="ed-evolution-carousel"]');
     await expect(carousel).toBeVisible();
 
     await expect(page.locator('[data-testid="ed-evolution-carousel-prev"]')).toBeVisible();
     await expect(page.locator('[data-testid="ed-evolution-carousel-next"]')).toBeVisible();
+
+    const carouselCount = page.locator('[data-testid="ed-evolution-carousel-count"]');
+    await expect(carouselCount).toBeVisible();
+    await expect(carouselCount).toContainText(/\d+\s*\/\s*\d+/);
   });
 
   test('carousel scrolls when navigation buttons are clicked', async ({ page }) => {

--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -39,8 +39,8 @@ async function switchToExecutiveDirector(page: Page): Promise<void> {
   const personaSelector = page.locator('[data-testid="dev-tools-bar-persona-selector"]');
   await personaSelector.locator('text=Executive Director').click();
 
-  // Wait for the dashboard to re-render with the marketing overview section
-  await page.waitForSelector('[data-testid="marketing-overview-section"]', { timeout: DATA_LOAD_TIMEOUT });
+  // Wait for the dashboard to re-render with the ED evolution section
+  await page.waitForSelector('[data-testid="ed-evolution-section"]', { timeout: DATA_LOAD_TIMEOUT });
 }
 
 /**
@@ -62,27 +62,27 @@ test.describe('Marketing Overview Section', () => {
   });
 
   test('renders the marketing overview section with title', async ({ page }) => {
-    const section = page.locator('[data-testid="marketing-overview-section"]');
+    const section = page.locator('[data-testid="ed-evolution-section"]');
     await expect(section).toBeVisible();
 
     const heading = section.locator('h2');
-    await expect(heading).toContainText('Executive Director Overview');
+    await expect(heading).toContainText('Marketing Metrics');
 
     const subtitle = section.locator('p');
     await expect(subtitle).toContainText('North Star KPIs');
   });
 
   test('renders carousel with navigation controls', async ({ page }) => {
-    const carousel = page.locator('[data-testid="marketing-overview-carousel"]');
+    const carousel = page.locator('[data-testid="ed-evolution-carousel"]');
     await expect(carousel).toBeVisible();
 
-    await expect(page.locator('[data-testid="marketing-overview-carousel-prev"]')).toBeVisible();
-    await expect(page.locator('[data-testid="marketing-overview-carousel-next"]')).toBeVisible();
+    await expect(page.locator('[data-testid="ed-evolution-carousel-prev"]')).toBeVisible();
+    await expect(page.locator('[data-testid="ed-evolution-carousel-next"]')).toBeVisible();
   });
 
   test('carousel scrolls when navigation buttons are clicked', async ({ page }) => {
-    const carousel = page.locator('[data-testid="marketing-overview-carousel"]');
-    const nextBtn = page.locator('[data-testid="marketing-overview-carousel-next"]');
+    const carousel = page.locator('[data-testid="ed-evolution-carousel"]');
+    const nextBtn = page.locator('[data-testid="ed-evolution-carousel-next"]');
 
     const initialScroll = await carousel.evaluate((el) => el.scrollLeft);
     await nextBtn.click();
@@ -155,12 +155,9 @@ test.describe('Marketing Metric Cards', () => {
     await expect(card).toContainText('Social Media');
   });
 
-  test('renders Key Insights card', async ({ page }) => {
-    const card = page.locator('[data-testid="marketing-overview-key-insights"]');
-    await card.scrollIntoViewIfNeeded();
-    await expect(card).toBeVisible();
-    await expect(card).toContainText('Marketing Metrics');
-    await expect(card).toContainText('Key Insights');
+  test('renders filter pills', async ({ page }) => {
+    const filters = page.locator('[data-testid="ed-evolution-filters"]');
+    await expect(filters).toBeVisible();
   });
 });
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -57,7 +57,7 @@
                       <div class="flex items-center justify-between">
                         <div class="flex items-center gap-1.5">
                           @if (row.color) {
-                            <span class="w-2 h-2 rounded-full flex-shrink-0" [style.background-color]="row.color"></span>
+                            <span class="w-2 h-2 rounded-full flex-shrink-0" [style.background-color]="row.color" aria-hidden="true" role="presentation"></span>
                           }
                           <span class="text-xs text-gray-500">{{ row.label }}</span>
                         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -20,7 +20,9 @@
         ariaLabel="Scroll left"
         (onClick)="scrollShadowDirective()?.scrollLeft()"
         data-testid="ed-evolution-carousel-prev" />
-      <span class="text-xs text-gray-500 tabular-nums" data-testid="ed-evolution-carousel-count">{{ totalCardCount() }} cards</span>
+      <span class="text-xs text-gray-500 tabular-nums" data-testid="ed-evolution-carousel-count"
+        >{{ totalCardCount() }} {{ totalCardCount() === 1 ? 'card' : 'cards' }}</span
+      >
       <lfx-button
         icon="fa-light fa-chevron-right"
         [outlined]="true"

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -4,7 +4,7 @@
 <section data-testid="ed-evolution-section">
   <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
     <div class="flex flex-col gap-1">
-      <h2 class="mb-0"><i class="fa-light fa-chart-line-up mr-2"></i>Marketing Metrics</h2>
+      <h2 class="mb-0"><i class="fa-light fa-chart-line-up mr-2" aria-hidden="true"></i>Marketing Metrics</h2>
       <p class="text-sm text-gray-500 mb-0">North Star KPIs · Brand · Influence</p>
       <!-- Filter Pills -->
       <lfx-filter-pills [options]="filterOptions" [selectedFilter]="selectedFilter()" (filterChange)="setFilter($event)" data-testid="ed-evolution-filters" />

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -20,6 +20,7 @@
         ariaLabel="Scroll left"
         (onClick)="scrollShadowDirective()?.scrollLeft()"
         data-testid="ed-evolution-carousel-prev" />
+      <span class="text-xs text-gray-500 tabular-nums" data-testid="ed-evolution-carousel-count">{{ totalCardCount() }} cards</span>
       <lfx-button
         icon="fa-light fa-chevron-right"
         [outlined]="true"
@@ -52,7 +53,12 @@
                   @for (row of card.dualSignals; track row.label; let last = $last) {
                     <div class="flex flex-col gap-1 py-2">
                       <div class="flex items-center justify-between">
-                        <span class="text-xs text-gray-500">{{ row.label }}</span>
+                        <div class="flex items-center gap-1.5">
+                          @if (row.color) {
+                            <span class="w-2 h-2 rounded-full flex-shrink-0" [style.background-color]="row.color"></span>
+                          }
+                          <span class="text-xs text-gray-500">{{ row.label }}</span>
+                        </div>
                         @if (row.changePercentage) {
                           <span
                             class="text-xs font-medium"
@@ -78,7 +84,7 @@
                   }
                 }
                 @if (card.caption) {
-                  <div class="text-[10px] text-gray-400 mt-1">{{ card.caption }}</div>
+                  <div class="text-xs text-gray-500 mt-1">{{ card.caption }}</div>
                 }
               </div>
             </ng-template>
@@ -166,38 +172,6 @@
         <ng-container *ngTemplateOutlet="metricCardTpl; context: { $implicit: card }"></ng-container>
       }
 
-      <!-- Marketing Metrics Key Insights Card (between North Star and Brand/Influence) -->
-      @if (showInsightsCard()) {
-        <lfx-card styleClass="flex-shrink-0 w-[calc(100vw-3rem)] md:w-80 h-full" data-testid="marketing-overview-key-insights">
-          <div class="flex flex-col h-full">
-            <div class="flex items-center gap-2 mb-3">
-              <i class="fa-light fa-lightbulb w-4 h-4 text-gray-500 flex-shrink-0"></i>
-              <h5 class="text-sm font-medium">Marketing Metrics</h5>
-            </div>
-            <div class="flex-1 flex flex-col gap-1.5 p-3 bg-gray-50 rounded-lg">
-              <h6 class="flex items-center gap-1.5 text-xs font-semibold text-gray-900 mb-1">
-                <i class="fa-light fa-lightbulb text-gray-400"></i>
-                Key Insights
-              </h6>
-              @for (insight of marketingInsights(); track insight) {
-                <div class="flex items-start gap-1.5 text-xs text-gray-700 leading-snug">
-                  <span class="mt-1.5 w-1 h-1 rounded-full bg-gray-400 flex-shrink-0"></span>
-                  <span>{{ insight }}</span>
-                </div>
-              }
-            </div>
-            <div class="mt-2 text-right">
-              <lfx-button
-                label="View details"
-                [link]="true"
-                size="small"
-                (onClick)="handleCardClick(DashboardDrawerType.NorthStarEngagedCommunity)"
-                data-testid="marketing-overview-insights-view-details" />
-            </div>
-          </div>
-        </lfx-card>
-      }
-
       @for (card of nonNorthStarCards(); track card.testId) {
         <ng-container *ngTemplateOutlet="metricCardTpl; context: { $implicit: card }"></ng-container>
       }
@@ -221,7 +195,7 @@
   <!-- Data source hint -->
   <div class="flex items-center gap-1 mt-2 text-xs text-gray-400">
     <i class="fa-light fa-circle-info"></i>
-    <span>Hover over any card for data source details</span>
+    <span>Hover over any card for more details</span>
   </div>
 </section>
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -4,7 +4,7 @@
 <section data-testid="ed-evolution-section">
   <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
     <div class="flex flex-col gap-1">
-      <h2 class="mb-0">Executive Director Overview</h2>
+      <h2 class="mb-0"><i class="fa-light fa-chart-line-up mr-2"></i>Marketing Metrics</h2>
       <p class="text-sm text-gray-500 mb-0">North Star KPIs · Brand · Influence</p>
       <!-- Filter Pills -->
       <lfx-filter-pills [options]="filterOptions" [selectedFilter]="selectedFilter()" (filterChange)="setFilter($event)" data-testid="ed-evolution-filters" />

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -54,7 +54,11 @@
                       <div class="flex items-center justify-between">
                         <span class="text-xs text-gray-500">{{ row.label }}</span>
                         @if (row.changePercentage) {
-                          <span class="text-xs font-medium" [class.text-emerald-600]="row.trend === 'up'" [class.text-red-600]="row.trend === 'down'">
+                          <span
+                            class="text-xs font-medium"
+                            [class.text-emerald-600]="row.trend === 'up'"
+                            [class.text-red-600]="row.trend === 'down'"
+                            [class.text-gray-500]="row.trend === 'neutral'">
                             {{ row.changePercentage }}
                           </span>
                         }
@@ -99,7 +103,11 @@
                 <div class="flex items-center gap-2">
                   <span class="text-xl font-semibold text-gray-900">{{ card.value }}</span>
                   @if (card.changePercentage) {
-                    <span class="text-xs font-medium" [class.text-emerald-600]="card.trend === 'up'" [class.text-red-600]="card.trend === 'down'">
+                    <span
+                      class="text-xs font-medium"
+                      [class.text-emerald-600]="card.trend === 'up'"
+                      [class.text-red-600]="card.trend === 'down'"
+                      [class.text-gray-500]="card.trend === 'neutral'">
                       {{ card.changePercentage }}
                     </span>
                   }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -5,7 +5,6 @@ import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal, viewChild } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
-import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { MetricCardComponent } from '@components/metric-card/metric-card.component';
@@ -25,7 +24,6 @@ import {
   MetricCategory,
   RevenueImpactResponse,
 } from '@lfx-one/shared/interfaces';
-import { formatNumber } from '@lfx-one/shared/utils';
 
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -149,7 +147,6 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
   imports: [
     NgTemplateOutlet,
     ButtonComponent,
-    CardComponent,
     ChartComponent,
     FilterPillsComponent,
     MetricCardComponent,
@@ -206,9 +203,7 @@ export class MarketingOverviewComponent {
 
   protected readonly northStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category === 'memberships'));
   protected readonly nonNorthStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category !== 'memberships'));
-  protected readonly showInsightsCard = computed<boolean>(() => this.northStarCards().length > 0);
-
-  protected readonly marketingInsights: Signal<string[]> = this.initMarketingInsights();
+  protected readonly totalCardCount = computed<number>(() => this.filteredCards().length);
 
   // === Public Methods ===
   public handleCardClick(drawerType: DashboardDrawerType): void {
@@ -260,46 +255,5 @@ export class MarketingOverviewComponent {
       ),
       { initialValue: EMPTY_ED_EVOLUTION_DATA }
     ) as Signal<EdEvolutionData>;
-  }
-
-  private initMarketingInsights(): Signal<string[]> {
-    return computed(() => {
-      const data = this.edEvolutionData();
-      // `unit: 'pp'` indicates the change value is a percentage-point delta (difference
-      // between two percentages). Rendering it as "%" would misrepresent the metric.
-      const signals: { label: string; change: number; detail: string; unit: '%' | 'pp' }[] = [
-        {
-          label: 'Engaged community',
-          change: data.engagedCommunity.changePercentage,
-          detail: formatNumber(data.engagedCommunity.totalMembers),
-          unit: '%',
-        },
-        {
-          label: 'Member base',
-          change: data.memberAcquisition.changePercentage,
-          detail: formatNumber(data.memberAcquisition.totalMembers),
-          unit: '%',
-        },
-        {
-          label: 'Flywheel re-engagement',
-          change: data.flywheel.reengagement?.reengagementMomChange ?? 0,
-          detail: `${(data.flywheel.reengagement?.reengagementRate ?? 0).toFixed(1)}%`,
-          unit: 'pp',
-        },
-        {
-          label: 'Member retention',
-          change: data.memberRetention.changePercentage,
-          detail: `${data.memberRetention.renewalRate.toFixed(1)}%`,
-          unit: '%',
-        },
-      ];
-
-      const sorted = signals.filter((s) => s.change !== 0).sort((a, b) => Math.abs(b.change) - Math.abs(a.change));
-
-      return sorted.slice(0, 3).map((s) => {
-        const direction = s.change > 0 ? 'up' : 'down';
-        return `${s.label} is ${direction} ${Math.abs(s.change).toFixed(1)}${s.unit} — now at ${s.detail}`;
-      });
-    });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.html
@@ -11,43 +11,6 @@
 
   <!-- Dashboard Sections -->
   <div class="flex flex-col gap-6" data-testid="ed-dashboard-sections-grid">
-    <!-- Executive Director Overview - Single Carousel Lane (North Star + Marketing) -->
-    @defer (on idle) {
-      <lfx-marketing-overview />
-    } @placeholder {
-      <section data-testid="ed-dashboard-metrics-placeholder">
-        <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
-          <div class="flex flex-col gap-3">
-            <p-skeleton width="16rem" height="1.5rem" />
-            <p-skeleton width="18rem" height="1rem" />
-          </div>
-          <div class="flex items-center gap-2">
-            <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
-            <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
-          </div>
-        </div>
-        <div class="flex gap-4 overflow-hidden">
-          @for (i of [1, 2, 3, 4, 5, 6, 7, 8]; track i) {
-            <div class="p-4 bg-white border border-gray-200 rounded-lg flex-shrink-0 w-[calc(100vw-3rem)] md:w-80">
-              <div class="flex flex-col gap-2">
-                <div class="flex items-center gap-2">
-                  <p-skeleton width="1rem" height="1rem" borderRadius="4px" />
-                  <p-skeleton width="8rem" height="0.875rem" />
-                </div>
-                <div class="mt-3 w-full h-16">
-                  <p-skeleton width="100%" height="100%" borderRadius="8px" />
-                </div>
-                <div class="flex flex-col gap-1 mt-auto">
-                  <p-skeleton width="3rem" height="1.75rem" />
-                  <p-skeleton width="70%" height="0.75rem" />
-                </div>
-              </div>
-            </div>
-          }
-        </div>
-      </section>
-    }
-
     <!-- Foundation Health -->
     @defer (on idle) {
       <lfx-foundation-health />
@@ -70,6 +33,43 @@
                 <div class="flex items-center gap-2">
                   <p-skeleton width="1rem" height="1rem" borderRadius="4px" />
                   <p-skeleton width="6rem" height="0.875rem" />
+                </div>
+                <div class="mt-3 w-full h-16">
+                  <p-skeleton width="100%" height="100%" borderRadius="8px" />
+                </div>
+                <div class="flex flex-col gap-1 mt-auto">
+                  <p-skeleton width="3rem" height="1.75rem" />
+                  <p-skeleton width="70%" height="0.75rem" />
+                </div>
+              </div>
+            </div>
+          }
+        </div>
+      </section>
+    }
+
+    <!-- Marketing Metrics -->
+    @defer (on idle) {
+      <lfx-marketing-overview />
+    } @placeholder {
+      <section data-testid="ed-dashboard-metrics-placeholder">
+        <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
+          <div class="flex flex-col gap-3">
+            <p-skeleton width="16rem" height="1.5rem" />
+            <p-skeleton width="18rem" height="1rem" />
+          </div>
+          <div class="flex items-center gap-2">
+            <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
+            <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
+          </div>
+        </div>
+        <div class="flex gap-4 overflow-hidden">
+          @for (i of [1, 2, 3, 4, 5, 6, 7]; track i) {
+            <div class="p-4 bg-white border border-gray-200 rounded-lg flex-shrink-0 w-[calc(100vw-3rem)] md:w-80">
+              <div class="flex flex-col gap-2">
+                <div class="flex items-center gap-2">
+                  <p-skeleton width="1rem" height="1rem" borderRadius="4px" />
+                  <p-skeleton width="8rem" height="0.875rem" />
                 </div>
                 <div class="mt-3 w-full h-16">
                   <p-skeleton width="100%" height="100%" borderRadius="8px" />

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.html
@@ -60,6 +60,7 @@
           </div>
           <div class="flex items-center gap-2">
             <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
+            <p-skeleton width="3.5rem" height="0.75rem" />
             <p-skeleton width="2rem" height="2rem" borderRadius="4px" />
           </div>
         </div>

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
@@ -9,18 +9,28 @@
   (click)="handleClick()">
   <div class="flex flex-col gap-2 h-full justify-between">
     @if (loading()) {
-      <!-- Loading Skeleton State -->
+      <!-- Loading Skeleton — mirrors the five-region card anatomy -->
+      <!-- 1. Icon + Title -->
       <div class="flex items-center gap-2">
-        <p-skeleton width="1rem" height="1rem" borderRadius="4px" />
-        <p-skeleton width="6rem" height="0.875rem" />
+        <p-skeleton width="1rem" height="1rem" borderRadius="4px" animation="wave" />
+        <p-skeleton width="6rem" height="0.875rem" animation="wave" />
       </div>
-      <div class="mt-3 w-full h-16">
-        <p-skeleton width="100%" height="100%" borderRadius="8px" />
+      <!-- 2. Description (two lines) -->
+      <div class="flex flex-col gap-1 -mt-1">
+        <p-skeleton width="100%" height="0.625rem" animation="wave" />
+        <p-skeleton width="75%" height="0.625rem" animation="wave" />
       </div>
-      <div class="flex flex-col gap-1 mt-auto">
-        <p-skeleton width="3rem" height="1.75rem" />
-        <p-skeleton width="70%" height="0.75rem" />
+      <!-- 3. Sparkline area -->
+      <div class="mt-1 w-full h-16">
+        <p-skeleton width="100%" height="100%" borderRadius="8px" animation="wave" />
       </div>
+      <!-- 4. Big metric + delta pill -->
+      <div class="flex items-center gap-2 mt-auto">
+        <p-skeleton width="3rem" height="1.75rem" animation="wave" />
+        <p-skeleton width="4rem" height="1rem" borderRadius="9999px" animation="wave" />
+      </div>
+      <!-- 5. Footer / subtitle -->
+      <p-skeleton width="60%" height="0.75rem" animation="wave" />
     } @else {
       <!-- Header: Icon + Title -->
       <div class="flex items-center gap-2">

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
@@ -32,7 +32,7 @@
 
       <!-- Description -->
       @if (description()) {
-        <p class="text-[11px] text-gray-400 leading-snug -mt-1 mb-0">{{ description() }}</p>
+        <p class="text-[11px] text-gray-500 leading-snug -mt-1 mb-0">{{ description() }}</p>
       }
 
       <!-- Body: Chart or Custom Content -->
@@ -63,6 +63,7 @@
                   class="text-xs font-medium"
                   [class.text-emerald-600]="trend() === 'up'"
                   [class.text-red-600]="trend() === 'down'"
+                  [class.text-gray-500]="trend() === 'neutral'"
                   data-testid="metric-card-change-percentage">
                   {{ changePercentage() }}
                 </span>

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.html
@@ -46,8 +46,8 @@
       }
 
       <!-- Body: Chart or Custom Content -->
-      @if (customContentTemplate) {
-        <ng-container [ngTemplateOutlet]="customContentTemplate"></ng-container>
+      @if (customContentTemplate()) {
+        <ng-container [ngTemplateOutlet]="customContentTemplate()!"></ng-container>
       } @else {
         <div class="mt-3 w-full h-16">
           @if (chartData()) {

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass, NgTemplateOutlet } from '@angular/common';
-import { Component, ContentChild, input, output, TemplateRef } from '@angular/core';
+import { Component, contentChild, input, output, TemplateRef } from '@angular/core';
 import { ChartComponent } from '@components/chart/chart.component';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
@@ -15,7 +15,7 @@ import type { ChartData, ChartOptions, ChartType } from 'chart.js';
   templateUrl: './metric-card.component.html',
 })
 export class MetricCardComponent {
-  @ContentChild('customContent', { static: false }) public customContentTemplate?: TemplateRef<unknown>;
+  public readonly customContentTemplate = contentChild<TemplateRef<unknown>>('customContent');
 
   // Header inputs
   public readonly title = input.required<string>();

--- a/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts
+++ b/apps/lfx-one/src/app/shared/components/metric-card/metric-card.component.ts
@@ -32,7 +32,7 @@ export class MetricCardComponent {
   public readonly value = input<string>();
   public readonly subtitle = input<string>();
   public readonly valueTooltip = input<string>();
-  public readonly trend = input<'up' | 'down'>();
+  public readonly trend = input<'up' | 'down' | 'neutral'>();
   public readonly changePercentage = input<string>();
 
   // Styling

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -641,9 +641,10 @@ function protoSparkline(data: number[], color: string) {
 
 /** Build a flat sparkline that Chart.js can actually render visibly.
  *  A constant array makes min===max, collapsing the Y range to zero and hiding the line.
- *  Adding ±2% variation gives Chart.js a real range while looking nearly flat. */
+ *  Adding ±2% variation (floor 0.1) gives Chart.js a real range while looking nearly flat.
+ *  Lower bound is clamped to 0 so non-negative metrics never dip below zero. */
 function flatSparklineData(value: number): number[] {
-  const nudge = Math.max(value * 0.02, 1);
+  const nudge = Math.max(Math.abs(value) * 0.02, 0.1);
   return [Math.max(value - nudge, 0), value, value, value, value, value + nudge];
 }
 

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -649,18 +649,18 @@ function flatSparklineData(value: number): number[] {
 }
 
 /** Normalize a server-provided trend: treat zero change as neutral instead of up.
- *  Rounds to 1 decimal to match display precision — a server value of 0.03 displays
- *  as "+0.0%" and should be neutral, not green. */
+ *  Uses Number(toFixed(1)) to match roundForDisplay() — both helpers agree on the
+ *  same rounding path so the trend color never diverges from the displayed label. */
 function normalizeTrend(change: number, serverTrend: 'up' | 'down'): 'up' | 'down' | 'neutral' {
-  if (Math.round(change * 10) === 0) return 'neutral';
+  if (Number(change.toFixed(1)) === 0) return 'neutral';
   return serverTrend;
 }
 
 /** Derive trend direction from a numeric change value.
- *  Uses the same rounding threshold as normalizeTrend so the direction
- *  matches the formatted display string. */
+ *  Uses Number(toFixed(1)) — same rounding path as normalizeTrend and
+ *  roundForDisplay() so the direction matches the formatted display string. */
 function trendFromChange(change: number): 'up' | 'down' | 'neutral' {
-  if (Math.round(change * 10) === 0) return 'neutral';
+  if (Number(change.toFixed(1)) === 0) return 'neutral';
   return change > 0 ? 'up' : 'down';
 }
 

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -640,7 +640,7 @@ function protoSparkline(data: number[], color: string) {
 }
 
 /** Helper to build a dual-signal row with sparkline */
-function protoDualSignal(label: string, value: string, data: number[], color: string, change?: string, trend?: 'up' | 'down'): DualSignalRow {
+function protoDualSignal(label: string, value: string, data: number[], color: string, change?: string, trend?: 'up' | 'down' | 'neutral'): DualSignalRow {
   return {
     label,
     value,
@@ -688,11 +688,11 @@ function paidMediaMomChange(trend: { spend: number }[]): string | undefined {
 }
 
 /** Compute trend direction from a paid media monthly trend series */
-function paidMediaTrend(trend: { spend: number }[]): 'up' | 'down' | undefined {
+function paidMediaTrend(trend: { spend: number }[]): 'up' | 'down' | 'neutral' | undefined {
   if (trend.length < 2) return undefined;
   const prev = trend[trend.length - 2].spend;
   const curr = trend[trend.length - 1].spend;
-  return curr >= prev ? 'up' : 'down';
+  return curr === prev ? 'neutral' : curr > prev ? 'up' : 'down';
 }
 
 /** Extract values from NorthStarMonthlyDataPoint[] */
@@ -721,9 +721,11 @@ function eventAttrMomChange(series: number[]): string | undefined {
 }
 
 /** Compute trend direction from event-attribution monthly revenue series */
-function eventAttrTrendDirection(series: number[]): 'up' | 'down' | undefined {
+function eventAttrTrendDirection(series: number[]): 'up' | 'down' | 'neutral' | undefined {
   if (series.length < 2) return undefined;
-  return series[series.length - 1] >= series[series.length - 2] ? 'up' : 'down';
+  const curr = series[series.length - 1];
+  const prev = series[series.length - 2];
+  return curr === prev ? 'neutral' : curr > prev ? 'up' : 'down';
 }
 
 /**
@@ -745,8 +747,8 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Event attendees who engage via newsletter, community, working groups, training, code, or web within 90 days.',
       value: `${flywheel.reengagement.reengagementRate.toFixed(1)}%`,
       changePercentage: formatPpMomChange(flywheel.reengagement.reengagementMomChange),
-      trend: flywheel.reengagement.reengagementMomChange >= 0 ? 'up' : 'down',
-      subtitle: 'Re-engagement within 90 days · Sparkline: monthly re-engaged count',
+      trend: flywheel.reengagement.reengagementMomChange === 0 ? 'neutral' : flywheel.reengagement.reengagementMomChange > 0 ? 'up' : 'down',
+      subtitle: 'Re-engagement within 90 days',
       chartData: flywheel.monthlyData.length > 0 ? protoSparkline(monthlyValues(flywheel.monthlyData), lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText:
@@ -779,7 +781,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       value: formatNumber(engagedCommunity.totalMembers),
       changePercentage: formatMomChange(engagedCommunity.changePercentage),
       trend: engagedCommunity.trend,
-      subtitle: `${Object.values(engagedCommunity.breakdown).filter((v) => v > 0).length} channels · Last 6 months`,
+      subtitle: 'Last 6 months',
       chartData: protoSparkline(engagedCommunity.monthlyData.length > 0 ? monthlyValues(engagedCommunity.monthlyData) : [0], lfxColors.blue[500]),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Unique individuals active across Slack, Discord, GitHub, and mailing lists in the last 90 days.',
@@ -794,8 +796,8 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Year-to-date event count, attendees, and net revenue with YoY comparison.',
       value: formatNumber(eventGrowth.totalRegistrants),
       changePercentage: formatYoyChange(eventGrowth.registrantYoyChange),
-      trend: eventGrowth.registrantYoyChange >= 0 ? 'up' : 'down',
-      subtitle: `${formatNumber(eventGrowth.totalEvents)} events · YTD registrants`,
+      trend: eventGrowth.registrantYoyChange === 0 ? 'neutral' : eventGrowth.registrantYoyChange > 0 ? 'up' : 'down',
+      subtitle: `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD registrants`,
       chartData: eventGrowth.monthlyData.length > 0 ? protoSparkline(monthlyValues(eventGrowth.monthlyData), lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Year-to-date event attendees and YoY change. Source: Event registrations.',
@@ -854,7 +856,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           [],
           lfxColors.emerald[500],
           formatPpMomChange(brandHealth.sentimentMomChangePp),
-          brandHealth.sentimentMomChangePp >= 0 ? 'up' : 'down'
+          brandHealth.sentimentMomChangePp === 0 ? 'neutral' : brandHealth.sentimentMomChangePp > 0 ? 'up' : 'down'
         ),
       ],
       caption: `${formatNumber(brandHealth.totalMentions)} mentions · Last 6 months`,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -639,6 +639,21 @@ function protoSparkline(data: number[], color: string) {
   };
 }
 
+/** Build a flat sparkline that Chart.js can actually render visibly.
+ *  A constant array makes min===max, collapsing the Y range to zero and hiding the line.
+ *  Adding ±2% variation gives Chart.js a real range while looking nearly flat. */
+function flatSparklineData(value: number): number[] {
+  const nudge = Math.max(value * 0.02, 1);
+  return [value - nudge, value, value, value, value, value + nudge];
+}
+
+/** Normalize a server-provided trend: treat zero change as neutral instead of up.
+ *  Rounds to 1 decimal to match display precision — a server value of 0.03 displays
+ *  as "+0.0%" and should be neutral, not green. */
+function normalizeTrend(change: number, serverTrend: 'up' | 'down'): 'up' | 'down' | 'neutral' {
+  return Math.round(change * 10) === 0 ? 'neutral' : serverTrend;
+}
+
 /** Helper to build a dual-signal row with sparkline */
 function protoDualSignal(label: string, value: string, data: number[], color: string, change?: string, trend?: 'up' | 'down' | 'neutral'): DualSignalRow {
   return {
@@ -647,6 +662,7 @@ function protoDualSignal(label: string, value: string, data: number[], color: st
     changePercentage: change,
     trend,
     chartData: data.length > 0 ? protoSparkline(data, color) : EMPTY_CHART_DATA,
+    color,
   };
 }
 
@@ -687,12 +703,15 @@ function paidMediaMomChange(trend: { spend: number }[]): string | undefined {
   return formatMomChange(((curr - prev) / prev) * 100);
 }
 
-/** Compute trend direction from a paid media monthly trend series */
+/** Compute trend direction from a paid media monthly trend series.
+ *  Uses the same MoM % formula as paidMediaMomChange so the color matches the displayed text. */
 function paidMediaTrend(trend: { spend: number }[]): 'up' | 'down' | 'neutral' | undefined {
   if (trend.length < 2) return undefined;
   const prev = trend[trend.length - 2].spend;
   const curr = trend[trend.length - 1].spend;
-  return curr === prev ? 'neutral' : curr > prev ? 'up' : 'down';
+  if (prev === 0) return undefined;
+  const pct = ((curr - prev) / prev) * 100;
+  return Math.round(pct * 10) === 0 ? 'neutral' : pct > 0 ? 'up' : 'down';
 }
 
 /** Extract values from NorthStarMonthlyDataPoint[] */
@@ -720,18 +739,26 @@ function eventAttrMomChange(series: number[]): string | undefined {
   return formatMomChange(((curr - prev) / prev) * 100);
 }
 
-/** Compute trend direction from event-attribution monthly revenue series */
+/** Compute trend direction from event-attribution monthly revenue series.
+ *  Uses the same MoM % formula as eventAttrMomChange so the color matches the displayed text. */
 function eventAttrTrendDirection(series: number[]): 'up' | 'down' | 'neutral' | undefined {
   if (series.length < 2) return undefined;
-  const curr = series[series.length - 1];
   const prev = series[series.length - 2];
-  return curr === prev ? 'neutral' : curr > prev ? 'up' : 'down';
+  const curr = series[series.length - 1];
+  if (prev === 0) return undefined;
+  const pct = ((curr - prev) / prev) * 100;
+  return Math.round(pct * 10) === 0 ? 'neutral' : pct > 0 ? 'up' : 'down';
 }
 
 /**
  * Build ED Evolution dashboard cards from live API data.
  * 4 North Star + 2 Brand + 1 Influence.
  * Member Retention is merged into the Member Growth drawer.
+ *
+ * Sparkline color semantics:
+ *  - Blue  (lfxColors.blue[500])   — volume/reach metric (primary signal on every card)
+ *  - Violet (lfxColors.violet[500]) — secondary dimension on dual-signal cards (spend, sessions, sentiment)
+ * Emerald/red are reserved for delta indicators (up/down), never sparkline stroke.
  */
 export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricCard[] {
   const { flywheel, memberAcquisition, memberRetention, engagedCommunity, eventGrowth, brandReach, brandHealth, revenueImpact } = data;
@@ -747,9 +774,12 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Event attendees who engage via newsletter, community, working groups, training, code, or web within 90 days.',
       value: `${flywheel.reengagement.reengagementRate.toFixed(1)}%`,
       changePercentage: formatPpMomChange(flywheel.reengagement.reengagementMomChange),
-      trend: flywheel.reengagement.reengagementMomChange === 0 ? 'neutral' : flywheel.reengagement.reengagementMomChange > 0 ? 'up' : 'down',
-      subtitle: 'Re-engagement within 90 days',
-      chartData: flywheel.monthlyData.length > 0 ? protoSparkline(monthlyValues(flywheel.monthlyData), lfxColors.blue[500]) : EMPTY_CHART_DATA,
+      trend: Math.round(flywheel.reengagement.reengagementMomChange * 10) === 0 ? 'neutral' : flywheel.reengagement.reengagementMomChange > 0 ? 'up' : 'down',
+      subtitle: 'MoM · Last 6 months',
+      chartData: protoSparkline(
+        flywheel.monthlyData.length > 0 ? monthlyValues(flywheel.monthlyData) : flatSparklineData(flywheel.reengagement.reengagementRate),
+        lfxColors.blue[500]
+      ),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText:
         'Percentage of event attendees who re-engage via newsletter, community, or working groups within 90 days post-event. Change shown in percentage points (pp) MoM.',
@@ -764,7 +794,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Total paying corporate members with quarterly net new count and associated revenue.',
       value: formatNumber(memberAcquisition.totalMembers),
       changePercentage: formatMomChange(memberAcquisition.changePercentage),
-      trend: memberAcquisition.trend,
+      trend: normalizeTrend(memberAcquisition.changePercentage, memberAcquisition.trend),
       subtitle: `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · Last 6 months`,
       chartData: protoSparkline(memberAcquisition.totalMembersMonthlyData.length > 0 ? memberAcquisition.totalMembersMonthlyData : [0], lfxColors.blue[500]),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
@@ -780,7 +810,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Unique individuals active across 7 channels — Slack, Discord, GitHub, mailing lists, training, web, and code — in the last 90 days.',
       value: formatNumber(engagedCommunity.totalMembers),
       changePercentage: formatMomChange(engagedCommunity.changePercentage),
-      trend: engagedCommunity.trend,
+      trend: normalizeTrend(engagedCommunity.changePercentage, engagedCommunity.trend),
       subtitle: 'Last 6 months',
       chartData: protoSparkline(engagedCommunity.monthlyData.length > 0 ? monthlyValues(engagedCommunity.monthlyData) : [0], lfxColors.blue[500]),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
@@ -796,9 +826,12 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Year-to-date event count, attendees, and net revenue with YoY comparison.',
       value: formatNumber(eventGrowth.totalRegistrants),
       changePercentage: formatYoyChange(eventGrowth.registrantYoyChange),
-      trend: eventGrowth.registrantYoyChange === 0 ? 'neutral' : eventGrowth.registrantYoyChange > 0 ? 'up' : 'down',
-      subtitle: `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD registrants`,
-      chartData: eventGrowth.monthlyData.length > 0 ? protoSparkline(monthlyValues(eventGrowth.monthlyData), lfxColors.blue[500]) : EMPTY_CHART_DATA,
+      trend: Math.round(eventGrowth.registrantYoyChange * 10) === 0 ? 'neutral' : eventGrowth.registrantYoyChange > 0 ? 'up' : 'down',
+      subtitle: `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD`,
+      chartData: protoSparkline(
+        eventGrowth.monthlyData.length > 0 ? monthlyValues(eventGrowth.monthlyData) : flatSparklineData(eventGrowth.totalRegistrants),
+        lfxColors.blue[500]
+      ),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Year-to-date event attendees and YoY change.',
       drawerType: DashboardDrawerType.NorthStarEventGrowth,
@@ -822,7 +855,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           [],
           lfxColors.blue[500],
           formatMomChange(brandReach.changePercentage),
-          brandReach.trend
+          normalizeTrend(brandReach.changePercentage, brandReach.trend)
         ),
         protoDualSignal(
           'Monthly Sessions',
@@ -854,9 +887,9 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           'Positive Sentiment',
           `${brandHealth.sentiment.positive.toFixed(1)}%`,
           [],
-          lfxColors.emerald[500],
+          lfxColors.violet[500],
           formatPpMomChange(brandHealth.sentimentMomChangePp),
-          brandHealth.sentimentMomChangePp === 0 ? 'neutral' : brandHealth.sentimentMomChangePp > 0 ? 'up' : 'down'
+          Math.round(brandHealth.sentimentMomChangePp * 10) === 0 ? 'neutral' : brandHealth.sentimentMomChangePp > 0 ? 'up' : 'down'
         ),
       ],
       caption: `${formatNumber(brandHealth.totalMentions)} mentions · Last 6 months`,
@@ -873,7 +906,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       testId: 'ed-evo-revenue-impact',
       description: 'Revenue attributed to marketing touchpoints (last-touch model) alongside paid media spend.',
       customContentType: 'dual-signal',
-      caption: `Last-touch attribution · Last 6 months`,
+      caption: 'Last 6 months',
       dualSignals: [
         (() => {
           const eventAttrSeries = eventAttrMonthlyRevenueSeries(revenueImpact.eventRegistrationAttribution.monthlyTrend);
@@ -891,7 +924,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           'Paid Media',
           formatCurrency(revenueImpact.paidMedia.adSpend),
           revenueImpact.paidMedia.monthlyTrend.map((r) => r.spend),
-          lfxColors.emerald[500],
+          lfxColors.violet[500],
           paidMediaMomChange(revenueImpact.paidMedia.monthlyTrend),
           paidMediaTrend(revenueImpact.paidMedia.monthlyTrend)
         ),

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -815,7 +815,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       changePercentage: formatMomChange(memberAcquisition.changePercentage),
       trend: normalizeTrend(memberAcquisition.changePercentage, memberAcquisition.trend),
       subtitle: `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · Last 6 months`,
-      chartData: protoSparkline(memberAcquisition.totalMembersMonthlyData.length > 0 ? memberAcquisition.totalMembersMonthlyData : [0], lfxColors.blue[500]),
+      chartData: protoSparkline(
+        memberAcquisition.totalMembersMonthlyData.length > 0 ? memberAcquisition.totalMembersMonthlyData : flatSparklineData(memberAcquisition.totalMembers),
+        lfxColors.blue[500]
+      ),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Total paying corporate members with monthly net new over the last 6 months.',
       drawerType: DashboardDrawerType.NorthStarMemberAcquisition,
@@ -831,7 +834,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       changePercentage: formatMomChange(engagedCommunity.changePercentage),
       trend: normalizeTrend(engagedCommunity.changePercentage, engagedCommunity.trend),
       subtitle: 'Last 6 months',
-      chartData: protoSparkline(engagedCommunity.monthlyData.length > 0 ? monthlyValues(engagedCommunity.monthlyData) : [0], lfxColors.blue[500]),
+      chartData: protoSparkline(
+        engagedCommunity.monthlyData.length > 0 ? monthlyValues(engagedCommunity.monthlyData) : flatSparklineData(engagedCommunity.totalMembers),
+        lfxColors.blue[500]
+      ),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Unique individuals active across Slack, Discord, GitHub, and mailing lists in the last 90 days.',
       drawerType: DashboardDrawerType.NorthStarEngagedCommunity,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -768,7 +768,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       subtitle: `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · Last 6 months`,
       chartData: protoSparkline(memberAcquisition.totalMembersMonthlyData.length > 0 ? memberAcquisition.totalMembersMonthlyData : [0], lfxColors.blue[500]),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-      tooltipText: 'Total paying corporate members with monthly net new over the last 6 months. Source: Salesforce B2B memberships.',
+      tooltipText: 'Total paying corporate members with monthly net new over the last 6 months.',
       drawerType: DashboardDrawerType.NorthStarMemberAcquisition,
     } as DashboardMetricCard,
     {
@@ -800,7 +800,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       subtitle: `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD registrants`,
       chartData: eventGrowth.monthlyData.length > 0 ? protoSparkline(monthlyValues(eventGrowth.monthlyData), lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-      tooltipText: 'Year-to-date event attendees and YoY change. Source: Event registrations.',
+      tooltipText: 'Year-to-date event attendees and YoY change.',
       drawerType: DashboardDrawerType.NorthStarEventGrowth,
     } as DashboardMetricCard,
 
@@ -811,7 +811,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'brand',
       testId: 'ed-evo-brand-reach',
-      description: 'Social followers across all platforms and monthly website sessions from GA4.',
+      description: 'Social followers across all platforms and monthly website sessions.',
       customContentType: 'dual-signal',
       dualSignals: [
         protoDualSignal(
@@ -841,7 +841,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'brand',
       testId: 'ed-evo-brand-health',
-      description: 'Total brand mentions from Octolens social listening with sentiment breakdown.',
+      description: 'Total brand mentions with sentiment breakdown.',
       customContentType: 'dual-signal',
       dualSignals: [
         protoDualSignal(
@@ -860,7 +860,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
         ),
       ],
       caption: `${formatNumber(brandHealth.totalMentions)} mentions · Last 6 months`,
-      tooltipText: 'Total brand mentions across social and web (Octolens) with sentiment breakdown.',
+      tooltipText: 'Total brand mentions across social and web with sentiment breakdown.',
       drawerType: DashboardDrawerType.BrandHealth,
     } as DashboardMetricCard,
 

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -677,22 +677,33 @@ export const ED_EVOLUTION_FILTER_OPTIONS: FilterPillOption[] = [
   { id: 'influence', label: 'Influence' },
 ];
 
+/** Round to 1 decimal place, normalizing JS negative zero to positive zero.
+ *  e.g. -0.03 → "0.0" not "-0.0", so the displayed text matches neutral trend styling. */
+function roundForDisplay(value: number): string {
+  const rounded = Number(value.toFixed(1));
+  // Object.is distinguishes -0 from 0 — normalise to positive zero
+  return (Object.is(rounded, -0) ? 0 : rounded).toFixed(1);
+}
+
 /** Format a MoM change as a display string */
 function formatMomChange(change: number): string {
-  const sign = change >= 0 ? '+' : '';
-  return `${sign}${change.toFixed(1)}% MoM`;
+  const formatted = roundForDisplay(change);
+  const sign = !formatted.startsWith('-') ? '+' : '';
+  return `${sign}${formatted}% MoM`;
 }
 
 /** Format a YoY change as a display string */
 function formatYoyChange(change: number): string {
-  const sign = change >= 0 ? '+' : '';
-  return `${sign}${change.toFixed(1)}% YoY`;
+  const formatted = roundForDisplay(change);
+  const sign = !formatted.startsWith('-') ? '+' : '';
+  return `${sign}${formatted}% YoY`;
 }
 
 /** Format a percentage-point MoM change as a display string */
 function formatPpMomChange(change: number): string {
-  const sign = change >= 0 ? '+' : '';
-  return `${sign}${change.toFixed(1)}pp MoM`;
+  const formatted = roundForDisplay(change);
+  const sign = !formatted.startsWith('-') ? '+' : '';
+  return `${sign}${formatted}pp MoM`;
 }
 
 /** Compute MoM change display from a paid media monthly trend series (last two months of spend) */

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -644,7 +644,7 @@ function protoSparkline(data: number[], color: string) {
  *  Adding ±2% variation gives Chart.js a real range while looking nearly flat. */
 function flatSparklineData(value: number): number[] {
   const nudge = Math.max(value * 0.02, 1);
-  return [value - nudge, value, value, value, value, value + nudge];
+  return [Math.max(value - nudge, 0), value, value, value, value, value + nudge];
 }
 
 /** Normalize a server-provided trend: treat zero change as neutral instead of up.

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -652,7 +652,16 @@ function flatSparklineData(value: number): number[] {
  *  Rounds to 1 decimal to match display precision — a server value of 0.03 displays
  *  as "+0.0%" and should be neutral, not green. */
 function normalizeTrend(change: number, serverTrend: 'up' | 'down'): 'up' | 'down' | 'neutral' {
-  return Math.round(change * 10) === 0 ? 'neutral' : serverTrend;
+  if (Math.round(change * 10) === 0) return 'neutral';
+  return serverTrend;
+}
+
+/** Derive trend direction from a numeric change value.
+ *  Uses the same rounding threshold as normalizeTrend so the direction
+ *  matches the formatted display string. */
+function trendFromChange(change: number): 'up' | 'down' | 'neutral' {
+  if (Math.round(change * 10) === 0) return 'neutral';
+  return change > 0 ? 'up' : 'down';
 }
 
 /** Helper to build a dual-signal row with sparkline */
@@ -722,8 +731,7 @@ function paidMediaTrend(trend: { spend: number }[]): 'up' | 'down' | 'neutral' |
   const prev = trend[trend.length - 2].spend;
   const curr = trend[trend.length - 1].spend;
   if (prev === 0) return undefined;
-  const pct = ((curr - prev) / prev) * 100;
-  return Math.round(pct * 10) === 0 ? 'neutral' : pct > 0 ? 'up' : 'down';
+  return trendFromChange(((curr - prev) / prev) * 100);
 }
 
 /** Extract values from NorthStarMonthlyDataPoint[] */
@@ -758,8 +766,7 @@ function eventAttrTrendDirection(series: number[]): 'up' | 'down' | 'neutral' | 
   const prev = series[series.length - 2];
   const curr = series[series.length - 1];
   if (prev === 0) return undefined;
-  const pct = ((curr - prev) / prev) * 100;
-  return Math.round(pct * 10) === 0 ? 'neutral' : pct > 0 ? 'up' : 'down';
+  return trendFromChange(((curr - prev) / prev) * 100);
 }
 
 /**
@@ -786,7 +793,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Event attendees who engage via newsletter, community, working groups, training, code, or web within 90 days.',
       value: `${flywheel.reengagement.reengagementRate.toFixed(1)}%`,
       changePercentage: formatPpMomChange(flywheel.reengagement.reengagementMomChange),
-      trend: Math.round(flywheel.reengagement.reengagementMomChange * 10) === 0 ? 'neutral' : flywheel.reengagement.reengagementMomChange > 0 ? 'up' : 'down',
+      trend: trendFromChange(flywheel.reengagement.reengagementMomChange),
       subtitle: 'MoM · Last 6 months',
       chartData: protoSparkline(
         flywheel.monthlyData.length > 0 ? monthlyValues(flywheel.monthlyData) : flatSparklineData(flywheel.reengagement.reengagementRate),
@@ -838,7 +845,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Year-to-date event count, attendees, and net revenue with YoY comparison.',
       value: formatNumber(eventGrowth.totalRegistrants),
       changePercentage: formatYoyChange(eventGrowth.registrantYoyChange),
-      trend: Math.round(eventGrowth.registrantYoyChange * 10) === 0 ? 'neutral' : eventGrowth.registrantYoyChange > 0 ? 'up' : 'down',
+      trend: trendFromChange(eventGrowth.registrantYoyChange),
       subtitle: `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD`,
       chartData: protoSparkline(
         eventGrowth.monthlyData.length > 0 ? monthlyValues(eventGrowth.monthlyData) : flatSparklineData(eventGrowth.totalRegistrants),
@@ -901,7 +908,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           [],
           lfxColors.violet[500],
           formatPpMomChange(brandHealth.sentimentMomChangePp),
-          Math.round(brandHealth.sentimentMomChangePp * 10) === 0 ? 'neutral' : brandHealth.sentimentMomChangePp > 0 ? 'up' : 'down'
+          trendFromChange(brandHealth.sentimentMomChangePp)
         ),
       ],
       caption: `${formatNumber(brandHealth.totalMentions)} mentions · Last 6 months`,

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -321,6 +321,8 @@ export interface DualSignalRow {
   trend?: 'up' | 'down' | 'neutral';
   /** Sparkline chart data for this signal */
   chartData?: ChartData<ChartType>;
+  /** Sparkline color — rendered as a legend dot beside the label */
+  color?: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -56,7 +56,7 @@ export interface DashboardMetricCard {
   icon?: string;
 
   /** Trend direction indicator */
-  trend?: 'up' | 'down';
+  trend?: 'up' | 'down' | 'neutral';
 
   /** Percentage change value (e.g., '+12.4%') */
   changePercentage?: string;
@@ -318,7 +318,7 @@ export interface DualSignalRow {
   /** Change percentage display (e.g., "+8.2% MoM") */
   changePercentage?: string;
   /** Trend direction */
-  trend?: 'up' | 'down';
+  trend?: 'up' | 'down' | 'neutral';
   /** Sparkline chart data for this signal */
   chartData?: ChartData<ChartType>;
 }


### PR DESCRIPTION
## Summary
- **Fix zero-delta green bug**: near-zero server values (e.g., 0.03) that display as "+0.0%" now show neutral gray instead of misleading green — applies to all trend computations
- **Codify sparkline color system**: blue = volume/reach (primary), violet = secondary dimension; add color legend dots to dual-signal cards
- **Standardize card footers**: consistent time-window placement, methodology moved to tooltips, unified caption styling
- **Reorder dashboard sections**: Foundation Health at top, Marketing Metrics below with renamed header and icon
- **Remove data source references** (Octolens, GA4, Salesforce) from user-facing descriptions
- **Polish**: neutral trend state, description contrast bump, grammar fixes, skeleton upgrade, pager card count

LFXV2-1468

## Test plan
- [ ] Foundation Health section renders above Marketing Metrics
- [ ] Marketing Metrics header shows chart icon + "Marketing Metrics" text
- [ ] Brand Reach Social Followers and Brand Health Positive Sentiment show gray (not green) for +0.0% deltas
- [ ] Dual-signal cards (Brand Reach, Brand Health, Attribution) show colored legend dots (blue/violet)
- [ ] Brand Health "Positive Sentiment" sparkline is violet, not green
- [ ] Paid Media sparkline is violet, not green
- [ ] Card footers end with time window; no data source names visible
- [ ] Carousel shows card count between arrows
- [ ] Skeleton placeholders render correctly during loading

🤖 Generated with [Claude Code](https://claude.ai/claude-code)