### PR TITLE
feat(meetings): show current rsvp on list card

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -270,7 +270,8 @@
             <!-- Organizer view with optional toggle for invited organizers -->
             @if (canToggleRsvpView() && showMyRsvp()) {
               <!-- Show RSVP Button Group when organizer toggles to set their own RSVP -->
-              <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="occurrence()?.occurrence_id"> </lfx-rsvp-button-group>
+              <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="occurrence()?.occurrence_id" (rsvpChanged)="onRsvpChanged($event)">
+              </lfx-rsvp-button-group>
             } @else {
               <!-- Show RSVP Details for organizers (default view) -->
               <lfx-meeting-rsvp-details
@@ -309,7 +310,8 @@
           <!-- Show RSVP Selection for authenticated invited non-organizers (upcoming meetings only) -->
           @if (isInvited()) {
             @defer (on idle) {
-              <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="occurrence()?.occurrence_id"> </lfx-rsvp-button-group>
+              <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="occurrence()?.occurrence_id" (rsvpChanged)="onRsvpChanged($event)">
+              </lfx-rsvp-button-group>
             } @placeholder {
               <div class="rounded-md p-3 flex flex-col gap-2 flex-1 bg-gray-100/60 animate-pulse min-h-[80px]"></div>
             }
@@ -359,6 +361,17 @@
           </div>
         }
 
+        <!-- Current user's RSVP status chip (organizer + invited, guest-count view, already responded) -->
+        @if (canToggleRsvpView() && !showMyRsvp() && currentUserRsvpLabel(); as rsvpLabel) {
+          <div class="flex items-center gap-2 px-3 py-1.5 rounded-md bg-gray-50 border border-gray-200 text-xs" data-testid="current-user-rsvp-status">
+            @if (currentUserRsvpIcon(); as iconClass) {
+              <i [class]="iconClass"></i>
+            }
+            <span class="text-gray-600">Your RSVP:</span>
+            <span class="font-medium text-gray-900">{{ rsvpLabel }}</span>
+          </div>
+        }
+
         <!-- Action Buttons for People Column -->
         <div class="flex gap-2" [ngClass]="{ 'mt-3.5': !pastMeeting() || meeting().organizer }">
           @if (meeting().organizer) {
@@ -376,7 +389,7 @@
               <lfx-button
                 class="w-full"
                 [icon]="showMyRsvp() ? 'fa-light fa-users' : 'fa-light fa-hand'"
-                [label]="showMyRsvp() ? 'Show Guests' : 'Set My RSVP'"
+                [label]="rsvpToggleLabel()"
                 size="small"
                 severity="secondary"
                 styleClass="w-full"

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -44,6 +44,7 @@ import {
   MeetingAttachment,
   MeetingCancelOccurrenceResult,
   MeetingOccurrence,
+  MeetingRsvp,
   MEETING_TYPE_CONFIGS,
   PastMeeting,
   PastMeetingAttachment,
@@ -65,7 +66,7 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DrawerModule } from 'primeng/drawer';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
-import { BehaviorSubject, catchError, combineLatest, filter, map, of, pairwise, switchMap, take, tap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, filter, map, merge, of, pairwise, Subject, switchMap, take, tap } from 'rxjs';
 
 import { CancelOccurrenceConfirmationComponent } from '../../components/cancel-occurrence-confirmation/cancel-occurrence-confirmation.component';
 import { MeetingMaterialsDrawerComponent } from '../meeting-materials-drawer/meeting-materials-drawer.component';
@@ -161,6 +162,15 @@ export class MeetingCardComponent implements OnInit {
   // True when user is both an organizer AND invited to the meeting (for non-past meetings)
   public readonly canToggleRsvpView: Signal<boolean> = computed(() => !!this.meeting().organizer && this.isInvited() && !this.pastMeeting());
 
+  // Current user's RSVP for this meeting — fetched when the user can toggle (organizer + invited)
+  // so the card can surface an "Update My RSVP" label/chip instead of the generic "Set My RSVP"
+  // prompt when a response already exists.
+  public readonly currentUserRsvp: Signal<MeetingRsvp | null> = this.initCurrentUserRsvp();
+  public readonly currentUserRsvpLabel: Signal<string | null> = this.initCurrentUserRsvpLabel();
+  public readonly currentUserRsvpIcon: Signal<string | null> = this.initCurrentUserRsvpIcon();
+  public readonly rsvpToggleLabel: Signal<string> = this.initRsvpToggleLabel();
+  private rsvpUpdateTrigger$ = new Subject<MeetingRsvp>();
+
   public readonly meetingTitle: Signal<string> = this.initMeetingTitle();
   public readonly meetingDescription: Signal<string> = this.initMeetingDescription();
   public readonly hasAiCompanion: Signal<boolean> = this.initHasAiCompanion();
@@ -243,6 +253,13 @@ export class MeetingCardComponent implements OnInit {
 
   public onRsvpViewToggle(): void {
     this.showMyRsvp.set(!this.showMyRsvp());
+  }
+
+  public onRsvpChanged(rsvp: MeetingRsvp): void {
+    // rsvp-button-group emits the confirmed response after its POST succeeds. Push it directly
+    // into the signal stream so the card's toggle label updates instantly, bypassing the
+    // query-service indexing window that otherwise makes a refetch return stale data.
+    this.rsvpUpdateTrigger$.next(rsvp);
   }
 
   public onDrawerHide(): void {
@@ -782,6 +799,70 @@ export class MeetingCardComponent implements OnInit {
       }
 
       return params;
+    });
+  }
+
+  private initCurrentUserRsvp(): Signal<MeetingRsvp | null> {
+    const meeting$ = toObservable(this.meeting);
+    const occurrence$ = toObservable(this.occurrence);
+    const authenticated$ = toObservable(this.authenticated);
+    const canToggle$ = toObservable(this.canToggleRsvpView);
+
+    // Server-side fetch: only runs when the user is an organizer + invited (canToggleRsvpView is true).
+    const serverFetch$ = combineLatest([meeting$, occurrence$, authenticated$, canToggle$]).pipe(
+      switchMap(([meeting, occurrence, authenticated, canToggle]) => {
+        if (!authenticated || !canToggle || !meeting?.id) {
+          return of(null);
+        }
+        const occurrenceId = meeting.recurrence ? occurrence?.occurrence_id : undefined;
+        // Service already catches+logs errors and returns of(null); defensive catchError here is a safety net.
+        return this.meetingService.getMeetingRsvpForCurrentUser(meeting.id, occurrenceId).pipe(catchError(() => of(null)));
+      })
+    );
+
+    // Merge server fetches with updates pushed from onRsvpChanged. The button-group emits after its
+    // POST succeeds, so trusting that value avoids the query-service indexing lag.
+    return toSignal(merge(serverFetch$, this.rsvpUpdateTrigger$.asObservable()), { initialValue: null });
+  }
+
+  private initCurrentUserRsvpLabel(): Signal<string | null> {
+    return computed(() => {
+      const rsvp = this.currentUserRsvp();
+      if (!rsvp) return null;
+      switch (rsvp.response_type) {
+        case 'accepted':
+          return 'Yes';
+        case 'declined':
+          return 'No';
+        case 'maybe':
+          return 'Maybe';
+        default:
+          return rsvp.response_type;
+      }
+    });
+  }
+
+  private initCurrentUserRsvpIcon(): Signal<string | null> {
+    return computed(() => {
+      const rsvp = this.currentUserRsvp();
+      if (!rsvp) return null;
+      switch (rsvp.response_type) {
+        case 'accepted':
+          return 'fa-solid fa-circle-check text-emerald-500';
+        case 'declined':
+          return 'fa-solid fa-circle-xmark text-red-500';
+        case 'maybe':
+          return 'fa-solid fa-clock text-amber-500';
+        default:
+          return null;
+      }
+    });
+  }
+
+  private initRsvpToggleLabel(): Signal<string> {
+    return computed(() => {
+      if (this.showMyRsvp()) return 'Show Guests';
+      return this.currentUserRsvp() ? 'Update My RSVP' : 'Set My RSVP';
     });
   }
 }


### PR DESCRIPTION
## Summary

Applies the detail-page RSVP-status pattern (introduced in #514) to the meeting card in the `/meetings` list view so **organizer-invited users see their existing response at a glance** instead of only "Set My RSVP".

## Implementation

- New `currentUserRsvp: Signal<MeetingRsvp | null>` on `MeetingCardComponent`, fetched via `meetingService.getMeetingRsvpForCurrentUser(id, occurrenceId)` only when the card's `canToggleRsvpView` is true (organizer + invited + not past)
- Merges the server fetch with a `Subject<MeetingRsvp>` fed by `rsvpChanged` emits from the inner `rsvp-button-group`, so the card's chip + toggle label update **instantly** after a submit, bypassing the query-service indexing window that otherwise returns stale data
- Toggle button label flips from "Set My RSVP" → "Update My RSVP" when a response exists
- Status chip (icon + color + label) appears above the action row when the card is in guest-count view and the user has already responded

## JIRA

- Follow-up to [LFXV2-1546](https://linuxfoundation.atlassian.net/browse/LFXV2-1546) (split from #514 to keep that PR focused)

## Trade-off

- **N extra `/rsvp/me` fetches** on the meetings list page — one per visible organizer-invited card. Lazy (only fires when the `canToggleRsvpView` gate is true). Will be retired once LFXV2-1545 Approach A enriches `/api/user/meetings` with `user_rsvp`.

## Out of scope

- Non-organizer invited cards (already show a highlighted button group inline — no gap).
- List card in My Meetings dashboard section (`lfx-dashboard-meeting-card` is a different component).

## Test plan

- [ ] Deploy preview loads `/meetings` (Upcoming, Me lens or any project lens).
- [ ] For a meeting where the current user is organizer + invited and has NOT yet RSVP'd: toggle button reads "Set My RSVP" (unchanged).
- [ ] For a meeting where the current user is organizer + invited AND has RSVP'd Yes/No/Maybe: toggle button reads "Update My RSVP" and the "Your RSVP: X" chip appears above the action row with the correct icon + color.
- [ ] Clicking "Update My RSVP" → picking a response in the button group → chip updates instantly (no refresh required).
- [ ] Non-organizer invited flow unchanged (button group rendered directly, with the selected option highlighted).

## Depends on

- [PR #514](https://github.com/linuxfoundation/lfx-v2-ui/pull/514) — merged first (establishes the chip pattern and `rsvpChanged` wiring on the detail page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1546]: https://linuxfoundation.atlassian.net/browse/LFXV2-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ