### PR TITLE
feat(meetings): show current rsvp status on detail page

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -347,7 +347,8 @@
               <div class="w-full md:w-[296px] flex flex-col gap-2">
                 @if (canToggleRsvpView() && showMyRsvp()) {
                   <!-- Show RSVP Button Group when organizer toggles to set their own RSVP -->
-                  <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="currentOccurrence()?.occurrence_id"> </lfx-rsvp-button-group>
+                  <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="currentOccurrence()?.occurrence_id" (rsvpChanged)="onRsvpChanged($event)">
+                  </lfx-rsvp-button-group>
                 } @else {
                   <!-- Show RSVP Details for organizers (default view) -->
                   <lfx-meeting-rsvp-details
@@ -363,11 +364,22 @@
                   </lfx-meeting-rsvp-details>
                 }
                 @if (canToggleRsvpView()) {
+                  @if (!showMyRsvp() && currentUserRsvpLabel(); as rsvpLabel) {
+                    <div
+                      class="flex items-center gap-2 px-3 py-1.5 rounded-md bg-gray-50 border border-gray-200 text-xs"
+                      data-testid="current-user-rsvp-status">
+                      @if (currentUserRsvpIcon(); as iconClass) {
+                        <i [class]="iconClass" aria-hidden="true"></i>
+                      }
+                      <span class="text-gray-600">Your RSVP:</span>
+                      <span class="font-medium text-gray-900">{{ rsvpLabel }}</span>
+                    </div>
+                  }
                   <lfx-button
                     class="w-full"
                     styleClass="w-full"
                     [icon]="showMyRsvp() ? 'fa-light fa-users' : 'fa-light fa-hand'"
-                    [label]="showMyRsvp() ? 'Show Guests' : 'Set My RSVP'"
+                    [label]="rsvpToggleLabel()"
                     size="small"
                     severity="secondary"
                     (onClick)="onRsvpViewToggle()"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -224,7 +224,11 @@ export class MeetingJoinComponent implements OnInit {
   public rsvpToggleLabel: Signal<string>;
   // Emits the freshly-submitted RSVP from the button-group so the chip updates immediately,
   // bypassing any query-service indexing lag that would otherwise return stale data on refetch.
-  private rsvpUpdateTrigger$ = new Subject<MeetingRsvp>();
+  private readonly rsvpUpdateTrigger$ = new Subject<MeetingRsvp>();
+  // Monotonic counter bumped on every manual RSVP update. Captured at fetch dispatch time and
+  // checked on response; if it has advanced, the server response is stale relative to a newer
+  // optimistic update and is dropped so the chip doesn't revert.
+  private rsvpUpdateCounter = 0;
 
   // Form value signals for reactivity
   public formValues: Signal<{ name: string; email: string; organization: string }>;
@@ -906,6 +910,7 @@ export class MeetingJoinComponent implements OnInit {
           if (evt.type === 'update') {
             // Button-group emits the confirmed RSVP after a successful POST — trust it, cancel
             // any in-flight server fetch so query-service indexing lag can't overwrite.
+            this.rsvpUpdateCounter++;
             return of(evt.data);
           }
           const [meeting, occurrence, authenticated, canToggle] = evt.data;
@@ -914,9 +919,16 @@ export class MeetingJoinComponent implements OnInit {
             return of(null);
           }
           const occurrenceId = meeting.recurrence ? occurrence?.occurrence_id : undefined;
-          // startWith(null) resets the signal on navigation so a stale chip from the prior meeting
-          // doesn't linger. Service already catches errors.
-          return this.meetingService.getMeetingRsvpForCurrentUser(meeting.id, occurrenceId).pipe(startWith(null));
+          // Capture the current update revision at fetch dispatch time. If a manual update
+          // bumps the counter before the server response arrives (typically because the
+          // query-service hasn't indexed the new RSVP yet), the filter drops both the
+          // `startWith(null)` reset and the stale server value so the optimistic local
+          // update stays visible and the chip doesn't flash back.
+          const counterAtDispatch = this.rsvpUpdateCounter;
+          return this.meetingService.getMeetingRsvpForCurrentUser(meeting.id, occurrenceId).pipe(
+            startWith(null),
+            filter(() => this.rsvpUpdateCounter === counterAtDispatch)
+          );
         })
       ),
       { initialValue: null }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -29,6 +29,7 @@ import {
   MeetingAttachment,
   MeetingOccurrence,
   MeetingRegistrant,
+  MeetingRsvp,
   PastMeetingAttachment,
   PastMeetingParticipant,
   PastMeetingRecording,
@@ -60,9 +61,11 @@ import {
   EMPTY,
   filter,
   map,
+  merge,
   Observable,
   of,
   startWith,
+  Subject,
   switchMap,
   take,
   tap,
@@ -212,6 +215,17 @@ export class MeetingJoinComponent implements OnInit {
   public canToggleRsvpView: Signal<boolean>;
   public showMyRsvp: WritableSignal<boolean> = signal<boolean>(false);
 
+  // Current user's RSVP for this meeting (null when not responded). Fetched at this level so
+  // the detail page can show the RSVP status even in the default guest-count view, without
+  // waiting for the user to click "Set My RSVP" to mount the button-group child.
+  public currentUserRsvp: Signal<MeetingRsvp | null>;
+  public currentUserRsvpLabel: Signal<string | null>;
+  public currentUserRsvpIcon: Signal<string | null>;
+  public rsvpToggleLabel: Signal<string>;
+  // Emits the freshly-submitted RSVP from the button-group so the chip updates immediately,
+  // bypassing any query-service indexing lag that would otherwise return stale data on refetch.
+  private rsvpUpdateTrigger$ = new Subject<MeetingRsvp>();
+
   // Form value signals for reactivity
   public formValues: Signal<{ name: string; email: string; organization: string }>;
 
@@ -243,6 +257,10 @@ export class MeetingJoinComponent implements OnInit {
     this.isInvited = this.initializeIsInvited();
     this.canRegisterForMeeting = this.initializeCanRegisterForMeeting();
     this.canToggleRsvpView = this.initializeCanToggleRsvpView();
+    this.currentUserRsvp = this.initializeCurrentUserRsvp();
+    this.currentUserRsvpLabel = this.initializeCurrentUserRsvpLabel();
+    this.currentUserRsvpIcon = this.initializeCurrentUserRsvpIcon();
+    this.rsvpToggleLabel = this.initializeRsvpToggleLabel();
 
     this.returnTo = this.initializeReturnTo();
     this.canJoinMeeting = this.initializeCanJoinMeeting();
@@ -312,6 +330,13 @@ export class MeetingJoinComponent implements OnInit {
 
   public onRsvpViewToggle(): void {
     this.showMyRsvp.set(!this.showMyRsvp());
+  }
+
+  public onRsvpChanged(rsvp: MeetingRsvp): void {
+    // rsvp-button-group emits the confirmed RSVP after the POST succeeds. Push it directly into the
+    // signal stream so the chip updates instantly, even when the backend polling window times out
+    // before the query service has indexed the new RSVP (server would still return stale on refetch).
+    this.rsvpUpdateTrigger$.next(rsvp);
   }
 
   public openMaterialsDrawer(): void {
@@ -847,6 +872,74 @@ export class MeetingJoinComponent implements OnInit {
 
   private initializeCanToggleRsvpView(): Signal<boolean> {
     return computed(() => !!this.meeting()?.organizer && this.isInvited());
+  }
+
+  private initializeCurrentUserRsvp(): Signal<MeetingRsvp | null> {
+    const meeting$ = toObservable(this.meeting);
+    const occurrence$ = toObservable(this.currentOccurrence);
+    const authenticated$ = toObservable(this.authenticated);
+    const canToggle$ = toObservable(this.canToggleRsvpView);
+
+    // Server-side fetch: runs once per meeting/occurrence change.
+    const serverFetch$ = combineLatest([meeting$, occurrence$, authenticated$, canToggle$]).pipe(
+      switchMap(([meeting, occurrence, authenticated, canToggle]) => {
+        // Only fetch when the user can actually RSVP (organizer + invited). Non-organizer invited
+        // users are already handled by the rsvp-button-group component directly.
+        if (!authenticated || !canToggle || !meeting?.id) {
+          return of(null);
+        }
+        const occurrenceId = meeting.recurrence ? occurrence?.occurrence_id : undefined;
+        // startWith(null) resets the signal on each refresh so a stale "Your RSVP" chip from the
+        // previous meeting doesn't linger during client-side navigation. Service already handles errors.
+        return this.meetingService.getMeetingRsvpForCurrentUser(meeting.id, occurrenceId).pipe(startWith(null));
+      })
+    );
+
+    // Merge server fetches with in-component updates pushed by onRsvpChanged. The button-group
+    // emits after its POST succeeds, so trusting that value avoids the query-service indexing
+    // window that otherwise makes a refetch return the pre-update state.
+    return toSignal(merge(serverFetch$, this.rsvpUpdateTrigger$.asObservable()), { initialValue: null });
+  }
+
+  private initializeCurrentUserRsvpLabel(): Signal<string | null> {
+    return computed(() => {
+      const rsvp = this.currentUserRsvp();
+      if (!rsvp) return null;
+      switch (rsvp.response_type) {
+        case 'accepted':
+          return 'Yes';
+        case 'declined':
+          return 'No';
+        case 'maybe':
+          return 'Maybe';
+        default:
+          return rsvp.response_type;
+      }
+    });
+  }
+
+  private initializeCurrentUserRsvpIcon(): Signal<string | null> {
+    return computed(() => {
+      const rsvp = this.currentUserRsvp();
+      if (!rsvp) return null;
+      switch (rsvp.response_type) {
+        case 'accepted':
+          return 'fa-solid fa-circle-check text-emerald-500';
+        case 'declined':
+          return 'fa-solid fa-circle-xmark text-red-500';
+        case 'maybe':
+          return 'fa-solid fa-clock text-amber-500';
+        default:
+          return null;
+      }
+    });
+  }
+
+  private initializeRsvpToggleLabel(): Signal<string> {
+    return computed(() => {
+      if (this.showMyRsvp()) return 'Show Guests';
+      return this.currentUserRsvp() ? 'Update My RSVP' : 'Set My RSVP';
+    });
   }
 
   private initializeEmailError(): Signal<boolean> {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -880,25 +880,47 @@ export class MeetingJoinComponent implements OnInit {
     const authenticated$ = toObservable(this.authenticated);
     const canToggle$ = toObservable(this.canToggleRsvpView);
 
-    // Server-side fetch: runs once per meeting/occurrence change.
-    const serverFetch$ = combineLatest([meeting$, occurrence$, authenticated$, canToggle$]).pipe(
-      switchMap(([meeting, occurrence, authenticated, canToggle]) => {
-        // Only fetch when the user can actually RSVP (organizer + invited). Non-organizer invited
-        // users are already handled by the rsvp-button-group component directly.
-        if (!authenticated || !canToggle || !meeting?.id) {
-          return of(null);
-        }
-        const occurrenceId = meeting.recurrence ? occurrence?.occurrence_id : undefined;
-        // startWith(null) resets the signal on each refresh so a stale "Your RSVP" chip from the
-        // previous meeting doesn't linger during client-side navigation. Service already handles errors.
-        return this.meetingService.getMeetingRsvpForCurrentUser(meeting.id, occurrenceId).pipe(startWith(null));
+    // Fetch trigger: meeting/occurrence/auth/canToggle changes. Deduped on a stable key so that
+    // derived signals settling in the same microtask don't cause redundant emissions.
+    const fetchTrigger$ = combineLatest([meeting$, occurrence$, authenticated$, canToggle$]).pipe(
+      distinctUntilChanged(([m1, o1, a1, c1], [m2, o2, a2, c2]) => {
+        const occ1 = m1?.recurrence ? o1?.occurrence_id : undefined;
+        const occ2 = m2?.recurrence ? o2?.occurrence_id : undefined;
+        return m1?.id === m2?.id && occ1 === occ2 && a1 === a2 && c1 === c2;
       })
     );
 
-    // Merge server fetches with in-component updates pushed by onRsvpChanged. The button-group
-    // emits after its POST succeeds, so trusting that value avoids the query-service indexing
-    // window that otherwise makes a refetch return the pre-update state.
-    return toSignal(merge(serverFetch$, this.rsvpUpdateTrigger$.asObservable()), { initialValue: null });
+    // Single pipeline routing both fetch triggers and manual updates through switchMap:
+    // - fetch events cancel any in-flight fetch AND a previously-emitted manual update stays as
+    //   the last emission only if no subsequent event overrides it
+    // - manual update events (rsvpUpdateTrigger$) short-circuit with the confirmed RSVP, cancelling
+    //   any in-flight server fetch so a late server response can't revert the chip to stale data
+    const source$ = merge(
+      fetchTrigger$.pipe(map((v) => ({ type: 'fetch' as const, data: v }))),
+      this.rsvpUpdateTrigger$.pipe(map((rsvp) => ({ type: 'update' as const, data: rsvp })))
+    );
+
+    return toSignal(
+      source$.pipe(
+        switchMap((evt) => {
+          if (evt.type === 'update') {
+            // Button-group emits the confirmed RSVP after a successful POST — trust it, cancel
+            // any in-flight server fetch so query-service indexing lag can't overwrite.
+            return of(evt.data);
+          }
+          const [meeting, occurrence, authenticated, canToggle] = evt.data;
+          // Only fetch when the user can actually RSVP (organizer + invited).
+          if (!authenticated || !canToggle || !meeting?.id) {
+            return of(null);
+          }
+          const occurrenceId = meeting.recurrence ? occurrence?.occurrence_id : undefined;
+          // startWith(null) resets the signal on navigation so a stale chip from the prior meeting
+          // doesn't linger. Service already catches errors.
+          return this.meetingService.getMeetingRsvpForCurrentUser(meeting.id, occurrenceId).pipe(startWith(null));
+        })
+      ),
+      { initialValue: null }
+    );
   }
 
   private initializeCurrentUserRsvpLabel(): Signal<string | null> {


### PR DESCRIPTION
## Summary

Split out of PR #514 — ships independently.

Organizer-invited users on the meeting detail page (\`/meetings/:id\`) now see their **current RSVP status at a glance** instead of only the generic "Set My RSVP" button. The default guest-count view stays; a small status chip + updated toggle label surface the user's response alongside.

## Implementation

- \`meeting-join.component.ts\` — four new signals:
  - \`currentUserRsvp: Signal<MeetingRsvp | null>\` — fetched via \`getMeetingRsvpForCurrentUser(meeting.id, occurrenceId)\` when the user is authenticated + organizer + invited. Uses \`startWith(null)\` so a prior meeting's RSVP doesn't linger during client-side navigation.
  - \`currentUserRsvpLabel\` — formats \`response_type\` into "Yes" / "No" / "Maybe"
  - \`currentUserRsvpIcon\` — maps to a Font Awesome class + Tailwind color (✓ emerald-500 / ✗ red-500 / ⏱ amber-500)
  - \`rsvpToggleLabel\` — "Show Guests" when in button-group view, else "Update My RSVP" when a response exists, else "Set My RSVP"
- \`rsvpUpdateTrigger\$: Subject<MeetingRsvp>\` merged with the server fetch in \`initializeCurrentUserRsvp\`. When \`rsvp-button-group\` emits \`rsvpChanged\`, \`onRsvpChanged(rsvp)\` pushes the confirmed RSVP into the stream — the chip updates **instantly**, bypassing the query-service indexing window that otherwise makes a refetch return stale data.
- \`meeting-join.component.html\` — inline status chip between the guest-count card and the toggle button; toggle label swapped to \`rsvpToggleLabel()\`; \`(rsvpChanged)="onRsvpChanged(\$event)"\` wired.

## Scope

**2 files, +107/-2.** Single fetch per meeting view — no N+1 pattern, no loops. Non-organizer invited flow unchanged (already shows the button group directly with highlighted state).

## JIRA

- [LFXV2-1546](https://linuxfoundation.atlassian.net/browse/LFXV2-1546) (split from #514)

## Related

- **PR #520** — RSVP scope=single bug fix (split from #514)
- **Pending RSVP filter** from the original #514 has been **dropped** and will be re-filed as a follow-up once LFXV2-1545 Approach A enriches \`/api/user/meetings\` with \`my_rsvp\` (eliminates the need for per-meeting client-side fetches).

## Test plan

- [ ] Open a meeting where you're organizer + invited AND have already RSVP'd. Chip shows "Your RSVP: Yes/No/Maybe" with correct icon/color. Toggle reads "Update My RSVP".
- [ ] Click toggle → button group appears with your response highlighted → pick a different option → chip updates immediately when you toggle back.
- [ ] Open a meeting where you're organizer + invited but haven't RSVP'd. Chip is hidden; toggle reads "Set My RSVP".
- [ ] Navigate between meetings (same session): stale chip does not flash from the previous meeting.
- [ ] Non-organizer invited flow unchanged — button group shown directly with highlighted selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1546]: https://linuxfoundation.atlassian.net/browse/LFXV2-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ