### PR TITLE
feat(health-metrics): board meeting & flywheel cards, ED guard, analytics

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -4,6 +4,7 @@
 import { Routes } from '@angular/router';
 
 import { authGuard } from './shared/guards/auth.guard';
+import { executiveDirectorGuard } from './shared/guards/executive-director.guard';
 
 export const routes: Routes = [
   {
@@ -28,6 +29,7 @@ export const routes: Routes = [
       {
         path: 'foundation/health-metrics',
         data: { lens: 'foundation' },
+        canActivate: [executiveDirectorGuard],
         loadComponent: () => import('./modules/dashboards/health-metrics/health-metrics.component').then((m) => m.HealthMetricsComponent),
       },
       // Project Lens dashboard (placeholder — reuses DashboardComponent for now)

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
@@ -8,7 +8,15 @@ import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { createHorizontalBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
-import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import {
+  buildFlywheelKeyInsights,
+  buildFlywheelRecommendedActions,
+  formatNumber,
+  getFlywheelReengagement,
+  hexToRgba,
+  splitByPriority,
+  type MarketingSplitByPriority,
+} from '@lfx-one/shared/utils';
 import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -54,26 +62,12 @@ export class FlywheelConversionDrawerComponent {
     monthlyData: [],
   });
 
-  private readonly defaultReengagement: NonNullable<FlywheelConversionResponse['reengagement']> = {
-    totalReengaged: 0,
-    reengagementRate: 0,
-    reengagementMomChange: 0,
-    reengagedToNewsletter: 0,
-    reengagedToCommunity: 0,
-    reengagedToWorkingGroup: 0,
-    reengagedToTraining: 0,
-    reengagedToCode: 0,
-    reengagedToWeb: 0,
-  };
-
   // === Computed Signals ===
   protected readonly formattedEventAttendees: Signal<string> = computed(() => formatNumber(this.data().funnel.eventAttendees));
-  protected readonly reengagement: Signal<NonNullable<FlywheelConversionResponse['reengagement']>> = computed(
-    () => this.data().reengagement ?? this.defaultReengagement
-  );
+  protected readonly reengagement: Signal<NonNullable<FlywheelConversionResponse['reengagement']>> = computed(() => getFlywheelReengagement(this.data()));
   protected readonly reengagementRate: Signal<string> = computed(() => `${this.reengagement().reengagementRate.toFixed(1)}%`);
-  protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
-  protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
+  protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = computed(() => buildFlywheelRecommendedActions(this.data()));
+  protected readonly keyInsights: Signal<MarketingKeyInsight[]> = computed(() => buildFlywheelKeyInsights(this.data()));
   private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
 
   protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
@@ -158,128 +152,6 @@ export class FlywheelConversionDrawerComponent {
   }
 
   // === Private Initializers ===
-  private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
-    return computed(() => {
-      const { conversionRate, funnel, monthlyData } = this.data();
-      const reengagement = this.reengagement();
-      const actions: MarketingRecommendedAction[] = [];
-
-      if (conversionRate === 0 && funnel.eventAttendees === 0 && monthlyData.length === 0) {
-        return actions;
-      }
-
-      // Low WG re-engagement relative to community re-engagement
-      if (funnel.eventAttendees > 0 && reengagement.reengagedToWorkingGroup > 0 && reengagement.reengagedToCommunity > 0) {
-        const wgRate = (reengagement.reengagedToWorkingGroup / funnel.eventAttendees) * 100;
-        const communityRate = (reengagement.reengagedToCommunity / funnel.eventAttendees) * 100;
-        if (wgRate < communityRate * 0.5) {
-          actions.push({
-            title: 'Improve working group re-engagement path',
-            description: `WG re-engagement at ${wgRate.toFixed(1)}% vs ${communityRate.toFixed(1)}% for community — attendees need clearer path to participate`,
-            priority: 'high',
-            dueLabel: 'This quarter',
-            actionType: 'conversion',
-          });
-        }
-      }
-
-      // Declining re-engagement rate
-      if (reengagement.reengagementMomChange < -5) {
-        actions.push({
-          title: 'Address re-engagement rate decline',
-          description: `Re-engagement dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% MoM — review post-event follow-up effectiveness`,
-          priority: 'high',
-          dueLabel: 'This month',
-          actionType: 'decline',
-        });
-      }
-
-      // Low overall re-engagement
-      if (reengagement.reengagementRate > 0 && reengagement.reengagementRate < 10 && funnel.eventAttendees > 0) {
-        actions.push({
-          title: 'Add post-event engagement CTAs',
-          description: `Only ${reengagement.reengagementRate.toFixed(1)}% re-engagement — add community join and working group prompts to event follow-ups`,
-          priority: 'medium',
-          dueLabel: 'Next event',
-          actionType: 'content',
-        });
-      }
-
-      if (actions.length === 0) {
-        actions.push({
-          title: 'Continue flywheel optimization',
-          description: `${reengagement.reengagementRate.toFixed(1)}% re-engagement rate${reengagement.reengagementMomChange > 0 ? ` — improving ${reengagement.reengagementMomChange.toFixed(1)}%` : ''} across ${formatNumber(funnel.eventAttendees)} attendees`,
-          priority: 'low',
-          dueLabel: 'Ongoing',
-          actionType: 'growth',
-        });
-      }
-
-      return actions;
-    });
-  }
-
-  private initKeyInsights(): Signal<MarketingKeyInsight[]> {
-    return computed(() => {
-      const { conversionRate, funnel, monthlyData } = this.data();
-      const reengagement = this.reengagement();
-      const insights: MarketingKeyInsight[] = [];
-
-      if (conversionRate === 0 && funnel.eventAttendees === 0 && monthlyData.length === 0) {
-        return insights;
-      }
-
-      // Best re-engagement path
-      if (funnel.eventAttendees > 0) {
-        const paths = [
-          { name: 'Community', value: reengagement.reengagedToCommunity },
-          { name: 'Working group', value: reengagement.reengagedToWorkingGroup },
-          { name: 'Newsletter', value: reengagement.reengagedToNewsletter },
-          { name: 'Training', value: reengagement.reengagedToTraining },
-          { name: 'Code', value: reengagement.reengagedToCode },
-          { name: 'Web', value: reengagement.reengagedToWeb },
-        ]
-          .filter((p) => p.value > 0)
-          .sort((a, b) => b.value - a.value);
-
-        if (paths.length > 0) {
-          const bestRate = (paths[0].value / funnel.eventAttendees) * 100;
-          insights.push({ text: `${paths[0].name} is the highest re-engagement path at ${bestRate.toFixed(1)}% of attendees`, type: 'driver' });
-        }
-
-        // Weakest path
-        if (paths.length > 1) {
-          const worstRate = (paths[paths.length - 1].value / funnel.eventAttendees) * 100;
-          insights.push({ text: `${paths[paths.length - 1].name} re-engagement lowest at ${worstRate.toFixed(1)}%`, type: 'warning' });
-        }
-      }
-
-      // Re-engagement MoM trend
-      if (reengagement.reengagementMomChange > 3) {
-        insights.push({ text: `Re-engagement rate trending up ${reengagement.reengagementMomChange.toFixed(1)}% — flywheel is accelerating`, type: 'driver' });
-      } else if (reengagement.reengagementMomChange < -3) {
-        insights.push({
-          text: `Re-engagement rate dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% — flywheel is slowing`,
-          type: 'warning',
-        });
-      }
-
-      // Re-engaged count trend (monthlyData.value = TOTAL_REENGAGED)
-      if (monthlyData.length >= 3) {
-        const recent3 = monthlyData.slice(-3);
-        const isGrowing = recent3[0].value < recent3[1].value && recent3[1].value < recent3[2].value;
-        const isShrinking = recent3[0].value > recent3[1].value && recent3[1].value > recent3[2].value;
-        if (isGrowing) {
-          insights.push({ text: `Re-engaged members growing for 3 consecutive months — ${formatNumber(recent3[2].value)} this month`, type: 'driver' });
-        } else if (isShrinking) {
-          insights.push({ text: `Re-engaged members declining for 3 consecutive months — ${formatNumber(recent3[2].value)} this month`, type: 'warning' });
-        }
-      }
-
-      return insights;
-    });
-  }
-
   private initTrendChartData(): Signal<ChartData<'line'>> {
     return computed(() => {
       const { monthlyData } = this.data();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -247,7 +247,7 @@ export class MarketingOverviewComponent {
       foundation$.pipe(
         switchMap((slug) =>
           forkJoin({
-            flywheel: safe('flywheel', this.analyticsService.getFlywheelConversion(slug)),
+            flywheel: safe('flywheel', this.analyticsService.getFlywheelConversion(slug).pipe(map((r) => r ?? EMPTY_ED_EVOLUTION_DATA.flywheel))),
             memberAcquisition: safe('memberAcquisition', this.analyticsService.getMemberAcquisition(slug)),
             memberRetention: safe('memberRetention', this.analyticsService.getMemberRetention(slug)),
             engagedCommunity: safe('engagedCommunity', this.analyticsService.getEngagedCommunity(slug)),

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.html
@@ -1,0 +1,157 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex h-full flex-col gap-4 rounded-lg border border-gray-200 bg-white p-5" data-testid="board-meeting-card">
+  <!-- Header -->
+  <div class="flex items-center justify-between gap-4" data-testid="board-meeting-card-header">
+    <h3 class="text-sm font-bold tracking-wide text-gray-900 uppercase" data-testid="board-meeting-title">Board Meeting Participation</h3>
+    @if (addPastMeetingUrl()) {
+      <div class="text-xs text-gray-500">
+        Missing a meeting?
+        <a
+          [href]="addPastMeetingUrl()"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-medium text-blue-600 hover:text-blue-800 hover:underline"
+          aria-label="Add a past board meeting in PCC"
+          data-testid="board-meeting-add-meeting-link">
+          Add past meeting
+        </a>
+      </div>
+    }
+  </div>
+
+  @if (loading()) {
+    <!-- Loading Skeletons -->
+    <div class="flex flex-col gap-4" data-testid="board-meeting-card-skeleton">
+      <div class="flex gap-8">
+        <div class="flex flex-col gap-1">
+          <p-skeleton width="4rem" height="2.5rem" />
+          <p-skeleton width="6rem" height="0.75rem" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <p-skeleton width="4rem" height="2.5rem" />
+          <p-skeleton width="8rem" height="0.75rem" />
+        </div>
+      </div>
+      <p-skeleton width="100%" height="12rem" />
+    </div>
+  } @else if (!hasData()) {
+    <!-- No Data State (slug not resolved) -->
+    <div class="flex items-center justify-center py-8" data-testid="board-meeting-card-no-data">
+      <p class="text-sm text-gray-500">No Board Meeting Participation Data Available</p>
+    </div>
+  } @else {
+    <!-- Metrics Row -->
+    <div class="flex gap-12" data-testid="board-meeting-card-metrics">
+      <!-- Total Meetings -->
+      <div class="flex flex-col gap-0.5" data-testid="board-meeting-total-meetings">
+        <div class="flex items-baseline gap-2">
+          <span class="text-3xl font-bold text-gray-900">{{ summaryData().totalMeetings }}</span>
+          @if (showTotalMeetingsChange()) {
+            <span
+              class="text-sm font-medium"
+              [class.text-red-600]="totalMeetingsChangeIsNegative()"
+              [class.text-emerald-600]="!totalMeetingsChangeIsNegative()"
+              data-testid="board-meeting-total-meetings-change">
+              {{ formattedTotalMeetingsChange() }}
+            </span>
+          }
+        </div>
+        <span class="text-xs text-gray-500">Total Meetings</span>
+      </div>
+
+      <!-- Avg. Meeting Attendance -->
+      <div class="flex flex-col gap-0.5" data-testid="board-meeting-avg-attendance">
+        <div class="flex items-baseline gap-2">
+          <span class="text-3xl font-bold text-gray-900">{{ formattedAvgAttendance() }}%</span>
+          @if (showAvgAttendanceChange()) {
+            <span
+              class="text-sm font-medium"
+              [class.text-red-600]="avgAttendanceChangeIsNegative()"
+              [class.text-emerald-600]="!avgAttendanceChangeIsNegative()"
+              data-testid="board-meeting-avg-attendance-change">
+              {{ formattedAvgAttendanceChange() }}
+            </span>
+          }
+        </div>
+        <span class="text-xs text-gray-500">Avg. Meeting Attendance</span>
+      </div>
+    </div>
+
+    <!-- Invitees Data Table -->
+    @if (hasInvitees()) {
+      <div class="max-h-[300px] overflow-auto rounded-md border border-gray-200" data-testid="board-meeting-table">
+        <table class="w-full border-collapse text-left">
+          <thead class="sticky top-0 z-10 bg-gray-50">
+            <tr class="border-b border-gray-200">
+              @for (col of columnHeaders(); track col.field) {
+                <th
+                  scope="col"
+                  class="px-3 py-2"
+                  [class.w-[30%]]="col.field === 'inviteeFullName'"
+                  [class.w-[25%]]="col.field === 'organizationName' || col.field === 'lastAttended'"
+                  [class.w-[20%]]="col.field === 'attendancePercent'"
+                  [attr.aria-sort]="col.ariaSort"
+                  [attr.data-testid]="'board-meeting-th-' + col.field">
+                  <button type="button" class="inline-flex w-full items-center gap-1 text-xs font-semibold tracking-wide text-gray-600 uppercase hover:text-gray-900" (click)="onSort(col.field)">
+                    {{ col.label }}
+                    <i class="fa-solid text-xs text-gray-400" [class]="col.iconClass"></i>
+                  </button>
+                </th>
+              }
+            </tr>
+          </thead>
+          <tbody>
+            @for (row of displayRows(); track $index; let rowIndex = $index) {
+              <tr class="border-b border-gray-100 last:border-b-0" [attr.data-testid]="'board-meeting-row-' + rowIndex">
+                <!-- Name -->
+                <td class="px-3 py-2">
+                  <div class="flex flex-col gap-0.5 min-w-0">
+                    <span class="truncate text-sm font-semibold text-gray-900">{{ row.displayName }}</span>
+                    @if (row.displayJobTitle) {
+                      <span class="truncate text-xs italic text-gray-500">{{ row.displayJobTitle }}</span>
+                    }
+                  </div>
+                </td>
+
+                <!-- Organization -->
+                <td class="px-3 py-2">
+                  @if (row.organizationUrl) {
+                    <a
+                      [href]="row.organizationUrl"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="inline-block max-w-full truncate text-sm text-blue-600 hover:text-blue-800 hover:underline"
+                      data-testid="board-meeting-org-link">
+                      {{ row.organizationName }}
+                    </a>
+                  } @else {
+                    <span class="inline-block max-w-full truncate text-sm text-gray-700">{{ row.organizationName }}</span>
+                  }
+                </td>
+
+                <!-- Attended (%) -->
+                <td class="px-3 py-2">
+                  <span class="text-sm" [class.text-red-600]="row.isLowAttendance" [class.text-gray-900]="!row.isLowAttendance">
+                    {{ row.attendanceLabel }}
+                  </span>
+                </td>
+
+                <!-- Last Attended -->
+                <td class="px-3 py-2">
+                  <span class="text-sm text-gray-900">{{ row.lastAttendedLabel }}</span>
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    } @else {
+      <!-- Empty table state: summary data exists but no invitees match for this range -->
+      <div class="flex items-center justify-center rounded-md border border-dashed border-gray-200 py-8" data-testid="board-meeting-table-empty">
+        <p class="text-sm text-gray-500">No Board Meeting Participation</p>
+      </div>
+    }
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.html
@@ -96,7 +96,7 @@
                   [attr.data-testid]="'board-meeting-th-' + col.field">
                   <button type="button" class="inline-flex w-full items-center gap-1 text-xs font-semibold tracking-wide text-gray-600 uppercase hover:text-gray-900" (click)="onSort(col.field)">
                     {{ col.label }}
-                    <i class="fa-solid text-xs text-gray-400" [class]="col.iconClass"></i>
+                    <i [class]="col.iconClass"></i>
                   </button>
                 </th>
               }

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.scss
@@ -1,0 +1,6 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+:host {
+  display: block;
+}

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.ts
@@ -109,11 +109,11 @@ export class BoardMeetingCardComponent {
     return BoardMeetingCardComponent.columnDefs.map(({ field, label }) => {
       const isActive = activeField === field;
       let ariaSort: 'ascending' | 'descending' | 'none' = 'none';
-      let iconClass = 'fa-sort';
+      let iconClass = 'fa-solid text-xs text-gray-400 fa-sort';
 
       if (isActive) {
         ariaSort = activeOrder === 1 ? 'ascending' : 'descending';
-        iconClass = activeOrder === 1 ? 'fa-sort-up' : 'fa-sort-down';
+        iconClass = `fa-solid text-xs text-gray-400 ${activeOrder === 1 ? 'fa-sort-up' : 'fa-sort-down'}`;
       }
 
       return { field, label, ariaSort, iconClass };

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.ts
@@ -14,7 +14,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { initializeRangeDataFetching } from '@shared/utils/health-metrics-data.util';
 import { SkeletonModule } from 'primeng/skeleton';
 
-import { environment } from '../../../../../environments/environment';
+import { environment } from '@environments/environment';
 
 import type {
   BoardMeetingColumnHeader,

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.ts
@@ -1,0 +1,223 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, input, PLATFORM_ID, signal } from '@angular/core';
+import {
+  HEALTH_METRICS_BOARD_MEETING_DEFAULT_SUMMARY,
+  HEALTH_METRICS_BOARD_MEETING_JOB_TITLE_MAX_LENGTH,
+  HEALTH_METRICS_BOARD_MEETING_LOW_ATTENDANCE_THRESHOLD,
+} from '@lfx-one/shared/constants';
+import { parseLocalDateString } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { initializeRangeDataFetching } from '@shared/utils/health-metrics-data.util';
+import { SkeletonModule } from 'primeng/skeleton';
+
+import { environment } from '../../../../../environments/environment';
+
+import type {
+  BoardMeetingColumnHeader,
+  BoardMeetingDisplayRow,
+  BoardMeetingInviteeRow,
+  BoardMeetingParticipationSummaryResponse,
+  BoardMeetingSortField,
+  BoardMeetingSortOrder,
+  HealthMetricsRange,
+} from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-board-meeting-card',
+  standalone: true,
+  imports: [SkeletonModule],
+  templateUrl: './board-meeting-card.component.html',
+  styleUrl: './board-meeting-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BoardMeetingCardComponent {
+  private readonly analyticsService = inject(AnalyticsService);
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  public readonly range = input<HealthMetricsRange>('YTD');
+
+  protected readonly pccUrl = environment.urls.pcc;
+
+  protected readonly loading = signal(true);
+  protected readonly summaryData = signal<BoardMeetingParticipationSummaryResponse>(HEALTH_METRICS_BOARD_MEETING_DEFAULT_SUMMARY);
+
+  protected readonly sortField = signal<BoardMeetingSortField>('lastAttended');
+  protected readonly sortOrder = signal<BoardMeetingSortOrder>(-1);
+
+  protected readonly projectId = computed(() => this.summaryData().projectId);
+  protected readonly hasData = computed(() => this.summaryData().dataAvailable);
+  protected readonly hasInvitees = computed(() => this.summaryData().invitees.length > 0);
+
+  protected readonly addPastMeetingUrl = computed(() => {
+    const id = this.projectId();
+    if (!id) return '';
+    return `${this.pccUrl}/project/${id}/collaboration/meetings/manage-meeting?isPast=true`;
+  });
+
+  protected readonly formattedAvgAttendance = computed(() => {
+    return Math.round(this.summaryData().avgMeetingAttendance * 100);
+  });
+
+  protected readonly showTotalMeetingsChange = computed(() => {
+    const change = this.summaryData().totalMeetingsChange;
+    return change !== null && change !== 0;
+  });
+
+  protected readonly showAvgAttendanceChange = computed(() => {
+    const change = this.summaryData().avgMeetingAttendanceChange;
+    return change !== null && change !== 0;
+  });
+
+  protected readonly formattedTotalMeetingsChange = computed(() => {
+    const change = this.summaryData().totalMeetingsChange ?? 0;
+    const pct = Math.abs(change * 100).toFixed(0);
+    return `${change < 0 ? '↓' : '↑'} ${pct}%`;
+  });
+
+  protected readonly formattedAvgAttendanceChange = computed(() => {
+    const change = this.summaryData().avgMeetingAttendanceChange ?? 0;
+    const pct = Math.abs(change * 100).toFixed(0);
+    return `${change < 0 ? '↓' : '↑'} ${pct}%`;
+  });
+
+  protected readonly totalMeetingsChangeIsNegative = computed(() => {
+    const change = this.summaryData().totalMeetingsChange ?? 0;
+    return change < 0;
+  });
+
+  protected readonly avgAttendanceChangeIsNegative = computed(() => {
+    const change = this.summaryData().avgMeetingAttendanceChange ?? 0;
+    return change < 0;
+  });
+
+  private static readonly columnDefs: { field: BoardMeetingSortField; label: string }[] = [
+    { field: 'inviteeFullName', label: 'Name' },
+    { field: 'organizationName', label: 'Organization' },
+    { field: 'attendancePercent', label: 'Attended (%)' },
+    { field: 'lastAttended', label: 'Last Attended' },
+  ];
+
+  protected readonly columnHeaders = computed<BoardMeetingColumnHeader[]>(() => {
+    const activeField = this.sortField();
+    const activeOrder = this.sortOrder();
+    return BoardMeetingCardComponent.columnDefs.map(({ field, label }) => {
+      const isActive = activeField === field;
+      let ariaSort: 'ascending' | 'descending' | 'none' = 'none';
+      let iconClass = 'fa-sort';
+
+      if (isActive) {
+        ariaSort = activeOrder === 1 ? 'ascending' : 'descending';
+        iconClass = activeOrder === 1 ? 'fa-sort-up' : 'fa-sort-down';
+      }
+
+      return { field, label, ariaSort, iconClass };
+    });
+  });
+
+  protected readonly displayRows = computed<BoardMeetingDisplayRow[]>(() => {
+    const rows = this.summaryData().invitees;
+    const field = this.sortField();
+    const order = this.sortOrder();
+    const id = this.projectId();
+
+    if (rows.length === 0) return [];
+
+    const sorted = [...rows];
+    sorted.sort((a, b) => BoardMeetingCardComponent.compareRows(a, b, field, order));
+
+    return sorted.map((row) => ({
+      displayName: BoardMeetingCardComponent.toTitleCase(row.inviteeFullName),
+      displayJobTitle: BoardMeetingCardComponent.formatJobTitle(row.inviteeJobTitle),
+      organizationName: row.organizationName,
+      organizationUrl: id && row.organizationId ? `${this.pccUrl}/project/${id}/reports/health-metrics/members/${row.organizationId}` : '',
+      attendanceLabel: `${row.meetingsAttended}/${row.meetingsInvited} (${Math.round(row.attendancePercent * 100)}%)`,
+      isLowAttendance: row.attendancePercent < HEALTH_METRICS_BOARD_MEETING_LOW_ATTENDANCE_THRESHOLD,
+      lastAttendedLabel: BoardMeetingCardComponent.formatLastAttended(row.lastAttended),
+    }));
+  });
+
+  public constructor() {
+    if (isPlatformBrowser(this.platformId)) {
+      this.initializeDataFetching();
+    }
+  }
+
+  protected onSort(field: BoardMeetingSortField): void {
+    if (this.sortField() === field) {
+      this.sortOrder.update((o) => (o === 1 ? -1 : 1));
+      return;
+    }
+    this.sortField.set(field);
+    this.sortOrder.set(field === 'lastAttended' ? -1 : 1);
+  }
+
+  private static toTitleCase(name: string): string {
+    if (!name) return '';
+    return name
+      .toLowerCase()
+      .replace(/\b[a-z]/g, (char) => char.toUpperCase())
+      .replace(/(['-])([a-z])/g, (_match, separator, char) => `${separator}${char.toUpperCase()}`);
+  }
+
+  private static formatJobTitle(jobTitle: string | null): string | null {
+    if (!jobTitle || jobTitle === 'Unavailable') return null;
+    if (jobTitle.length > HEALTH_METRICS_BOARD_MEETING_JOB_TITLE_MAX_LENGTH) {
+      return `${jobTitle.slice(0, HEALTH_METRICS_BOARD_MEETING_JOB_TITLE_MAX_LENGTH).trimEnd()}…`;
+    }
+    return jobTitle;
+  }
+
+  private static formatLastAttended(lastAttended: string | null): string {
+    if (!lastAttended) return '–';
+    try {
+      const date = parseLocalDateString(lastAttended);
+      return date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+    } catch {
+      return '–';
+    }
+  }
+
+  private static compareRows(a: BoardMeetingInviteeRow, b: BoardMeetingInviteeRow, field: BoardMeetingSortField, order: BoardMeetingSortOrder): number {
+    if (field === 'lastAttended') {
+      const aTime = BoardMeetingCardComponent.parseLastAttendedTime(a.lastAttended);
+      const bTime = BoardMeetingCardComponent.parseLastAttendedTime(b.lastAttended);
+      if (aTime === null && bTime === null) return 0;
+      if (aTime === null) return 1;
+      if (bTime === null) return -1;
+      return (aTime - bTime) * order;
+    }
+    if (field === 'attendancePercent') {
+      return (a.attendancePercent - b.attendancePercent) * order;
+    }
+    const aStr = (a[field] ?? '').toString().toLowerCase();
+    const bStr = (b[field] ?? '').toString().toLowerCase();
+    return aStr.localeCompare(bStr) * order;
+  }
+
+  private static parseLastAttendedTime(lastAttended: string | null): number | null {
+    if (!lastAttended) return null;
+    try {
+      return parseLocalDateString(lastAttended).getTime();
+    } catch {
+      return null;
+    }
+  }
+
+  private initializeDataFetching(): void {
+    initializeRangeDataFetching({
+      projectContextService: this.projectContextService,
+      range: this.range,
+      loading: this.loading,
+      data: this.summaryData,
+      defaultValue: HEALTH_METRICS_BOARD_MEETING_DEFAULT_SUMMARY,
+      fetchFn: (slug, range) => this.analyticsService.getBoardMeetingParticipationSummary(slug, range),
+      destroyRef: this.destroyRef,
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.html
@@ -1,0 +1,120 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex h-full flex-col gap-4 rounded-lg border border-gray-200 bg-white p-5" data-testid="health-metrics-flywheel-card">
+  <!-- Header -->
+  <div class="flex items-center justify-between" data-testid="health-metrics-flywheel-header">
+    <h3 class="text-sm font-bold tracking-wide text-gray-900 uppercase" data-testid="health-metrics-flywheel-title">Flywheel Conversion Rate</h3>
+    @if (!loading() && hasFlywheelData()) {
+      <button
+        class="ignore-download flex h-8 w-8 items-center justify-center rounded text-gray-400 hover:text-gray-600"
+        type="button"
+        (click)="downloadCard()"
+        aria-label="Download Flywheel Conversion Rate card as image"
+        title="Download Flywheel Conversion Rate card as image"
+        data-testid="health-metrics-flywheel-download">
+        <i class="fa-solid fa-arrow-down-to-bracket text-sm"></i>
+      </button>
+    }
+  </div>
+
+  <!-- Description -->
+  <div class="rounded-md bg-gray-50 px-4 py-3" data-testid="health-metrics-flywheel-description">
+    <p class="text-xs text-gray-500">
+      Percentage of event attendees who engage with newsletter, community, or working groups within 90 days after an event.
+      This metric reflects the latest monthly window and is not affected by the page year filter.
+    </p>
+  </div>
+
+  @if (loading()) {
+    <!-- Loading Skeleton -->
+    <div class="flex flex-col gap-4" data-testid="health-metrics-flywheel-skeleton">
+      <div class="flex gap-8">
+        <div class="flex flex-col gap-1">
+          <p-skeleton width="6rem" height="2.5rem" />
+          <p-skeleton width="8rem" height="0.75rem" />
+        </div>
+        <div class="flex flex-col gap-1">
+          <p-skeleton width="5rem" height="1.75rem" />
+          <p-skeleton width="6rem" height="0.75rem" />
+        </div>
+      </div>
+      <p-skeleton width="8rem" height="1rem" />
+      <p-skeleton width="100%" height="12rem" borderRadius="4px" />
+      <p-skeleton width="100%" height="3rem" borderRadius="8px" />
+    </div>
+  } @else if (!hasFlywheelData()) {
+    <!-- No Data State -->
+    <div class="flex items-center justify-center py-10" data-testid="health-metrics-flywheel-no-data">
+      <p class="text-sm text-gray-500">No Flywheel Conversion Data Available</p>
+    </div>
+  } @else {
+    <!-- Summary Row -->
+    @if (summary(); as summaryView) {
+      <div class="flex flex-wrap items-start gap-8" data-testid="health-metrics-flywheel-summary">
+        <div class="flex flex-col gap-0.5" data-testid="health-metrics-flywheel-current-rate">
+          <span class="text-3xl font-bold text-gray-900">{{ formattedCurrentConversion() }}</span>
+          <div class="flex items-center gap-1">
+            <span class="text-xs text-gray-500">Conversion Rate</span>
+            <span
+              class="flex items-center gap-0.5 text-xs font-medium"
+              [class.text-emerald-600]="summaryView.trend === 'up'"
+              [class.text-red-600]="summaryView.trend === 'down'"
+              data-testid="health-metrics-flywheel-trend">
+              <i class="fa-light text-xs" [class.fa-arrow-up]="summaryView.trend === 'up'" [class.fa-arrow-down]="summaryView.trend === 'down'"></i>
+              {{ formattedChangePercentage() }}
+            </span>
+          </div>
+        </div>
+
+        <div class="flex flex-col gap-0.5" data-testid="health-metrics-flywheel-previous-rate">
+          <span class="text-xl font-semibold text-gray-500">{{ formattedPreviousConversion() }}</span>
+          <span class="text-xs text-gray-500">Previous Period</span>
+        </div>
+      </div>
+    }
+
+    <hr class="border-gray-200" />
+
+    <!-- Funnel Stages -->
+    <div class="flex flex-col gap-2" data-testid="health-metrics-flywheel-funnel-section">
+      <h4 class="text-sm font-bold text-gray-900">Funnel Stages</h4>
+      <div class="h-[220px]" data-testid="health-metrics-flywheel-funnel-chart">
+        <lfx-chart type="bar" [data]="funnelChartData()" [options]="funnelChartOptions" height="100%"></lfx-chart>
+      </div>
+      <!-- Screen-reader / test-friendly label list mirroring the chart stage order -->
+      <ul class="sr-only" data-testid="health-metrics-flywheel-funnel-stages" aria-label="Flywheel funnel stages">
+        @for (stage of funnelStages(); track stage.label) {
+          <li [attr.data-stage]="stage.label" [attr.data-count]="stage.count">{{ stage.label }}: {{ stage.count }}</li>
+        }
+      </ul>
+    </div>
+
+    <!-- Insight Banner -->
+    @if (banner(); as bannerView) {
+      <div
+        class="flex items-start gap-3 rounded-lg border p-4"
+        [class.bg-amber-50]="bannerView.priorityGroup === 'attention'"
+        [class.border-amber-200]="bannerView.priorityGroup === 'attention'"
+        [class.bg-emerald-50]="bannerView.priorityGroup === 'performing'"
+        [class.border-emerald-200]="bannerView.priorityGroup === 'performing'"
+        data-testid="health-metrics-flywheel-banner">
+        <i
+          class="mt-0.5 text-sm"
+          [class.fa-solid]="bannerView.priorityGroup === 'attention'"
+          [class.fa-circle]="bannerView.priorityGroup === 'attention'"
+          [class.text-amber-500]="bannerView.priorityGroup === 'attention'"
+          [class.fa-light]="bannerView.priorityGroup === 'performing'"
+          [class.fa-bullseye]="bannerView.priorityGroup === 'performing'"
+          [class.text-emerald-500]="bannerView.priorityGroup === 'performing'"></i>
+        <span
+          class="text-sm"
+          [class.text-amber-800]="bannerView.priorityGroup === 'attention'"
+          [class.text-emerald-800]="bannerView.priorityGroup === 'performing'"
+          data-testid="health-metrics-flywheel-banner-text">
+          {{ bannerView.text }}
+        </span>
+      </div>
+    }
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.scss
@@ -1,0 +1,7 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+:host {
+  display: block;
+  height: 100%;
+}

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, PLATFORM_ID, signal } from '@angular/core';
+import type { Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
 import { createHorizontalBarChartOptions, DASHBOARD_TOOLTIP_CONFIG, HEALTH_METRICS_FLYWHEEL_CONVERSION_DECIMAL_PLACES, lfxColors } from '@lfx-one/shared/constants';

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.ts
@@ -2,15 +2,15 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, inject, input, PLATFORM_ID, signal, Signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
 import { createHorizontalBarChartOptions, DASHBOARD_TOOLTIP_CONFIG, HEALTH_METRICS_FLYWHEEL_CONVERSION_DECIMAL_PLACES, lfxColors } from '@lfx-one/shared/constants';
 import { buildFlywheelCardSummary, buildFlywheelFunnelStages, formatNumber, selectFlywheelBannerView } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { downloadCardAsImage } from '@shared/utils/download-card.util';
-import { filter, map, switchMap, tap } from 'rxjs';
+import { catchError, filter, finalize, map, of, switchMap, tap } from 'rxjs';
 import { SkeletonModule } from 'primeng/skeleton';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -36,7 +36,6 @@ export class FlywheelConversionCardComponent {
   private readonly elementRef = inject(ElementRef);
   private readonly analyticsService = inject(AnalyticsService);
   private readonly projectContextService = inject(ProjectContextService);
-  private readonly destroyRef = inject(DestroyRef);
   private readonly platformId = inject(PLATFORM_ID);
 
   // === Inputs ===
@@ -45,7 +44,7 @@ export class FlywheelConversionCardComponent {
 
   // === Internal State ===
   protected readonly loading = signal(true);
-  private readonly data = signal<FlywheelConversionResponse | null>(null);
+  private readonly data: Signal<FlywheelConversionResponse | null> = this.initDataFromServer();
 
   // === Computed Signals ===
   protected readonly summary: Signal<FlywheelCardSummaryView | null> = computed(() => buildFlywheelCardSummary(this.data()));
@@ -144,38 +143,29 @@ export class FlywheelConversionCardComponent {
     },
   });
 
-  public constructor() {
-    if (isPlatformBrowser(this.platformId)) {
-      this.initializeDataFetching();
-    }
-  }
-
   // === Protected Methods ===
   protected downloadCard(): void {
     if (this.loading() || !this.hasFlywheelData()) return;
     downloadCardAsImage(this.elementRef.nativeElement, 'flywheel-conversion-rate');
   }
 
-  private initializeDataFetching(): void {
-    toObservable(this.projectContextService.selectedFoundation)
-      .pipe(
+  private initDataFromServer(): Signal<FlywheelConversionResponse | null> {
+    if (!isPlatformBrowser(this.platformId)) {
+      return signal<FlywheelConversionResponse | null>(null);
+    }
+    return toSignal(
+      toObservable(this.projectContextService.selectedFoundation).pipe(
         map((foundation) => foundation?.slug || ''),
         filter((slug): slug is string => !!slug),
-        tap(() => {
-          this.loading.set(true);
-          this.data.set(null);
-        }),
-        switchMap((slug) => this.analyticsService.getFlywheelConversion(slug)),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe({
-        next: (result) => {
-          this.data.set(result);
-          this.loading.set(false);
-        },
-        error: () => {
-          this.loading.set(false);
-        },
-      });
+        tap(() => this.loading.set(true)),
+        switchMap((slug) =>
+          this.analyticsService.getFlywheelConversion(slug).pipe(
+            catchError(() => of(null)),
+            finalize(() => this.loading.set(false))
+          )
+        )
+      ),
+      { initialValue: null }
+    );
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.ts
@@ -1,0 +1,181 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, inject, input, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { ChartComponent } from '@components/chart/chart.component';
+import { createHorizontalBarChartOptions, DASHBOARD_TOOLTIP_CONFIG, HEALTH_METRICS_FLYWHEEL_CONVERSION_DECIMAL_PLACES, lfxColors } from '@lfx-one/shared/constants';
+import { buildFlywheelCardSummary, buildFlywheelFunnelStages, formatNumber, selectFlywheelBannerView } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { downloadCardAsImage } from '@shared/utils/download-card.util';
+import { filter, map, switchMap, tap } from 'rxjs';
+import { SkeletonModule } from 'primeng/skeleton';
+
+import type { ChartData, ChartOptions } from 'chart.js';
+import type {
+  FlywheelCardSummaryView,
+  FlywheelConversionResponse,
+  FlywheelHealthMetricsBannerView,
+  FlywheelHealthMetricsFunnelStage,
+  HealthMetricsRange,
+} from '@lfx-one/shared/interfaces';
+
+const CONVERSION_PRECISION = HEALTH_METRICS_FLYWHEEL_CONVERSION_DECIMAL_PLACES;
+
+@Component({
+  selector: 'lfx-flywheel-conversion-card',
+  standalone: true,
+  imports: [ChartComponent, SkeletonModule],
+  templateUrl: './flywheel-conversion-card.component.html',
+  styleUrl: './flywheel-conversion-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FlywheelConversionCardComponent {
+  private readonly elementRef = inject(ElementRef);
+  private readonly analyticsService = inject(AnalyticsService);
+  private readonly projectContextService = inject(ProjectContextService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  // === Inputs ===
+  // TODO: wire range through to server once dbt NORTH_STAR_FLYWHEEL_CONVERSION supports range columns
+  public readonly range = input<HealthMetricsRange>('YTD');
+
+  // === Internal State ===
+  protected readonly loading = signal(true);
+  private readonly data = signal<FlywheelConversionResponse | null>(null);
+
+  // === Computed Signals ===
+  protected readonly summary: Signal<FlywheelCardSummaryView | null> = computed(() => buildFlywheelCardSummary(this.data()));
+
+  protected readonly funnelStages: Signal<FlywheelHealthMetricsFunnelStage[]> = computed(() => buildFlywheelFunnelStages(this.data()));
+
+  protected readonly banner: Signal<FlywheelHealthMetricsBannerView | null> = computed(() => selectFlywheelBannerView(this.data()));
+
+  protected readonly hasFlywheelData: Signal<boolean> = computed(() => {
+    const payload = this.data();
+    if (!payload) return false;
+    const attendees = payload.funnel?.eventAttendees ?? 0;
+    const totalReengaged = payload.reengagement?.totalReengaged ?? 0;
+    const monthlyCount = payload.monthlyData?.length ?? 0;
+    return (payload.conversionRate ?? 0) > 0 || attendees > 0 || totalReengaged > 0 || monthlyCount > 0;
+  });
+
+  /** Current conversion rate formatted to two decimal places (e.g. "12.34%"). */
+  protected readonly formattedCurrentConversion: Signal<string> = computed(() => {
+    const summary = this.summary();
+    if (!summary) return '—';
+    return `${summary.currentConversionRate.toFixed(CONVERSION_PRECISION)}%`;
+  });
+
+  /** Signed change percentage formatted for display (e.g. "+0.99%", "-4.61%"). */
+  protected readonly formattedChangePercentage: Signal<string> = computed(() => {
+    const summary = this.summary();
+    if (!summary) return '';
+    const sign = summary.changePercentage >= 0 ? '+' : '-';
+    return `${sign}${Math.abs(summary.changePercentage).toFixed(CONVERSION_PRECISION)}%`;
+  });
+
+  /** Previous-period conversion rate formatted to two decimal places. */
+  protected readonly formattedPreviousConversion: Signal<string> = computed(() => {
+    const summary = this.summary();
+    if (!summary) return '—';
+    return `${summary.previousPeriodConversionRate.toFixed(CONVERSION_PRECISION)}%`;
+  });
+
+  /** Chart.js data for the funnel horizontal bar chart. */
+  protected readonly funnelChartData: Signal<ChartData<'bar'>> = computed(() => {
+    const stages = this.funnelStages();
+    return {
+      labels: stages.map((s) => s.label),
+      datasets: [
+        {
+          data: stages.map((s) => s.count),
+          backgroundColor: [
+            lfxColors.blue[700],
+            lfxColors.blue[600],
+            lfxColors.blue[500],
+            lfxColors.blue[400],
+            lfxColors.blue[400],
+            lfxColors.blue[300],
+            lfxColors.blue[300],
+          ],
+          borderRadius: { topLeft: 0, bottomLeft: 0, topRight: 4, bottomRight: 4 },
+          borderSkipped: 'start',
+        },
+      ],
+    };
+  });
+
+  /** Chart.js options for the funnel horizontal bar chart. */
+  protected readonly funnelChartOptions: ChartOptions<'bar'> = createHorizontalBarChartOptions({
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        ...DASHBOARD_TOOLTIP_CONFIG,
+        callbacks: {
+          label: (ctx) => ` ${formatNumber(ctx.parsed.x ?? 0)} people`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: true, color: lfxColors.gray[300] },
+        ticks: {
+          color: lfxColors.gray[500],
+          font: { size: 11 },
+          callback: (value) => {
+            const num = Number(value);
+            if (num >= 1_000) return `${(num / 1_000).toFixed(0)}K`;
+            return String(num);
+          },
+        },
+      },
+      y: {
+        display: true,
+        grid: { display: false },
+        border: { display: false },
+        ticks: { color: lfxColors.gray[600], font: { size: 12 } },
+      },
+    },
+  });
+
+  public constructor() {
+    if (isPlatformBrowser(this.platformId)) {
+      this.initializeDataFetching();
+    }
+  }
+
+  // === Protected Methods ===
+  protected downloadCard(): void {
+    if (this.loading() || !this.hasFlywheelData()) return;
+    downloadCardAsImage(this.elementRef.nativeElement, 'flywheel-conversion-rate');
+  }
+
+  private initializeDataFetching(): void {
+    toObservable(this.projectContextService.selectedFoundation)
+      .pipe(
+        map((foundation) => foundation?.slug || ''),
+        filter((slug): slug is string => !!slug),
+        tap(() => {
+          this.loading.set(true);
+          this.data.set(null);
+        }),
+        switchMap((slug) => this.analyticsService.getFlywheelConversion(slug)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe({
+        next: (result) => {
+          this.data.set(result);
+          this.loading.set(false);
+        },
+        error: () => {
+          this.loading.set(false);
+        },
+      });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/health-metrics.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/health-metrics.component.html
@@ -6,7 +6,9 @@
   <div class="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
     <div class="flex flex-col gap-1">
       <h2 class="text-xl font-semibold text-gray-900" data-testid="health-metrics-title">Health Metrics</h2>
-      <p class="text-sm text-gray-500">Operational health metrics across your foundation.</p>
+      @if (hasFoundation()) {
+        <p class="text-sm text-gray-500">Operational health metrics across your foundation.</p>
+      }
     </div>
     <div class="flex items-center gap-4">
       <span class="text-sm text-gray-500 whitespace-nowrap">{{ dateRangeLabel() }}</span>
@@ -94,9 +96,15 @@
       <lfx-training-certification-card [range]="selectedRange()" />
     </div>
 
-    <!-- Code Contribution -->
+    <!-- Code Contribution & Flywheel Conversion Rate -->
     <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
       <lfx-code-contribution-card [range]="selectedRange()" />
+      <lfx-flywheel-conversion-card [range]="selectedRange()" />
+    </div>
+
+    <!-- Board Meeting Participation -->
+    <div class="grid grid-cols-1 gap-4">
+      <lfx-board-meeting-card [range]="selectedRange()" />
     </div>
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/health-metrics.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/health-metrics.component.ts
@@ -1,14 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { isPlatformBrowser, NgClass } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, inject, PLATFORM_ID, signal } from '@angular/core';
+import { NgClass } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { Router } from '@angular/router';
 import { SkeletonModule } from 'primeng/skeleton';
-import { HEALTH_METRICS_STATUS_COUNT, HEALTH_METRICS_SUMMARY_CARDS } from '@lfx-one/shared/constants';
+import { buildHealthMetricsYearOptions, getYearForRange, HEALTH_METRICS_STATUS_COUNT, HEALTH_METRICS_SUMMARY_CARDS } from '@lfx-one/shared/constants';
 import { AnalyticsService } from '@services/analytics.service';
-import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { catchError, filter, forkJoin, map, of, switchMap, tap } from 'rxjs';
 import { MembershipChurnTierCardComponent } from './membership-churn-tier-card/membership-churn-tier-card.component';
@@ -18,8 +16,10 @@ import { ParticipatingOrgsCardComponent } from './participating-orgs-card/partic
 import { EventsCardComponent } from './events-card/events-card.component';
 import { TrainingCertificationCardComponent } from './training-certification-card/training-certification-card.component';
 import { CodeContributionCardComponent } from './code-contribution-card/code-contribution-card.component';
+import { BoardMeetingCardComponent } from './board-meeting-card/board-meeting-card.component';
+import { FlywheelConversionCardComponent } from './flywheel-conversion-card/flywheel-conversion-card.component';
 
-import type { HealthMetricsData, DisplayCard, HealthMetricsRange, HealthMetricsYearOption } from '@lfx-one/shared/interfaces';
+import type { HealthMetricsData, DisplayCard, HealthMetricsRange } from '@lfx-one/shared/interfaces';
 
 const DEFAULT_DATA: HealthMetricsData = {
   totalValue: null,
@@ -41,6 +41,8 @@ const DEFAULT_DATA: HealthMetricsData = {
     EventsCardComponent,
     TrainingCertificationCardComponent,
     CodeContributionCardComponent,
+    BoardMeetingCardComponent,
+    FlywheelConversionCardComponent,
   ],
   templateUrl: './health-metrics.component.html',
   styleUrl: './health-metrics.component.scss',
@@ -48,10 +50,7 @@ const DEFAULT_DATA: HealthMetricsData = {
 })
 export class HealthMetricsComponent {
   private readonly analyticsService = inject(AnalyticsService);
-  private readonly personaService = inject(PersonaService);
   private readonly projectContextService = inject(ProjectContextService);
-  private readonly router = inject(Router);
-  private readonly platformId = inject(PLATFORM_ID);
   private readonly destroyRef = inject(DestroyRef);
 
   protected readonly loading = signal(false);
@@ -61,33 +60,19 @@ export class HealthMetricsComponent {
 
   protected readonly hasFoundation = computed(() => !!this.projectContextService.selectedFoundation());
 
-  protected readonly yearOptions = computed((): HealthMetricsYearOption[] => {
-    const currentYear = new Date().getFullYear();
-    return [
-      { label: `${currentYear - 3}`, range: 'COMPLETED_YEAR_3', year: currentYear - 3 },
-      { label: `${currentYear - 2}`, range: 'COMPLETED_YEAR_2', year: currentYear - 2 },
-      { label: `${currentYear - 1}`, range: 'COMPLETED_YEAR', year: currentYear - 1 },
-      { label: 'YTD', range: 'YTD', year: currentYear },
-    ];
-  });
+  protected readonly yearOptions = computed(() => buildHealthMetricsYearOptions());
 
   protected readonly dateRangeLabel = computed(() => {
     const range = this.selectedRange();
     const now = new Date();
-    const currentYear = now.getFullYear();
 
     if (range === 'YTD') {
-      const start = new Date(currentYear, 0, 1).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
+      const start = new Date(now.getFullYear(), 0, 1).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
       const end = now.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
       return `${start} \u2013 ${end}`;
     }
 
-    const yearMap: Record<string, number> = {
-      COMPLETED_YEAR: currentYear - 1,
-      COMPLETED_YEAR_2: currentYear - 2,
-      COMPLETED_YEAR_3: currentYear - 3,
-    };
-    const year = yearMap[range] ?? currentYear;
+    const year = getYearForRange(range);
     const start = new Date(year, 0, 1).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
     const end = new Date(year, 11, 31).toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
     return `${start} \u2013 ${end}`;
@@ -120,15 +105,6 @@ export class HealthMetricsComponent {
   });
 
   public constructor() {
-    if (isPlatformBrowser(this.platformId)) {
-      effect(() => {
-        const persona = this.personaService.currentPersona();
-        if (persona && persona !== 'executive-director') {
-          this.router.navigate(['/foundation/overview']);
-        }
-      });
-    }
-
     this.initializeDataFetching();
   }
 
@@ -150,7 +126,7 @@ export class HealthMetricsComponent {
             totalValue: this.analyticsService.getFoundationValueConcentration(slug).pipe(catchError(() => of(null))),
             totalProjects: this.analyticsService.getFoundationTotalProjects(slug).pipe(catchError(() => of(null))),
             totalMembers: this.analyticsService.getFoundationTotalMembers(slug).pipe(catchError(() => of(null))),
-            flywheel: this.analyticsService.getFlywheelConversion(slug).pipe(catchError(() => of(null))),
+            flywheel: this.analyticsService.getFlywheelConversion(slug),
           })
         ),
         takeUntilDestroyed(this.destroyRef)

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/membership-churn-tier-card/membership-churn-tier-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/membership-churn-tier-card/membership-churn-tier-card.component.html
@@ -9,7 +9,8 @@
       class="ignore-download flex h-8 w-8 items-center justify-center rounded text-gray-400 hover:text-gray-600 disabled:cursor-not-allowed disabled:opacity-50"
       [disabled]="loading()"
       (click)="downloadCard()"
-      aria-label="Download card as image"
+      aria-label="Download Membership Churn Per Tier card as image"
+      title="Download Membership Churn Per Tier card as image"
       data-testid="membership-churn-tier-card-download">
       <i class="fa-solid fa-arrow-down-to-bracket text-sm"></i>
     </button>
@@ -32,6 +33,12 @@
       </div>
     </div>
     <p-skeleton width="100%" height="0.0625rem" />
+    <!-- Optimistic tier-row placeholders; the "Churn by Tier" section hides when no tiers exist. -->
+    <p-skeleton width="30%" height="0.75rem" />
+    <p-skeleton width="100%" height="2rem" />
+    <p-skeleton width="100%" height="2rem" />
+    <p-skeleton width="100%" height="2rem" />
+    <p-skeleton width="100%" height="0.0625rem" />
     <p-skeleton width="60%" height="0.875rem" />
     <p-skeleton width="60%" height="0.875rem" />
   } @else {
@@ -50,6 +57,25 @@
         <span class="text-2xl font-bold text-gray-900">{{ formattedMembersLost() }}</span>
       </div>
     </div>
+
+    <!-- Churn by Tier -->
+    @if (tiers().length) {
+      <div class="flex flex-col gap-2 border-t border-gray-200 pt-3" data-testid="membership-churn-tier-card-tiers">
+        <span class="text-xs font-semibold text-gray-700">Churn by Tier</span>
+        @for (row of tiers(); track row.tier) {
+          <div class="flex items-center justify-between rounded-md bg-gray-50 px-3 py-2 text-sm">
+            <span class="min-w-0 truncate font-medium text-gray-900">{{ row.tier }}</span>
+            <div class="flex flex-shrink-0 items-center gap-6">
+              <span class="font-semibold" [class.text-red-600]="row.churnRatePct > 0" [class.text-emerald-600]="row.churnRatePct === 0">
+                {{ row.churnRatePct }}%
+              </span>
+              <span class="text-gray-600">{{ row.valueLostLabel }} lost</span>
+              <span class="text-gray-600">{{ row.membersLabel }}</span>
+            </div>
+          </div>
+        }
+      </div>
+    }
 
     <!-- Comparison Section -->
     <div class="border-t border-gray-200 pt-3" data-testid="membership-churn-tier-card-comparison">

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/membership-churn-tier-card/membership-churn-tier-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/membership-churn-tier-card/membership-churn-tier-card.component.ts
@@ -5,13 +5,14 @@ import { isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, inject, input, PLATFORM_ID, signal } from '@angular/core';
 import { SkeletonModule } from 'primeng/skeleton';
 import { HEALTH_METRICS_MEMBERSHIP_CHURN_DEFAULT_SUMMARY } from '@lfx-one/shared/constants';
+import { formatValueLost } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { environment } from '@environments/environment';
 import { downloadCardAsImage } from '@shared/utils/download-card.util';
 import { initializeRangeDataFetching } from '@shared/utils/health-metrics-data.util';
 
-import type { HealthMetricsRange, MembershipChurnPerTierSummaryResponse } from '@lfx-one/shared/interfaces';
+import type { HealthMetricsRange, MembershipChurnDisplayTierRow, MembershipChurnPerTierSummaryResponse } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-membership-churn-tier-card',
@@ -37,6 +38,13 @@ export class MembershipChurnTierCardComponent {
   protected readonly previousYear = computed(() => this.summaryData().previousYear);
   protected readonly comparisonAvailable = computed(() => this.summaryData().comparisonAvailable);
   protected readonly trend = computed(() => this.summaryData().trend);
+  protected readonly tiers = computed<MembershipChurnDisplayTierRow[]>(() =>
+    (this.summaryData().tiers ?? []).map((row) => ({
+      ...row,
+      valueLostLabel: formatValueLost(row.valueLost),
+      membersLabel: `${row.membersLost} ${row.membersLost === 1 ? 'member' : 'members'}`,
+    }))
+  );
 
   protected readonly formattedChurnRate = computed(() => {
     const pct = this.currentPeriod().churnRatePct;
@@ -44,14 +52,7 @@ export class MembershipChurnTierCardComponent {
   });
 
   protected readonly formattedValueLostHeadline = computed(() => {
-    const value = this.currentPeriod().valueLost;
-    if (value >= 1_000_000) {
-      return `$${(value / 1_000_000).toFixed(1)}M`;
-    }
-    if (value >= 1_000) {
-      return `$${Math.round(value / 1_000)}K`;
-    }
-    return `$${value.toLocaleString()}`;
+    return formatValueLost(this.currentPeriod().valueLost);
   });
 
   protected readonly formattedMembersLost = computed(() => {

--- a/apps/lfx-one/src/app/shared/guards/executive-director.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/executive-director.guard.ts
@@ -1,0 +1,27 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+import { PersonaService } from '../services/persona.service';
+
+/**
+ * Route guard that restricts access to executive-director-only pages.
+ *
+ * Works on both server and client: PersonaService is cookie-seeded so
+ * currentPersona() returns a synchronous value during SSR without
+ * waiting for API hydration. Non-ED users are redirected to the
+ * foundation overview on every platform.
+ */
+export const executiveDirectorGuard: CanActivateFn = () => {
+  const personaService = inject(PersonaService);
+  const router = inject(Router);
+  const persona = personaService.currentPersona();
+
+  if (persona === 'executive-director') {
+    return true;
+  }
+
+  return router.parseUrl('/foundation/overview');
+};

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -60,6 +60,7 @@ import {
   ParticipatingOrgsSummaryResponse,
   TrainingCertificationSummaryResponse,
   CodeContributionSummaryResponse,
+  BoardMeetingParticipationSummaryResponse,
   SocialMediaResponse,
   SocialReachResponse,
   WebActivitiesSummaryResponse,
@@ -962,38 +963,12 @@ export class AnalyticsService {
   }
 
   /**
-   * Get flywheel conversion rate metrics from Snowflake North Star views
+   * Get flywheel conversion rate metrics from Snowflake North Star views.
+   * Returns null on HTTP failure so consumers can distinguish "error" from "real zeros".
    */
-  public getFlywheelConversion(foundationSlug: string): Observable<FlywheelConversionResponse> {
+  public getFlywheelConversion(foundationSlug: string): Observable<FlywheelConversionResponse | null> {
     return this.http.get<FlywheelConversionResponse>('/api/analytics/flywheel-conversion', { params: { foundationSlug } }).pipe(
-      catchError(() => {
-        return of({
-          conversionRate: 0,
-          changePercentage: 0,
-          trend: 'up' as const,
-          funnel: {
-            eventAttendees: 0,
-            convertedToNewsletter: 0,
-            convertedToCommunity: 0,
-            convertedToWorkingGroup: 0,
-            convertedToTraining: 0,
-            convertedToCode: 0,
-            convertedToWeb: 0,
-          },
-          reengagement: {
-            totalReengaged: 0,
-            reengagementRate: 0,
-            reengagementMomChange: 0,
-            reengagedToNewsletter: 0,
-            reengagedToCommunity: 0,
-            reengagedToWorkingGroup: 0,
-            reengagedToTraining: 0,
-            reengagedToCode: 0,
-            reengagedToWeb: 0,
-          },
-          monthlyData: [],
-        });
-      })
+      catchError(() => of(null))
     );
   }
 
@@ -1067,6 +1042,7 @@ export class AnalyticsService {
           currentPeriod: { churnRatePct: 0, valueLost: 0, membersLost: 0 },
           previousYear: null,
           trend: null,
+          tiers: [],
         });
       })
     );
@@ -1135,6 +1111,28 @@ export class AnalyticsService {
           committers: 0,
           maintainers: 0,
           reviewers: 0,
+        });
+      })
+    );
+  }
+
+  public getBoardMeetingParticipationSummary(foundationSlug: string, range: string = 'YTD'): Observable<BoardMeetingParticipationSummaryResponse> {
+    const params: Record<string, string> = { foundationSlug };
+    if (range && range !== 'YTD') {
+      params['range'] = range;
+    }
+    return this.http.get<BoardMeetingParticipationSummaryResponse>('/api/analytics/board-meeting-participation-summary', { params }).pipe(
+      catchError(() => {
+        return of({
+          dataAvailable: false,
+          projectId: '',
+          projectSlug: '',
+          range: (range || 'YTD') as BoardMeetingParticipationSummaryResponse['range'],
+          totalMeetings: 0,
+          totalMeetingsChange: null,
+          avgMeetingAttendance: 0,
+          avgMeetingAttendanceChange: null,
+          invitees: [],
         });
       })
     );

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -4,7 +4,7 @@
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError, ServiceValidationError } from '../errors';
-import { getStringQueryParam, parseEntityType } from '../helpers/validation.helper';
+import { assertHealthMetricsRange, getStringQueryParam, parseEntityType } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { OrganizationService } from '../services/organization.service';
 import { ProjectService } from '../services/project.service';
@@ -2198,12 +2198,7 @@ export class AnalyticsController {
         });
       }
 
-      const validRanges = ['YTD', 'COMPLETED_YEAR', 'COMPLETED_YEAR_2', 'COMPLETED_YEAR_3', 'COMPLETED_YEAR_4'];
-      if (!validRanges.includes(range)) {
-        throw ServiceValidationError.forField('range', `Invalid range value. Allowed: ${validRanges.join(', ')}`, {
-          operation: 'get_membership_churn_per_tier_summary',
-        });
-      }
+      assertHealthMetricsRange(range, 'get_membership_churn_per_tier_summary');
 
       const response = await this.projectService.getMembershipChurnPerTierSummary(foundationSlug, range);
 
@@ -2325,12 +2320,7 @@ export class AnalyticsController {
         });
       }
 
-      const validRanges = ['YTD', 'COMPLETED_YEAR', 'COMPLETED_YEAR_2', 'COMPLETED_YEAR_3', 'COMPLETED_YEAR_4'];
-      if (!validRanges.includes(range)) {
-        throw ServiceValidationError.forField('range', `Invalid range value. Allowed: ${validRanges.join(', ')}`, {
-          operation: 'get_training_certification_summary',
-        });
-      }
+      assertHealthMetricsRange(range, 'get_training_certification_summary');
 
       const response = await this.projectService.getTrainingCertificationSummary(foundationSlug, range);
 
@@ -2370,12 +2360,7 @@ export class AnalyticsController {
         });
       }
 
-      const validRanges = ['YTD', 'COMPLETED_YEAR', 'COMPLETED_YEAR_2', 'COMPLETED_YEAR_3', 'COMPLETED_YEAR_4'];
-      if (!validRanges.includes(range)) {
-        throw ServiceValidationError.forField('range', `Invalid range value. Allowed: ${validRanges.join(', ')}`, {
-          operation: 'get_code_contribution_summary',
-        });
-      }
+      assertHealthMetricsRange(range, 'get_code_contribution_summary');
 
       const response = await this.projectService.getCodeContributionSummary(foundationSlug, range);
 
@@ -2384,6 +2369,49 @@ export class AnalyticsController {
         project_id: response.projectId,
         range: response.range,
         data_available: response.dataAvailable,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/analytics/board-meeting-participation-summary
+   * Get Board Meeting Participation summary for a foundation
+   * Query params: foundationSlug (required), range (optional, default 'YTD')
+   */
+  public async getBoardMeetingParticipationSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_board_meeting_participation_summary');
+
+    try {
+      const foundationSlug = req.query['foundationSlug'] as string | undefined;
+      const range = (req.query['range'] as string | undefined) || 'YTD';
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_board_meeting_participation_summary',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_board_meeting_participation_summary',
+        });
+      }
+
+      const validatedRange = assertHealthMetricsRange(range, 'get_board_meeting_participation_summary');
+
+      const response = await this.projectService.getBoardMeetingParticipationSummary(foundationSlug, validatedRange);
+
+      logger.success(req, 'get_board_meeting_participation_summary', startTime, {
+        foundation_slug: foundationSlug,
+        project_id: response.projectId,
+        range: response.range,
+        data_available: response.dataAvailable,
+        total_meetings: response.totalMeetings,
+        invitees_count: response.invitees.length,
       });
 
       res.json(response);

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2198,9 +2198,9 @@ export class AnalyticsController {
         });
       }
 
-      assertHealthMetricsRange(range, 'get_membership_churn_per_tier_summary');
+      const validatedRange = assertHealthMetricsRange(range, 'get_membership_churn_per_tier_summary');
 
-      const response = await this.projectService.getMembershipChurnPerTierSummary(foundationSlug, range);
+      const response = await this.projectService.getMembershipChurnPerTierSummary(foundationSlug, validatedRange);
 
       logger.success(req, 'get_membership_churn_per_tier_summary', startTime, {
         foundation_slug: foundationSlug,
@@ -2320,9 +2320,9 @@ export class AnalyticsController {
         });
       }
 
-      assertHealthMetricsRange(range, 'get_training_certification_summary');
+      const validatedRange = assertHealthMetricsRange(range, 'get_training_certification_summary');
 
-      const response = await this.projectService.getTrainingCertificationSummary(foundationSlug, range);
+      const response = await this.projectService.getTrainingCertificationSummary(foundationSlug, validatedRange);
 
       logger.success(req, 'get_training_certification_summary', startTime, {
         foundation_slug: foundationSlug,
@@ -2360,9 +2360,9 @@ export class AnalyticsController {
         });
       }
 
-      assertHealthMetricsRange(range, 'get_code_contribution_summary');
+      const validatedRange = assertHealthMetricsRange(range, 'get_code_contribution_summary');
 
-      const response = await this.projectService.getCodeContributionSummary(foundationSlug, range);
+      const response = await this.projectService.getCodeContributionSummary(foundationSlug, validatedRange);
 
       logger.success(req, 'get_code_contribution_summary', startTime, {
         foundation_slug: foundationSlug,

--- a/apps/lfx-one/src/server/helpers/validation.helper.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.ts
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 import { Request, NextFunction } from 'express';
+import { HEALTH_METRICS_RANGES, isHealthMetricsRange } from '@lfx-one/shared/constants';
 import { ServiceValidationError } from '../errors';
+
+import type { HealthMetricsRange } from '@lfx-one/shared/interfaces';
 
 /**
  * Common validation utilities for controllers
@@ -119,6 +122,17 @@ export function validateRequiredParameter<T>(
 export function getStringQueryParam(req: Request, name: string): string | undefined {
   const value = req.query[name];
   return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Validates and narrows a raw range string to a HealthMetricsRange.
+ * Throws ServiceValidationError when the value is not in the allowed set.
+ */
+export function assertHealthMetricsRange(range: string, operation: string): HealthMetricsRange {
+  if (!isHealthMetricsRange(range)) {
+    throw ServiceValidationError.forField('range', `Invalid range value. Allowed: ${HEALTH_METRICS_RANGES.join(', ')}`, { operation });
+  }
+  return range;
 }
 
 const VALID_ENTITY_TYPES = ['foundation', 'project'] as const;

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -170,6 +170,9 @@ router.get('/training-certification-summary', (req, res, next) => analyticsContr
 // Code Contribution summary endpoint (health metrics page)
 router.get('/code-contribution-summary', (req, res, next) => analyticsController.getCodeContributionSummary(req, res, next));
 
+// Board Meeting Participation summary endpoint (health metrics page)
+router.get('/board-meeting-participation-summary', (req, res, next) => analyticsController.getBoardMeetingParticipationSummary(req, res, next));
+
 // ED dashboard marketing endpoints — backed by ANALYTICS.PLATINUM_LFX_ONE.* Snowflake views
 router.get('/event-growth', (req, res, next) => analyticsController.getEventGrowth(req, res, next));
 router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -4514,6 +4514,10 @@ export class ProjectService {
    */
   private static toIsoDate(value: string | Date | null | undefined): string | null {
     if (!value) return null;
+    if (typeof value === 'string') {
+      const match = value.match(/^\d{4}-\d{2}-\d{2}/);
+      if (match) return match[0];
+    }
     const date = value instanceof Date ? value : new Date(String(value));
     return Number.isNaN(date.getTime()) ? null : date.toISOString().slice(0, 10);
   }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3568,7 +3568,7 @@ export class ProjectService {
     const summaryRow = summaryResult.rows?.[0];
     const inviteeRows = inviteesResult.rows ?? [];
     const resolvedProjectId = summaryRow?.PROJECT_ID ?? '';
-    const dataAvailable = !!resolvedProjectId && (summaryRow?.TOTAL_MEETINGS ?? 0) > 0;
+    const dataAvailable = !!resolvedProjectId;
 
     if (!dataAvailable) {
       logger.warning(undefined, 'get_board_meeting_participation_summary', 'No usable board meeting data for foundation', {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2991,7 +2991,7 @@ export class ProjectService {
       )
       SELECT
         REPLACE(membership_tier, ' Membership', '') AS TIER,
-        ROUND(IFNULL(SUM(churn_rate), 0) * 100, 1) AS CHURN_RATE_PCT,
+        ROUND(DIV0NULL(SUM(total_churned_accounts), SUM(membership_count)) * 100, 1) AS CHURN_RATE_PCT,
         IFNULL(SUM(membership_value_lost), 0) AS VALUE_LOST,
         IFNULL(SUM(total_churned_accounts), 0) AS MEMBERS_LOST
       FROM ANALYTICS.PLATINUM.MEMBERSHIP_CHURN

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -4,6 +4,8 @@
 import { NATS_CONFIG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import {
+  BoardMeetingInviteeRow,
+  BoardMeetingParticipationSummaryResponse,
   BrandHealthResponse,
   BrandHealthTopProject,
   BrandReachPlatformType,
@@ -52,10 +54,12 @@ import {
   HealthEventsMonthlyResponse,
   HealthMetricsAggregatedRow,
   HealthMetricsDailyResponse,
+  HealthMetricsRange,
   LifecycleStage,
   MemberAcquisitionResponse,
   MemberRetentionResponse,
   MembershipChurnPerTierSummaryResponse,
+  MembershipChurnTierRow,
   MonthlyMemberCountWithFoundation,
   MultiFoundationSummaryResponse,
   NorthStarMonthlyDataPoint,
@@ -138,6 +142,16 @@ export class ProjectService {
       COMPLETED_YEAR_2: 'PREV_COMPLETED_YEAR',
       COMPLETED_YEAR_3: '3RD_LAST_COMPLETED_YEAR',
       COMPLETED_YEAR_4: '4th_LAST_COMPLETED_YEAR',
+    },
+    // Prefix convention for ANALYTICS.PLATINUM.MEETING_ATTENDEES columns.
+    // Columns are named {prefix}meetings_invited / {prefix}meetings_attended.
+    // Note the leading underscore for year 3/4 per dbt platinum_meeting_attendees.sql.
+    boardMeetingInvitee: {
+      YTD: 'ytd_',
+      COMPLETED_YEAR: 'last_completed_year_',
+      COMPLETED_YEAR_2: 'prev_completed_year_',
+      COMPLETED_YEAR_3: '_3rd_last_completed_year_',
+      COMPLETED_YEAR_4: '_4th_last_completed_year_',
     },
   };
 
@@ -2900,7 +2914,6 @@ export class ProjectService {
             AND year_start IS NOT NULL
             AND ${previousYearPredicate}
             AND membership_tier IS NOT NULL
-            AND membership_tier != 'Associate Membership'
         ),
         previous_per_tier AS (
           SELECT
@@ -2929,6 +2942,8 @@ export class ProjectService {
         FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
         WHERE project_slug = ?
       ),
+      -- Associate Membership is included in churn-rate denominator to match the per-tier breakdown.
+      -- Both headline and tier-level numbers now reconcile: SUM(tiers.valueLost) === headline.valueLost.
       current_total AS (
         SELECT
           DIV0NULL(SUM(total_churned_accounts), SUM(membership_count)) AS TOTAL_CHURN_RATE
@@ -2937,7 +2952,6 @@ export class ProjectService {
           AND year_start IS NOT NULL
           AND ${currentYearPredicate}
           AND membership_tier IS NOT NULL
-          AND membership_tier != 'Associate Membership'
       ),
       current_per_tier AS (
         SELECT
@@ -2962,7 +2976,53 @@ export class ProjectService {
       SELECT * FROM final
     `;
 
-    const result = await this.snowflakeService.execute<ChurnSummaryRow>(query, [foundationSlug]);
+    interface TierRow {
+      TIER: string;
+      CHURN_RATE_PCT: number;
+      VALUE_LOST: number;
+      MEMBERS_LOST: number;
+    }
+
+    const tierQuery = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      )
+      SELECT
+        REPLACE(membership_tier, ' Membership', '') AS TIER,
+        ROUND(IFNULL(SUM(churn_rate), 0) * 100, 1) AS CHURN_RATE_PCT,
+        IFNULL(SUM(membership_value_lost), 0) AS VALUE_LOST,
+        IFNULL(SUM(total_churned_accounts), 0) AS MEMBERS_LOST
+      FROM ANALYTICS.PLATINUM.MEMBERSHIP_CHURN
+      WHERE project_id = (SELECT project_id FROM slug_resolve LIMIT 1)
+        AND year_start IS NOT NULL
+        AND ${currentYearPredicate}
+        AND membership_tier IS NOT NULL
+        AND membership_value_lost IS NOT NULL
+      GROUP BY membership_tier
+      ORDER BY
+        CASE REPLACE(membership_tier, ' Membership', '')
+          WHEN 'Platinum' THEN 1
+          WHEN 'Gold'     THEN 2
+          WHEN 'Silver'   THEN 3
+          WHEN 'Associate' THEN 4
+          ELSE 5
+        END,
+        TIER
+    `;
+
+    const [result, tierResult] = await Promise.all([
+      this.snowflakeService.execute<ChurnSummaryRow>(query, [foundationSlug]),
+      this.snowflakeService.execute<TierRow>(tierQuery, [foundationSlug]),
+    ]);
+
+    const tiers: MembershipChurnTierRow[] = (tierResult.rows ?? []).map((r) => ({
+      tier: r.TIER,
+      churnRatePct: r.CHURN_RATE_PCT ?? 0,
+      valueLost: r.VALUE_LOST ?? 0,
+      membersLost: r.MEMBERS_LOST ?? 0,
+    }));
 
     const zeroDefault: MembershipChurnPerTierSummaryResponse = {
       projectId: '',
@@ -2971,6 +3031,7 @@ export class ProjectService {
       currentPeriod: { churnRatePct: 0, valueLost: 0, membersLost: 0 },
       previousYear: comparisonAvailable ? { churnRatePct: 0, valueLost: 0, membersLost: 0 } : null,
       trend: null,
+      tiers,
     };
 
     if (!result.rows || result.rows.length === 0) {
@@ -3017,6 +3078,7 @@ export class ProjectService {
       currentPeriod,
       previousYear,
       trend,
+      tiers,
     };
   }
 
@@ -3407,6 +3469,154 @@ export class ProjectService {
       committers: row?.COMMITTERS_ALL_TIME ?? 0,
       maintainers: row?.MAINTAINERS_ALL_TIME ?? 0,
       reviewers: row?.REVIEWERS_ALL_TIME ?? 0,
+    };
+  }
+
+  /**
+   * Get Board Meeting Participation summary for a foundation from Snowflake.
+   * Two parallel reads:
+   *   - Summary: ANALYTICS.PLATINUM.MEETING_ATTENDANCE (project-level counters + dbt change ratios)
+   *   - Invitees: ANALYTICS.PLATINUM.MEETING_ATTENDEES (per-invitee rows filtered to invited > 0)
+   * Both scoped by project_id resolved from foundationSlug via the slug-resolve CTE.
+   * voting_status defaults to 'Voting Rep' and is applied as a bound parameter.
+   * @param foundationSlug - Foundation slug used to resolve project_id via slug-resolve CTE
+   * @param range - Reporting window (default 'YTD')
+   * Voting status is hard-coded to 'Voting Rep' per product requirement.
+   * @returns Normalized response with summary counters and invitee rows
+   */
+  public async getBoardMeetingParticipationSummary(
+    foundationSlug: string,
+    range: HealthMetricsRange = 'YTD'
+  ): Promise<BoardMeetingParticipationSummaryResponse> {
+    logger.debug(undefined, 'get_board_meeting_participation_summary', 'Fetching board meeting participation', {
+      foundation_slug: foundationSlug,
+      range,
+    });
+
+    const VOTING_STATUS = 'Voting Rep';
+    interface SummaryRow {
+      PROJECT_ID: string;
+      TOTAL_MEETINGS: number;
+      AVG_MEETING_ATTENDANCE: number;
+      TOTAL_MEETINGS_CHANGE: number | null;
+      AVG_MEETING_ATTENDANCE_CHANGE: number | null;
+    }
+
+    interface InviteeRow {
+      INVITEE_FULL_NAME: string | null;
+      INVITEE_JOB_TITLE: string | null;
+      ACCOUNT_NAME: string | null;
+      ACCOUNT_ID: string | null;
+      INVITEE_LAST_MEETING_ATTENDED: string | Date | null;
+      MEETINGS_ATTENDED: number | null;
+      MEETINGS_INVITED: number | null;
+    }
+
+    // Suffix for MEETING_ATTENDANCE columns (e.g., "_ytd", "_last_completed_year")
+    const summarySuffix = this.getRangeSuffix(range);
+    // Prefix for MEETING_ATTENDEES columns (e.g., "ytd_", "_3rd_last_completed_year_")
+    const inviteePrefix = this.getRangeSuffix(range, 'boardMeetingInvitee');
+
+    // Summary query: MIN() aggregation over per-org rows since project_meetings_* and
+    // avg_org_attendance_* values repeat across all org rows for the same project.
+    // Pin to one resolved project_id via LIMIT 1 to avoid cross-project merges.
+    const summaryQuery = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      )
+      SELECT
+        (SELECT project_id FROM slug_resolve LIMIT 1) AS PROJECT_ID,
+        IFNULL(MIN(ma.project_meetings${summarySuffix}), 0) AS TOTAL_MEETINGS,
+        IFNULL(MIN(ma.avg_org_attendance${summarySuffix}), 0) AS AVG_MEETING_ATTENDANCE,
+        MIN(ma.project_meetings${summarySuffix}_change) AS TOTAL_MEETINGS_CHANGE,
+        MIN(ma.avg_org_attendance${summarySuffix}_change) AS AVG_MEETING_ATTENDANCE_CHANGE
+      FROM ANALYTICS.PLATINUM.MEETING_ATTENDANCE ma
+      WHERE ma.project_id = (SELECT project_id FROM slug_resolve LIMIT 1)
+        AND ma.voting_status = ?
+    `;
+
+    // Invitees query: filters rows with zero invited meetings (matches lfx-pcc behavior).
+    // attendance_percent is not on MEETING_ATTENDEES, so we compute from attended/invited.
+    // Pin to one resolved project_id via LIMIT 1 to match the summary query.
+    const inviteesQuery = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      )
+      SELECT
+        mat.invitee_full_name AS INVITEE_FULL_NAME,
+        mat.invitee_job_title AS INVITEE_JOB_TITLE,
+        mat.account_name AS ACCOUNT_NAME,
+        mat.account_id AS ACCOUNT_ID,
+        mat.invitee_last_meeting_attended AS INVITEE_LAST_MEETING_ATTENDED,
+        IFNULL(mat.${inviteePrefix}meetings_attended, 0) AS MEETINGS_ATTENDED,
+        IFNULL(mat.${inviteePrefix}meetings_invited, 0) AS MEETINGS_INVITED
+      FROM ANALYTICS.PLATINUM.MEETING_ATTENDEES mat
+      WHERE mat.project_id = (SELECT project_id FROM slug_resolve LIMIT 1)
+        AND mat.voting_status = ?
+        AND mat.${inviteePrefix}meetings_invited > 0
+    `;
+
+    const [summaryResult, inviteesResult] = await Promise.all([
+      this.snowflakeService.execute<SummaryRow>(summaryQuery, [foundationSlug, VOTING_STATUS]),
+      this.snowflakeService.execute<InviteeRow>(inviteesQuery, [foundationSlug, VOTING_STATUS]),
+    ]);
+
+    const summaryRow = summaryResult.rows?.[0];
+    const inviteeRows = inviteesResult.rows ?? [];
+    const resolvedProjectId = summaryRow?.PROJECT_ID ?? '';
+    const dataAvailable = !!resolvedProjectId && (summaryRow?.TOTAL_MEETINGS ?? 0) > 0;
+
+    if (!dataAvailable) {
+      logger.warning(undefined, 'get_board_meeting_participation_summary', 'No usable board meeting data for foundation', {
+        foundation_slug: foundationSlug,
+        range,
+        resolved_project_id: resolvedProjectId || null,
+        total_meetings: summaryRow?.TOTAL_MEETINGS ?? 0,
+      });
+    } else {
+      logger.debug(undefined, 'get_board_meeting_participation_summary', 'Snowflake results received', {
+        foundation_slug: foundationSlug,
+        range,
+        resolved_project_id: resolvedProjectId,
+        total_meetings: summaryRow?.TOTAL_MEETINGS ?? 0,
+        invitee_count: inviteeRows.length,
+      });
+    }
+
+    const invitees: BoardMeetingInviteeRow[] = dataAvailable
+      ? inviteeRows.map((row) => {
+          const attended = row.MEETINGS_ATTENDED ?? 0;
+          const invited = row.MEETINGS_INVITED ?? 0;
+          const attendancePercent = invited > 0 ? Math.round((attended / invited) * 100) / 100 : 0;
+          const lastAttended = ProjectService.toIsoDate(row.INVITEE_LAST_MEETING_ATTENDED);
+
+          return {
+            inviteeFullName: row.INVITEE_FULL_NAME ?? '',
+            inviteeJobTitle: row.INVITEE_JOB_TITLE ?? null,
+            organizationName: row.ACCOUNT_NAME ?? '',
+            organizationId: row.ACCOUNT_ID ?? null,
+            meetingsAttended: attended,
+            meetingsInvited: invited,
+            attendancePercent,
+            lastAttended,
+          };
+        })
+      : [];
+
+    return {
+      dataAvailable,
+      projectId: resolvedProjectId,
+      projectSlug: dataAvailable ? foundationSlug : '',
+      range,
+      totalMeetings: summaryRow?.TOTAL_MEETINGS ?? 0,
+      totalMeetingsChange: summaryRow?.TOTAL_MEETINGS_CHANGE ?? null,
+      avgMeetingAttendance: summaryRow?.AVG_MEETING_ATTENDANCE ?? 0,
+      avgMeetingAttendanceChange: summaryRow?.AVG_MEETING_ATTENDANCE_CHANGE ?? null,
+      invitees,
     };
   }
 
@@ -4294,5 +4504,17 @@ export class ProjectService {
     if (full === 'YTD') return { prefix: '', suffix: 'YTD' };
     const lastUnderscore = full.lastIndexOf('_');
     return { prefix: full.substring(0, lastUnderscore + 1), suffix: full.substring(lastUnderscore + 1) };
+  }
+
+  /**
+   * Normalize a Snowflake date/timestamp value into an ISO date string (YYYY-MM-DD),
+   * or null when the source value is missing or unparseable.
+   * Snowflake drivers may return Date objects or ISO-shaped strings depending on
+   * column type; non-date values silently return null rather than garbage.
+   */
+  private static toIsoDate(value: string | Date | null | undefined): string | null {
+    if (!value) return null;
+    const date = value instanceof Date ? value : new Date(String(value));
+    return Number.isNaN(date.getTime()) ? null : date.toISOString().slice(0, 10);
   }
 }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2999,7 +2999,6 @@ export class ProjectService {
         AND year_start IS NOT NULL
         AND ${currentYearPredicate}
         AND membership_tier IS NOT NULL
-        AND membership_value_lost IS NOT NULL
       GROUP BY membership_tier
       ORDER BY
         CASE REPLACE(membership_tier, ' Membership', '')

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -30,6 +30,10 @@ import type {
 
 export const HEALTH_METRICS_RANGES: readonly HealthMetricsRange[] = ['YTD', 'COMPLETED_YEAR', 'COMPLETED_YEAR_2', 'COMPLETED_YEAR_3', 'COMPLETED_YEAR_4'];
 
+/**
+ * Runtime type guard that narrows an unknown value to `HealthMetricsRange`.
+ * Returns true when `value` is a string present in `HEALTH_METRICS_RANGES`.
+ */
 export function isHealthMetricsRange(value: unknown): value is HealthMetricsRange {
   return typeof value === 'string' && (HEALTH_METRICS_RANGES as readonly string[]).includes(value);
 }
@@ -50,17 +54,21 @@ export function getYearForRange(range: HealthMetricsRange): number {
 
 /**
  * Builds the year-filter options for the Health Metrics page.
- * Reuse this instead of inline array construction in components.
+ * Derived from `HEALTH_METRICS_RANGES` + `RANGE_YEAR_OFFSET` so ordering
+ * and offsets stay in sync with the canonical range list.
  */
 export function buildHealthMetricsYearOptions(): HealthMetricsYearOption[] {
   const currentYear = new Date().getFullYear();
-  return [
-    { label: `${currentYear - 4}`, range: 'COMPLETED_YEAR_4', year: currentYear - 4 },
-    { label: `${currentYear - 3}`, range: 'COMPLETED_YEAR_3', year: currentYear - 3 },
-    { label: `${currentYear - 2}`, range: 'COMPLETED_YEAR_2', year: currentYear - 2 },
-    { label: `${currentYear - 1}`, range: 'COMPLETED_YEAR', year: currentYear - 1 },
-    { label: 'YTD', range: 'YTD', year: currentYear },
-  ];
+  return [...HEALTH_METRICS_RANGES]
+    .reverse()
+    .map((range) => {
+      const year = currentYear - RANGE_YEAR_OFFSET[range];
+      return {
+        label: range === 'YTD' ? 'YTD' : `${year}`,
+        range,
+        year,
+      };
+    });
 }
 
 // ============================================

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -7,19 +7,62 @@ import { EMPTY_CHART_DATA, NO_TOOLTIP_CHART_OPTIONS } from './chart-options.cons
 import { lfxColors } from './colors.constants';
 
 import type {
+  BoardMeetingParticipationSummaryResponse,
   CodeContributionSummaryResponse,
   DashboardMetricCard,
   DualSignalRow,
   EdEvolutionData,
   EventsSummaryResponse,
   FilterPillOption,
+  HealthMetricsRange,
   HealthMetricsSummaryCard,
+  HealthMetricsYearOption,
   MembershipChurnPerTierSummaryResponse,
   NpsSummaryResponse,
   OutstandingBalanceSummaryResponse,
   ParticipatingOrgsSummaryResponse,
   TrainingCertificationSummaryResponse,
 } from '../interfaces';
+
+// ============================================
+// Health Metrics — Range Constants
+// ============================================
+
+export const HEALTH_METRICS_RANGES: readonly HealthMetricsRange[] = ['YTD', 'COMPLETED_YEAR', 'COMPLETED_YEAR_2', 'COMPLETED_YEAR_3', 'COMPLETED_YEAR_4'];
+
+export function isHealthMetricsRange(value: unknown): value is HealthMetricsRange {
+  return typeof value === 'string' && (HEALTH_METRICS_RANGES as readonly string[]).includes(value);
+}
+
+/** Maps each HealthMetricsRange to its calendar year offset from the current year. */
+const RANGE_YEAR_OFFSET: Record<HealthMetricsRange, number> = {
+  YTD: 0,
+  COMPLETED_YEAR: 1,
+  COMPLETED_YEAR_2: 2,
+  COMPLETED_YEAR_3: 3,
+  COMPLETED_YEAR_4: 4,
+};
+
+/** Returns the calendar year for a given range. */
+export function getYearForRange(range: HealthMetricsRange): number {
+  return new Date().getFullYear() - (RANGE_YEAR_OFFSET[range] ?? 0);
+}
+
+/**
+ * Builds the year-filter options for the Health Metrics page.
+ * Reuse this instead of inline array construction in components.
+ */
+export function buildHealthMetricsYearOptions(): HealthMetricsYearOption[] {
+  const currentYear = new Date().getFullYear();
+  return [
+    { label: `${currentYear - 4}`, range: 'COMPLETED_YEAR_4', year: currentYear - 4 },
+    { label: `${currentYear - 3}`, range: 'COMPLETED_YEAR_3', year: currentYear - 3 },
+    { label: `${currentYear - 2}`, range: 'COMPLETED_YEAR_2', year: currentYear - 2 },
+    { label: `${currentYear - 1}`, range: 'COMPLETED_YEAR', year: currentYear - 1 },
+    { label: 'YTD', range: 'YTD', year: currentYear },
+  ];
+}
+
 // ============================================
 // Health Metrics Page (Summary Cards)
 // ============================================
@@ -63,7 +106,28 @@ export const HEALTH_METRICS_SUMMARY_CARDS: readonly HealthMetricsSummaryCard[] =
   },
 ];
 
-export const HEALTH_METRICS_STATUS_COUNT = 8;
+export const HEALTH_METRICS_BODY_BLOCK_KEYS = [
+  'participating-orgs',
+  'nps',
+  'membership-churn',
+  'outstanding-balance',
+  'events',
+  'training-certification',
+  'code-contribution',
+  'flywheel-conversion',
+  'board-meeting',
+] as const;
+
+export const HEALTH_METRICS_STATUS_COUNT = HEALTH_METRICS_BODY_BLOCK_KEYS.length;
+
+// ============================================
+// Board Meeting Card — Thresholds & Limits
+// ============================================
+
+export const HEALTH_METRICS_BOARD_MEETING_LOW_ATTENDANCE_THRESHOLD = 0.5;
+export const HEALTH_METRICS_BOARD_MEETING_JOB_TITLE_MAX_LENGTH = 50;
+
+export const HEALTH_METRICS_FLYWHEEL_CONVERSION_DECIMAL_PLACES = 2;
 
 // ============================================
 // Marketing Action Icon Map
@@ -557,6 +621,18 @@ export const HEALTH_METRICS_CODE_CONTRIBUTION_DEFAULT_SUMMARY: CodeContributionS
   reviewers: 0,
 };
 
+export const HEALTH_METRICS_BOARD_MEETING_DEFAULT_SUMMARY: BoardMeetingParticipationSummaryResponse = {
+  dataAvailable: false,
+  projectId: '',
+  projectSlug: '',
+  range: 'YTD',
+  totalMeetings: 0,
+  totalMeetingsChange: null,
+  avgMeetingAttendance: 0,
+  avgMeetingAttendanceChange: null,
+  invitees: [],
+};
+
 export const HEALTH_METRICS_EVENTS_DEFAULT_SUMMARY: EventsSummaryResponse = {
   projectId: '',
   totalEvents: 0,
@@ -576,6 +652,7 @@ export const HEALTH_METRICS_MEMBERSHIP_CHURN_DEFAULT_SUMMARY: MembershipChurnPer
   currentPeriod: { churnRatePct: 0, valueLost: 0, membersLost: 0 },
   previousYear: null,
   trend: null,
+  tiers: [],
 };
 
 export const HEALTH_METRICS_NPS_DEFAULT_SUMMARY: NpsSummaryResponse = {

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -399,6 +399,32 @@ export interface MembershipChurnTrendSummary {
 }
 
 /**
+ * Per-tier churn row for the "Churn by Tier" breakdown
+ * @description One row per membership tier returned by Snowflake (no allowlist).
+ * Tier labels have the trailing " Membership" suffix stripped (PCC parity).
+ */
+export interface MembershipChurnTierRow {
+  /** Display-ready tier name (e.g. "Platinum", "Strategic") */
+  tier: string;
+  /** Tier-level churn rate as a display-friendly percentage (e.g. 8.0 means 8%) */
+  churnRatePct: number;
+  /** Monetary loss for this tier in whole dollars */
+  valueLost: number;
+  /** Count of churned accounts for this tier */
+  membersLost: number;
+}
+
+/**
+ * Pre-formatted display row for the membership churn tier breakdown.
+ * Extends the data row with a pre-computed value-lost label so the
+ * template does not call a formatting method on every render cycle.
+ */
+export interface MembershipChurnDisplayTierRow extends MembershipChurnTierRow {
+  valueLostLabel: string;
+  membersLabel: string;
+}
+
+/**
  * Consolidated Membership Churn Per Tier summary from BFF
  * @description Single-response contract for the Health Metrics churn card.
  * Query semantics aligned with lfx-pcc MembershipQueriesService (membershipTotalChurnRate + membershipChurnRate).
@@ -417,6 +443,8 @@ export interface MembershipChurnPerTierSummaryResponse {
   previousYear: MembershipChurnPeriodSummary | null;
   /** Trend direction and multiplier; null when comparison is unavailable or non-finite */
   trend: MembershipChurnTrendSummary | null;
+  /** Per-tier breakdown ordered Platinum > Gold > Silver > Associate > others (alpha); empty when no data */
+  tiers: MembershipChurnTierRow[];
 }
 
 /**
@@ -609,4 +637,161 @@ export interface CodeContributionSummaryResponse {
   maintainers: number;
   /** All-time reviewer count (fixed regardless of range) */
   reviewers: number;
+}
+
+/**
+ * Board Meeting Participation reporting range type alias for shared Health Metrics range.
+ * Maps to range-specific columns in ANALYTICS.PLATINUM.MEETING_ATTENDANCE / MEETING_ATTENDEES.
+ */
+export type BoardMeetingParticipationRange = HealthMetricsRange;
+
+/** Keys eligible for client-side sorting on the Board Meeting invitee table. */
+export type BoardMeetingSortField = 'inviteeFullName' | 'organizationName' | 'attendancePercent' | 'lastAttended';
+
+/** 1 = ascending, -1 = descending. */
+export type BoardMeetingSortOrder = 1 | -1;
+
+/**
+ * Per-invitee row for the Board Meeting Participation data table.
+ * Derived from ANALYTICS.PLATINUM.MEETING_ATTENDEES. Each element represents one person
+ * (keyed by full name + account), not one organization — multiple invitees may share the
+ * same organization.
+ */
+export interface BoardMeetingInviteeRow {
+  /** Invitee full name from Snowflake INVITEE_FULL_NAME; frontend title-cases for display */
+  inviteeFullName: string;
+  /**
+   * Job title from Snowflake INVITEE_JOB_TITLE. The dbt sentinel value "Unavailable"
+   * is passed through as-is; the frontend treats it as missing and hides the secondary line.
+   */
+  inviteeJobTitle: string | null;
+  /** Organization display name from Snowflake ACCOUNT_NAME (rendered as blue link) */
+  organizationName: string;
+  /** Organization / account UUID for PCC member-details deep link; null when missing from Snowflake */
+  organizationId: string | null;
+  /** Number of meetings attended in the selected range */
+  meetingsAttended: number;
+  /** Number of meetings invited to in the selected range */
+  meetingsInvited: number;
+  /**
+   * Fractional attendance ratio 0–1 (e.g., 0.0 = 0%, 1.0 = 100%).
+   * Frontend multiplies by 100 for percentage display.
+   * NOTE: field is named "Percent" for backward compatibility but the unit is a 0–1 ratio.
+   * TODO: consider renaming to `attendanceRatio` in a future cleanup pass.
+   */
+  attendancePercent: number;
+  /**
+   * ISO date string of the invitee's last attended meeting, or null when never attended.
+   * Frontend formats as full date (e.g., "December 9, 2025") or renders "–" for null.
+   */
+  lastAttended: string | null;
+}
+
+/**
+ * Pre-formatted display row for the board-meeting invitee table.
+ * Computed once per data update so the template binds to strings/booleans
+ * rather than calling formatting methods on every change-detection cycle.
+ */
+export interface BoardMeetingDisplayRow {
+  displayName: string;
+  displayJobTitle: string | null;
+  organizationName: string;
+  organizationUrl: string;
+  attendanceLabel: string;
+  isLowAttendance: boolean;
+  lastAttendedLabel: string;
+}
+
+/**
+ * Pre-computed sort/aria state for a single column header in the board-meeting table.
+ */
+export interface BoardMeetingColumnHeader {
+  field: BoardMeetingSortField;
+  label: string;
+  ariaSort: 'ascending' | 'descending' | 'none';
+  iconClass: string;
+}
+
+/**
+ * Board Meeting Participation summary response from BFF.
+ * Single normalized card-ready payload backed by two parallel Snowflake reads against
+ * ANALYTICS.PLATINUM.MEETING_ATTENDANCE (summary counters) and MEETING_ATTENDEES (invitee rows).
+ */
+export interface BoardMeetingParticipationSummaryResponse {
+  /** true when the slug-resolve CTE found a project; false triggers "No Board Meeting Participation Data Available" */
+  dataAvailable: boolean;
+  /** Snowflake PROJECT_ID UUID echoed for PCC deep link construction; empty string when dataAvailable is false */
+  projectId: string;
+  /** Foundation/project slug echoed for context */
+  projectSlug: string;
+  /** Effective reporting range used by the queries */
+  range: BoardMeetingParticipationRange;
+  /** Total board meetings for the selected range */
+  totalMeetings: number;
+  /**
+   * Period-over-period change ratio for total meetings (e.g., -0.15 = 15% decrease).
+   * Raw dbt value, not divided by 100. Null when no prior period data.
+   */
+  totalMeetingsChange: number | null;
+  /**
+   * Average organization attendance as fractional ratio 0–1 (e.g., 0.77 = 77%).
+   * Frontend multiplies by 100 for percentage display.
+   */
+  avgMeetingAttendance: number;
+  /**
+   * Period-over-period change ratio for average attendance.
+   * Raw dbt value, not divided by 100. Null when no prior period data.
+   */
+  avgMeetingAttendanceChange: number | null;
+  /** Per-invitee rows for the data table; empty array when no invitees match for the selected range */
+  invitees: BoardMeetingInviteeRow[];
+}
+
+// ============================================
+// Flywheel Conversion Rate (Health Metrics Card)
+// ============================================
+
+/**
+ * Derived summary view for the Flywheel Conversion Rate Health Metrics card.
+ * Produced client-side from the reused FlywheelConversionResponse — there is no
+ * new backend field for previousPeriodConversionRate in v1; it is computed as
+ * `conversionRate - changePercentage` per the clarified spec.
+ */
+export interface FlywheelCardSummaryView {
+  /** Current conversion rate (primary metric) from `FlywheelConversionResponse.conversionRate` */
+  currentConversionRate: number;
+  /** Derived previous-period conversion rate: `conversionRate - changePercentage` */
+  previousPeriodConversionRate: number;
+  /** Raw change percentage from `FlywheelConversionResponse.changePercentage` */
+  changePercentage: number;
+  /** Trend direction mirrored from `FlywheelConversionResponse.trend` */
+  trend: 'up' | 'down';
+}
+
+/**
+ * Single funnel stage for the Flywheel Conversion Rate Health Metrics card.
+ * The card renders the 7 stages in the fixed drawer order and each stage's
+ * bar length is proportional to the top-of-funnel attendee count.
+ */
+export interface FlywheelHealthMetricsFunnelStage {
+  /** Stage label displayed on the left side of the horizontal bar */
+  label: string;
+  /** Raw stage count from the reused flywheel response */
+  count: number;
+  /** Display width percentage relative to Event Attendees; 0 when attendees is 0 */
+  widthPct: number;
+}
+
+/**
+ * Single prioritized banner message rendered at the bottom of the Flywheel
+ * Conversion Rate Health Metrics card. The card shows at most one message and
+ * hides the banner when the reused flywheel logic yields nothing relevant.
+ */
+export interface FlywheelHealthMetricsBannerView {
+  /** Business-facing message text shown on the banner */
+  text: string;
+  /** Whether the selected message came from an action or an insight */
+  sourceType: 'action' | 'insight';
+  /** Which priority group the message came from — drives banner visual treatment */
+  priorityGroup: 'attention' | 'performing';
 }

--- a/packages/shared/src/utils/flywheel.utils.ts
+++ b/packages/shared/src/utils/flywheel.utils.ts
@@ -26,7 +26,7 @@ export const FLYWHEEL_FUNNEL_STAGE_LABELS = [
   'Re-engaged to Web',
 ] as const;
 
-/** Zero-filled fallback for the optional `reengagement` block on the reused response. */
+/** Zero-filled fallback used when `data` is null/undefined. */
 const DEFAULT_REENGAGEMENT: NonNullable<FlywheelConversionResponse['reengagement']> = {
   totalReengaged: 0,
   reengagementRate: 0,
@@ -40,8 +40,8 @@ const DEFAULT_REENGAGEMENT: NonNullable<FlywheelConversionResponse['reengagement
 };
 
 /**
- * Returns the reused `reengagement` block or a zero-filled fallback. Using a
- * single source for this default avoids drift between the drawer and the card.
+ * Returns the `reengagement` block from the response, or a zero-filled fallback
+ * when `data` itself is null/undefined. Single source to avoid drift between drawer and card.
  */
 export function getFlywheelReengagement(data: FlywheelConversionResponse | null | undefined): NonNullable<FlywheelConversionResponse['reengagement']> {
   return data?.reengagement ?? DEFAULT_REENGAGEMENT;

--- a/packages/shared/src/utils/flywheel.utils.ts
+++ b/packages/shared/src/utils/flywheel.utils.ts
@@ -65,8 +65,8 @@ export function buildFlywheelCardSummary(data: FlywheelConversionResponse | null
 
 /**
  * Builds the Health Metrics card funnel stages in the fixed re-engagement order.
- * Width percentages are relative to `funnel.eventAttendees` and clamped to [0, 100]
- * so very small counts still render a visible bar while zero attendees render empty bars.
+ * Width percentages are relative to `funnel.eventAttendees` and clamped to [0, 100],
+ * while zero attendees render empty bars.
  */
 export function buildFlywheelFunnelStages(data: FlywheelConversionResponse | null | undefined): FlywheelHealthMetricsFunnelStage[] {
   if (!data) return [];

--- a/packages/shared/src/utils/flywheel.utils.ts
+++ b/packages/shared/src/utils/flywheel.utils.ts
@@ -13,8 +13,8 @@ import { formatNumber } from './number.utils';
 import { splitByPriority } from './marketing.utils';
 
 /**
- * Seven re-engagement funnel stages reused by the Flywheel Conversion Rate
- * Health Metrics card and the existing flywheel drawer, in required display order.
+ * Seven re-engagement funnel stages in the required display order for the
+ * shared Flywheel Health Metrics funnel helpers defined in this module.
  */
 export const FLYWHEEL_FUNNEL_STAGE_LABELS = [
   'Event Attendees',

--- a/packages/shared/src/utils/flywheel.utils.ts
+++ b/packages/shared/src/utils/flywheel.utils.ts
@@ -1,0 +1,269 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type {
+  FlywheelCardSummaryView,
+  FlywheelConversionResponse,
+  FlywheelHealthMetricsBannerView,
+  FlywheelHealthMetricsFunnelStage,
+  MarketingKeyInsight,
+  MarketingRecommendedAction,
+} from '../interfaces';
+import { formatNumber } from './number.utils';
+import { splitByPriority } from './marketing.utils';
+
+/**
+ * Seven re-engagement funnel stages reused by the Flywheel Conversion Rate
+ * Health Metrics card and the existing flywheel drawer, in required display order.
+ */
+export const FLYWHEEL_FUNNEL_STAGE_LABELS = [
+  'Event Attendees',
+  'Re-engaged to Community',
+  'Re-engaged to WG',
+  'Re-engaged to Newsletter',
+  'Re-engaged to Training',
+  'Re-engaged to Code',
+  'Re-engaged to Web',
+] as const;
+
+/** Zero-filled fallback for the optional `reengagement` block on the reused response. */
+const DEFAULT_REENGAGEMENT: NonNullable<FlywheelConversionResponse['reengagement']> = {
+  totalReengaged: 0,
+  reengagementRate: 0,
+  reengagementMomChange: 0,
+  reengagedToNewsletter: 0,
+  reengagedToCommunity: 0,
+  reengagedToWorkingGroup: 0,
+  reengagedToTraining: 0,
+  reengagedToCode: 0,
+  reengagedToWeb: 0,
+};
+
+/**
+ * Returns the reused `reengagement` block or a zero-filled fallback. Using a
+ * single source for this default avoids drift between the drawer and the card.
+ */
+export function getFlywheelReengagement(data: FlywheelConversionResponse | null | undefined): NonNullable<FlywheelConversionResponse['reengagement']> {
+  return data?.reengagement ?? DEFAULT_REENGAGEMENT;
+}
+
+/**
+ * Builds the Health Metrics card summary row from the reused flywheel payload.
+ * Returns null when no payload is available so the card can render its no-data state.
+ */
+export function buildFlywheelCardSummary(data: FlywheelConversionResponse | null | undefined): FlywheelCardSummaryView | null {
+  if (!data) return null;
+  const currentConversionRate = data.conversionRate ?? 0;
+  const changePercentage = data.changePercentage ?? 0;
+  return {
+    currentConversionRate,
+    previousPeriodConversionRate: currentConversionRate - changePercentage,
+    changePercentage,
+    trend: data.trend ?? 'up',
+  };
+}
+
+/**
+ * Builds the Health Metrics card funnel stages in the fixed re-engagement order.
+ * Width percentages are relative to `funnel.eventAttendees` and clamped to [0, 100]
+ * so very small counts still render a visible bar while zero attendees render empty bars.
+ */
+export function buildFlywheelFunnelStages(data: FlywheelConversionResponse | null | undefined): FlywheelHealthMetricsFunnelStage[] {
+  if (!data) return [];
+
+  const reengagement = getFlywheelReengagement(data);
+  const attendees = data.funnel?.eventAttendees ?? 0;
+
+  const counts: number[] = [
+    attendees,
+    reengagement.reengagedToCommunity ?? 0,
+    reengagement.reengagedToWorkingGroup ?? 0,
+    reengagement.reengagedToNewsletter ?? 0,
+    reengagement.reengagedToTraining ?? 0,
+    reengagement.reengagedToCode ?? 0,
+    reengagement.reengagedToWeb ?? 0,
+  ];
+
+  return FLYWHEEL_FUNNEL_STAGE_LABELS.map((label, i) => {
+    const count = counts[i];
+    if (attendees <= 0) {
+      return { label, count, widthPct: 0 };
+    }
+    const pct = (count / attendees) * 100;
+    const clamped = Math.max(0, Math.min(100, pct));
+    return { label, count, widthPct: clamped };
+  });
+}
+
+/**
+ * Returns the reused flywheel recommended actions. Same rule engine as the existing
+ * drawer — extracted verbatim so the drawer and card cannot drift in message content.
+ */
+export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse | null | undefined): MarketingRecommendedAction[] {
+  if (!data) return [];
+
+  const { conversionRate, funnel, monthlyData } = data;
+  const reengagement = getFlywheelReengagement(data);
+  const attendees = funnel?.eventAttendees ?? 0;
+
+  const actions: MarketingRecommendedAction[] = [];
+
+  if ((conversionRate ?? 0) === 0 && attendees === 0 && (monthlyData?.length ?? 0) === 0) {
+    return actions;
+  }
+
+  if (attendees > 0 && reengagement.reengagedToWorkingGroup > 0 && reengagement.reengagedToCommunity > 0) {
+    const wgRate = (reengagement.reengagedToWorkingGroup / attendees) * 100;
+    const communityRate = (reengagement.reengagedToCommunity / attendees) * 100;
+    if (wgRate < communityRate * 0.5) {
+      actions.push({
+        title: 'Improve working group re-engagement path',
+        description: `WG re-engagement at ${wgRate.toFixed(1)}% vs ${communityRate.toFixed(1)}% for community — attendees need clearer path to participate`,
+        priority: 'high',
+        dueLabel: 'This quarter',
+        actionType: 'conversion',
+      });
+    }
+  }
+
+  if (reengagement.reengagementMomChange < -5) {
+    actions.push({
+      title: 'Address re-engagement rate decline',
+      description: `Re-engagement dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% MoM — review post-event follow-up effectiveness`,
+      priority: 'high',
+      dueLabel: 'This month',
+      actionType: 'decline',
+    });
+  }
+
+  if (reengagement.reengagementRate > 0 && reengagement.reengagementRate < 10 && attendees > 0) {
+    actions.push({
+      title: 'Add post-event engagement CTAs',
+      description: `Only ${reengagement.reengagementRate.toFixed(1)}% re-engagement — add community join and working group prompts to event follow-ups`,
+      priority: 'medium',
+      dueLabel: 'Next event',
+      actionType: 'content',
+    });
+  }
+
+  if (actions.length === 0) {
+    const growthSuffix = reengagement.reengagementMomChange > 0 ? ` — improving ${reengagement.reengagementMomChange.toFixed(1)}%` : '';
+    actions.push({
+      title: 'Continue flywheel optimization',
+      description: `${reengagement.reengagementRate.toFixed(1)}% re-engagement rate${growthSuffix} across ${formatNumber(attendees)} attendees`,
+      priority: 'low',
+      dueLabel: 'Ongoing',
+      actionType: 'growth',
+    });
+  }
+
+  return actions;
+}
+
+/**
+ * Returns the reused flywheel key insights. Same rule engine as the existing drawer.
+ */
+export function buildFlywheelKeyInsights(data: FlywheelConversionResponse | null | undefined): MarketingKeyInsight[] {
+  if (!data) return [];
+
+  const { conversionRate, funnel, monthlyData } = data;
+  const reengagement = getFlywheelReengagement(data);
+  const attendees = funnel?.eventAttendees ?? 0;
+  const insights: MarketingKeyInsight[] = [];
+
+  if ((conversionRate ?? 0) === 0 && attendees === 0 && (monthlyData?.length ?? 0) === 0) {
+    return insights;
+  }
+
+  if (attendees > 0) {
+    const paths = [
+      { name: 'Community', value: reengagement.reengagedToCommunity },
+      { name: 'Working group', value: reengagement.reengagedToWorkingGroup },
+      { name: 'Newsletter', value: reengagement.reengagedToNewsletter },
+      { name: 'Training', value: reengagement.reengagedToTraining },
+      { name: 'Code', value: reengagement.reengagedToCode },
+      { name: 'Web', value: reengagement.reengagedToWeb },
+    ]
+      .filter((p) => p.value > 0)
+      .sort((a, b) => b.value - a.value);
+
+    if (paths.length > 0) {
+      const bestRate = (paths[0].value / attendees) * 100;
+      insights.push({ text: `${paths[0].name} is the highest re-engagement path at ${bestRate.toFixed(1)}% of attendees`, type: 'driver' });
+    }
+
+    if (paths.length > 1) {
+      const worstRate = (paths[paths.length - 1].value / attendees) * 100;
+      insights.push({ text: `${paths[paths.length - 1].name} re-engagement lowest at ${worstRate.toFixed(1)}%`, type: 'warning' });
+    }
+  }
+
+  if (reengagement.reengagementMomChange > 3) {
+    insights.push({ text: `Re-engagement rate trending up ${reengagement.reengagementMomChange.toFixed(1)}% — flywheel is accelerating`, type: 'driver' });
+  } else if (reengagement.reengagementMomChange < -3) {
+    insights.push({
+      text: `Re-engagement rate dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% — flywheel is slowing`,
+      type: 'warning',
+    });
+  }
+
+  if (monthlyData && monthlyData.length >= 3) {
+    const recent3 = monthlyData.slice(-3);
+    const isGrowing = recent3[0].value < recent3[1].value && recent3[1].value < recent3[2].value;
+    const isShrinking = recent3[0].value > recent3[1].value && recent3[1].value > recent3[2].value;
+    if (isGrowing) {
+      insights.push({ text: `Re-engaged members growing for 3 consecutive months — ${formatNumber(recent3[2].value)} this month`, type: 'driver' });
+    } else if (isShrinking) {
+      insights.push({ text: `Re-engaged members declining for 3 consecutive months — ${formatNumber(recent3[2].value)} this month`, type: 'warning' });
+    }
+  }
+
+  return insights;
+}
+
+/**
+ * Picks the single prioritized banner message for the Health Metrics card.
+ *
+ * Selection order (first match wins):
+ *   1. Attention action with `priority === 'high'`
+ *   2. Attention action with `priority === 'medium'`
+ *   3. Attention insight (type === 'warning')
+ *   4. Performing action (any — only 'low' end up here)
+ *   5. Performing insight (driver/info)
+ *
+ * Returns `null` when no relevant message is available so the card can hide the banner.
+ */
+export function selectFlywheelBannerView(data: FlywheelConversionResponse | null | undefined): FlywheelHealthMetricsBannerView | null {
+  if (!data) return null;
+
+  const actions = buildFlywheelRecommendedActions(data);
+  const insights = buildFlywheelKeyInsights(data);
+  const split = splitByPriority(actions, insights);
+
+  const highAction = split.attentionActions.find((a) => a.priority === 'high');
+  if (highAction) {
+    return { text: highAction.description || highAction.title, sourceType: 'action', priorityGroup: 'attention' };
+  }
+
+  const mediumAction = split.attentionActions.find((a) => a.priority === 'medium');
+  if (mediumAction) {
+    return { text: mediumAction.description || mediumAction.title, sourceType: 'action', priorityGroup: 'attention' };
+  }
+
+  const attentionInsight = split.attentionInsights[0];
+  if (attentionInsight) {
+    return { text: attentionInsight.text, sourceType: 'insight', priorityGroup: 'attention' };
+  }
+
+  const performingAction = split.performingActions[0];
+  if (performingAction) {
+    return { text: performingAction.description || performingAction.title, sourceType: 'action', priorityGroup: 'performing' };
+  }
+
+  const performingInsight = split.performingInsights[0];
+  if (performingInsight) {
+    return { text: performingInsight.text, sourceType: 'insight', priorityGroup: 'performing' };
+  }
+
+  return null;
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -19,3 +19,4 @@ export * from './platform.utils';
 export * from './project.utils';
 export * from './badge.utils';
 export * from './marketing.utils';
+export * from './flywheel.utils';

--- a/packages/shared/src/utils/number.utils.ts
+++ b/packages/shared/src/utils/number.utils.ts
@@ -36,16 +36,16 @@ export function formatCurrency(num: number): string {
 /**
  * Format a monetary value-lost figure using compact notation.
  * Suitable for displaying churn, refund, or write-off amounts.
- * - Values >= 1 000 000 → "$X.XM"
- * - Values >= 1 000     → "$XK" (rounded to nearest K)
- * - Smaller values      → "$X,XXX" (locale-formatted)
+ * - Handles negative numbers, NaN, and Infinity gracefully
+ * - Values >= 999,950 are displayed as "$X.XM"
+ * - Values >= 1,000 are displayed as "$X.XK"
+ * - Smaller values use locale-formatted strings with "$" prefix
  */
 export function formatValueLost(value: number): string {
-  if (value >= 1_000_000) {
-    return `$${(value / 1_000_000).toFixed(1)}M`;
-  }
-  if (value >= 1_000) {
-    return `$${Math.round(value / 1_000)}K`;
-  }
-  return `$${value.toLocaleString()}`;
+  if (!Number.isFinite(value)) return '$0';
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  if (abs >= 999_950) return `${sign}$${(abs / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${sign}$${(abs / 1_000).toFixed(1)}K`;
+  return `${sign}$${abs.toLocaleString()}`;
 }

--- a/packages/shared/src/utils/number.utils.ts
+++ b/packages/shared/src/utils/number.utils.ts
@@ -32,3 +32,20 @@ export function formatCurrency(num: number): string {
   if (abs >= 1_000) return `${sign}$${(abs / 1_000).toFixed(1)}K`;
   return `${sign}$${abs.toLocaleString()}`;
 }
+
+/**
+ * Format a monetary value-lost figure using compact notation.
+ * Suitable for displaying churn, refund, or write-off amounts.
+ * - Values >= 1 000 000 → "$X.XM"
+ * - Values >= 1 000     → "$XK" (rounded to nearest K)
+ * - Smaller values      → "$X,XXX" (locale-formatted)
+ */
+export function formatValueLost(value: number): string {
+  if (value >= 1_000_000) {
+    return `$${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (value >= 1_000) {
+    return `$${Math.round(value / 1_000)}K`;
+  }
+  return `$${value.toLocaleString()}`;
+}


### PR DESCRIPTION
## Summary
- Add board meeting participation and flywheel conversion rate health metric cards
- Add executive director route guard to restrict health-metrics page access
- Extend analytics API, validation helper, and project service for board meeting participation and per-tier churn
- Extract shared flywheel utilities (summary, funnel stages, recommended actions, key insights) to prevent drift between drawer and card
- Add shared dashboard metric types, number formatting helpers, and health metrics range constants

## Review comment fixes (647e8ad3, c9f207c4)
- Fix icon `[class]` binding overwriting static Font Awesome classes in board meeting table
- Align `dataAvailable` with interface contract (slug resolution only, not meeting count)
- Harden `formatValueLost` for NaN/Infinity/negative values and K-to-M rollover near 1M
- Fix per-tier churn rate to use weighted `DIV0NULL` calculation instead of summing ratios
- Use `@environments/environment` path alias consistently across health metrics cards
- Capture `validatedRange` in controller endpoints for type narrowing
- Correct misleading JSDoc on `buildFlywheelFunnelStages`
- Add JSDoc to `isHealthMetricsRange` type guard
- Derive `buildHealthMetricsYearOptions` from `HEALTH_METRICS_RANGES` constants

## Notes
- All commits use `--signoff` (DCO)

Made with [Cursor](https://cursor.com)