### PR TITLE
feat(pending-actions): add votes and RSVP sources

### DIFF
--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -880,7 +880,10 @@ export class UserService {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
 
-    const [surveys, meetings, pendingVotes] = await Promise.all([
+    // RSVP-related fetches run alongside surveys/meetings/votes. Both are per-user, so they're
+    // cheap to issue in parallel and don't depend on the meeting list — we just filter to the
+    // in-window meetings after everything returns.
+    const [surveys, meetings, pendingVotes, userRsvps, activeRegistrantIds] = await Promise.all([
       this.projectService.getPendingActionSurveys(email, projectSlug).catch((error) => {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch surveys for pending actions', { err: error });
         return [];
@@ -895,22 +898,21 @@ export class UserService {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch pending votes', { err: error });
         return [] as Vote[];
       }),
+
+      this.fetchAllUserRsvps(req, email, username).catch((error) => {
+        logger.warning(req, 'get_user_pending_actions', 'Failed to fetch user RSVPs for pending actions', { err: error });
+        return [] as MeetingRsvp[];
+      }),
+
+      this.fetchUserActiveRegistrantIds(req, email, username).catch((error) => {
+        logger.warning(req, 'get_user_pending_actions', 'Failed to fetch user registrant IDs for pending actions', { err: error });
+        return new Set<string>();
+      }),
     ]);
 
-    // Meeting-based actions come in two flavors: Review Agenda (always emitted for meetings in the
-    // 2-week window) and Set RSVP (emitted only when the user hasn't RSVPed yet or RSVPed "maybe").
-    // The second depends on a cross-lookup against v1_meeting_rsvp keyed by the in-window meeting
-    // UIDs, so we compute the window once and reuse it.
     const inWindowMeetings = this.filterMeetingsInWindow(meetings);
     const meetingActions = this.transformMeetingsToActions(inWindowMeetings);
-
-    const meetingUids = Array.from(new Set(inWindowMeetings.map((m) => m.id).filter((id): id is string => !!id)));
-    const userRsvps = await this.fetchUserRsvpsForMeetings(req, meetingUids, email, username).catch((error) => {
-      logger.warning(req, 'get_user_pending_actions', 'Failed to fetch user RSVPs for pending actions', { err: error });
-      return [] as MeetingRsvp[];
-    });
-    const rsvpActions = this.transformMissingRsvpsToActions(inWindowMeetings, userRsvps);
-
+    const rsvpActions = this.transformMissingRsvpsToActions(inWindowMeetings, userRsvps, activeRegistrantIds);
     const voteActions = this.transformVotesToActions(pendingVotes);
 
     return [...surveys, ...meetingActions, ...voteActions, ...rsvpActions];
@@ -924,8 +926,11 @@ export class UserService {
    * across both tags and fields for this index.
    */
   private async fetchPendingVotes(req: Request, email: string, username: string | null, projectUid: string): Promise<Vote[]> {
+    // Normalize email to match the sibling user-scoped lookups in this file — un-normalized
+    // input silently misses rows when the caller passed a mixed-case address.
+    const normalizedEmail = email ? email.trim().toLowerCase() : '';
     const orClauses: string[] = [];
-    if (email) orClauses.push(`user_email:${email}`);
+    if (normalizedEmail) orClauses.push(`user_email:${normalizedEmail}`);
     if (username) orClauses.push(`username:${username}`);
     if (orClauses.length === 0) return [];
 
@@ -942,7 +947,7 @@ export class UserService {
       new Set(
         invitations
           .filter((iv) => iv.vote_status === IndividualVoteStatus.AWAITING_RESPONSE && iv.project_uid === projectUid && !iv.voter_removed)
-          .map((iv) => iv.vote_uid || iv.vote_id)
+          .map((iv) => iv.vote_uid ?? iv.vote_id)
           .filter((uid): uid is string => !!uid)
       )
     );
@@ -965,44 +970,48 @@ export class UserService {
   }
 
   /**
-   * Batched per-user RSVP lookup for a set of meetings. Uses `tags_or=[meeting_id:X, …]` chunked
-   * at 100 (URL-length guard) combined with `filters_or=[email:Y, username:Z]` so each request
-   * returns only this user's RSVPs against the window's meetings, instead of every RSVP ever
-   * recorded on them.
+   * Fetch every `v1_meeting_rsvp` row for the current user. We don't try to narrow by
+   * meeting_id on the server because `tags_or` isn't used elsewhere in this repo and the
+   * query service may silently ignore it — filtering meeting-side in code is both reliable
+   * and cheap at the typical per-user RSVP cardinality (dozens to low hundreds, paginated).
    */
-  private async fetchUserRsvpsForMeetings(req: Request, meetingUids: string[], email: string, username: string | null): Promise<MeetingRsvp[]> {
-    if (meetingUids.length === 0) return [];
+  private async fetchAllUserRsvps(req: Request, email: string, username: string | null): Promise<MeetingRsvp[]> {
     const orClauses: string[] = [];
     if (email) orClauses.push(`email:${email.toLowerCase()}`);
     if (username) orClauses.push(`username:${username}`);
     if (orClauses.length === 0) return [];
 
-    const BATCH_SIZE = 100;
-    const batches: string[][] = [];
-    for (let i = 0; i < meetingUids.length; i += BATCH_SIZE) {
-      batches.push(meetingUids.slice(i, i + BATCH_SIZE));
-    }
+    return fetchAllQueryResources<MeetingRsvp>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRsvp>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'v1_meeting_rsvp',
+        filters_or: orClauses,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+  }
 
-    const results = await Promise.all(
-      batches.map((batch) =>
-        fetchAllQueryResources<MeetingRsvp>(req, (pageToken) =>
-          this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRsvp>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-            type: 'v1_meeting_rsvp',
-            tags_or: batch.map((uid) => `meeting_id:${uid}`),
-            filters_or: orClauses,
-            ...(pageToken && { page_token: pageToken }),
-          })
-        ).catch((error) => {
-          logger.warning(req, 'fetch_user_rsvps_for_meetings', 'Batch RSVP fetch failed, skipping', {
-            batch_size: batch.length,
-            err: error,
-          });
-          return [] as MeetingRsvp[];
-        })
-      )
+  /**
+   * Fetch the UIDs of every currently-active registrant record for the current user. RSVP rows
+   * persist from removed registrations, so we use the same guard as
+   * `MeetingService.getMeetingRsvps`: keep only those RSVPs whose `registrant_id` matches an
+   * active registrant. Otherwise an old accepted/declined RSVP from a removed registration
+   * would incorrectly suppress a Set RSVP action for the user's current registration.
+   */
+  private async fetchUserActiveRegistrantIds(req: Request, email: string, username: string | null): Promise<Set<string>> {
+    const orClauses: string[] = [];
+    if (email) orClauses.push(`email:${email.toLowerCase()}`);
+    if (username) orClauses.push(`username:${username}`);
+    if (orClauses.length === 0) return new Set();
+
+    const registrants = await fetchAllQueryResources<MeetingRegistrant>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'v1_meeting_registrant',
+        filters_or: orClauses,
+        ...(pageToken && { page_token: pageToken }),
+      })
     );
 
-    return results.flat();
+    return new Set(registrants.map((r) => r.uid).filter((uid): uid is string => !!uid));
   }
 
   /**
@@ -1035,13 +1044,21 @@ export class UserService {
    * For each in-window meeting, emit a "Set RSVP" action when the user has no RSVP recorded or
    * the recorded RSVP is "maybe". Per-occurrence RSVPs count as a response for the series — a
    * user who has RSVPed any occurrence won't be nagged for a fresh top-level response.
+   *
+   * Before trusting an RSVP, require its `registrant_id` to be in the user's active registrant
+   * set so historical RSVPs from removed registrations can't suppress a needed Set RSVP action
+   * for the user's current registration.
    */
-  private transformMissingRsvpsToActions(meetings: Meeting[], rsvps: MeetingRsvp[]): PendingActionItem[] {
+  private transformMissingRsvpsToActions(meetings: Meeting[], rsvps: MeetingRsvp[], activeRegistrantIds: Set<string>): PendingActionItem[] {
     if (meetings.length === 0) return [];
+
+    const inWindowMeetingIds = new Set(meetings.map((m) => m.id).filter((id): id is string => !!id));
 
     // Keep the strongest signal per meeting: accepted/declined beats maybe beats nothing.
     const responseByMeeting = new Map<string, MeetingRsvp>();
     for (const rsvp of rsvps) {
+      if (!rsvp.meeting_id || !inWindowMeetingIds.has(rsvp.meeting_id)) continue;
+      if (!rsvp.registrant_id || !activeRegistrantIds.has(rsvp.registrant_id)) continue;
       const existing = responseByMeeting.get(rsvp.meeting_id);
       if (!existing || (existing.response_type === 'maybe' && rsvp.response_type !== 'maybe')) {
         responseByMeeting.set(rsvp.meeting_id, rsvp);
@@ -1087,9 +1104,14 @@ export class UserService {
   /**
    * Build a "Set RSVP" pending action for a single meeting. Links to the meeting detail page
    * where the RSVP UI lives; reuses the meeting password query param like `createMeetingAction`.
+   *
+   * For recurring series, `meeting.start_time` is the series start (often long past), so use
+   * the current-or-next occurrence's start time for the badge and formatted date. Falls back
+   * to `meeting.start_time` for single-occurrence meetings.
    */
   private createRsvpAction(meeting: Meeting): PendingActionItem {
-    const startTime = new Date(meeting.start_time);
+    const nextOccurrence = getCurrentOrNextOccurrence(meeting);
+    const startTime = new Date(nextOccurrence?.start_time ?? meeting.start_time);
     const badge = startTime.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
     const formattedDate = startTime.toLocaleDateString('en-US', {
       weekday: 'short',

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -880,10 +880,8 @@ export class UserService {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
 
-    // RSVP-related fetches run alongside surveys/meetings/votes. Both are per-user, so they're
-    // cheap to issue in parallel and don't depend on the meeting list — we just filter to the
-    // in-window meetings after everything returns.
-    const [surveys, meetings, pendingVotes, userRsvps, activeRegistrantIds] = await Promise.all([
+    // Phase 1: surveys, meetings, and pending votes are independent — issue them in parallel.
+    const [surveys, meetings, pendingVotes] = await Promise.all([
       this.projectService.getPendingActionSurveys(email, projectSlug).catch((error) => {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch surveys for pending actions', { err: error });
         return [];
@@ -898,22 +896,31 @@ export class UserService {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch pending votes', { err: error });
         return [] as Vote[];
       }),
-
-      this.fetchAllUserRsvps(req, email, username).catch((error) => {
-        logger.warning(req, 'get_user_pending_actions', 'Failed to fetch user RSVPs for pending actions', { err: error });
-        return [] as MeetingRsvp[];
-      }),
-
-      this.fetchUserActiveRegistrantIds(req, email, username).catch((error) => {
-        logger.warning(req, 'get_user_pending_actions', 'Failed to fetch user registrant IDs for pending actions', { err: error });
-        return new Set<string>();
-      }),
     ]);
 
     const inWindowMeetings = this.filterMeetingsInWindow(meetings);
     const meetingActions = this.transformMeetingsToActions(inWindowMeetings);
-    const rsvpActions = this.transformMissingRsvpsToActions(inWindowMeetings, userRsvps, activeRegistrantIds);
     const voteActions = this.transformVotesToActions(pendingVotes);
+
+    // Phase 2: RSVP + registrant lookups are only meaningful when there are in-window meetings
+    // to evaluate. Skip them otherwise — avoids two full paginated per-user scans per request
+    // for users with no upcoming meetings in the window.
+    //
+    // Fail closed on the RSVP prerequisites: if either lookup errors, we can't distinguish
+    // "user hasn't RSVPed" from "we don't know", and a transient failure must not turn every
+    // in-window meeting into a bogus Set RSVP nag. Suppress the whole source on error.
+    let rsvpActions: PendingActionItem[] = [];
+    if (inWindowMeetings.length > 0) {
+      try {
+        const [userRsvps, activeRegistrantIds] = await Promise.all([
+          this.fetchAllUserRsvps(req, email, username),
+          this.fetchUserActiveRegistrantIds(req, email, username),
+        ]);
+        rsvpActions = this.transformMissingRsvpsToActions(inWindowMeetings, userRsvps, activeRegistrantIds);
+      } catch (error) {
+        logger.warning(req, 'get_user_pending_actions', 'RSVP prerequisite lookup failed, suppressing Set RSVP actions', { err: error });
+      }
+    }
 
     // Order by actionability: someone is waiting on RSVPs and votes have closing windows, so
     // those go first. Surveys are time-bounded by their cutoff. Review Agenda is informational
@@ -938,20 +945,28 @@ export class UserService {
     if (username) orClauses.push(`username:${username}`);
     if (orClauses.length === 0) return [];
 
-    const invitations = await fetchAllQueryResources<IndividualVote>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<IndividualVote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        type: 'individual_vote',
-        filters_or: orClauses,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    // failOnPartial: completeness matters — a truncated response can silently miss an
+    // awaiting-response vote, producing the wrong pending-action list. The caller already
+    // catches and degrades, so fail closed here instead of accepting partial state.
+    const invitations = await fetchAllQueryResources<IndividualVote>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<IndividualVote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'individual_vote',
+          filters_or: orClauses,
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      { failOnPartial: true }
     );
 
     // Awaiting-response invitations scoped to this project. voter_removed entries are historical.
+    // NOTE: `poll_uid`/`poll_id` is the parent vote's id (what `/votes/{uid}` expects).
+    // `vote_uid`/`vote_id` is the individual-vote record id — using those would 404.
     const pendingVoteUids = Array.from(
       new Set(
         invitations
           .filter((iv) => iv.vote_status === IndividualVoteStatus.AWAITING_RESPONSE && iv.project_uid === projectUid && !iv.voter_removed)
-          .map((iv) => iv.vote_uid ?? iv.vote_id)
+          .map((iv) => iv.poll_uid ?? iv.poll_id)
           .filter((uid): uid is string => !!uid)
       )
     );
@@ -985,12 +1000,17 @@ export class UserService {
     if (username) orClauses.push(`username:${username}`);
     if (orClauses.length === 0) return [];
 
-    return fetchAllQueryResources<MeetingRsvp>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRsvp>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        type: 'v1_meeting_rsvp',
-        filters_or: orClauses,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    // failOnPartial: a truncated page set could silently miss an accepted RSVP and cause a
+    // bogus Set RSVP action. Caller fails closed on any throw and suppresses the whole source.
+    return fetchAllQueryResources<MeetingRsvp>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRsvp>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'v1_meeting_rsvp',
+          filters_or: orClauses,
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      { failOnPartial: true }
     );
   }
 
@@ -1007,12 +1027,17 @@ export class UserService {
     if (username) orClauses.push(`username:${username}`);
     if (orClauses.length === 0) return new Set();
 
-    const registrants = await fetchAllQueryResources<MeetingRegistrant>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        type: 'v1_meeting_registrant',
-        filters_or: orClauses,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    // failOnPartial: a missing registrant UID here means an RSVP-guard lookup would wrongly
+    // reject a still-active registrant's RSVP, which then fires a duplicate Set RSVP nag.
+    const registrants = await fetchAllQueryResources<MeetingRegistrant>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'v1_meeting_registrant',
+          filters_or: orClauses,
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      { failOnPartial: true }
     );
 
     return new Set(registrants.map((r) => r.uid).filter((uid): uid is string => !!uid));

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import { NATS_CONFIG, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
-import { IndividualVoteStatus, NatsSubjects, PollStatus } from '@lfx-one/shared/enums';
+import { NatsSubjects, PollStatus } from '@lfx-one/shared/enums';
 import {
   ActiveWeeksStreakResponse,
   ActiveWeeksStreakRow,
   ApiGatewayUserProfile,
-  IndividualVote,
   Meeting,
   MeetingOccurrence,
   MeetingRegistrant,
@@ -930,43 +929,56 @@ export class UserService {
   }
 
   /**
-   * Queries the `individual_vote` index for this user's open invitations and fetches full Vote
-   * details for each. Returns only polls that are still `active` with an `end_time` in the future.
-   * `individual_vote` is per-user so the `filters_or` on email/username is the natural filter —
-   * `vote_status` is applied in-code because the query service doesn't expose a stable AND filter
-   * across both tags and fields for this index.
+   * Queries the `vote_response` index for this user's participation rows and returns the polls
+   * they've been invited to but haven't submitted yet. `vote_response` is the real upstream
+   * indexed type (`lfx.index.vote_response` from `lfx-v2-voting-service`) — the earlier
+   * `individual_vote` type was fabricated in the shared interface and the query returned zero
+   * rows in practice.
+   *
+   * ITX creates a `vote_response` record per invitee on poll initiation and stamps
+   * `vote_status='submitted'` once the user actually casts. "Pending" is therefore:
+   *   - `vote_status !== 'submitted'`  (not cast yet)
+   *   - `!voter_removed`               (active invitation)
+   *   - scoped to the current project
+   * Then fetch the Vote details and keep only those still `active` with an `end_time` in the
+   * future.
    */
   private async fetchPendingVotes(req: Request, email: string, username: string | null, projectUid: string): Promise<Vote[]> {
-    // Normalize email to match the sibling user-scoped lookups in this file — un-normalized
-    // input silently misses rows when the caller passed a mixed-case address.
     const normalizedEmail = email ? email.trim().toLowerCase() : '';
     const orClauses: string[] = [];
     if (normalizedEmail) orClauses.push(`user_email:${normalizedEmail}`);
     if (username) orClauses.push(`username:${username}`);
     if (orClauses.length === 0) return [];
 
-    // failOnPartial: completeness matters — a truncated response can silently miss an
-    // awaiting-response vote, producing the wrong pending-action list. The caller already
-    // catches and degrades, so fail closed here instead of accepting partial state.
-    const invitations = await fetchAllQueryResources<IndividualVote>(
+    interface VoteResponseRow {
+      vote_uid?: string;
+      vote_id?: string;
+      poll_id?: string;
+      project_uid?: string;
+      vote_status?: string;
+      voter_removed?: boolean;
+    }
+
+    // failOnPartial: completeness matters — a truncated response can silently miss a pending
+    // invitation. The caller already catches and degrades, so fail closed here.
+    const responses = await fetchAllQueryResources<VoteResponseRow>(
       req,
       (pageToken) =>
-        this.microserviceProxy.proxyRequest<QueryServiceResponse<IndividualVote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-          type: 'individual_vote',
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<VoteResponseRow>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'vote_response',
           filters_or: orClauses,
           ...(pageToken && { page_token: pageToken }),
         }),
       { failOnPartial: true }
     );
 
-    // Awaiting-response invitations scoped to this project. voter_removed entries are historical.
-    // NOTE: `poll_uid`/`poll_id` is the parent vote's id (what `/votes/{uid}` expects).
-    // `vote_uid`/`vote_id` is the individual-vote record id — using those would 404.
+    // `vote_uid` is the v2 parent poll UID (what `/votes/{uid}` expects); `poll_id` is the v1
+    // fallback per the upstream indexer contract. Neither is the individual-response id.
     const pendingVoteUids = Array.from(
       new Set(
-        invitations
-          .filter((iv) => iv.vote_status === IndividualVoteStatus.AWAITING_RESPONSE && iv.project_uid === projectUid && !iv.voter_removed)
-          .map((iv) => iv.poll_uid ?? iv.poll_id)
+        responses
+          .filter((r) => r.vote_status !== 'submitted' && !r.voter_removed && r.project_uid === projectUid)
+          .map((r) => r.vote_uid ?? r.poll_id)
           .filter((uid): uid is string => !!uid)
       )
     );

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -915,7 +915,11 @@ export class UserService {
     const rsvpActions = this.transformMissingRsvpsToActions(inWindowMeetings, userRsvps, activeRegistrantIds);
     const voteActions = this.transformVotesToActions(pendingVotes);
 
-    return [...surveys, ...meetingActions, ...voteActions, ...rsvpActions];
+    // Order by actionability: someone is waiting on RSVPs and votes have closing windows, so
+    // those go first. Surveys are time-bounded by their cutoff. Review Agenda is informational
+    // (read-before-meeting) and goes last — with the 5-item display cap, plentiful meetings
+    // shouldn't crowd out the rows the user actually has to respond to.
+    return [...rsvpActions, ...voteActions, ...surveys, ...meetingActions];
   }
 
   /**

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -2,14 +2,16 @@
 // SPDX-License-Identifier: MIT
 
 import { NATS_CONFIG, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
-import { NatsSubjects } from '@lfx-one/shared/enums';
+import { IndividualVoteStatus, NatsSubjects, PollStatus } from '@lfx-one/shared/enums';
 import {
   ActiveWeeksStreakResponse,
   ActiveWeeksStreakRow,
   ApiGatewayUserProfile,
+  IndividualVote,
   Meeting,
   MeetingOccurrence,
   MeetingRegistrant,
+  MeetingRsvp,
   PastMeeting,
   PastMeetingParticipant,
   PendingActionItem,
@@ -24,6 +26,7 @@ import {
   UserProjectsResponse,
   UserPullRequestsResponse,
   UserPullRequestsRow,
+  Vote,
 } from '@lfx-one/shared/interfaces';
 import { getCurrentOrNextOccurrence, hasMeetingEnded, parseToInt } from '@lfx-one/shared/utils';
 import { Request } from 'express';
@@ -864,14 +867,20 @@ export class UserService {
   }
 
   /**
-   * Aggregate pending actions for the current user within a project scope.
-   * Sources (all parallel): non-responded surveys (Snowflake) and upcoming meetings
-   * the user is registered on within the next two weeks. No meeting-type filter — a
-   * working-group meeting next week is as much a pending action as a board meeting.
+   * Aggregate pending actions for the current user within a project scope. Sources run in parallel
+   * with per-source `.catch(() => [])` so one flaky source can't wipe the list:
+   *   - Non-responded surveys (Snowflake)
+   *   - Upcoming meetings within the next two weeks (Review Agenda action)
+   *   - Active votes the user hasn't cast (Cast Vote action)
+   *   - Missing or "maybe" RSVPs for meetings in the 2-week window (Set RSVP action)
+   * No meeting-type filter — a working-group meeting next week is as much a pending action as
+   * a board meeting.
    */
   private async getUserPendingActions(req: Request, email: string, projectSlug: string, projectUid: string): Promise<PendingActionItem[]> {
-    // Fetch surveys and user-specific meetings in parallel
-    const [surveys, meetings] = await Promise.all([
+    const rawUsername = await getUsernameFromAuth(req);
+    const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
+
+    const [surveys, meetings, pendingVotes] = await Promise.all([
       this.projectService.getPendingActionSurveys(email, projectSlug).catch((error) => {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch surveys for pending actions', { err: error });
         return [];
@@ -879,14 +888,232 @@ export class UserService {
 
       this.getUserMeetings(req, email, projectUid).catch((error) => {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch user meetings for pending actions', { err: error });
-        return [];
+        return [] as Meeting[];
+      }),
+
+      this.fetchPendingVotes(req, email, username, projectUid).catch((error) => {
+        logger.warning(req, 'get_user_pending_actions', 'Failed to fetch pending votes', { err: error });
+        return [] as Vote[];
       }),
     ]);
 
-    // Transform all upcoming meetings within the next 2 weeks (not just board meetings).
-    const meetingActions = this.transformMeetingsToActions(meetings);
+    // Meeting-based actions come in two flavors: Review Agenda (always emitted for meetings in the
+    // 2-week window) and Set RSVP (emitted only when the user hasn't RSVPed yet or RSVPed "maybe").
+    // The second depends on a cross-lookup against v1_meeting_rsvp keyed by the in-window meeting
+    // UIDs, so we compute the window once and reuse it.
+    const inWindowMeetings = this.filterMeetingsInWindow(meetings);
+    const meetingActions = this.transformMeetingsToActions(inWindowMeetings);
 
-    return [...surveys, ...meetingActions];
+    const meetingUids = Array.from(new Set(inWindowMeetings.map((m) => m.id).filter((id): id is string => !!id)));
+    const userRsvps = await this.fetchUserRsvpsForMeetings(req, meetingUids, email, username).catch((error) => {
+      logger.warning(req, 'get_user_pending_actions', 'Failed to fetch user RSVPs for pending actions', { err: error });
+      return [] as MeetingRsvp[];
+    });
+    const rsvpActions = this.transformMissingRsvpsToActions(inWindowMeetings, userRsvps);
+
+    const voteActions = this.transformVotesToActions(pendingVotes);
+
+    return [...surveys, ...meetingActions, ...voteActions, ...rsvpActions];
+  }
+
+  /**
+   * Queries the `individual_vote` index for this user's open invitations and fetches full Vote
+   * details for each. Returns only polls that are still `active` with an `end_time` in the future.
+   * `individual_vote` is per-user so the `filters_or` on email/username is the natural filter —
+   * `vote_status` is applied in-code because the query service doesn't expose a stable AND filter
+   * across both tags and fields for this index.
+   */
+  private async fetchPendingVotes(req: Request, email: string, username: string | null, projectUid: string): Promise<Vote[]> {
+    const orClauses: string[] = [];
+    if (email) orClauses.push(`user_email:${email}`);
+    if (username) orClauses.push(`username:${username}`);
+    if (orClauses.length === 0) return [];
+
+    const invitations = await fetchAllQueryResources<IndividualVote>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<IndividualVote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'individual_vote',
+        filters_or: orClauses,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+
+    // Awaiting-response invitations scoped to this project. voter_removed entries are historical.
+    const pendingVoteUids = Array.from(
+      new Set(
+        invitations
+          .filter((iv) => iv.vote_status === IndividualVoteStatus.AWAITING_RESPONSE && iv.project_uid === projectUid && !iv.voter_removed)
+          .map((iv) => iv.vote_uid || iv.vote_id)
+          .filter((uid): uid is string => !!uid)
+      )
+    );
+    if (pendingVoteUids.length === 0) return [];
+
+    const now = Date.now();
+    const votes = await Promise.all(
+      pendingVoteUids.map((uid) =>
+        this.microserviceProxy.proxyRequest<Vote>(req, 'LFX_V2_SERVICE', `/votes/${uid}`, 'GET').catch((error) => {
+          logger.warning(req, 'fetch_pending_votes', 'Failed to fetch vote details, skipping', {
+            vote_uid: uid,
+            err: error,
+          });
+          return null;
+        })
+      )
+    );
+
+    return votes.filter((v): v is Vote => v !== null && v.status === PollStatus.ACTIVE && !!v.end_time && new Date(v.end_time).getTime() > now);
+  }
+
+  /**
+   * Batched per-user RSVP lookup for a set of meetings. Uses `tags_or=[meeting_id:X, …]` chunked
+   * at 100 (URL-length guard) combined with `filters_or=[email:Y, username:Z]` so each request
+   * returns only this user's RSVPs against the window's meetings, instead of every RSVP ever
+   * recorded on them.
+   */
+  private async fetchUserRsvpsForMeetings(req: Request, meetingUids: string[], email: string, username: string | null): Promise<MeetingRsvp[]> {
+    if (meetingUids.length === 0) return [];
+    const orClauses: string[] = [];
+    if (email) orClauses.push(`email:${email.toLowerCase()}`);
+    if (username) orClauses.push(`username:${username}`);
+    if (orClauses.length === 0) return [];
+
+    const BATCH_SIZE = 100;
+    const batches: string[][] = [];
+    for (let i = 0; i < meetingUids.length; i += BATCH_SIZE) {
+      batches.push(meetingUids.slice(i, i + BATCH_SIZE));
+    }
+
+    const results = await Promise.all(
+      batches.map((batch) =>
+        fetchAllQueryResources<MeetingRsvp>(req, (pageToken) =>
+          this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRsvp>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+            type: 'v1_meeting_rsvp',
+            tags_or: batch.map((uid) => `meeting_id:${uid}`),
+            filters_or: orClauses,
+            ...(pageToken && { page_token: pageToken }),
+          })
+        ).catch((error) => {
+          logger.warning(req, 'fetch_user_rsvps_for_meetings', 'Batch RSVP fetch failed, skipping', {
+            batch_size: batch.length,
+            err: error,
+          });
+          return [] as MeetingRsvp[];
+        })
+      )
+    );
+
+    return results.flat();
+  }
+
+  /**
+   * Narrow the meeting list to those with at least one active occurrence (or a single-occurrence
+   * meeting) whose start falls inside the 2-week window and hasn't ended yet (with buffer).
+   * Mirrors the filter inside `transformMeetingsToActions` so both derived sources (Review Agenda
+   * actions and Set RSVP actions) operate on the exact same set of meetings.
+   */
+  private filterMeetingsInWindow(meetings: Meeting[]): Meeting[] {
+    const now = new Date();
+    const twoWeeksFromNow = new Date(now.getTime() + this.twoWeeksMs);
+    return meetings.filter((meeting) => {
+      if (meeting.occurrences && meeting.occurrences.length > 0) {
+        return meeting.occurrences.some((occ) => {
+          if (occ.status === 'cancel') return false;
+          const startTime = new Date(occ.start_time);
+          const durationMinutes = parseToInt(occ.duration) ?? parseToInt(meeting.duration) ?? 0;
+          const endWithBuffer = new Date(startTime.getTime() + (durationMinutes + this.bufferMinutes) * 60 * 1000);
+          return now < endWithBuffer && startTime <= twoWeeksFromNow;
+        });
+      }
+      const startTime = new Date(meeting.start_time);
+      const durationMinutes = parseToInt(meeting.duration) ?? 0;
+      const endWithBuffer = new Date(startTime.getTime() + (durationMinutes + this.bufferMinutes) * 60 * 1000);
+      return now < endWithBuffer && startTime <= twoWeeksFromNow;
+    });
+  }
+
+  /**
+   * For each in-window meeting, emit a "Set RSVP" action when the user has no RSVP recorded or
+   * the recorded RSVP is "maybe". Per-occurrence RSVPs count as a response for the series — a
+   * user who has RSVPed any occurrence won't be nagged for a fresh top-level response.
+   */
+  private transformMissingRsvpsToActions(meetings: Meeting[], rsvps: MeetingRsvp[]): PendingActionItem[] {
+    if (meetings.length === 0) return [];
+
+    // Keep the strongest signal per meeting: accepted/declined beats maybe beats nothing.
+    const responseByMeeting = new Map<string, MeetingRsvp>();
+    for (const rsvp of rsvps) {
+      const existing = responseByMeeting.get(rsvp.meeting_id);
+      if (!existing || (existing.response_type === 'maybe' && rsvp.response_type !== 'maybe')) {
+        responseByMeeting.set(rsvp.meeting_id, rsvp);
+      }
+    }
+
+    const actions: PendingActionItem[] = [];
+    for (const meeting of meetings) {
+      if (!meeting.id) continue;
+      const rsvp = responseByMeeting.get(meeting.id);
+      if (rsvp && rsvp.response_type !== 'maybe') continue;
+      actions.push(this.createRsvpAction(meeting));
+    }
+    return actions;
+  }
+
+  /**
+   * Build a "Cast Vote" pending action per active vote. Links to the votes drawer on the
+   * My Activity page where casting actually happens — there's no standalone vote-detail route.
+   */
+  private transformVotesToActions(votes: Vote[]): PendingActionItem[] {
+    return votes.map((vote) => {
+      const endDate = new Date(vote.end_time);
+      const badge = endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+      const formattedEnd = endDate.toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+      });
+      return {
+        type: 'Cast Vote',
+        badge,
+        text: `Cast your vote on ${vote.name}`,
+        icon: 'fa-regular fa-check-to-slot',
+        severity: 'warn',
+        buttonText: 'Cast Vote',
+        buttonLink: '/my-activity',
+        date: `Closes ${formattedEnd}`,
+      };
+    });
+  }
+
+  /**
+   * Build a "Set RSVP" pending action for a single meeting. Links to the meeting detail page
+   * where the RSVP UI lives; reuses the meeting password query param like `createMeetingAction`.
+   */
+  private createRsvpAction(meeting: Meeting): PendingActionItem {
+    const startTime = new Date(meeting.start_time);
+    const badge = startTime.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    const formattedDate = startTime.toLocaleDateString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+
+    const params = new URLSearchParams();
+    if (meeting.password) params.set('password', meeting.password);
+    const queryString = params.toString();
+    const buttonLink = queryString ? `/meetings/${meeting.id}?${queryString}` : `/meetings/${meeting.id}`;
+
+    return {
+      type: 'Set RSVP',
+      badge,
+      text: `RSVP to ${meeting.title}`,
+      icon: 'fa-regular fa-calendar-check',
+      severity: 'warn',
+      buttonText: 'Set RSVP',
+      buttonLink,
+      date: formattedDate,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Follow-up to #539. Extends the persona-agnostic pending-actions aggregator with two new sources so the list reflects everything the user owes the system, not just surveys + upcoming meetings.

- **Pending votes** — active polls the user has been invited to but hasn't cast (`individual_vote` index, `vote_status='awaiting response'`, scoped to the active project, filtered to polls still `active` with `end_time` in the future)
- **Pending RSVPs** — meetings in the 2-week window where the user has no recorded RSVP or has RSVPed `'maybe'`

Backend-only. The existing display cap + hide-aware refill in `PendingActionsComponent` already handles variable sources, so no frontend changes are needed.

## Changes

### `apps/lfx-one/src/server/services/user.service.ts`

- `fetchPendingVotes` — queries `individual_vote` with `filters_or=[user_email, username]` for the caller, filters in-code to `vote_status === 'awaiting response'` scoped to the active `project_uid` (skipping `voter_removed` entries), then fetches `Vote` details in parallel and keeps only polls that are still `active` with `end_time > now`.
- `fetchUserRsvpsForMeetings` — batched per-user RSVP lookup. Uses `tags_or=[meeting_id:X, …]` chunked at 100 (URL-length guard) combined with `filters_or=[email, username]` so each request returns only the caller's RSVPs against the 2-week window's meetings.
- `filterMeetingsInWindow` — reuses the 2-week window logic so meeting-actions (Review Agenda) and RSVP-actions (Set RSVP) operate on the exact same set of meetings.
- `transformVotesToActions` — emits `Cast Vote` items linking to `/my-activity` (the votes drawer lives there — there's no standalone vote-detail route).
- `transformMissingRsvpsToActions` / `createRsvpAction` — emits `Set RSVP` items linking to `/meetings/{id}`. Skipped when the user has an accepted/declined RSVP; `maybe` is still treated as pending. Per-occurrence RSVPs count as a response for the series so users aren't nagged for each occurrence of a recurring meeting.
- `getUserPendingActions` — runs surveys / meetings / pending votes in parallel via `Promise.all` with per-source `.catch(() => [])` so one flaky source can't wipe the list. RSVP lookup fires after meetings return since it depends on the in-window meeting UIDs.

## Test plan

- [ ] Board member: pending actions card shows surveys + meetings + votes + RSVPs mixed, dismissal refills the window
- [ ] Maintainer: same (was already wired in #539)
- [ ] Contributor: same
- [ ] Vote cast → row disappears on next refresh (not immediately — individual_vote index refresh)
- [ ] RSVP set to accepted/declined → `Set RSVP` row disappears
- [ ] RSVP set to `maybe` → `Set RSVP` row stays (intentional)
- [ ] Meeting ends → Review Agenda row disappears
- [ ] With no active votes / no missing RSVPs: existing surveys + meetings still render unchanged
- [ ] One source failing (e.g., votes endpoint 500) → other sources still render; warning logged server-side

## Related

- Follows #539 (persona-agnostic aggregator)
- No upstream Go service changes — both sources read existing indexed data via `/query/resources`

🤖 Generated with [Claude Code](https://claude.ai/code)