### PR TITLE
fix(ui): align ED cards and expand engaged community breakdown

### DIFF
--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -634,10 +634,16 @@ test.describe('API Response Validation', () => {
     expect(breakdown).toHaveProperty('communityMembers');
     expect(breakdown).toHaveProperty('workingGroupMembers');
     expect(breakdown).toHaveProperty('certifiedIndividuals');
+    expect(breakdown).toHaveProperty('webVisitors');
+    expect(breakdown).toHaveProperty('codeContributors');
+    expect(breakdown).toHaveProperty('trainingEnrollees');
     expect(typeof breakdown.newsletterSubscribers).toBe('number');
     expect(typeof breakdown.communityMembers).toBe('number');
     expect(typeof breakdown.workingGroupMembers).toBe('number');
     expect(typeof breakdown.certifiedIndividuals).toBe('number');
+    expect(typeof breakdown.webVisitors).toBe('number');
+    expect(typeof breakdown.codeContributors).toBe('number');
+    expect(typeof breakdown.trainingEnrollees).toBe('number');
 
     // Monthly data shape (if data exists)
     if (body.monthlyData.length > 0) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -151,7 +151,7 @@
         <h3 class="text-sm font-semibold text-gray-900">Community Breakdown</h3>
         <p class="text-sm text-gray-600">Members by engagement channel (deduplicated)</p>
       </div>
-      <div class="h-[160px]" data-testid="engaged-community-drawer-breakdown-chart">
+      <div class="h-[220px]" data-testid="engaged-community-drawer-breakdown-chart">
         <lfx-chart type="bar" [data]="breakdownChartData()" [options]="breakdownChartOptions" height="100%"></lfx-chart>
       </div>
     </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -31,7 +31,15 @@ export class EngagedCommunityDrawerComponent {
     totalMembers: 0,
     changePercentage: 0,
     trend: 'up',
-    breakdown: { newsletterSubscribers: 0, communityMembers: 0, workingGroupMembers: 0, certifiedIndividuals: 0 },
+    breakdown: {
+      newsletterSubscribers: 0,
+      communityMembers: 0,
+      workingGroupMembers: 0,
+      certifiedIndividuals: 0,
+      webVisitors: 0,
+      codeContributors: 0,
+      trainingEnrollees: 0,
+    },
     monthlyData: [],
   });
   public readonly brandReachData = input<BrandReachResponse>({
@@ -235,12 +243,16 @@ export class EngagedCommunityDrawerComponent {
         }
       }
 
-      // Segment composition — keep in sync with initBreakdownChartData (Community / Working Groups / Certified)
+      // Segment composition — keep in sync with initBreakdownChartData (all 7 engagement channels)
       if (totalMembers > 0) {
         const segments = [
           { name: 'Community members', value: breakdown.communityMembers },
           { name: 'Working group members', value: breakdown.workingGroupMembers },
           { name: 'Certified individuals', value: breakdown.certifiedIndividuals },
+          { name: 'Web visitors', value: breakdown.webVisitors },
+          { name: 'Code contributors', value: breakdown.codeContributors },
+          { name: 'Training enrollees', value: breakdown.trainingEnrollees },
+          { name: 'Newsletter subscribers', value: breakdown.newsletterSubscribers },
         ].sort((a, b) => b.value - a.value);
         const top = segments[0];
         const topShare = (top.value / totalMembers) * 100;
@@ -318,11 +330,27 @@ export class EngagedCommunityDrawerComponent {
     return computed(() => {
       const { breakdown } = this.data();
       return {
-        labels: ['Community', 'Working Groups', 'Certified'],
+        labels: ['Community', 'Working Groups', 'Newsletter', 'Training', 'Code', 'Web', 'Certified'],
         datasets: [
           {
-            data: [breakdown.communityMembers, breakdown.workingGroupMembers, breakdown.certifiedIndividuals],
-            backgroundColor: [lfxColors.blue[500], lfxColors.blue[300], lfxColors.blue[200]],
+            data: [
+              breakdown.communityMembers,
+              breakdown.workingGroupMembers,
+              breakdown.newsletterSubscribers,
+              breakdown.trainingEnrollees,
+              breakdown.codeContributors,
+              breakdown.webVisitors,
+              breakdown.certifiedIndividuals,
+            ],
+            backgroundColor: [
+              lfxColors.blue[700],
+              lfxColors.blue[500],
+              lfxColors.blue[400],
+              lfxColors.blue[300],
+              lfxColors.emerald[600],
+              lfxColors.emerald[500],
+              lfxColors.emerald[400],
+            ],
             borderRadius: { topLeft: 0, bottomLeft: 0, topRight: 4, bottomRight: 4 },
             borderSkipped: 'start',
           },

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -115,6 +115,7 @@ export class EngagedCommunityDrawerComponent {
     },
     scales: {
       x: {
+        type: 'logarithmic',
         display: true,
         grid: { color: lfxColors.gray[200], lineWidth: 1 },
         border: { display: true, color: lfxColors.gray[300] },
@@ -123,6 +124,10 @@ export class EngagedCommunityDrawerComponent {
           font: { size: 11 },
           callback: (value) => {
             const num = Number(value);
+            // Only label powers of 10 to avoid overlap on log scale
+            const log = Math.log10(num);
+            if (Math.abs(log - Math.round(log)) > 0.01) return '';
+            if (num >= 1_000_000) return `${(num / 1_000_000).toFixed(0)}M`;
             if (num >= 1_000) return `${(num / 1_000).toFixed(0)}K`;
             return String(num);
           },

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -109,7 +109,11 @@ export class EngagedCommunityDrawerComponent {
       tooltip: {
         ...DASHBOARD_TOOLTIP_CONFIG,
         callbacks: {
-          label: (ctx) => ` ${formatNumber(ctx.parsed.x ?? 0)} members`,
+          label: (ctx) => {
+            const raw = ctx.raw as number;
+            // Display original value (unclamped) in tooltip
+            return ` ${formatNumber(raw <= 1 ? 0 : raw)} members`;
+          },
         },
       },
     },
@@ -124,6 +128,7 @@ export class EngagedCommunityDrawerComponent {
           font: { size: 11 },
           callback: (value) => {
             const num = Number(value);
+            if (!Number.isFinite(num) || num <= 0) return '';
             // Only label powers of 10 to avoid overlap on log scale
             const log = Math.log10(num);
             if (Math.abs(log - Math.round(log)) > 0.01) return '';
@@ -338,6 +343,8 @@ export class EngagedCommunityDrawerComponent {
         labels: ['Community', 'Working Groups', 'Newsletter', 'Training', 'Code', 'Web', 'Certified'],
         datasets: [
           {
+            // Clamp to minimum 1 for log scale rendering; tooltip callback
+            // maps values ≤1 back to 0 for display.
             data: [
               breakdown.communityMembers,
               breakdown.workingGroupMembers,
@@ -346,7 +353,7 @@ export class EngagedCommunityDrawerComponent {
               breakdown.codeContributors,
               breakdown.webVisitors,
               breakdown.certifiedIndividuals,
-            ],
+            ].map((v) => Math.max(v, 1)),
             backgroundColor: [
               lfxColors.blue[700],
               lfxColors.blue[500],

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -111,8 +111,8 @@ export class EngagedCommunityDrawerComponent {
         callbacks: {
           label: (ctx) => {
             const raw = ctx.raw as number;
-            // Display original value (unclamped) in tooltip
-            return ` ${formatNumber(raw <= 1 ? 0 : raw)} members`;
+            // Sentinel 0.5 = original 0 (clamped for log scale); real 1s stay at 1
+            return ` ${formatNumber(raw < 1 ? 0 : raw)} members`;
           },
         },
       },
@@ -343,8 +343,9 @@ export class EngagedCommunityDrawerComponent {
         labels: ['Community', 'Working Groups', 'Newsletter', 'Training', 'Code', 'Web', 'Certified'],
         datasets: [
           {
-            // Clamp to minimum 1 for log scale rendering; tooltip callback
-            // maps values ≤1 back to 0 for display.
+            // Clamp to 0.5 (not 1) for log scale rendering so original 0s
+            // are distinguishable from real 1s. Tooltip uses raw < 1 to
+            // map the sentinel back to 0.
             data: [
               breakdown.communityMembers,
               breakdown.workingGroupMembers,
@@ -353,7 +354,7 @@ export class EngagedCommunityDrawerComponent {
               breakdown.codeContributors,
               breakdown.webVisitors,
               breakdown.certifiedIndividuals,
-            ].map((v) => Math.max(v, 1)),
+            ].map((v) => Math.max(v, 0.5)),
             backgroundColor: [
               lfxColors.blue[700],
               lfxColors.blue[500],

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -47,7 +47,7 @@
             [testId]="card.testId"
             [chartType]="card.chartType"
             [clickable]="!!card.drawerType"
-            [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+            [styleClass]="'w-[calc(100vw-3rem)] md:w-80'"
             (cardClick)="handleCardClick(card.drawerType!)">
             <ng-template #customContent>
               <div class="flex flex-col gap-0 flex-1">
@@ -103,7 +103,7 @@
             [testId]="card.testId"
             [chartType]="card.chartType"
             [clickable]="!!card.drawerType"
-            [styleClass]="'w-[calc(100vw-3rem)] md:w-96'"
+            [styleClass]="'w-[calc(100vw-3rem)] md:w-80'"
             (cardClick)="handleCardClick(card.drawerType!)">
             <ng-template #customContent>
               <div class="flex flex-col gap-2 flex-1">

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -92,7 +92,15 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
     totalMembers: 0,
     changePercentage: 0,
     trend: 'up',
-    breakdown: { newsletterSubscribers: 0, communityMembers: 0, workingGroupMembers: 0, certifiedIndividuals: 0 },
+    breakdown: {
+      newsletterSubscribers: 0,
+      communityMembers: 0,
+      workingGroupMembers: 0,
+      certifiedIndividuals: 0,
+      webVisitors: 0,
+      codeContributors: 0,
+      trainingEnrollees: 0,
+    },
     monthlyData: [],
   },
   eventGrowth: {

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -954,6 +954,9 @@ export class AnalyticsService {
             communityMembers: 0,
             workingGroupMembers: 0,
             certifiedIndividuals: 0,
+            webVisitors: 0,
+            codeContributors: 0,
+            trainingEnrollees: 0,
           },
           monthlyData: [],
         });

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2398,6 +2398,9 @@ export class ProjectService {
           COMMUNITY_MEMBERS,
           WORKING_GROUP_MEMBERS,
           CERTIFIED_INDIVIDUALS,
+          WEB_VISITORS,
+          CODE_CONTRIBUTORS,
+          TRAINING_ENROLLEES,
           TOTAL_ENGAGED_MEMBERS,
           MOM_CHANGE_PERCENTAGE
         FROM ANALYTICS.PLATINUM_LFX_ONE.NORTH_STAR_ENGAGED_COMMUNITY
@@ -2412,6 +2415,9 @@ export class ProjectService {
         COMMUNITY_MEMBERS: number;
         WORKING_GROUP_MEMBERS: number;
         CERTIFIED_INDIVIDUALS: number;
+        WEB_VISITORS: number;
+        CODE_CONTRIBUTORS: number;
+        TRAINING_ENROLLEES: number;
         TOTAL_ENGAGED_MEMBERS: number;
         MOM_CHANGE_PERCENTAGE: number;
       }>(query, [foundationSlug]);
@@ -2426,6 +2432,9 @@ export class ProjectService {
             communityMembers: 0,
             workingGroupMembers: 0,
             certifiedIndividuals: 0,
+            webVisitors: 0,
+            codeContributors: 0,
+            trainingEnrollees: 0,
           },
           monthlyData: [],
         };
@@ -2434,8 +2443,14 @@ export class ProjectService {
       const latest = result.rows[0];
 
       // Server-side recompute: exclude newsletter subscribers (unreliable data).
-      // Sum only community + working group + certified for totals and MoM change.
-      const sumSegments = (row: (typeof result.rows)[0]) => (row.COMMUNITY_MEMBERS ?? 0) + (row.WORKING_GROUP_MEMBERS ?? 0) + (row.CERTIFIED_INDIVIDUALS ?? 0);
+      // Sum all engagement channels for totals and MoM change.
+      const sumSegments = (row: (typeof result.rows)[0]) =>
+        (row.COMMUNITY_MEMBERS ?? 0) +
+        (row.WORKING_GROUP_MEMBERS ?? 0) +
+        (row.CERTIFIED_INDIVIDUALS ?? 0) +
+        (row.WEB_VISITORS ?? 0) +
+        (row.CODE_CONTRIBUTORS ?? 0) +
+        (row.TRAINING_ENROLLEES ?? 0);
 
       const currentTotal = sumSegments(latest);
       let changePercentage = 0;
@@ -2463,6 +2478,9 @@ export class ProjectService {
           communityMembers: latest.COMMUNITY_MEMBERS ?? 0,
           workingGroupMembers: latest.WORKING_GROUP_MEMBERS ?? 0,
           certifiedIndividuals: latest.CERTIFIED_INDIVIDUALS ?? 0,
+          webVisitors: latest.WEB_VISITORS ?? 0,
+          codeContributors: latest.CODE_CONTRIBUTORS ?? 0,
+          trainingEnrollees: latest.TRAINING_ENROLLEES ?? 0,
         },
         monthlyData,
       };
@@ -2480,6 +2498,9 @@ export class ProjectService {
           communityMembers: 0,
           workingGroupMembers: 0,
           certifiedIndividuals: 0,
+          webVisitors: 0,
+          codeContributors: 0,
+          trainingEnrollees: 0,
         },
         monthlyData: [],
       };

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2442,8 +2442,9 @@ export class ProjectService {
 
       const latest = result.rows[0];
 
-      // Server-side recompute: exclude newsletter subscribers (unreliable data).
-      // Sum all engagement channels for totals and MoM change.
+      // Server-side recompute: newsletter subscribers are excluded from totals and MoM
+      // because the data is unreliable, but we still return the raw value in the breakdown
+      // for optional display. Sum the 6 reliable channels for totals and MoM change.
       const sumSegments = (row: (typeof result.rows)[0]) =>
         (row.COMMUNITY_MEMBERS ?? 0) +
         (row.WORKING_GROUP_MEMBERS ?? 0) +
@@ -2474,7 +2475,7 @@ export class ProjectService {
         changePercentage,
         trend: changePercentage >= 0 ? 'up' : 'down',
         breakdown: {
-          newsletterSubscribers: 0,
+          newsletterSubscribers: latest.NEWSLETTER_SUBSCRIBERS ?? 0,
           communityMembers: latest.COMMUNITY_MEMBERS ?? 0,
           workingGroupMembers: latest.WORKING_GROUP_MEMBERS ?? 0,
           certifiedIndividuals: latest.CERTIFIED_INDIVIDUALS ?? 0,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -839,7 +839,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
         lfxColors.blue[500]
       ),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-      tooltipText: 'Unique individuals active across Slack, Discord, GitHub, and mailing lists in the last 90 days.',
+      tooltipText: 'Unique individuals active across Slack, Discord, GitHub, mailing lists, training, web, and code in the last 90 days.',
       drawerType: DashboardDrawerType.NorthStarEngagedCommunity,
     } as DashboardMetricCard,
     {
@@ -858,7 +858,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
         lfxColors.blue[500]
       ),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
-      tooltipText: 'Year-to-date event attendees and YoY change.',
+      tooltipText: 'Year-to-date event registrants and YoY change.',
       drawerType: DashboardDrawerType.NorthStarEventGrowth,
     } as DashboardMetricCard,
 

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -801,7 +801,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       ),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText:
-        'Percentage of event attendees who re-engage via newsletter, community, or working groups within 90 days post-event. Change shown in percentage points (pp) MoM.',
+        'Percentage of event attendees who re-engage via newsletter, community, working groups, training, code, or web within 90 days post-event. Change shown in percentage points (pp) MoM.',
       drawerType: DashboardDrawerType.NorthStarFlywheelConversion,
     } as DashboardMetricCard,
     {

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2841,7 +2841,7 @@ export interface NorthStarMonthlyDataPoint {
 
 /**
  * API response for Engaged Community Size metric
- * Newsletter + community + WG + certified individuals (deduplicated)
+ * 7 channels: newsletter, community, WG, certified, web, code, training (deduplicated)
  */
 export interface EngagedCommunitySizeResponse {
   totalMembers: number;

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2840,8 +2840,10 @@ export interface NorthStarMonthlyDataPoint {
 }
 
 /**
- * API response for Engaged Community Size metric
- * 7 channels: newsletter, community, WG, certified, web, code, training (deduplicated)
+ * API response for Engaged Community Size metric.
+ * Breakdown covers 7 channels: newsletter, community, WG, certified, web, code, training.
+ * `totalMembers` and `changePercentage` exclude newsletterSubscribers (unreliable data);
+ * newsletter is returned only in `breakdown` for display purposes.
  */
 export interface EngagedCommunitySizeResponse {
   totalMembers: number;

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2852,6 +2852,9 @@ export interface EngagedCommunitySizeResponse {
     communityMembers: number;
     workingGroupMembers: number;
     certifiedIndividuals: number;
+    webVisitors: number;
+    codeContributors: number;
+    trainingEnrollees: number;
   };
   monthlyData: NorthStarMonthlyDataPoint[];
 }


### PR DESCRIPTION
## Summary
- Align marketing metric card width with foundation health cards (`md:w-96` → `md:w-80`)
- Expand Engaged Community breakdown chart from 3 to all 7 channels (Community, Working Groups, Newsletter, Training, Code, Web, Certified)
- Use logarithmic scale on breakdown chart to handle 2K–4M range across channels
- Update interface, backend query, analytics service fallback, and E2E tests for new breakdown fields

## Changes
- **Card alignment**: Match marketing cards to foundation health card width (320px)
- **Backend**: Query 3 additional Snowflake columns (`WEB_VISITORS`, `CODE_CONTRIBUTORS`, `TRAINING_ENROLLEES`) from `NORTH_STAR_ENGAGED_COMMUNITY` — columns already exist in the deployed dbt model
- **Interface**: Add `webVisitors`, `codeContributors`, `trainingEnrollees` to `EngagedCommunitySizeResponse.breakdown`
- **Drawer UI**: Expand breakdown chart to 7 bars with blue→emerald color gradient, log scale x-axis with power-of-10 ticks, and taller chart height (220px)
- **Insights**: Composition analysis now considers all 7 segments

## Stacked on
Builds on [PR #512](https://github.com/linuxfoundation/lfx-v2-ui/pull/512) (first 5 commits are shared). Once #512 merges, this PR's diff will reduce to the 2 new commits.

## Test plan
- [ ] Verify marketing cards match foundation health card width
- [ ] Open Engaged Community drawer → Community Breakdown chart shows 7 bars
- [ ] All bars are visible on log scale (Web ~4M doesn't crush smaller channels)
- [ ] X-axis labels show clean power-of-10 values (100, 1K, 10K, etc.)
- [ ] Hover tooltip shows exact member count for each channel
- [ ] Key insights section references largest segment from all 7 channels

🤖 Generated with [Claude Code](https://claude.ai/claude-code)