### PR TITLE
fix(surveys): use display status for dashboard pill and surveys table

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -101,7 +101,7 @@
           <div class="px-4 py-2.5">
             <p-skeleton width="6rem" height="1rem" />
           </div>
-        } @else {
+        } @else if (summaryPills().openSurveys > 0) {
           <div class="flex items-center gap-2 px-4 py-2.5">
             <i class="fa-solid fa-square-poll-horizontal text-blue-600"></i>
             <span class="text-gray-700">{{ summaryPills().openSurveys }} surveys open</span>

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -21,7 +21,7 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { ROLE_PRIORITY, VOTING_STATUS_PRIORITY } from '@lfx-one/shared/constants';
 import { SurveyStatus } from '@lfx-one/shared/enums';
-import { getActiveOccurrences } from '@lfx-one/shared/utils';
+import { getActiveOccurrences, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 
 import { AnalyticsService } from '@services/analytics.service';
 import { HiddenActionsService } from '@services/hidden-actions.service';
@@ -230,7 +230,7 @@ export class MultiPersonaDashboardComponent {
   private initOpenSurveysCount(): Signal<number> {
     return toSignal(
       this.surveyService.getMySurveys().pipe(
-        map((surveys) => surveys.filter((s) => s.survey_status === SurveyStatus.OPEN || s.survey_status === SurveyStatus.SENT).length),
+        map((surveys) => surveys.filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN).length),
         catchError(() => of(0)),
         tap(() => this.openSurveysLoading.set(false))
       ),

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.html
@@ -145,9 +145,9 @@
         </td>
 
         <td>
-          @if (survey.survey_status === SurveyStatus.CLOSED) {
+          @if (survey.displayStatus === SurveyStatus.CLOSED) {
             <span class="text-sm text-gray-700">{{ survey.survey_cutoff_date | date: 'MMM d, y' }}</span>
-          } @else if (survey.survey_status === SurveyStatus.DRAFT) {
+          } @else if (survey.displayStatus === SurveyStatus.DRAFT) {
             <span class="text-sm text-gray-700">&mdash;</span>
           } @else if (survey.survey_cutoff_date) {
             @let dueDateLabelValue = survey.survey_cutoff_date | dueDateLabel;
@@ -168,7 +168,7 @@
 
         <td>
           <div class="flex items-center justify-end gap-1">
-            @if (hasPMOAccess() && survey.survey_status === SurveyStatus.DRAFT) {
+            @if (hasPMOAccess() && survey.displayStatus === SurveyStatus.DRAFT) {
               <lfx-button label="Edit" severity="primary" size="small" [text]="true" styleClass="" [attr.data-testid]="'surveys-edit-' + survey.uid"> </lfx-button>
               <lfx-button
                 label="Delete"
@@ -180,17 +180,7 @@
                 [disabled]="isDeleting()"
                 [attr.data-testid]="'surveys-delete-' + survey.uid">
               </lfx-button>
-            } @else if (survey.survey_status === SurveyStatus.SENT || survey.survey_status === SurveyStatus.OPEN) {
-              <lfx-button
-                label="Results"
-                severity="primary"
-                size="small"
-                [text]="true"
-                styleClass=""
-                (onClick)="onViewResults(survey.uid)"
-                [attr.data-testid]="'surveys-results-' + survey.uid">
-              </lfx-button>
-            } @else if (survey.survey_status === SurveyStatus.CLOSED) {
+            } @else if (survey.displayStatus === SurveyStatus.OPEN || survey.displayStatus === SurveyStatus.CLOSED) {
               <lfx-button
                 label="Results"
                 severity="primary"

--- a/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/surveys-table/surveys-table.component.ts
@@ -14,8 +14,8 @@ import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { SURVEY_LABEL, SURVEY_TYPE_LABELS, SurveyStatus } from '@lfx-one/shared';
-import { FilterPillOption } from '@lfx-one/shared/interfaces';
-import { Survey } from '@lfx-one/shared/interfaces';
+import { FilterPillOption, Survey } from '@lfx-one/shared/interfaces';
+import { getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { DueDateLabelPipe } from '@pipes/due-date-label.pipe';
 import { RelativeDueDatePipe } from '@pipes/relative-due-date.pipe';
 import { SurveyStatusLabelPipe } from '@pipes/survey-status-label.pipe';
@@ -96,7 +96,7 @@ export class SurveysTableComponent {
   private readonly searchTerm: Signal<string> = this.initSearchTerm();
   protected readonly groupOptions: Signal<{ label: string; value: string | null }[]> = this.initGroupOptions();
   protected readonly typeOptions: Signal<{ label: string; value: string | null }[]> = this.initTypeOptions();
-  protected readonly filteredSurveys: Signal<Survey[]> = this.initFilteredSurveys();
+  protected readonly filteredSurveys: Signal<(Survey & { displayStatus: SurveyStatus })[]> = this.initFilteredSurveys();
   protected readonly isFiltered = computed(() =>
     this.searchTerm() !== '' || this.statusTab() !== 'all' || this.groupFilter() !== null || this.typeFilter() !== null
   );
@@ -235,9 +235,14 @@ export class SurveysTableComponent {
     });
   }
 
-  private initFilteredSurveys(): Signal<Survey[]> {
+  private initFilteredSurveys(): Signal<(Survey & { displayStatus: SurveyStatus })[]> {
     return computed(() => {
-      let filtered = this.surveys();
+      // Precompute displayStatus once per row so the template, filter, and sort
+      // all agree on cutoff/case-normalized status (matches what the badge pipe shows).
+      let filtered = this.surveys().map((survey) => ({
+        ...survey,
+        displayStatus: getSurveyDisplayStatus(survey),
+      }));
 
       const searchTerm = this.searchTerm()?.toLowerCase() || '';
       if (searchTerm) {
@@ -246,11 +251,10 @@ export class SurveysTableComponent {
 
       const statusTab = this.statusTab();
       if (statusTab !== 'all') {
-        const openStatuses: SurveyStatus[] = [SurveyStatus.OPEN, SurveyStatus.SENT];
         if (statusTab === 'open') {
-          filtered = filtered.filter((survey) => openStatuses.includes((survey.survey_status as string).toLowerCase() as SurveyStatus));
+          filtered = filtered.filter((survey) => survey.displayStatus === SurveyStatus.OPEN);
         } else if (statusTab === 'closed') {
-          filtered = filtered.filter((survey) => (survey.survey_status as string).toLowerCase() === SurveyStatus.CLOSED);
+          filtered = filtered.filter((survey) => survey.displayStatus === SurveyStatus.CLOSED);
         }
       }
 
@@ -269,9 +273,8 @@ export class SurveysTableComponent {
   }
 
   // === Private Helpers ===
-  private sortSurveys(surveys: Survey[]): Survey[] {
+  private sortSurveys<T extends Survey & { displayStatus: SurveyStatus }>(surveys: T[]): T[] {
     const statusPriority: Record<string, number> = {
-      [SurveyStatus.SENT]: 1,
       [SurveyStatus.OPEN]: 1,
       [SurveyStatus.DRAFT]: 2,
       [SurveyStatus.SCHEDULED]: 3,
@@ -279,11 +282,8 @@ export class SurveysTableComponent {
     };
 
     return [...surveys].sort((a, b) => {
-      const statusA = a.survey_status;
-      const statusB = b.survey_status;
-
-      if (statusA !== statusB) {
-        return (statusPriority[statusA] ?? 5) - (statusPriority[statusB] ?? 5);
+      if (a.displayStatus !== b.displayStatus) {
+        return (statusPriority[a.displayStatus] ?? 5) - (statusPriority[b.displayStatus] ?? 5);
       }
 
       const dateA = a.survey_cutoff_date ? new Date(a.survey_cutoff_date).getTime() : Infinity;


### PR DESCRIPTION
# Summary

This pull request refactors how survey status is determined and used throughout the multi-persona dashboard and surveys table components. Instead of directly referencing `survey_status`, it introduces a computed `displayStatus` property for each survey, which uses the `getSurveyDisplayStatus` utility. This ensures consistent status handling in filtering, sorting, and UI display.

**Survey status handling improvements:**

* The `getSurveyDisplayStatus` utility is now imported and used in both `multi-persona-dashboard.component.ts` and `surveys-table.component.ts` to compute a normalized `displayStatus` for each survey. [[1]](diffhunk://#diff-e3aa55bbbed259a389e64e4b8b3b223da7d0a40c2179253a4a30e89408376197L24-R24) [[2]](diffhunk://#diff-81ad82a7643e9ed4aea8948247fa2a94b9bc2c05fd9edea98d3f37dc8c548ee6R18)
* The `filteredSurveys` signal now returns surveys with an added `displayStatus` property, ensuring all downstream logic (filtering, sorting, and templates) uses the normalized status. [[1]](diffhunk://#diff-81ad82a7643e9ed4aea8948247fa2a94b9bc2c05fd9edea98d3f37dc8c548ee6L96-R97) [[2]](diffhunk://#diff-81ad82a7643e9ed4aea8948247fa2a94b9bc2c05fd9edea98d3f37dc8c548ee6L235-R243)

**Filtering and sorting logic updates:**

* Survey filtering by status tab (open/closed) now uses `displayStatus` instead of raw `survey_status`, improving consistency and reliability.
* The sorting function now sorts by `displayStatus` rather than `survey_status`, and the `SENT` status is no longer prioritized separately.

**Template updates for status display:**

* All template references to `survey_status` in `surveys-table.component.html` are replaced with `displayStatus`, ensuring UI elements and actions reflect the computed status. [[1]](diffhunk://#diff-560f3028e18f4a781374ad659560c29b0ab27fcf7d8082f3f0739ed0d69848d2L144-R146) [[2]](diffhunk://#diff-560f3028e18f4a781374ad659560c29b0ab27fcf7d8082f3f0739ed0d69848d2L167-R167) [[3]](diffhunk://#diff-560f3028e18f4a781374ad659560c29b0ab27fcf7d8082f3f0739ed0d69848d2L180-R180)

**Dashboard survey count logic:**

* The open surveys count in the multi-persona dashboard now counts surveys where `getSurveyDisplayStatus(survey)` is `OPEN`, instead of checking both `OPEN` and `SENT` statuses directly.