### PR TITLE
fix(meetings): send occurrence_id in rsvp body not url

### DIFF
--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -834,19 +834,20 @@ export class MeetingService {
 
     const registrantId = registrants[0].uid;
 
-    // Build effective meeting ID for occurrence-specific RSVPs
-    const effectiveMeetingId = rsvpData.occurrence_id ? `${meetingUid}-${rsvpData.occurrence_id}` : meetingUid;
-
+    // occurrence_id goes in the request body — the upstream meeting-service concatenates it with
+    // meeting_id internally when calling the Zoom ITX API (see the OpenAPI description for
+    // SubmitItxMeetingResponseRequestBody.occurrence_id in lfx-v2-meeting-service).
     const requestData: ITXCreateMeetingResponseRequest = {
       response: rsvpData.response,
       scope: rsvpData.scope,
       registrant_id: registrantId,
+      ...(rsvpData.occurrence_id ? { occurrence_id: rsvpData.occurrence_id } : {}),
     };
 
     const result = await this.microserviceProxy.proxyRequest<ITXMeetingResponseResult>(
       req,
       'LFX_V2_SERVICE',
-      `/itx/meetings/${effectiveMeetingId}/responses`,
+      `/itx/meetings/${meetingUid}/responses`,
       'POST',
       {},
       requestData

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -947,6 +947,8 @@ export interface ITXCreateMeetingResponseRequest {
   scope: RsvpScope;
   /** User's registrant ID */
   registrant_id: string;
+  /** Occurrence ID for recurring meetings; the upstream meeting-service concatenates it with the meeting ID when calling ITX */
+  occurrence_id?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

**Prod blocker fix** — split out of PR #514 as a narrow, independently-mergeable change.

When a user selects "Only this instance" (scope=single) for an RSVP on a recurring meeting, the POST returned **403 Forbidden** from the upstream meeting-service. Root cause: the Express proxy was concatenating `occurrence_id` into the upstream URL path as \`{meeting_id}-{occurrence_id}\`, while omitting it from the request body.

Per the upstream \`lfx-v2-meeting-service\` OpenAPI contract, \`occurrence_id\` belongs in the **request body** — the upstream Go service does the concatenation internally before forwarding to the Zoom ITX API.

## Changes

- \`apps/lfx-one/src/server/services/meeting.service.ts\` — removed the \`effectiveMeetingId\` composite. URL is now always \`/itx/meetings/{meetingUid}/responses\`. \`occurrence_id\` is included in \`requestData\` via spread when present.
- \`packages/shared/src/interfaces/meeting.interface.ts\` — added \`occurrence_id?: string\` to \`ITXCreateMeetingResponseRequest\`.

## Upstream contract reference

From \`lfx-v2-meeting-service\` OpenAPI spec — \`SubmitItxMeetingResponseRequestBody.occurrence_id\` description:
> "The occurrence ID for recurring meetings (concatenated with meeting_id as meeting_id-occurrence_id when calling ITX)"

## JIRA

- [LFXV2-1546](https://linuxfoundation.atlassian.net/browse/LFXV2-1546) (split from #514)

## Test plan

- [ ] On a recurring meeting, Set My RSVP → pick Maybe → choose "Only this instance" → submission succeeds (no 403)
- [ ] Regression: Set My RSVP → Yes → "All occurrences" still works
- [ ] Regression: Non-recurring meeting RSVP submission still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1546]: https://linuxfoundation.atlassian.net/browse/LFXV2-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ