### PR TITLE
fix(ui): align transactions dashboard styling with app design system

### DIFF
--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
@@ -60,7 +60,7 @@
             }
           </td>
 
-          <!-- Amount column -->
+          <!-- Transaction Value column -->
           <td class="text-right">
             <span class="font-medium text-gray-900">{{ transaction.netRevenue | currency: 'USD' }}</span>
           </td>

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.html
@@ -13,45 +13,24 @@
     <lfx-filter-pills [options]="tabOptions" [selectedFilter]="activeTab()" (filterChange)="onTabChange($event)" />
   </div>
 
-  <!-- Loading state -->
-  @if (transactions() === undefined) {
-    <div data-testid="transactions-loading">
-      <div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden animate-pulse">
-        <div class="grid grid-cols-5 gap-4 px-4 py-3 border-b border-gray-100">
-          @for (i of [1, 2, 3, 4, 5]; track i) {
-            <div class="h-3 bg-gray-200 rounded"></div>
-          }
-        </div>
-        @for (i of [1, 2, 3, 4, 5]; track i) {
-          <div class="grid grid-cols-5 gap-4 px-4 py-4 border-b border-gray-100 last:border-0">
-            <div class="h-3 bg-gray-100 rounded w-3/4"></div>
-            <div class="h-3 bg-gray-100 rounded w-2/3"></div>
-            <div class="h-3 bg-gray-100 rounded w-1/2"></div>
-            <div class="h-3 bg-gray-100 rounded w-1/3"></div>
-            <div class="h-3 bg-gray-100 rounded w-1/4 ml-auto"></div>
-          </div>
-        }
-      </div>
-    </div>
-  } @else if (filteredTransactions().length === 0) {
-    <!-- Empty state -->
-    <div class="flex flex-col items-center justify-center py-20 text-center gap-4" data-testid="transactions-empty-state">
-      <i class="fa-light fa-receipt text-6xl text-gray-300"></i>
-      <div class="flex flex-col gap-2 max-w-md">
-        <h2 class="text-lg font-semibold text-gray-700">No transactions yet</h2>
-        <p class="text-gray-500 text-sm">Your Linux Foundation purchase history will appear here. Recent purchases may take up to 48 hours to be reflected.</p>
-      </div>
-    </div>
-  } @else {
-    <!-- Transactions table -->
-    <lfx-table [value]="paginatedTransactions()" data-testid="transactions-table">
+  <!-- Transactions table -->
+  <lfx-card>
+    <lfx-table
+      [value]="filteredTransactions()"
+      [loading]="transactions() === undefined"
+      [paginator]="filteredTransactions().length > 10"
+      [rows]="10"
+      [rowsPerPageOptions]="[10, 25, 50]"
+      [first]="tableFirst()"
+      (onPage)="tableFirst.set($event.first)"
+      data-testid="transactions-table">
       <ng-template #header>
         <tr>
           <th class="w-[35%]">Name</th>
           <th class="w-[20%]">Order ID</th>
           <th class="w-[15%]">Date</th>
           <th class="w-[15%]">Type</th>
-          <th class="w-[15%] text-right">Amount</th>
+          <th class="w-[15%] text-right">Transaction Value</th>
         </tr>
       </ng-template>
 
@@ -59,17 +38,17 @@
         <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'transactions-row-' + transaction.id">
           <!-- Name column -->
           <td>
-            <span class="text-xs text-gray-900">{{ transaction.name }}</span>
+            <span class="text-gray-900">{{ transaction.name }}</span>
           </td>
 
           <!-- Order ID column -->
           <td>
-            <span class="text-xs text-gray-500 font-mono">{{ transaction.orderId }}</span>
+            <span class="text-gray-500 font-mono">{{ transaction.orderId }}</span>
           </td>
 
           <!-- Date column -->
           <td>
-            <span class="text-xs text-gray-700">{{ transaction.createdDate | date: 'mediumDate' }}</span>
+            <span class="text-gray-700">{{ transaction.createdDate | date: 'mediumDate' }}</span>
           </td>
 
           <!-- Type column -->
@@ -77,13 +56,13 @@
             @if (transaction.transactionType) {
               <lfx-tag [value]="transaction.transactionType" severity="secondary" [styleClass]="transaction.transactionType | transactionTypeStyle" />
             } @else {
-              <span class="text-xs text-gray-400">&mdash;</span>
+              <span class="text-gray-400">&mdash;</span>
             }
           </td>
 
           <!-- Amount column -->
           <td class="text-right">
-            <span class="text-xs font-medium text-gray-900">{{ transaction.netRevenue | currency: 'USD' }}</span>
+            <span class="font-medium text-gray-900">{{ transaction.netRevenue | currency: 'USD' }}</span>
           </td>
         </tr>
       </ng-template>
@@ -92,55 +71,10 @@
         <tr>
           <td colspan="5" class="text-center py-8">
             <i class="fa-light fa-receipt text-3xl text-gray-400 mb-2 block"></i>
-            <p class="text-sm text-gray-500">No transactions found</p>
+            <p class="text-sm text-gray-500">No transactions found. Recent purchases may take up to 48 hours to appear.</p>
           </td>
         </tr>
       </ng-template>
     </lfx-table>
-
-    <!-- Pagination row -->
-    @if (totalPages() > 1) {
-      <div class="flex items-center justify-between mt-4" data-testid="transactions-pagination">
-        <span class="text-xs text-gray-400">Showing {{ firstIndex() }}–{{ lastIndex() }} of {{ filteredTransactions().length }}</span>
-        <div class="flex gap-1">
-          <button
-            type="button"
-            class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-700 transition-colors"
-            [class.opacity-50]="currentPage() === 1"
-            [class.cursor-not-allowed]="currentPage() === 1"
-            [class.hover:bg-gray-200]="currentPage() !== 1"
-            [disabled]="currentPage() === 1"
-            (click)="goToPage(currentPage() - 1)"
-            data-testid="pagination-prev">
-            Prev
-          </button>
-          @for (page of pageNumbers(); track page) {
-            <button
-              type="button"
-              class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium transition-colors"
-              [class.bg-blue-500]="currentPage() === page"
-              [class.text-white]="currentPage() === page"
-              [class.bg-gray-100]="currentPage() !== page"
-              [class.text-gray-700]="currentPage() !== page"
-              [class.hover:bg-gray-200]="currentPage() !== page"
-              (click)="goToPage(page)"
-              [attr.data-testid]="'pagination-page-' + page">
-              {{ page }}
-            </button>
-          }
-          <button
-            type="button"
-            class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-gray-100 text-gray-700 transition-colors"
-            [class.opacity-50]="currentPage() === totalPages()"
-            [class.cursor-not-allowed]="currentPage() === totalPages()"
-            [class.hover:bg-gray-200]="currentPage() !== totalPages()"
-            [disabled]="currentPage() === totalPages()"
-            (click)="goToPage(currentPage() + 1)"
-            data-testid="pagination-next">
-            Next
-          </button>
-        </div>
-      </div>
-    }
-  }
+  </lfx-card>
 </div>

--- a/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/transactions/transactions-dashboard/transactions-dashboard.component.ts
@@ -16,6 +16,7 @@ import {
 } from '@lfx-one/shared/constants';
 import { FilterPillOption, Transaction } from '@lfx-one/shared/interfaces';
 
+import { CardComponent } from '@components/card/card.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -45,7 +46,7 @@ const TAB_TYPE_MAP: Record<string, string> = {
 
 @Component({
   selector: 'lfx-transactions-dashboard',
-  imports: [FilterPillsComponent, TableComponent, TagComponent, CurrencyPipe, DatePipe, TransactionTypeStylePipe],
+  imports: [CardComponent, FilterPillsComponent, TableComponent, TagComponent, CurrencyPipe, DatePipe, TransactionTypeStylePipe],
   templateUrl: './transactions-dashboard.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -56,34 +57,19 @@ export class TransactionsDashboardComponent {
   // ─── Configuration ─────────────────────────────────────────────────────────
   protected readonly subtitle = PAGE_SUBTITLE;
   protected readonly tabOptions = TAB_OPTIONS;
-  protected readonly pageSize = 10;
 
   // ─── Writable Signals ──────────────────────────────────────────────────────
   protected readonly activeTab = signal<string>('all');
-  protected readonly currentPage = signal<number>(1);
+  protected readonly tableFirst = signal<number>(0);
 
   // ─── Computed Signals ──────────────────────────────────────────────────────
   protected readonly transactions: Signal<Transaction[] | undefined> = this.initTransactions();
   protected readonly filteredTransactions: Signal<Transaction[]> = this.initFilteredTransactions();
-  protected readonly totalPages: Signal<number> = computed(() => Math.max(1, Math.ceil(this.filteredTransactions().length / this.pageSize)));
-  protected readonly paginatedTransactions: Signal<Transaction[]> = computed(() => {
-    const start = (this.currentPage() - 1) * this.pageSize;
-    return this.filteredTransactions().slice(start, start + this.pageSize);
-  });
-  protected readonly pageNumbers: Signal<number[]> = computed(() => Array.from({ length: this.totalPages() }, (_, i) => i + 1));
-  protected readonly firstIndex: Signal<number> = computed(() => (this.filteredTransactions().length === 0 ? 0 : (this.currentPage() - 1) * this.pageSize + 1));
-  protected readonly lastIndex: Signal<number> = computed(() => Math.min(this.currentPage() * this.pageSize, this.filteredTransactions().length));
 
   // ─── Protected Methods ─────────────────────────────────────────────────────
   protected onTabChange(tabId: string): void {
     this.activeTab.set(tabId);
-    this.currentPage.set(1);
-  }
-
-  protected goToPage(page: number): void {
-    if (page >= 1 && page <= this.totalPages()) {
-      this.currentPage.set(page);
-    }
+    this.tableFirst.set(0);
   }
 
   // ─── Private Initializers ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replace hand-rolled loading skeleton with `lfx-table` built-in `[loading]` input
- Replace custom Prev/Next pagination buttons with `lfx-table` built-in paginator
- Wrap table in `lfx-card` to match votes/surveys table patterns
- Reset pagination to page 1 when switching filter tabs
- Update column label from "Amount" to "Transaction Value" to match design

## Actual Implementation

<img width="1410" height="885" alt="Screenshot 2026-04-20 at 11 53 08 AM" src="https://github.com/user-attachments/assets/59290af6-2cd2-45aa-919a-c15ec81a2c3a" />

## Test plan

- [ ] Navigate to My Transactions — table loads with skeleton then data
- [ ] Switch between filter tabs — verify results filter correctly and pagination resets to page 1
- [ ] Verify pagination appears when a tab has more than 10 results
- [ ] Verify empty state shows when a tab has no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)