### PR TITLE
fix(ui): show sparkline trend with available data and adjust subtitles

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -72,7 +72,7 @@
           </div>
         </lfx-card>
       </div>
-      @if (data().sentimentMomChangePp !== 0) {
+      @if (data().totalMentions > 0 && data().sentimentMomChangePp !== 0) {
         <div class="flex items-center gap-2 text-sm text-gray-500">
           <span>Positive Sentiment MoM:</span>
           <span class="font-semibold" [class.text-green-600]="data().sentimentMomChangePp > 0" [class.text-red-600]="data().sentimentMomChangePp < 0">

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -28,40 +28,57 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="brand-health-drawer-content">
-    <!-- Summary Stats -->
-    <div class="flex gap-4" data-testid="brand-health-drawer-stats">
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Total Mentions</span>
-          @if (data().totalMentions > 0) {
-            <span class="text-2xl font-semibold text-gray-900">{{ data().totalMentions | number }}</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Positive Sentiment</span>
-          @if (data().totalMentions > 0) {
-            <span class="text-2xl font-semibold text-gray-900">{{ data().sentiment.positive | number: '1.1-1' }}%</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-      @if (data().sentimentMomChangePp !== 0) {
+    <!-- Summary Stats + Sentiment Breakdown -->
+    <div class="flex flex-col gap-4" data-testid="brand-health-drawer-stats">
+      <div class="flex gap-4">
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">MoM Growth</span>
-            <span
-              class="text-2xl font-semibold"
-              [class.text-green-600]="data().sentimentMomChangePp > 0"
-              [class.text-red-600]="data().sentimentMomChangePp < 0">
-              {{ formattedSentimentMom() }}pp
-            </span>
+            <span class="text-sm text-gray-500">Total Mentions</span>
+            @if (data().totalMentions > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ data().totalMentions | number }}</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
           </div>
         </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Positive</span>
+            @if (data().totalMentions > 0) {
+              <span class="text-2xl font-semibold text-green-600">{{ data().sentiment.positive | number: '1.1-1' }}%</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Neutral</span>
+            @if (data().totalMentions > 0) {
+              <span class="text-2xl font-semibold text-gray-600">{{ data().sentiment.neutral | number: '1.1-1' }}%</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Negative</span>
+            @if (data().totalMentions > 0) {
+              <span class="text-2xl font-semibold text-red-600">{{ data().sentiment.negative | number: '1.1-1' }}%</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+      @if (data().sentimentMomChangePp !== 0) {
+        <div class="flex items-center gap-2 text-sm text-gray-500">
+          <span>Positive Sentiment MoM:</span>
+          <span class="font-semibold" [class.text-green-600]="data().sentimentMomChangePp > 0" [class.text-red-600]="data().sentimentMomChangePp < 0">
+            {{ formattedSentimentMom() }}pp
+          </span>
+        </div>
       }
     </div>
 
@@ -152,37 +169,6 @@
       } @else {
         <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="brand-health-drawer-mentions-empty">
           Mentions trend data not yet available
-        </div>
-      }
-    </div>
-
-    <!-- Sentiment Breakdown -->
-    <div class="flex flex-col gap-4" data-testid="brand-health-drawer-sentiment">
-      <h3 class="text-sm font-semibold text-gray-900">Sentiment Breakdown</h3>
-      @if (data().sentiment.positive + data().sentiment.neutral + data().sentiment.negative > 0) {
-        <div class="flex gap-4">
-          <lfx-card styleClass="flex-1">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Positive</span>
-              <span class="text-2xl font-semibold text-green-600">{{ data().sentiment.positive | number: '1.1-1' }}%</span>
-            </div>
-          </lfx-card>
-          <lfx-card styleClass="flex-1">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Neutral</span>
-              <span class="text-2xl font-semibold text-gray-600">{{ data().sentiment.neutral | number: '1.1-1' }}%</span>
-            </div>
-          </lfx-card>
-          <lfx-card styleClass="flex-1">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Negative</span>
-              <span class="text-2xl font-semibold text-red-600">{{ data().sentiment.negative | number: '1.1-1' }}%</span>
-            </div>
-          </lfx-card>
-        </div>
-      } @else {
-        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-health-drawer-sentiment-empty">
-          Sentiment data not yet available
         </div>
       }
     </div>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/board-meeting-card/board-meeting-card.component.html
@@ -94,7 +94,10 @@
                   [class.w-[20%]]="col.field === 'attendancePercent'"
                   [attr.aria-sort]="col.ariaSort"
                   [attr.data-testid]="'board-meeting-th-' + col.field">
-                  <button type="button" class="inline-flex w-full items-center gap-1 text-xs font-semibold tracking-wide text-gray-600 uppercase hover:text-gray-900" (click)="onSort(col.field)">
+                  <button
+                    type="button"
+                    class="inline-flex w-full items-center gap-1 text-xs font-semibold tracking-wide text-gray-600 uppercase hover:text-gray-900"
+                    (click)="onSort(col.field)">
                     {{ col.label }}
                     <i [class]="col.iconClass"></i>
                   </button>

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.html
@@ -21,8 +21,8 @@
   <!-- Description -->
   <div class="rounded-md bg-gray-50 px-4 py-3" data-testid="health-metrics-flywheel-description">
     <p class="text-xs text-gray-500">
-      Percentage of event attendees who engage with newsletter, community, or working groups within 90 days after an event.
-      This metric reflects the latest monthly window and is not affected by the page year filter.
+      Percentage of event attendees who engage with newsletter, community, or working groups within 90 days after an event. This metric reflects the latest
+      monthly window and is not affected by the page year filter.
     </p>
   </div>
 

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/flywheel-conversion-card/flywheel-conversion-card.component.ts
@@ -6,7 +6,12 @@ import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input
 import type { Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
-import { createHorizontalBarChartOptions, DASHBOARD_TOOLTIP_CONFIG, HEALTH_METRICS_FLYWHEEL_CONVERSION_DECIMAL_PLACES, lfxColors } from '@lfx-one/shared/constants';
+import {
+  createHorizontalBarChartOptions,
+  DASHBOARD_TOOLTIP_CONFIG,
+  HEALTH_METRICS_FLYWHEEL_CONVERSION_DECIMAL_PLACES,
+  lfxColors,
+} from '@lfx-one/shared/constants';
 import { buildFlywheelCardSummary, buildFlywheelFunnelStages, formatNumber, selectFlywheelBannerView } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -970,9 +970,7 @@ export class AnalyticsService {
    * Returns null on HTTP failure so consumers can distinguish "error" from "real zeros".
    */
   public getFlywheelConversion(foundationSlug: string): Observable<FlywheelConversionResponse | null> {
-    return this.http.get<FlywheelConversionResponse>('/api/analytics/flywheel-conversion', { params: { foundationSlug } }).pipe(
-      catchError(() => of(null))
-    );
+    return this.http.get<FlywheelConversionResponse>('/api/analytics/flywheel-conversion', { params: { foundationSlug } }).pipe(catchError(() => of(null)));
   }
 
   /**

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -923,7 +923,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       value: formatNumber(memberAcquisition.totalMembers),
       changePercentage: formatMomChange(memberAcquisition.changePercentage),
       trend: normalizeTrend(memberAcquisition.changePercentage, memberAcquisition.trend),
-      subtitle: `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · ${trendWindow(memberAcquisition.totalMembersMonthlyData.length) || 'Last 6 months'}`,
+      subtitle:
+        memberAcquisition.totalMembersMonthlyData.length > 0
+          ? `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · ${trendWindow(memberAcquisition.totalMembersMonthlyData.length)}`
+          : `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}%`,
       chartData: protoSparkline(
         memberAcquisition.totalMembersMonthlyData.length > 0 ? memberAcquisition.totalMembersMonthlyData : flatSparklineData(memberAcquisition.totalMembers),
         lfxColors.blue[500]
@@ -942,7 +945,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       value: formatNumber(engagedCommunity.totalMembers),
       changePercentage: formatMomChange(engagedCommunity.changePercentage),
       trend: normalizeTrend(engagedCommunity.changePercentage, engagedCommunity.trend),
-      subtitle: trendWindow(engagedCommunity.monthlyData.length) || 'Last 6 months',
+      subtitle: trendWindow(engagedCommunity.monthlyData.length),
       chartData: protoSparkline(
         engagedCommunity.monthlyData.length > 0 ? monthlyValues(engagedCommunity.monthlyData) : flatSparklineData(engagedCommunity.totalMembers),
         lfxColors.blue[500]
@@ -961,7 +964,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       value: formatNumber(eventGrowth.totalRegistrants),
       changePercentage: formatYoyChange(eventGrowth.registrantYoyChange),
       trend: trendFromChange(eventGrowth.registrantYoyChange),
-      subtitle: `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · ${trendWindow(eventGrowth.monthlyData.length) || 'YTD'}`,
+      subtitle:
+        eventGrowth.monthlyData.length > 0
+          ? `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · ${trendWindow(eventGrowth.monthlyData.length)}`
+          : `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'}`,
       chartData: protoSparkline(
         eventGrowth.monthlyData.length > 0 ? monthlyValues(eventGrowth.monthlyData) : flatSparklineData(eventGrowth.totalRegistrants),
         lfxColors.blue[500]
@@ -1000,7 +1006,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           normalizeTrend(brandReach.sessionMomChangePct, brandReach.sessionMomChangePct >= 0 ? 'up' : 'down')
         ),
       ],
-      caption: `${brandReach.activePlatforms} platforms · ${trendWindow(Math.ceil(brandReach.weeklyTrend.length / 4)) || 'Last 6 months'}`,
+      caption:
+        brandReach.weeklyTrend.length > 0
+          ? `${brandReach.activePlatforms} platforms · ${trendWindow(Math.ceil(brandReach.weeklyTrend.length / 4))}`
+          : `${brandReach.activePlatforms} platforms`,
       tooltipText: 'Social followers across all platforms (stock) and monthly website sessions (flow). Shown separately — these are different metric types.',
       drawerType: DashboardDrawerType.BrandReach,
     } as DashboardMetricCard,
@@ -1023,7 +1032,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
         ),
         protoDualSignal('Positive Sentiment', `${brandHealth.sentiment.positive.toFixed(1)}%`, [], lfxColors.violet[500]),
       ],
-      caption: `${formatNumber(brandHealth.totalMentions)} mentions · ${trendWindow(brandHealth.monthlyMentions.length) || 'Last 6 months'}`,
+      caption:
+        brandHealth.monthlyMentions.length > 0
+          ? `${formatNumber(brandHealth.totalMentions)} mentions · ${trendWindow(brandHealth.monthlyMentions.length)}`
+          : `${formatNumber(brandHealth.totalMentions)} mentions`,
       tooltipText: 'Total brand mentions across social and web with sentiment breakdown.',
       drawerType: DashboardDrawerType.BrandHealth,
     } as DashboardMetricCard,
@@ -1037,7 +1049,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       testId: 'ed-evo-revenue-impact',
       description: 'Total revenue attributed to marketing touchpoints, with paid media revenue shown separately.',
       customContentType: 'dual-signal',
-      caption: trendWindow(revenueImpact.paidMedia.monthlyTrend.length) || 'Last 6 months',
+      caption: trendWindow(revenueImpact.paidMedia.monthlyTrend.length),
       dualSignals: [
         (() => {
           const eventAttrSeries = eventAttrMonthlyRevenueSeries(revenueImpact.eventRegistrationAttribution.monthlyTrend);

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -59,16 +59,14 @@ export function getYearForRange(range: HealthMetricsRange): number {
  */
 export function buildHealthMetricsYearOptions(): HealthMetricsYearOption[] {
   const currentYear = new Date().getFullYear();
-  return [...HEALTH_METRICS_RANGES]
-    .reverse()
-    .map((range) => {
-      const year = currentYear - RANGE_YEAR_OFFSET[range];
-      return {
-        label: range === 'YTD' ? 'YTD' : `${year}`,
-        range,
-        year,
-      };
-    });
+  return [...HEALTH_METRICS_RANGES].reverse().map((range) => {
+    const year = currentYear - RANGE_YEAR_OFFSET[range];
+    return {
+      label: range === 'YTD' ? 'YTD' : `${year}`,
+      range,
+      year,
+    };
+  });
 }
 
 // ============================================
@@ -733,6 +731,14 @@ function flatSparklineData(value: number): number[] {
   return [Math.max(value - nudge, 0), value, value, value, value, value + nudge];
 }
 
+/** Build a time-window label from the number of data points available.
+ *  Returns "Last N months" for any count, capped at 6. */
+function trendWindow(monthCount: number): string {
+  if (monthCount <= 0) return '';
+  if (monthCount >= 6) return 'Last 6 months';
+  return `Last ${monthCount} month${monthCount === 1 ? '' : 's'}`;
+}
+
 /** Normalize a server-provided trend: treat zero change as neutral instead of up.
  *  Uses Number(toFixed(1)) to match roundForDisplay() — both helpers agree on the
  *  same rounding path so the trend color never diverges from the displayed label. */
@@ -897,7 +903,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       value: `${flywheel.reengagement.reengagementRate.toFixed(1)}%`,
       changePercentage: formatPpMomChange(flywheel.reengagement.reengagementMomChange),
       trend: trendFromChange(flywheel.reengagement.reengagementMomChange),
-      subtitle: 'MoM · Last 6 months',
+      subtitle: flywheel.monthlyData.length > 0 ? `MoM · ${trendWindow(flywheel.monthlyData.length)}` : 'MoM',
       chartData: protoSparkline(
         flywheel.monthlyData.length > 0 ? monthlyValues(flywheel.monthlyData) : flatSparklineData(flywheel.reengagement.reengagementRate),
         lfxColors.blue[500]
@@ -917,7 +923,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       value: formatNumber(memberAcquisition.totalMembers),
       changePercentage: formatMomChange(memberAcquisition.changePercentage),
       trend: normalizeTrend(memberAcquisition.changePercentage, memberAcquisition.trend),
-      subtitle: `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · Last 6 months`,
+      subtitle: `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · ${trendWindow(memberAcquisition.totalMembersMonthlyData.length) || 'Last 6 months'}`,
       chartData: protoSparkline(
         memberAcquisition.totalMembersMonthlyData.length > 0 ? memberAcquisition.totalMembersMonthlyData : flatSparklineData(memberAcquisition.totalMembers),
         lfxColors.blue[500]
@@ -936,7 +942,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       value: formatNumber(engagedCommunity.totalMembers),
       changePercentage: formatMomChange(engagedCommunity.changePercentage),
       trend: normalizeTrend(engagedCommunity.changePercentage, engagedCommunity.trend),
-      subtitle: 'Last 6 months',
+      subtitle: trendWindow(engagedCommunity.monthlyData.length) || 'Last 6 months',
       chartData: protoSparkline(
         engagedCommunity.monthlyData.length > 0 ? monthlyValues(engagedCommunity.monthlyData) : flatSparklineData(engagedCommunity.totalMembers),
         lfxColors.blue[500]
@@ -955,7 +961,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       value: formatNumber(eventGrowth.totalRegistrants),
       changePercentage: formatYoyChange(eventGrowth.registrantYoyChange),
       trend: trendFromChange(eventGrowth.registrantYoyChange),
-      subtitle: `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD`,
+      subtitle: `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · ${trendWindow(eventGrowth.monthlyData.length) || 'YTD'}`,
       chartData: protoSparkline(
         eventGrowth.monthlyData.length > 0 ? monthlyValues(eventGrowth.monthlyData) : flatSparklineData(eventGrowth.totalRegistrants),
         lfxColors.blue[500]
@@ -994,7 +1000,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
           normalizeTrend(brandReach.sessionMomChangePct, brandReach.sessionMomChangePct >= 0 ? 'up' : 'down')
         ),
       ],
-      caption: `${brandReach.activePlatforms} platforms · Last 6 months`,
+      caption: `${brandReach.activePlatforms} platforms · ${trendWindow(Math.ceil(brandReach.weeklyTrend.length / 4)) || 'Last 6 months'}`,
       tooltipText: 'Social followers across all platforms (stock) and monthly website sessions (flow). Shown separately — these are different metric types.',
       drawerType: DashboardDrawerType.BrandReach,
     } as DashboardMetricCard,
@@ -1017,7 +1023,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
         ),
         protoDualSignal('Positive Sentiment', `${brandHealth.sentiment.positive.toFixed(1)}%`, [], lfxColors.violet[500]),
       ],
-      caption: `${formatNumber(brandHealth.totalMentions)} mentions · Last 6 months`,
+      caption: `${formatNumber(brandHealth.totalMentions)} mentions · ${trendWindow(brandHealth.monthlyMentions.length) || 'Last 6 months'}`,
       tooltipText: 'Total brand mentions across social and web with sentiment breakdown.',
       drawerType: DashboardDrawerType.BrandHealth,
     } as DashboardMetricCard,
@@ -1031,7 +1037,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       testId: 'ed-evo-revenue-impact',
       description: 'Total revenue attributed to marketing touchpoints, with paid media revenue shown separately.',
       customContentType: 'dual-signal',
-      caption: 'Last 6 months',
+      caption: trendWindow(revenueImpact.paidMedia.monthlyTrend.length) || 'Last 6 months',
       dualSignals: [
         (() => {
           const eventAttrSeries = eventAttrMonthlyRevenueSeries(revenueImpact.eventRegistrationAttribution.monthlyTrend);

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -966,8 +966,8 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       trend: trendFromChange(eventGrowth.registrantYoyChange),
       subtitle:
         eventGrowth.monthlyData.length > 0
-          ? `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · ${trendWindow(eventGrowth.monthlyData.length)}`
-          : `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'}`,
+          ? `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD · Trend: ${trendWindow(eventGrowth.monthlyData.length)}`
+          : `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD`,
       chartData: protoSparkline(
         eventGrowth.monthlyData.length > 0 ? monthlyValues(eventGrowth.monthlyData) : flatSparklineData(eventGrowth.totalRegistrants),
         lfxColors.blue[500]


### PR DESCRIPTION
## Summary
- Added `trendWindow()` helper that returns "Last N months" based on actual data point count instead of hardcoded "Last 6 months"
- Updated all 7 ED dashboard card subtitles/captions to dynamically reflect the real data window
- When fewer than 6 months of data exist (e.g. new foundations like AAIF), subtitles now show "Last 3 months" or "Last 1 month" instead of claiming 6
- Removed misleading "Last 6 months" fallback when 0 data points exist — cards now omit the time window entirely
- **Brand Health drawer**: consolidated sentiment breakdown (Positive/Neutral/Negative) into the top summary row alongside Total Mentions, removing the separate "Sentiment Breakdown" section from the middle of the drawer
- Fixed pipe precedence in committee table (`??` vs `|`)

LFXV2-1468

## Test plan
- [ ] Load ED dashboard for a foundation with full 6-month data (e.g. CNCF) — subtitles should still say "Last 6 months"
- [ ] Load ED dashboard for a foundation with partial data (e.g. AAIF) — subtitles should reflect actual data window (e.g. "Last 1 month")
- [ ] Verify sparklines render actual trend lines with available data points
- [ ] Open Brand Health drawer — Total Mentions, Positive, Neutral, Negative should all show in one row at the top
- [ ] Verify the old "Sentiment Breakdown" section no longer appears in the middle of the drawer
- [ ] Verify no regressions on other card values or layouts

🤖 Generated with [Claude Code](https://claude.ai/code)