### PR TITLE
feat(dashboards): add project staff card to foundation health

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
@@ -185,6 +185,13 @@
             }
           }
         }
+
+        <!-- Project Staff card — shown on 'all' (alongside metric cards) and 'staff' (solo) -->
+        @if (showStaffCard()) {
+          @if (selectedFoundation(); as foundation) {
+            <lfx-project-staff-card [projectUid]="foundation.uid" />
+          }
+        }
       </div>
 
       <!-- Right shadow fade -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -19,6 +19,7 @@ import { EventsDrawerComponent } from '../events-drawer/events-drawer.component'
 import { MaintainersDrawerComponent } from '../maintainers-drawer/maintainers-drawer.component';
 import { OrgDependencyDrawerComponent } from '../org-dependency-drawer/org-dependency-drawer.component';
 import { ProjectHealthScoresDrawerComponent } from '../project-health-scores-drawer/project-health-scores-drawer.component';
+import { ProjectStaffCardComponent } from '../project-staff-card/project-staff-card.component';
 import { TotalMembersDrawerComponent } from '../total-members-drawer/total-members-drawer.component';
 import { TotalProjectsDrawerComponent } from '../total-projects-drawer/total-projects-drawer.component';
 import { TotalValueDrawerComponent } from '../total-value-drawer/total-value-drawer.component';
@@ -39,6 +40,7 @@ import type {
     MetricCardComponent,
     DataCopilotComponent,
     ScrollShadowDirective,
+    ProjectStaffCardComponent,
     TotalValueDrawerComponent,
     TotalProjectsDrawerComponent,
     TotalMembersDrawerComponent,
@@ -92,7 +94,16 @@ export class FoundationHealthComponent {
     { id: 'contributors', label: 'Contribution' },
     { id: 'projects', label: 'Project' },
     { id: 'events', label: 'Event' },
+    { id: 'staff', label: 'Staff' },
   ];
+
+  // The Staff card sits in the same carousel as the metric cards. It renders on 'all' (alongside
+  // everything else) and on 'staff' (as the only card). Other filters hide it.
+  public readonly showStaffCard = computed(() => {
+    const filter = this.selectedFilter();
+    return filter === 'all' || filter === 'staff';
+  });
+  public readonly selectedFoundation = computed(() => this.projectContextService.selectedFoundation());
 
   public readonly sparklineOptions = BASE_LINE_CHART_OPTIONS;
   public readonly barChartOptions = BASE_BAR_CHART_OPTIONS;

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -172,6 +172,15 @@ export class FoundationHealthComponent {
   private initializeMetricCards() {
     return computed(() => {
       const filter = this.selectedFilter();
+
+      // Staff is a first-class filter with no backing metric-card — render the Project Staff card
+      // alone (handled by the template's `showStaffCard` branch). Returning [] explicitly avoids
+      // relying on the filter-by-category fallthrough below, which would silently re-break if a
+      // new card ever got the 'staff' category.
+      if (filter === 'staff') {
+        return [];
+      }
+
       const allCards = [
         { card: this.softwareValueCard(), category: 'projects' },
         { card: this.totalProjectsCard(), category: 'projects' },

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.html
@@ -27,6 +27,12 @@
           </div>
         }
       </div>
+    } @else if (hasError()) {
+      <div class="flex flex-col items-center justify-center gap-2 py-6" data-testid="project-staff-card-error">
+        <i class="fa-light fa-circle-exclamation text-xl text-red-400"></i>
+        <span class="text-xs text-gray-600">Couldn&apos;t load staff</span>
+        <span class="text-[11px] text-gray-400">Refresh the page to try again</span>
+      </div>
     } @else if (hasAnyStaff()) {
       <div class="flex flex-col divide-y divide-gray-100 flex-1 justify-around">
         @for (row of staff(); track row.key) {
@@ -40,7 +46,7 @@
             @if (row.user; as u) {
               <div class="flex items-center gap-2 min-w-0">
                 <lfx-avatar [image]="u.avatar ?? ''" [label]="u.name || u.email" shape="circle" size="normal" styleClass="w-6 h-6 text-xs" />
-                <span class="text-xs font-medium text-gray-900 truncate" [attr.title]="u.name">{{ u.name }}</span>
+                <span class="text-xs font-medium text-gray-900 truncate" [attr.title]="u.name || u.email">{{ u.name || u.email }}</span>
                 @if (u.email) {
                   <a
                     [href]="'mailto:' + u.email"

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.html
@@ -1,0 +1,68 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div
+  class="p-4 bg-white border border-gray-200 hover:border-blue-500 rounded-lg flex-shrink-0 h-full w-[calc(100vw-3rem)] md:w-80"
+  data-testid="project-staff-card-section">
+  <div class="flex flex-col gap-2 h-full">
+    <!-- Header: icon + title (matches lfx-metric-card layout) -->
+    <div class="flex items-center gap-2">
+      <i class="fa-light fa-users-gear w-4 h-4 text-gray-500 flex-shrink-0"></i>
+      <h5 class="text-sm font-medium flex-1">Project Staff</h5>
+    </div>
+
+    <!-- Body -->
+    @if (loading()) {
+      <div class="flex flex-col divide-y divide-gray-100">
+        @for (i of [0, 1, 2]; track i) {
+          <div class="flex items-center justify-between gap-2 py-2">
+            <div class="flex items-center gap-2 min-w-0">
+              <p-skeleton width="1rem" height="1rem" borderRadius="4px" />
+              <p-skeleton width="6rem" height="0.75rem" />
+            </div>
+            <div class="flex items-center gap-2">
+              <p-skeleton shape="circle" width="1.5rem" height="1.5rem" />
+              <p-skeleton width="4rem" height="0.75rem" />
+            </div>
+          </div>
+        }
+      </div>
+    } @else if (hasAnyStaff()) {
+      <div class="flex flex-col divide-y divide-gray-100 flex-1 justify-around">
+        @for (row of staff(); track row.key) {
+          <div class="flex items-center justify-between gap-2 py-2" [attr.data-testid]="'project-staff-card-row-' + row.key">
+            <!-- Role -->
+            <div class="flex items-center gap-2 min-w-0 shrink-0">
+              <i class="{{ row.icon }} text-gray-500 text-sm w-4 text-center shrink-0"></i>
+              <span class="text-xs font-medium text-gray-700 whitespace-nowrap">{{ row.label }}</span>
+            </div>
+            <!-- Person -->
+            @if (row.user; as u) {
+              <div class="flex items-center gap-2 min-w-0">
+                <lfx-avatar [image]="u.avatar ?? ''" [label]="u.name || u.email" shape="circle" size="normal" styleClass="w-6 h-6 text-xs" />
+                <span class="text-xs font-medium text-gray-900 truncate" [attr.title]="u.name">{{ u.name }}</span>
+                @if (u.email) {
+                  <a
+                    [href]="'mailto:' + u.email"
+                    class="shrink-0 text-gray-400 hover:text-blue-500 transition-colors"
+                    [attr.aria-label]="'Email ' + (u.name || u.email)"
+                    [attr.title]="u.email"
+                    (click)="$event.stopPropagation()">
+                    <i class="fa-light fa-envelope text-xs"></i>
+                  </a>
+                }
+              </div>
+            } @else {
+              <span class="text-xs text-gray-400">&mdash;</span>
+            }
+          </div>
+        }
+      </div>
+    } @else {
+      <div class="flex flex-col items-center justify-center gap-2 py-6" data-testid="project-staff-card-empty">
+        <i class="fa-light fa-user-slash text-xl text-gray-400"></i>
+        <span class="text-xs text-gray-500">No staff assigned</span>
+      </div>
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.ts
@@ -44,8 +44,7 @@ export class ProjectStaffCardComponent {
       switchMap((uid) =>
         this.permissionsService.getProjectSettings(uid).pipe(
           tap(() => this.loading.set(false)),
-          catchError((error) => {
-            console.error('Failed to fetch project settings:', error);
+          catchError(() => {
             this.loading.set(false);
             this.hasError.set(true);
             return of(null);

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.ts
@@ -1,0 +1,53 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { AvatarComponent } from '@components/avatar/avatar.component';
+import { ProjectSettings, UserInfo } from '@lfx-one/shared/interfaces';
+import { ProjectService } from '@services/project.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { filter, switchMap } from 'rxjs';
+
+interface StaffRow {
+  key: 'executive_director' | 'program_manager' | 'opportunity_owner';
+  label: string;
+  icon: string;
+  user: UserInfo | null | undefined;
+}
+
+@Component({
+  selector: 'lfx-project-staff-card',
+  imports: [AvatarComponent, SkeletonModule],
+  templateUrl: './project-staff-card.component.html',
+  styleUrl: './project-staff-card.component.scss',
+})
+export class ProjectStaffCardComponent {
+  private readonly projectService = inject(ProjectService);
+
+  public readonly projectUid = input.required<string>();
+
+  // Fetch the project settings document when `projectUid` becomes available. `filter` drops the
+  // empty string that `selectedProject()?.uid` can briefly emit before the project is resolved.
+  // The service catches HTTP errors and yields `null`, so `undefined` here means "still loading".
+  protected readonly settings: Signal<ProjectSettings | null | undefined> = toSignal(
+    toObservable(this.projectUid).pipe(
+      filter((uid): uid is string => !!uid),
+      switchMap((uid) => this.projectService.getProjectSettings(uid))
+    ),
+    { initialValue: undefined }
+  );
+
+  protected readonly loading = computed(() => this.settings() === undefined);
+
+  protected readonly staff: Signal<StaffRow[]> = computed(() => {
+    const s = this.settings();
+    return [
+      { key: 'executive_director', label: 'Executive Director', icon: 'fa-light fa-user-tie', user: s?.executive_director },
+      { key: 'program_manager', label: 'Program Manager', icon: 'fa-light fa-user-gear', user: s?.program_manager },
+      { key: 'opportunity_owner', label: 'Opportunity Owner', icon: 'fa-light fa-user-chart', user: s?.opportunity_owner },
+    ];
+  });
+
+  protected readonly hasAnyStaff = computed(() => this.staff().some((row) => !!row.user));
+}

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/project-staff-card.component.ts
@@ -1,13 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, input, Signal } from '@angular/core';
+import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { ProjectSettings, UserInfo } from '@lfx-one/shared/interfaces';
-import { ProjectService } from '@services/project.service';
+import { PermissionsService } from '@services/permissions.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { filter, switchMap } from 'rxjs';
+import { catchError, filter, of, switchMap, tap } from 'rxjs';
 
 interface StaffRow {
   key: 'executive_director' | 'program_manager' | 'opportunity_owner';
@@ -23,22 +23,38 @@ interface StaffRow {
   styleUrl: './project-staff-card.component.scss',
 })
 export class ProjectStaffCardComponent {
-  private readonly projectService = inject(ProjectService);
+  private readonly permissionsService = inject(PermissionsService);
 
   public readonly projectUid = input.required<string>();
 
-  // Fetch the project settings document when `projectUid` becomes available. `filter` drops the
-  // empty string that `selectedProject()?.uid` can briefly emit before the project is resolved.
-  // The service catches HTTP errors and yields `null`, so `undefined` here means "still loading".
-  protected readonly settings: Signal<ProjectSettings | null | undefined> = toSignal(
+  // `loading` and `hasError` are tracked separately from `settings` so the template can tell the
+  // three states apart: still fetching, fetch failed, fetch succeeded with no staff assigned.
+  // Bundling them into `null`-means-both (previous approach) hid genuine fetch failures behind the
+  // "No staff assigned" empty state.
+  protected readonly loading = signal(true);
+  protected readonly hasError = signal(false);
+
+  protected readonly settings: Signal<ProjectSettings | null> = toSignal(
     toObservable(this.projectUid).pipe(
       filter((uid): uid is string => !!uid),
-      switchMap((uid) => this.projectService.getProjectSettings(uid))
+      tap(() => {
+        this.loading.set(true);
+        this.hasError.set(false);
+      }),
+      switchMap((uid) =>
+        this.permissionsService.getProjectSettings(uid).pipe(
+          tap(() => this.loading.set(false)),
+          catchError((error) => {
+            console.error('Failed to fetch project settings:', error);
+            this.loading.set(false);
+            this.hasError.set(true);
+            return of(null);
+          })
+        )
+      )
     ),
-    { initialValue: undefined }
+    { initialValue: null }
   );
-
-  protected readonly loading = computed(() => this.settings() === undefined);
 
   protected readonly staff: Signal<StaffRow[]> = computed(() => {
     const s = this.settings();

--- a/apps/lfx-one/src/app/shared/services/permissions.service.ts
+++ b/apps/lfx-one/src/app/shared/services/permissions.service.ts
@@ -4,13 +4,17 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { AddUserToProjectRequest, ProjectPermissionUser, ProjectSettings, UpdateUserRoleRequest } from '@lfx-one/shared/interfaces';
-import { map, Observable } from 'rxjs';
+import { map, Observable, shareReplay } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
 })
 export class PermissionsService {
   private readonly http = inject(HttpClient);
+  // Per-UID cache so repeat mounts of the staff card don't re-hit the endpoint. Mirrors the
+  // getProject / getProjects pattern in ProjectService. shareReplay(1) replays the last emission
+  // (success or error) to late subscribers; a page refresh clears the cache for retries.
+  private readonly projectSettingsCache = new Map<string, Observable<ProjectSettings>>();
 
   // Add user to project with specified role
   public addUserToProject(project: string, request: AddUserToProjectRequest): Observable<void> {
@@ -27,9 +31,19 @@ export class PermissionsService {
     return this.http.delete<void>(`/api/projects/${project}/permissions/${username}`);
   }
 
+  // Fetch the raw project settings document. Errors are NOT caught here — callers track their own
+  // loading/error state so they can distinguish "fetch failed" from "settings loaded with no staff".
+  public getProjectSettings(uid: string): Observable<ProjectSettings> {
+    if (!this.projectSettingsCache.has(uid)) {
+      const settings$ = this.http.get<ProjectSettings>(`/api/projects/${uid}/permissions`).pipe(shareReplay(1));
+      this.projectSettingsCache.set(uid, settings$);
+    }
+    return this.projectSettingsCache.get(uid)!;
+  }
+
   // Fetch all user permissions for a project and transform to display format
   public getProjectPermissions(project: string): Observable<ProjectPermissionUser[]> {
-    return this.http.get<ProjectSettings>(`/api/projects/${project}/permissions`).pipe(
+    return this.getProjectSettings(project).pipe(
       map((settings: ProjectSettings) => {
         const users: ProjectPermissionUser[] = [];
 

--- a/apps/lfx-one/src/app/shared/services/permissions.service.ts
+++ b/apps/lfx-one/src/app/shared/services/permissions.service.ts
@@ -4,7 +4,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { AddUserToProjectRequest, ProjectPermissionUser, ProjectSettings, UpdateUserRoleRequest } from '@lfx-one/shared/interfaces';
-import { map, Observable, shareReplay } from 'rxjs';
+import { catchError, map, Observable, shareReplay, throwError } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -12,8 +12,8 @@ import { map, Observable, shareReplay } from 'rxjs';
 export class PermissionsService {
   private readonly http = inject(HttpClient);
   // Per-UID cache so repeat mounts of the staff card don't re-hit the endpoint. Mirrors the
-  // getProject / getProjects pattern in ProjectService. shareReplay(1) replays the last emission
-  // (success or error) to late subscribers; a page refresh clears the cache for retries.
+  // getProject / getProjects pattern in ProjectService. On error the cache entry is evicted so
+  // the next subscription retries with a fresh request instead of replaying the stuck error.
   private readonly projectSettingsCache = new Map<string, Observable<ProjectSettings>>();
 
   // Add user to project with specified role
@@ -31,11 +31,19 @@ export class PermissionsService {
     return this.http.delete<void>(`/api/projects/${project}/permissions/${username}`);
   }
 
-  // Fetch the raw project settings document. Errors are NOT caught here — callers track their own
+  // Fetch the raw project settings document. Errors are NOT swallowed — callers track their own
   // loading/error state so they can distinguish "fetch failed" from "settings loaded with no staff".
+  // The cache entry is evicted on error so a transient failure (network blip, 5xx) doesn't poison
+  // the cache and block retries for other consumers (e.g., getProjectPermissions below) on the same UID.
   public getProjectSettings(uid: string): Observable<ProjectSettings> {
     if (!this.projectSettingsCache.has(uid)) {
-      const settings$ = this.http.get<ProjectSettings>(`/api/projects/${uid}/permissions`).pipe(shareReplay(1));
+      const settings$ = this.http.get<ProjectSettings>(`/api/projects/${uid}/permissions`).pipe(
+        catchError((error) => {
+          this.projectSettingsCache.delete(uid);
+          return throwError(() => error);
+        }),
+        shareReplay(1)
+      );
       this.projectSettingsCache.set(uid, settings$);
     }
     return this.projectSettingsCache.get(uid)!;

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
-import { PendingActionItem, Project } from '@lfx-one/shared/interfaces';
+import { PendingActionItem, Project, ProjectSettings } from '@lfx-one/shared/interfaces';
 import { BehaviorSubject, catchError, Observable, of, shareReplay, tap } from 'rxjs';
 
 @Injectable({
@@ -88,6 +88,15 @@ export class ProjectService {
       catchError((error) => {
         console.error('Failed to fetch pending actions:', error);
         return of([]);
+      })
+    );
+  }
+
+  public getProjectSettings(uid: string): Observable<ProjectSettings | null> {
+    return this.http.get<ProjectSettings>(`/api/projects/${uid}/permissions`).pipe(
+      catchError((error) => {
+        console.error('Failed to fetch project settings:', error);
+        return of(null);
       })
     );
   }

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
-import { PendingActionItem, Project, ProjectSettings } from '@lfx-one/shared/interfaces';
+import { PendingActionItem, Project } from '@lfx-one/shared/interfaces';
 import { BehaviorSubject, catchError, Observable, of, shareReplay, tap } from 'rxjs';
 
 @Injectable({
@@ -88,15 +88,6 @@ export class ProjectService {
       catchError((error) => {
         console.error('Failed to fetch pending actions:', error);
         return of([]);
-      })
-    );
-  }
-
-  public getProjectSettings(uid: string): Observable<ProjectSettings | null> {
-    return this.http.get<ProjectSettings>(`/api/projects/${uid}/permissions`).pipe(
-      catchError((error) => {
-        console.error('Failed to fetch project settings:', error);
-        return of(null);
       })
     );
   }

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -45,6 +45,9 @@ export interface ProjectSettings {
   announcement_date: string;
   writers: UserInfo[];
   auditors: UserInfo[];
+  executive_director?: UserInfo | null;
+  program_manager?: UserInfo | null;
+  opportunity_owner?: UserInfo | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

Adds a "Project Staff" card to the Foundation Health section on the Foundation Lens (`/foundation/overview`). A new **Staff** filter pill joins All / Contribution / Project / Event — it's visible on the **All** filter alongside the metric cards, and shown solo on **Staff**.

Each card row renders the role label, an avatar (with initials fallback when the user has no avatar), the person's name, and a mailto envelope. Missing roles render an em dash; when all three are unassigned the card shows a "No staff assigned" empty state.

Visible to everyone who can view the Foundation Overview — no additional persona / role gating.

## Upstream dependency

Depends on the three new nullable `UserInfo` fields added to `ProjectSettings` in `lfx-v2-project-service`:

- `executive_director`
- `program_manager`
- `opportunity_owner`

`GET /projects/:uid/settings` now returns them. The Express proxy (`apps/lfx-one/src/server/services/project.service.ts`) was already pass-through, so no backend changes were needed on this repo — only the shared TypeScript interface and a new frontend service method.

## Changes

- `packages/shared/src/interfaces/project.interface.ts` — +3 optional `UserInfo | null` fields on `ProjectSettings`
- `apps/lfx-one/src/app/shared/services/permissions.service.ts` — new `getProjectSettings(uid)` method with per-UID `shareReplay(1)` cache (error-evicting); `getProjectPermissions()` refactored to consume it as a single source of truth. Endpoint path is `/api/projects/:uid/permissions` (Express proxy route; proxies upstream to `/projects/:uid/settings`)
- `apps/lfx-one/src/app/modules/dashboards/components/project-staff-card/` — new component (3 files): metric-card-sized layout with 3 divided rows + loading / error / empty states
- `apps/lfx-one/src/app/modules/dashboards/components/foundation-health/` — new **Staff** filter pill + card wired into the existing metric-card carousel

## Test plan

- [ ] Visit `/foundation/overview`, confirm the **Staff** pill appears at the end of the filter row
- [ ] On **All**, the Project Staff card renders as the last card in the carousel (same size as other metric cards)
- [ ] On **Staff**, only the Project Staff card renders
- [ ] On **Contribution / Project / Event**, the Project Staff card does NOT render
- [ ] When a role is assigned, the row shows avatar + name + envelope icon; clicking the envelope opens the mail client and does not trigger any parent click
- [ ] When a role is unassigned, the row shows an em dash
- [ ] When all three roles are null, the card shows "No staff assigned"
- [ ] On fetch failure, the card shows the "Couldn't load staff" error state (refresh retries via cache-eviction-on-error)
- [ ] Initials fallback renders when `avatar` is missing/broken
- [ ] Loading skeleton appears during the initial fetch
- [ ] Works for both ED persona and Board Member persona on the Foundation Lens

Refs: LFXV2-1541

🤖 Generated with [Claude Code](https://claude.com/claude-code)
