### PR TITLE
feat(events): filter event selection by visa/travel-fund request flags

### DIFF
--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, model, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, model, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { EventsService } from '@app/shared/services/events.service';
@@ -9,7 +9,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { EMPTY_MY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
-import { MyEvent, TimeFilterValue } from '@lfx-one/shared/interfaces';
+import { MyEvent, RequestType, TimeFilterValue } from '@lfx-one/shared/interfaces';
 import { catchError, combineLatest, debounceTime, EMPTY, finalize, of, scan, skip, switchMap, tap } from 'rxjs';
 import { EVENT_SELECTION_PAGE_SIZE } from '@lfx-one/shared/constants/events.constants';
 @Component({
@@ -24,6 +24,7 @@ export class EventSelectionComponent {
   private readonly fb = inject(NonNullableFormBuilder);
 
   public selectedEvent = model<MyEvent | null>(null);
+  public readonly requestType = input<RequestType | undefined>(undefined);
 
   // Search via its own form (required by lfx-input-text); debounced separately to avoid extra API calls on each keystroke
   public readonly searchForm = this.fb.group({ searchQuery: '' });
@@ -64,6 +65,8 @@ export class EventSelectionComponent {
     searchQuery: this.debouncedSearch() || undefined,
     ...this.computeTimeFilterParams(this.filtersValue().timeFilter as TimeFilterValue),
     country: this.filtersValue().locationFilter !== 'any' ? (this.filtersValue().locationFilter ?? undefined) : undefined,
+    isVisaRequestAccepted: this.requestType() === 'visa' ? true : undefined,
+    isTravelFundRequestAccepted: this.requestType() === 'travel-fund' ? true : undefined,
   }));
 
   // Initial events loaded reactively from activeFilters

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/travel-fund-application-dialog/travel-fund-application-dialog.component.html
@@ -17,7 +17,7 @@
     <!-- Step content -->
     <div class="scroll-area overflow-y-auto pr-1">
       @if (step() === 'select-event') {
-        <lfx-event-selection [(selectedEvent)]="selectedEvent" />
+        <lfx-event-selection [(selectedEvent)]="selectedEvent" requestType="travel-fund" />
       } @else if (step() === 'terms') {
         <lfx-travel-fund-terms />
       } @else if (step() === 'about-me') {

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-application-dialog/visa-request-application-dialog.component.html
@@ -17,7 +17,7 @@
     <!-- Step content -->
     @if (step() === 'select-event') {
       <div class="scroll-area overflow-y-auto pr-1">
-        <lfx-event-selection [(selectedEvent)]="selectedEvent" />
+        <lfx-event-selection [(selectedEvent)]="selectedEvent" requestType="visa" />
       </div>
     } @else if (step() === 'terms') {
       <lfx-visa-request-terms />

--- a/apps/lfx-one/src/app/shared/services/events.service.ts
+++ b/apps/lfx-one/src/app/shared/services/events.service.ts
@@ -48,6 +48,8 @@ export class EventsService {
     if (params.startDateFrom) httpParams = httpParams.set('startDateFrom', params.startDateFrom);
     if (params.startDateTo) httpParams = httpParams.set('startDateTo', params.startDateTo);
     if (params.country) httpParams = httpParams.set('country', params.country);
+    if (params.isVisaRequestAccepted) httpParams = httpParams.set('isVisaRequestAccepted', 'true');
+    if (params.isTravelFundRequestAccepted) httpParams = httpParams.set('isTravelFundRequestAccepted', 'true');
 
     return this.http.get<MyEventsResponse>('/api/events', { params: httpParams });
   }

--- a/apps/lfx-one/src/server/controllers/events.controller.ts
+++ b/apps/lfx-one/src/server/controllers/events.controller.ts
@@ -71,6 +71,8 @@ export class EventsController {
       const startDateFrom = req.query['startDateFrom'] ? String(req.query['startDateFrom']) : undefined;
       const startDateTo = req.query['startDateTo'] ? String(req.query['startDateTo']) : undefined;
       const country = req.query['country'] ? String(req.query['country']) : undefined;
+      const isVisaRequestAccepted = req.query['isVisaRequestAccepted'] === 'true' ? true : undefined;
+      const isTravelFundRequestAccepted = req.query['isTravelFundRequestAccepted'] === 'true' ? true : undefined;
 
       const pageSize = Number.isFinite(rawPageSize) && rawPageSize > 0 && rawPageSize <= MAX_EVENTS_PAGE_SIZE ? rawPageSize : DEFAULT_EVENTS_PAGE_SIZE;
       const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
@@ -106,6 +108,8 @@ export class EventsController {
         startDateTo,
         country,
         affiliatedProjectSlugs,
+        isVisaRequestAccepted,
+        isTravelFundRequestAccepted,
       });
 
       logger.success(req, 'get_my_events', startTime, {

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -69,6 +69,8 @@ export class EventsService {
       startDateTo,
       country,
       affiliatedProjectSlugs,
+      isVisaRequestAccepted,
+      isTravelFundRequestAccepted,
     } = options;
     const sortField = rawSortField && VALID_EVENT_SORT_FIELDS.has(rawSortField) ? rawSortField : DEFAULT_EVENT_SORT_FIELD;
     const normalizedSortOrder: EventSortOrder = sortOrder === 'DESC' ? 'DESC' : 'ASC';
@@ -103,6 +105,8 @@ export class EventsService {
       const startDateToFilter = startDateTo ? 'AND e.EVENT_START_DATE <= ?' : '';
       const countryFilter = country ? 'AND e.EVENT_COUNTRY = ?' : '';
       const registeredOnlyFilter = registeredOnly ? "AND r.EVENT_ID IS NOT NULL AND r.REGISTRATION_STATUS = 'Accepted'" : '';
+      const visaRequestAcceptedFilter = isVisaRequestAccepted ? 'AND r.IS_VISA_REQUEST_ACCEPTED = TRUE' : '';
+      const travelFundRequestAcceptedFilter = isTravelFundRequestAccepted ? 'AND r.IS_TRAVEL_FUND_ACCEPTED = TRUE' : '';
 
       const slugs = affiliatedProjectSlugs ?? [];
       const hasAffiliatedSlugs = slugs.length > 0;
@@ -164,7 +168,9 @@ export class EventsService {
             GROSS_REVENUE,
             TAX_AMOUNT,
             NET_REVENUE,
-            USER_ATTENDED
+            USER_ATTENDED,
+            IS_VISA_REQUEST_ACCEPTED,
+            IS_TRAVEL_FUND_ACCEPTED
           FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
           WHERE USER_EMAIL = ?
             AND IS_PAST_EVENT = FALSE
@@ -213,6 +219,8 @@ export class EventsService {
           ${startDateToFilter}
           ${countryFilter}
           ${registeredOnlyFilter}
+          ${visaRequestAcceptedFilter}
+          ${travelFundRequestAcceptedFilter}
         ORDER BY ${sortField} ${normalizedSortOrder}
         LIMIT ${normalizedPageSize} OFFSET ${normalizedOffset}
       `;

--- a/packages/shared/src/interfaces/events.interface.ts
+++ b/packages/shared/src/interfaces/events.interface.ts
@@ -236,6 +236,8 @@ export interface GetMyEventsParams {
   startDateTo?: string;
   /** Filter events by country (e.g. "United States") */
   country?: string;
+  isVisaRequestAccepted?: boolean;
+  isTravelFundRequestAccepted?: boolean;
 }
 
 /**
@@ -390,6 +392,10 @@ export interface GetMyEventsOptions {
   country?: string;
   /** Project slugs from persona detection — scopes upcoming events to affiliated projects */
   affiliatedProjectSlugs?: string[];
+  /** When true, only events where the user's visa letter request was accepted are returned */
+  isVisaRequestAccepted?: boolean;
+  /** When true, only events where the user's travel fund request was accepted are returned */
+  isTravelFundRequestAccepted?: boolean;
 }
 
 /**


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                          
  - Adds a `requestType` input to `lfx-event-selection` so callers can scope the event list by request type                                                                                                           
  - Visa request dialog now only shows events where the user's visa letter request was accepted (`IS_VISA_REQUEST_ACCEPTED = TRUE`)                                                                                   
  - Travel fund dialog now only shows events where the user's travel fund request was accepted (`IS_TRAVEL_FUND_ACCEPTED = TRUE`)                                                                                     
  - New flags flow end-to-end: shared interface → Angular service → Express controller → Snowflake query                                                                                                              
