### PR TITLE
feat(ui): add brand health social mentions to ED drawer

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -220,12 +220,17 @@
           <p class="text-sm text-red-700">Most relevant negative mentions by relevance score</p>
         </div>
         <div class="flex flex-col gap-3">
-          @for (mention of data().topNegativeMentions; track mention.url) {
+          @for (mention of data().topNegativeMentions; track $index) {
             <div class="flex flex-col gap-2 p-3 bg-white border border-red-200 rounded-lg" data-testid="brand-health-drawer-negative-mention">
               <div class="flex items-start justify-between gap-2">
                 <span class="text-sm font-medium text-gray-900 line-clamp-2">{{ mention.title || mention.body }}</span>
                 @if (mention.url) {
-                  <a [href]="mention.url" target="_blank" rel="noopener noreferrer" class="flex-shrink-0 text-gray-400 hover:text-blue-500">
+                  <a
+                    [href]="mention.url"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="flex-shrink-0 text-gray-400 hover:text-blue-500"
+                    aria-label="Open mention in new tab">
                     <i class="fa-light fa-arrow-up-right-from-square text-xs"></i>
                   </a>
                 }
@@ -264,12 +269,17 @@
           <p class="text-sm text-green-700">Most relevant positive mentions by relevance score</p>
         </div>
         <div class="flex flex-col gap-3">
-          @for (mention of data().topPositiveMentions; track mention.url) {
+          @for (mention of data().topPositiveMentions; track $index) {
             <div class="flex flex-col gap-2 p-3 bg-white border border-green-200 rounded-lg" data-testid="brand-health-drawer-positive-mention">
               <div class="flex items-start justify-between gap-2">
                 <span class="text-sm font-medium text-gray-900 line-clamp-2">{{ mention.title || mention.body }}</span>
                 @if (mention.url) {
-                  <a [href]="mention.url" target="_blank" rel="noopener noreferrer" class="flex-shrink-0 text-gray-400 hover:text-blue-500">
+                  <a
+                    [href]="mention.url"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="flex-shrink-0 text-gray-400 hover:text-blue-500"
+                    aria-label="Open mention in new tab">
                     <i class="fa-light fa-arrow-up-right-from-square text-xs"></i>
                   </a>
                 }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -50,21 +50,19 @@
           }
         </div>
       </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">MoM Growth</span>
-          @if (data().sentimentMomChangePp !== 0) {
+      @if (data().sentimentMomChangePp !== 0) {
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">MoM Growth</span>
             <span
               class="text-2xl font-semibold"
               [class.text-green-600]="data().sentimentMomChangePp > 0"
               [class.text-red-600]="data().sentimentMomChangePp < 0">
               {{ formattedSentimentMom() }}pp
             </span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
+          </div>
+        </lfx-card>
+      }
     </div>
 
     <!-- FIRST FOLD: Needs Your Attention -->
@@ -210,5 +208,93 @@
         </div>
       }
     </div>
+
+    <!-- Top Negative Mentions -->
+    @if (data().topNegativeMentions.length > 0) {
+      <div class="flex flex-col gap-4 p-4 border border-red-200 bg-red-50 rounded-lg" data-testid="brand-health-drawer-negative-mentions">
+        <div class="flex flex-col gap-1">
+          <h3 class="flex items-center gap-2 text-sm font-semibold text-red-800">
+            <i class="fa-light fa-thumbs-down text-red-500"></i>
+            Top Negative Mentions
+          </h3>
+          <p class="text-sm text-red-700">Most relevant negative mentions by relevance score</p>
+        </div>
+        <div class="flex flex-col gap-3">
+          @for (mention of data().topNegativeMentions; track mention.url) {
+            <div class="flex flex-col gap-2 p-3 bg-white border border-red-200 rounded-lg" data-testid="brand-health-drawer-negative-mention">
+              <div class="flex items-start justify-between gap-2">
+                <span class="text-sm font-medium text-gray-900 line-clamp-2">{{ mention.title || mention.body }}</span>
+                @if (mention.url) {
+                  <a [href]="mention.url" target="_blank" rel="noopener noreferrer" class="flex-shrink-0 text-gray-400 hover:text-blue-500">
+                    <i class="fa-light fa-arrow-up-right-from-square text-xs"></i>
+                  </a>
+                }
+              </div>
+              @if (mention.title && mention.body) {
+                <p class="text-xs text-gray-500 line-clamp-2">{{ mention.body }}</p>
+              }
+              <div class="flex items-center gap-3 text-xs text-gray-400">
+                @if (mention.author) {
+                  <span class="flex items-center gap-1">
+                    <i class="fa-light fa-user"></i>
+                    {{ mention.author }}
+                  </span>
+                }
+                @if (mention.sourcePlatform || mention.socialNetwork) {
+                  <span class="flex items-center gap-1">
+                    <i class="fa-light fa-globe"></i>
+                    {{ mention.socialNetwork || mention.sourcePlatform }}
+                  </span>
+                }
+              </div>
+            </div>
+          }
+        </div>
+      </div>
+    }
+
+    <!-- Top Positive Mentions -->
+    @if (data().topPositiveMentions.length > 0) {
+      <div class="flex flex-col gap-4 p-4 border border-green-200 bg-green-50 rounded-lg" data-testid="brand-health-drawer-positive-mentions">
+        <div class="flex flex-col gap-1">
+          <h3 class="flex items-center gap-2 text-sm font-semibold text-green-800">
+            <i class="fa-light fa-thumbs-up text-green-500"></i>
+            Top Positive Mentions
+          </h3>
+          <p class="text-sm text-green-700">Most relevant positive mentions by relevance score</p>
+        </div>
+        <div class="flex flex-col gap-3">
+          @for (mention of data().topPositiveMentions; track mention.url) {
+            <div class="flex flex-col gap-2 p-3 bg-white border border-green-200 rounded-lg" data-testid="brand-health-drawer-positive-mention">
+              <div class="flex items-start justify-between gap-2">
+                <span class="text-sm font-medium text-gray-900 line-clamp-2">{{ mention.title || mention.body }}</span>
+                @if (mention.url) {
+                  <a [href]="mention.url" target="_blank" rel="noopener noreferrer" class="flex-shrink-0 text-gray-400 hover:text-blue-500">
+                    <i class="fa-light fa-arrow-up-right-from-square text-xs"></i>
+                  </a>
+                }
+              </div>
+              @if (mention.title && mention.body) {
+                <p class="text-xs text-gray-500 line-clamp-2">{{ mention.body }}</p>
+              }
+              <div class="flex items-center gap-3 text-xs text-gray-400">
+                @if (mention.author) {
+                  <span class="flex items-center gap-1">
+                    <i class="fa-light fa-user"></i>
+                    {{ mention.author }}
+                  </span>
+                }
+                @if (mention.sourcePlatform || mention.socialNetwork) {
+                  <span class="flex items-center gap-1">
+                    <i class="fa-light fa-globe"></i>
+                    {{ mention.socialNetwork || mention.sourcePlatform }}
+                  </span>
+                }
+              </div>
+            </div>
+          }
+        </div>
+      </div>
+    }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -209,6 +209,40 @@
       }
     </div>
 
+    <!-- Reusable mention card template — used by both positive and negative sections -->
+    <ng-template #mentionCardTpl let-mention>
+      <div class="flex items-start justify-between gap-2">
+        <span class="text-sm font-medium text-gray-900 line-clamp-2">{{ mention.title || mention.body }}</span>
+        @if (mention.url) {
+          <a
+            [href]="mention.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex-shrink-0 text-gray-400 hover:text-blue-500"
+            aria-label="Open mention in new tab">
+            <i class="fa-light fa-arrow-up-right-from-square text-xs"></i>
+          </a>
+        }
+      </div>
+      @if (mention.title && mention.body) {
+        <p class="text-xs text-gray-500 line-clamp-2">{{ mention.body }}</p>
+      }
+      <div class="flex items-center gap-3 text-xs text-gray-400">
+        @if (mention.author) {
+          <span class="flex items-center gap-1">
+            <i class="fa-light fa-user"></i>
+            {{ mention.author }}
+          </span>
+        }
+        @if (mention.sourcePlatform || mention.socialNetwork) {
+          <span class="flex items-center gap-1">
+            <i class="fa-light fa-globe"></i>
+            {{ mention.socialNetwork || mention.sourcePlatform }}
+          </span>
+        }
+      </div>
+    </ng-template>
+
     <!-- Top Negative Mentions -->
     @if (data().topNegativeMentions.length > 0) {
       <div class="flex flex-col gap-4 p-4 border border-red-200 bg-red-50 rounded-lg" data-testid="brand-health-drawer-negative-mentions">
@@ -222,36 +256,7 @@
         <div class="flex flex-col gap-3">
           @for (mention of data().topNegativeMentions; track $index) {
             <div class="flex flex-col gap-2 p-3 bg-white border border-red-200 rounded-lg" data-testid="brand-health-drawer-negative-mention">
-              <div class="flex items-start justify-between gap-2">
-                <span class="text-sm font-medium text-gray-900 line-clamp-2">{{ mention.title || mention.body }}</span>
-                @if (mention.url) {
-                  <a
-                    [href]="mention.url"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="flex-shrink-0 text-gray-400 hover:text-blue-500"
-                    aria-label="Open mention in new tab">
-                    <i class="fa-light fa-arrow-up-right-from-square text-xs"></i>
-                  </a>
-                }
-              </div>
-              @if (mention.title && mention.body) {
-                <p class="text-xs text-gray-500 line-clamp-2">{{ mention.body }}</p>
-              }
-              <div class="flex items-center gap-3 text-xs text-gray-400">
-                @if (mention.author) {
-                  <span class="flex items-center gap-1">
-                    <i class="fa-light fa-user"></i>
-                    {{ mention.author }}
-                  </span>
-                }
-                @if (mention.sourcePlatform || mention.socialNetwork) {
-                  <span class="flex items-center gap-1">
-                    <i class="fa-light fa-globe"></i>
-                    {{ mention.socialNetwork || mention.sourcePlatform }}
-                  </span>
-                }
-              </div>
+              <ng-container *ngTemplateOutlet="mentionCardTpl; context: { $implicit: mention }"></ng-container>
             </div>
           }
         </div>
@@ -271,36 +276,7 @@
         <div class="flex flex-col gap-3">
           @for (mention of data().topPositiveMentions; track $index) {
             <div class="flex flex-col gap-2 p-3 bg-white border border-green-200 rounded-lg" data-testid="brand-health-drawer-positive-mention">
-              <div class="flex items-start justify-between gap-2">
-                <span class="text-sm font-medium text-gray-900 line-clamp-2">{{ mention.title || mention.body }}</span>
-                @if (mention.url) {
-                  <a
-                    [href]="mention.url"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="flex-shrink-0 text-gray-400 hover:text-blue-500"
-                    aria-label="Open mention in new tab">
-                    <i class="fa-light fa-arrow-up-right-from-square text-xs"></i>
-                  </a>
-                }
-              </div>
-              @if (mention.title && mention.body) {
-                <p class="text-xs text-gray-500 line-clamp-2">{{ mention.body }}</p>
-              }
-              <div class="flex items-center gap-3 text-xs text-gray-400">
-                @if (mention.author) {
-                  <span class="flex items-center gap-1">
-                    <i class="fa-light fa-user"></i>
-                    {{ mention.author }}
-                  </span>
-                }
-                @if (mention.sourcePlatform || mention.socialNetwork) {
-                  <span class="flex items-center gap-1">
-                    <i class="fa-light fa-globe"></i>
-                    {{ mention.socialNetwork || mention.sourcePlatform }}
-                  </span>
-                }
-              </div>
+              <ng-container *ngTemplateOutlet="mentionCardTpl; context: { $implicit: mention }"></ng-container>
             </div>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DecimalPipe } from '@angular/common';
+import { DecimalPipe, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
@@ -18,7 +18,7 @@ import type { BrandHealthResponse, MarketingKeyInsight, MarketingRecommendedActi
 @Component({
   selector: 'lfx-brand-health-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, ChartComponent, DecimalPipe, DrawerModule, MarketingActionIconPipe, TagComponent],
+  imports: [ButtonComponent, CardComponent, ChartComponent, DecimalPipe, DrawerModule, MarketingActionIconPipe, NgTemplateOutlet, TagComponent],
   templateUrl: './brand-health-drawer.component.html',
 })
 export class BrandHealthDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -33,6 +33,8 @@ export class BrandHealthDrawerComponent {
     trend: 'up',
     monthlyMentions: [],
     topProjects: [],
+    topPositiveMentions: [],
+    topNegativeMentions: [],
   });
 
   // === Static Config ===

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -200,7 +200,7 @@
         <h3 class="text-sm font-semibold text-gray-900">Top Events</h3>
         <p class="text-sm text-gray-600">
           {{ topEventsSortBy() === 'revenue' ? 'Highest revenue events' : 'Highest attendance events' }}
-          · YTD
+          · All Time
         </p>
       </div>
       @if (data().topEvents.length > 0) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, Signal, signal, viewChild } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { ChartComponent } from '@components/chart/chart.component';
@@ -29,7 +29,7 @@ import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ScrollShadowDirective } from '@shared/directives/scroll-shadow.directive';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, forkJoin, map, Observable, of, switchMap } from 'rxjs';
+import { catchError, forkJoin, map, Observable, of, switchMap, take } from 'rxjs';
 
 import { BrandHealthDrawerComponent } from '../brand-health-drawer/brand-health-drawer.component';
 import { BrandReachDrawerComponent } from '../brand-reach-drawer/brand-reach-drawer.component';
@@ -196,6 +196,7 @@ export class MarketingOverviewComponent {
   // === WritableSignals ===
   public readonly selectedFilter = signal<'all' | MetricCategory>('all');
   public readonly activeDrawer = signal<DashboardDrawerType | null>(null);
+  private readonly brandHealthMentions = signal<Pick<BrandHealthResponse, 'topPositiveMentions' | 'topNegativeMentions'> | null>(null);
 
   // === Computed Signals ===
   protected readonly edEvolutionData: Signal<EdEvolutionData> = this.initEdEvolutionData();
@@ -206,7 +207,11 @@ export class MarketingOverviewComponent {
   protected readonly engagedCommunityData = computed<EngagedCommunitySizeResponse>(() => this.edEvolutionData().engagedCommunity);
   protected readonly eventGrowthData = computed<EventGrowthResponse>(() => this.edEvolutionData().eventGrowth);
   protected readonly brandReachData = computed<BrandReachResponse>(() => this.edEvolutionData().brandReach);
-  protected readonly brandHealthData = computed<BrandHealthResponse>(() => this.edEvolutionData().brandHealth);
+  protected readonly brandHealthData = computed<BrandHealthResponse>(() => {
+    const base = this.edEvolutionData().brandHealth;
+    const mentions = this.brandHealthMentions();
+    return mentions ? { ...base, ...mentions } : base;
+  });
   protected readonly revenueImpactData = computed<RevenueImpactResponse>(() => this.edEvolutionData().revenueImpact);
 
   protected readonly filteredCards: Signal<DashboardMetricCard[]> = this.initFilteredCards();
@@ -215,9 +220,33 @@ export class MarketingOverviewComponent {
   protected readonly nonNorthStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category !== 'memberships'));
   protected readonly totalCardCount = computed<number>(() => this.filteredCards().length);
 
+  constructor() {
+    // Clear cached mentions when the foundation changes so stale data from a
+    // previously selected foundation isn't shown.
+    effect(() => {
+      this.projectContextService.selectedFoundation();
+      this.brandHealthMentions.set(null);
+    });
+  }
+
   // === Public Methods ===
   public handleCardClick(drawerType: DashboardDrawerType): void {
     this.activeDrawer.set(drawerType);
+
+    // Lazy-fetch mentions only when the Brand Health drawer is opened (avoids extra
+    // Snowflake round-trips on every dashboard load).
+    if (drawerType === DashboardDrawerType.BrandHealth && !this.brandHealthMentions()) {
+      const slug = this.projectContextService.selectedFoundation()?.slug || 'tlf';
+      this.analyticsService
+        .getBrandHealth(slug, true)
+        .pipe(take(1))
+        .subscribe((res) => {
+          this.brandHealthMentions.set({
+            topPositiveMentions: res.topPositiveMentions,
+            topNegativeMentions: res.topNegativeMentions,
+          });
+        });
+    }
   }
 
   public handleDrawerClose(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -133,6 +133,8 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
     trend: 'up',
     monthlyMentions: [],
     topProjects: [],
+    topPositiveMentions: [],
+    topNegativeMentions: [],
   },
   revenueImpact: {
     pipelineInfluenced: 0,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -227,11 +227,15 @@ export class MarketingOverviewComponent {
 
   // === Public Methods ===
   public handleCardClick(drawerType: DashboardDrawerType): void {
+    if (this.activeDrawer() === drawerType) {
+      return;
+    }
+
     this.activeDrawer.set(drawerType);
 
-    // Lazy-fetch mentions only when the Brand Health drawer is opened.
-    // The Subject + switchMap in initBrandHealthMentions() handles deduplication
-    // and cancels in-flight requests automatically on foundation change.
+    // Lazy-fetch mentions only when the Brand Health drawer is opened for the first time.
+    // Guarding repeated clicks on the already active drawer prevents duplicate trigger
+    // emissions while the initial mentions request is still in flight.
     if (drawerType === DashboardDrawerType.BrandHealth && !this.brandHealthMentions()) {
       this.mentionsTrigger$.next(this.projectContextService.selectedFoundation()?.slug || 'tlf');
     }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -197,13 +197,12 @@ export class MarketingOverviewComponent {
   public readonly selectedFilter = signal<'all' | MetricCategory>('all');
   public readonly activeDrawer = signal<DashboardDrawerType | null>(null);
 
+  // === Computed Signals ===
   // Lazy-fetch mentions via Subject trigger + switchMap (no manual subscribe).
   // Foundation changes automatically cancel in-flight requests via switchMap.
   private readonly mentionsTrigger$ = new Subject<string>();
   private readonly brandHealthMentions: Signal<Pick<BrandHealthResponse, 'topPositiveMentions' | 'topNegativeMentions'> | null> =
     this.initBrandHealthMentions();
-
-  // === Computed Signals ===
   protected readonly edEvolutionData: Signal<EdEvolutionData> = this.initEdEvolutionData();
 
   protected readonly flywheelData = computed<FlywheelConversionResponse>(() => this.edEvolutionData().flywheel);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -220,7 +220,7 @@ export class MarketingOverviewComponent {
   protected readonly nonNorthStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category !== 'memberships'));
   protected readonly totalCardCount = computed<number>(() => this.filteredCards().length);
 
-  constructor() {
+  public constructor() {
     // Clear cached mentions when the foundation changes so stale data from a
     // previously selected foundation isn't shown.
     effect(() => {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, effect, inject, Signal, signal, viewChild } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
@@ -29,7 +29,7 @@ import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ScrollShadowDirective } from '@shared/directives/scroll-shadow.directive';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, forkJoin, map, Observable, of, switchMap, take } from 'rxjs';
+import { catchError, forkJoin, map, Observable, of, skip, Subject, switchMap, tap } from 'rxjs';
 
 import { BrandHealthDrawerComponent } from '../brand-health-drawer/brand-health-drawer.component';
 import { BrandReachDrawerComponent } from '../brand-reach-drawer/brand-reach-drawer.component';
@@ -196,8 +196,12 @@ export class MarketingOverviewComponent {
   // === WritableSignals ===
   public readonly selectedFilter = signal<'all' | MetricCategory>('all');
   public readonly activeDrawer = signal<DashboardDrawerType | null>(null);
-  private readonly brandHealthMentions = signal<Pick<BrandHealthResponse, 'topPositiveMentions' | 'topNegativeMentions'> | null>(null);
-  private mentionsLoading = false;
+
+  // Lazy-fetch mentions via Subject trigger + switchMap (no manual subscribe).
+  // Foundation changes automatically cancel in-flight requests via switchMap.
+  private readonly mentionsTrigger$ = new Subject<string>();
+  private readonly brandHealthMentions: Signal<Pick<BrandHealthResponse, 'topPositiveMentions' | 'topNegativeMentions'> | null> =
+    this.initBrandHealthMentions();
 
   // === Computed Signals ===
   protected readonly edEvolutionData: Signal<EdEvolutionData> = this.initEdEvolutionData();
@@ -221,41 +225,15 @@ export class MarketingOverviewComponent {
   protected readonly nonNorthStarCards = computed<DashboardMetricCard[]>(() => this.filteredCards().filter((c) => c.category !== 'memberships'));
   protected readonly totalCardCount = computed<number>(() => this.filteredCards().length);
 
-  public constructor() {
-    // Clear cached mentions when the foundation changes so stale data from a
-    // previously selected foundation isn't shown.
-    effect(() => {
-      this.projectContextService.selectedFoundation();
-      this.brandHealthMentions.set(null);
-      this.mentionsLoading = false;
-    });
-  }
-
   // === Public Methods ===
   public handleCardClick(drawerType: DashboardDrawerType): void {
     this.activeDrawer.set(drawerType);
 
-    // Lazy-fetch mentions only when the Brand Health drawer is opened (avoids extra
-    // Snowflake round-trips on every dashboard load). The loading guard prevents
-    // duplicate requests from repeated clicks before the first resolves.
-    if (drawerType === DashboardDrawerType.BrandHealth && !this.brandHealthMentions() && !this.mentionsLoading) {
-      this.mentionsLoading = true;
-      const slug = this.projectContextService.selectedFoundation()?.slug || 'tlf';
-      this.analyticsService
-        .getBrandHealth(slug, true)
-        .pipe(take(1))
-        .subscribe((res) => {
-          this.mentionsLoading = false;
-          // Verify the foundation hasn't changed while the request was in-flight.
-          // The effect() clears brandHealthMentions on foundation change, but the
-          // subscribe callback could fire after the effect — guard against stale data.
-          const currentSlug = this.projectContextService.selectedFoundation()?.slug || 'tlf';
-          if (currentSlug !== slug) return;
-          this.brandHealthMentions.set({
-            topPositiveMentions: res.topPositiveMentions,
-            topNegativeMentions: res.topNegativeMentions,
-          });
-        });
+    // Lazy-fetch mentions only when the Brand Health drawer is opened.
+    // The Subject + switchMap in initBrandHealthMentions() handles deduplication
+    // and cancels in-flight requests automatically on foundation change.
+    if (drawerType === DashboardDrawerType.BrandHealth && !this.brandHealthMentions()) {
+      this.mentionsTrigger$.next(this.projectContextService.selectedFoundation()?.slug || 'tlf');
     }
   }
 
@@ -275,6 +253,31 @@ export class MarketingOverviewComponent {
       if (filterKey === 'all') return cards;
       return cards.filter((card) => card.category === filterKey);
     });
+  }
+
+  private initBrandHealthMentions(): Signal<Pick<BrandHealthResponse, 'topPositiveMentions' | 'topNegativeMentions'> | null> {
+    // Reset mentions when foundation changes — toObservable + tap replaces
+    // the previous effect() to avoid writing signals inside effect().
+    toObservable(this.projectContextService.selectedFoundation)
+      .pipe(
+        skip(1),
+        tap(() => this.mentionsTrigger$.next('')),
+        takeUntilDestroyed()
+      )
+      .subscribe();
+
+    return toSignal(
+      this.mentionsTrigger$.pipe(
+        switchMap((slug) => {
+          if (!slug) return of(null);
+          return this.analyticsService.getBrandHealth(slug, true).pipe(
+            map((res) => ({ topPositiveMentions: res.topPositiveMentions, topNegativeMentions: res.topNegativeMentions })),
+            catchError(() => of(null))
+          );
+        })
+      ),
+      { initialValue: null }
+    );
   }
 
   private initEdEvolutionData(): Signal<EdEvolutionData> {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -197,6 +197,7 @@ export class MarketingOverviewComponent {
   public readonly selectedFilter = signal<'all' | MetricCategory>('all');
   public readonly activeDrawer = signal<DashboardDrawerType | null>(null);
   private readonly brandHealthMentions = signal<Pick<BrandHealthResponse, 'topPositiveMentions' | 'topNegativeMentions'> | null>(null);
+  private mentionsLoading = false;
 
   // === Computed Signals ===
   protected readonly edEvolutionData: Signal<EdEvolutionData> = this.initEdEvolutionData();
@@ -226,6 +227,7 @@ export class MarketingOverviewComponent {
     effect(() => {
       this.projectContextService.selectedFoundation();
       this.brandHealthMentions.set(null);
+      this.mentionsLoading = false;
     });
   }
 
@@ -234,13 +236,21 @@ export class MarketingOverviewComponent {
     this.activeDrawer.set(drawerType);
 
     // Lazy-fetch mentions only when the Brand Health drawer is opened (avoids extra
-    // Snowflake round-trips on every dashboard load).
-    if (drawerType === DashboardDrawerType.BrandHealth && !this.brandHealthMentions()) {
+    // Snowflake round-trips on every dashboard load). The loading guard prevents
+    // duplicate requests from repeated clicks before the first resolves.
+    if (drawerType === DashboardDrawerType.BrandHealth && !this.brandHealthMentions() && !this.mentionsLoading) {
+      this.mentionsLoading = true;
       const slug = this.projectContextService.selectedFoundation()?.slug || 'tlf';
       this.analyticsService
         .getBrandHealth(slug, true)
         .pipe(take(1))
         .subscribe((res) => {
+          this.mentionsLoading = false;
+          // Verify the foundation hasn't changed while the request was in-flight.
+          // The effect() clears brandHealthMentions on foundation change, but the
+          // subscribe callback could fire after the effect — guard against stale data.
+          const currentSlug = this.projectContextService.selectedFoundation()?.slug || 'tlf';
+          if (currentSlug !== slug) return;
           this.brandHealthMentions.set({
             topPositiveMentions: res.topPositiveMentions,
             topNegativeMentions: res.topNegativeMentions,

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1224,6 +1224,8 @@ export class AnalyticsService {
           trend: 'up' as const,
           monthlyMentions: [],
           topProjects: [],
+          topPositiveMentions: [],
+          topNegativeMentions: [],
         })
       )
     );

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1214,21 +1214,23 @@ export class AnalyticsService {
    * @param foundationSlug Foundation slug used to filter Snowflake queries
    * @returns Observable emitting mention totals, sentiment percentages, and monthly history (or zeroed defaults on error)
    */
-  public getBrandHealth(foundationSlug: string): Observable<BrandHealthResponse> {
-    return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params: { foundationSlug } }).pipe(
-      catchError(() =>
-        of({
-          totalMentions: 0,
-          sentiment: { positive: 0, neutral: 0, negative: 0 },
-          sentimentMomChangePp: 0,
-          trend: 'up' as const,
-          monthlyMentions: [],
-          topProjects: [],
-          topPositiveMentions: [],
-          topNegativeMentions: [],
-        })
-      )
-    );
+  public getBrandHealth(foundationSlug: string, includeMentions = false): Observable<BrandHealthResponse> {
+    return this.http
+      .get<BrandHealthResponse>('/api/analytics/brand-health', { params: { foundationSlug, ...(includeMentions && { includeMentions: 'true' }) } })
+      .pipe(
+        catchError(() =>
+          of({
+            totalMentions: 0,
+            sentiment: { positive: 0, neutral: 0, negative: 0 },
+            sentimentMomChangePp: 0,
+            trend: 'up' as const,
+            monthlyMentions: [],
+            topProjects: [],
+            topPositiveMentions: [],
+            topNegativeMentions: [],
+          })
+        )
+      );
   }
 
   /**

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2488,7 +2488,8 @@ export class AnalyticsController {
         });
       }
 
-      const response = await this.projectService.getBrandHealth(foundationSlug);
+      const includeMentions = getStringQueryParam(req, 'includeMentions') === 'true';
+      const response = await this.projectService.getBrandHealth(foundationSlug, includeMentions);
 
       logger.success(req, 'get_brand_health', startTime, {
         foundation_slug: foundationSlug,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -4,6 +4,7 @@
 import { NATS_CONFIG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import {
+  BrandHealthMention,
   BrandHealthResponse,
   BrandHealthTopProject,
   BrandReachPlatformType,
@@ -3710,6 +3711,8 @@ export class ProjectService {
       trend: 'up',
       monthlyMentions: [],
       topProjects: [],
+      topPositiveMentions: [],
+      topNegativeMentions: [],
     };
 
     try {
@@ -3770,7 +3773,38 @@ export class ProjectService {
         LIMIT 5
       `;
 
-      const [summaryResult, trendResult, projectsResult] = await Promise.all([
+      const mentionsFilter = isUmbrella ? '' : 'AND FOUNDATION_SLUG = ?';
+      const mentionsParams = isUmbrella ? [] : [foundationSlug];
+
+      const positiveMentionsQuery = `
+        SELECT TITLE, BODY, AUTHOR, AUTHOR_PROFILE_LINK, SOURCE_PLATFORM, SOCIAL_NETWORK, SENTIMENT, URL, MENTION_TS
+        FROM ANALYTICS.PLATINUM_LFX_ONE.BRAND_HEALTH_MENTIONS
+        WHERE SENTIMENT = 'positive' ${mentionsFilter}
+        ORDER BY RELEVANCE_SCORE DESC, MENTION_TS DESC
+        LIMIT 10
+      `;
+
+      const negativeMentionsQuery = `
+        SELECT TITLE, BODY, AUTHOR, AUTHOR_PROFILE_LINK, SOURCE_PLATFORM, SOCIAL_NETWORK, SENTIMENT, URL, MENTION_TS
+        FROM ANALYTICS.PLATINUM_LFX_ONE.BRAND_HEALTH_MENTIONS
+        WHERE SENTIMENT = 'negative' ${mentionsFilter}
+        ORDER BY RELEVANCE_SCORE DESC, MENTION_TS DESC
+        LIMIT 10
+      `;
+
+      interface MentionRow {
+        TITLE: string;
+        BODY: string;
+        AUTHOR: string;
+        AUTHOR_PROFILE_LINK: string;
+        SOURCE_PLATFORM: string;
+        SOCIAL_NETWORK: string;
+        SENTIMENT: string;
+        URL: string;
+        MENTION_TS: string;
+      }
+
+      const [summaryResult, trendResult, projectsResult, positiveMentionsResult, negativeMentionsResult] = await Promise.all([
         this.snowflakeService.execute<{
           TOTAL_MENTIONS: number;
           POSITIVE: number;
@@ -3788,6 +3822,8 @@ export class ProjectService {
           MENTION_COUNT_30D: number;
           PROJECT_RANK?: number;
         }>(topProjectsQuery, sovParams),
+        this.snowflakeService.execute<MentionRow>(positiveMentionsQuery, mentionsParams),
+        this.snowflakeService.execute<MentionRow>(negativeMentionsQuery, mentionsParams),
       ]);
 
       if (summaryResult.rows.length === 0) {
@@ -3818,6 +3854,18 @@ export class ProjectService {
         mentions: row.MENTION_COUNT_30D ?? 0,
       }));
 
+      const mapMention = (row: MentionRow): BrandHealthMention => ({
+        title: row.TITLE ?? '',
+        body: row.BODY ?? '',
+        author: row.AUTHOR ?? '',
+        authorProfileLink: row.AUTHOR_PROFILE_LINK ?? '',
+        sourcePlatform: row.SOURCE_PLATFORM ?? '',
+        socialNetwork: row.SOCIAL_NETWORK ?? '',
+        sentiment: (row.SENTIMENT as BrandHealthMention['sentiment']) ?? 'neutral',
+        url: row.URL ?? '',
+        mentionDate: row.MENTION_TS ? new Date(row.MENTION_TS).toISOString() : '',
+      });
+
       return {
         totalMentions,
         sentiment: { positive: positivePct, neutral: neutralPct, negative: negativePct },
@@ -3825,6 +3873,8 @@ export class ProjectService {
         trend: sentimentMomChangePp >= 0 ? 'up' : 'down',
         monthlyMentions,
         topProjects,
+        topPositiveMentions: positiveMentionsResult.rows.map(mapMention),
+        topNegativeMentions: negativeMentionsResult.rows.map(mapMention),
       };
     } catch (error) {
       logger.error(undefined, 'get_brand_health', startTime, error instanceof Error ? error : new Error(String(error)), {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3700,7 +3700,7 @@ export class ProjectService {
    * Get brand health metrics from Snowflake (Share of Voice)
    * Queries ANALYTICS.PLATINUM_LFX_ONE.SHARE_OF_VOICE, SHARE_OF_VOICE_MONTHLY_TREND, SHARE_OF_VOICE_TOP_PROJECTS
    */
-  public async getBrandHealth(foundationSlug: string): Promise<BrandHealthResponse> {
+  public async getBrandHealth(foundationSlug: string, includeMentions = false): Promise<BrandHealthResponse> {
     const startTime = Date.now();
     logger.debug(undefined, 'get_brand_health', 'Fetching brand health (Share of Voice) from Snowflake', { foundation_slug: foundationSlug });
 
@@ -3804,6 +3804,7 @@ export class ProjectService {
         MENTION_TS: string;
       }
 
+      const emptyMentionRows = { rows: [] as MentionRow[] };
       const [summaryResult, trendResult, projectsResult, positiveMentionsResult, negativeMentionsResult] = await Promise.all([
         this.snowflakeService.execute<{
           TOTAL_MENTIONS: number;
@@ -3822,8 +3823,8 @@ export class ProjectService {
           MENTION_COUNT_30D: number;
           PROJECT_RANK?: number;
         }>(topProjectsQuery, sovParams),
-        this.snowflakeService.execute<MentionRow>(positiveMentionsQuery, mentionsParams),
-        this.snowflakeService.execute<MentionRow>(negativeMentionsQuery, mentionsParams),
+        includeMentions ? this.snowflakeService.execute<MentionRow>(positiveMentionsQuery, mentionsParams) : Promise.resolve(emptyMentionRows),
+        includeMentions ? this.snowflakeService.execute<MentionRow>(negativeMentionsQuery, mentionsParams) : Promise.resolve(emptyMentionRows),
       ]);
 
       if (summaryResult.rows.length === 0) {

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -3035,8 +3035,23 @@ export interface BrandHealthSentimentBreakdown {
 }
 
 /**
+ * Individual brand mention from Octolens / social listening
+ */
+export interface BrandHealthMention {
+  title: string;
+  body: string;
+  author: string;
+  authorProfileLink: string;
+  sourcePlatform: string;
+  socialNetwork: string;
+  sentiment: 'positive' | 'negative' | 'neutral';
+  url: string;
+  mentionDate: string;
+}
+
+/**
  * API response for Brand Health metric
- * Total mentions, sentiment breakdown, monthly mentions trend, top projects
+ * Total mentions, sentiment breakdown, monthly mentions trend, top projects, top mentions
  */
 export interface BrandHealthResponse {
   totalMentions: number;
@@ -3045,6 +3060,8 @@ export interface BrandHealthResponse {
   trend: 'up' | 'down';
   monthlyMentions: NorthStarMonthlyDataPoint[];
   topProjects: BrandHealthTopProject[];
+  topPositiveMentions: BrandHealthMention[];
+  topNegativeMentions: BrandHealthMention[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Surface top 10 positive and top 10 negative social mentions from `BRAND_HEALTH_MENTIONS` Snowflake table in the Brand Health drawer
- Negative mentions appear first so EDs see what needs attention
- Hide the MoM Growth stat card when no sentiment time-series data exists (currently hardcoded to 0)
- Correct Top Events subtitle from "YTD" to "All Time" to match the actual query scope

## Changes
| File | What |
|---|---|
| `analytics-data.interface.ts` | Add `BrandHealthMention` interface + two arrays on `BrandHealthResponse` |
| `project.service.ts` | Two new Snowflake queries against `BRAND_HEALTH_MENTIONS` with TLF umbrella support |
| `analytics.service.ts` | Update `getBrandHealth` catchError fallback with empty mention arrays |
| `marketing-overview.component.ts` | Update `EMPTY_ED_EVOLUTION_DATA` fallback |
| `brand-health-drawer.component.ts` | Add default values for new input fields |
| `brand-health-drawer.component.html` | Negative/positive mention sections, skip MoM card when 0 |
| `event-growth-drawer.component.html` | Fix "YTD" → "All Time" label |

## Stacked on
PR #512 (`fix/LFXV2-1468-ed-card-polish`) — merge that first, then retarget this to `main`.

## Test plan
- [ ] Select TLF → open Brand Health drawer → verify negative mentions section appears above positive
- [ ] Verify mention cards show title, body snippet, author, platform, and external link
- [ ] Verify MoM Growth stat card is hidden (no dash placeholder)
- [ ] Select a foundation with no mention data → verify sections don't render
- [ ] Open Event Growth drawer → verify "All Time" label on Top Events

🤖 Generated with [Claude Code](https://claude.ai/code)