### PR TITLE
fix(committees): rename active voting stat to voting enabled groups

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -68,7 +68,7 @@
                 } @else {
                   <p class="text-xl font-medium text-gray-900">{{ activeVoting() }}</p>
                 }
-                <p class="text-sm font-normal text-gray-900">Active Voting</p>
+                <p class="text-sm font-normal text-gray-900">Voting Enabled Groups</p>
               </div>
             </div>
           </div>
@@ -117,7 +117,7 @@
                 } @else {
                   <p class="text-xl font-medium text-gray-900">{{ myActiveVoting() }}</p>
                 }
-                <p class="text-sm font-normal text-gray-900">Active Voting</p>
+                <p class="text-sm font-normal text-gray-900">Voting Enabled Groups</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Renames the third stat card label on both the Me lens and Foundation/Project lens committee dashboards from **"Active Voting"** to **"Voting Enabled Groups"**.

The card is computed from the `enable_voting` capability flag — i.e. it counts groups that *can* hold votes, not groups with an in-flight ballot. The previous label read as in-progress voting activity, which contradicted both the underlying signal and the existing "Voting Enabled / Voting Disabled" wording already used by the committee table tooltip and the voting-status filter dropdown.

## Scope

- **1 file changed, 2 insertions, 2 deletions** (label string only).
- File: `apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html`.
- No logic, signal, computed, interface, template-binding, icon, or shared-package changes.
- E2E selectors key off `data-testid` attributes, not the label text — no test updates required.

## Notes for reviewers

This branch was force-pushed to rebase onto current `main` after review feedback. The previous push contained a repo-wide prettier reflow commit (`a403b92c`) that has since been subsumed by formatting already merged to `main` via other PRs; the rebase dropped that commit automatically (`patch contents already upstream`). The PR now contains only the user-facing label rename.

## Verification

- `./check-headers.sh` — pass
- `yarn format:check` — pass
- `yarn lint:check` — pass
- `yarn check-types` — pass
