### PR TITLE
fix(dashboard): remove dueLabel filler from drawer actions

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -107,7 +107,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -127,7 +127,7 @@ export class BrandHealthDrawerComponent {
           title: 'Address negative sentiment spike',
           description: `${sentiment.negative.toFixed(1)}% of mentions are negative — investigate top themes and coordinate response`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       }
@@ -137,7 +137,7 @@ export class BrandHealthDrawerComponent {
           title: 'Sentiment trending down',
           description: `Positive sentiment dropped ${Math.abs(sentimentMomChangePp).toFixed(1)}pp month-over-month — review recent coverage drivers`,
           priority: 'medium',
-          dueLabel: 'This month',
+
           actionType: 'engagement',
         });
       }
@@ -147,7 +147,7 @@ export class BrandHealthDrawerComponent {
           title: 'Maintain brand sentiment momentum',
           description: `${formatNumber(totalMentions)} mentions with ${sentiment.positive.toFixed(0)}% positive sentiment`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
@@ -87,7 +87,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
@@ -82,7 +82,7 @@ export class BrandReachDrawerComponent {
             title: 'Reduce platform concentration risk',
             description: `${top.name} holds ${topShare.toFixed(0)}% of ${formatNumber(totalSocialFollowers)} followers — a platform policy change could halve reach. Grow the next 2 largest channels`,
             priority: 'high',
-            dueLabel: 'This quarter',
+
             actionType: 'decline',
           });
         } else if (topShare > 55) {
@@ -90,7 +90,7 @@ export class BrandReachDrawerComponent {
             title: 'Watch platform concentration',
             description: `${top.name} is ${topShare.toFixed(0)}% of total followers — diversify before it crosses 70%`,
             priority: 'medium',
-            dueLabel: 'Next quarter',
+
             actionType: 'engagement',
           });
         }
@@ -102,7 +102,7 @@ export class BrandReachDrawerComponent {
           title: 'Expand platform footprint',
           description: `Active on only ${activePlatforms} platform${activePlatforms === 1 ? '' : 's'} — evaluate adding complementary networks to reduce single-network risk`,
           priority: 'medium',
-          dueLabel: 'This quarter',
+
           actionType: 'engagement',
         });
       }
@@ -116,7 +116,7 @@ export class BrandReachDrawerComponent {
             title: 'Web traffic over-reliant on one domain',
             description: `${topDomain.domain} drives ${topDomainShare.toFixed(0)}% of sessions — invest in secondary properties and cross-linking`,
             priority: 'medium',
-            dueLabel: 'This quarter',
+
             actionType: 'engagement',
           });
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -89,7 +89,6 @@
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-                <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -251,7 +251,7 @@ export class EmailCtrDrawerComponent {
           title: 'Test new call-to-action formats',
           description: `CTR dropped ${Math.abs(changePercentage)}% — experiment with button placement and copy in the next send`,
           priority: 'high',
-          dueLabel: 'Next send',
+
           actionType: 'optimize',
         });
       }
@@ -266,7 +266,7 @@ export class EmailCtrDrawerComponent {
             title: 'Optimize email subject lines',
             description: `Open rate declined from ${prevOpenRate.toFixed(1)}% to ${latestOpenRate.toFixed(1)}% — A/B test subject lines`,
             priority: latestOpenRate < prevOpenRate * 0.9 ? 'high' : 'medium',
-            dueLabel: 'Next send',
+
             actionType: 'content',
           });
         }
@@ -281,7 +281,7 @@ export class EmailCtrDrawerComponent {
             title: `Replicate "${best.campaignName}" approach`,
             description: `Top campaign has ${best.avgCtr.toFixed(1)}% CTR vs ${worst.avgCtr.toFixed(1)}% for "${worst.campaignName}" — apply winning format`,
             priority: 'medium',
-            dueLabel: 'This month',
+
             actionType: 'optimize',
           });
         }
@@ -292,7 +292,7 @@ export class EmailCtrDrawerComponent {
           title: 'Maintain current momentum',
           description: `CTR is trending up (+${changePercentage}%) — continue current content strategy`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -78,7 +78,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -205,7 +205,7 @@ export class EngagedCommunityDrawerComponent {
           title: 'Address community decline',
           description: `Engaged community dropped ${Math.abs(changePercentage).toFixed(1)}% vs last month — review engagement programs and onboarding flow`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       }
@@ -218,7 +218,7 @@ export class EngagedCommunityDrawerComponent {
             title: 'Grow working group participation',
             description: `Working groups hold only ${wgShare.toFixed(0)}% of engaged members (${formatNumber(breakdown.workingGroupMembers)}) — convert passive community members into active contributors`,
             priority: 'medium',
-            dueLabel: 'This quarter',
+
             actionType: 'engagement',
           });
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -128,7 +128,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
@@ -149,7 +149,7 @@ export class EventGrowthDrawerComponent {
           title: 'Reverse attendance decline',
           description: `Attendance dropped ${Math.abs(attendeeYoyChange).toFixed(1)}% YoY — review event mix, promotion windows, and channel performance`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       } else if (attendeeYoyChange <= -3) {
@@ -157,7 +157,7 @@ export class EventGrowthDrawerComponent {
           title: 'Attendance softening',
           description: `Attendance down ${Math.abs(attendeeYoyChange).toFixed(1)}% YoY — watch next event's registration pace`,
           priority: 'medium',
-          dueLabel: 'Next event',
+
           actionType: 'investigate',
         });
       }
@@ -168,7 +168,7 @@ export class EventGrowthDrawerComponent {
           title: 'Event revenue declining',
           description: `Total event revenue down ${Math.abs(revenueYoyChange).toFixed(1)}% YoY${revenuePerAttendeeText} — review sponsorship packages and ticket pricing`,
           priority: 'medium',
-          dueLabel: 'This quarter',
+
           actionType: 'revenue',
         });
       }
@@ -181,7 +181,7 @@ export class EventGrowthDrawerComponent {
             title: 'One event carries the portfolio',
             description: `${leadEvent.name} drives ${topShare.toFixed(0)}% of total attendance — a single weak year on this event would hit the whole portfolio`,
             priority: 'medium',
-            dueLabel: 'Next planning cycle',
+
             actionType: 'engagement',
           });
         }
@@ -195,7 +195,7 @@ export class EventGrowthDrawerComponent {
             title: 'Registrations falling 3 quarters straight',
             description: `Quarterly registrations fell from ${formatNumber(recent3[0].value)} to ${formatNumber(recent3[2].value)} — sustained decline, not a single bad event`,
             priority: 'high',
-            dueLabel: 'This quarter',
+
             actionType: 'decline',
           });
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -86,7 +86,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -108,7 +108,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -171,7 +171,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Reverse acquisition decline',
           description: `New member signups dropped ${Math.abs(changePercentage).toFixed(1)}% QoQ — review top-of-funnel channels, conversion paths, and outbound pipeline`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       } else if (changePercentage <= -5) {
@@ -179,7 +179,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Acquisition softening',
           description: `New member signups down ${Math.abs(changePercentage).toFixed(1)}% QoQ — watch next quarter's pipeline and renewal mix`,
           priority: 'medium',
-          dueLabel: 'Next quarter',
+
           actionType: 'investigate',
         });
       }
@@ -198,7 +198,6 @@ export class MemberAcquisitionDrawerComponent {
               title: 'Membership tier mix shifting down',
               description: `Revenue per new member fell ${declinePct.toFixed(0)}% (${formatCurrency(Math.abs(delta))}/member) — winning deals are smaller. Review tier positioning and sales qualification`,
               priority: 'high',
-              dueLabel: 'This quarter',
               actionType: 'revenue',
             });
           } else if (declinePct >= 5) {
@@ -206,7 +205,7 @@ export class MemberAcquisitionDrawerComponent {
               title: 'Watch tier mix trend',
               description: `Revenue per new member down ${declinePct.toFixed(0)}% QoQ — not yet urgent, but track whether next quarter's deals are smaller still`,
               priority: 'medium',
-              dueLabel: 'Next quarter',
+
               actionType: 'revenue',
             });
           }
@@ -337,7 +336,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Improve net revenue retention',
           description: `NRR at ${netRevenueRetention}% — significant revenue loss from existing members. Review downgrades and churn`,
           priority: 'high',
-          dueLabel: 'This quarter',
+
           actionType: 'revenue',
         });
       } else if (netRevenueRetention >= 90 && netRevenueRetention < 98) {
@@ -345,7 +344,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Monitor net revenue retention',
           description: `NRR at ${netRevenueRetention}% — revenue contraction from existing members. Explore upsell opportunities`,
           priority: 'medium',
-          dueLabel: 'Next quarter',
+
           actionType: 'revenue',
         });
       }
@@ -355,7 +354,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Address retention decline',
           description: `Renewal rate dropped ${Math.abs(changePercentage)}% — review member satisfaction and renewal outreach timing`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       }
@@ -365,7 +364,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Maintain retention excellence',
           description: `${renewalRate}% renewal rate${netRevenueRetention > 100 ? ` with ${netRevenueRetention}% NRR` : ''}`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -84,7 +84,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -67,7 +67,7 @@ export class MemberRetentionDrawerComponent {
           title: 'Improve net revenue retention',
           description: `NRR at ${netRevenueRetention}% — significant revenue loss from existing members. Review downgrades and churn`,
           priority: 'high',
-          dueLabel: 'This quarter',
+
           actionType: 'revenue',
         });
       } else if (netRevenueRetention >= 90 && netRevenueRetention < 98) {
@@ -75,7 +75,7 @@ export class MemberRetentionDrawerComponent {
           title: 'Monitor net revenue retention',
           description: `NRR at ${netRevenueRetention}% — revenue contraction from existing members. Explore upsell opportunities`,
           priority: 'medium',
-          dueLabel: 'Next quarter',
+
           actionType: 'revenue',
         });
       }
@@ -86,7 +86,7 @@ export class MemberRetentionDrawerComponent {
           title: 'Address retention decline',
           description: `Renewal rate dropped ${Math.abs(changePercentage)}% — review member satisfaction and renewal outreach timing`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       }
@@ -96,7 +96,7 @@ export class MemberRetentionDrawerComponent {
           title: 'Maintain retention excellence',
           description: `${renewalRate}% renewal rate${netRevenueRetention > 100 ? ` with ${netRevenueRetention}% NRR` : ''}`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
@@ -98,7 +98,6 @@
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-                <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -200,7 +200,7 @@ export class PaidSocialReachDrawerComponent {
           title: 'Cut or pause losing campaigns',
           description: `ROAS is ${roas.toFixed(2)}x — ${formatCurrency(lost)} spent above revenue earned. Pause bottom-performing campaigns before next cycle`,
           priority: 'high',
-          dueLabel: 'This week',
+
           actionType: 'decline',
         });
       } else if (totalSpend > 0 && roas >= 0.8 && roas < 1) {
@@ -208,7 +208,7 @@ export class PaidSocialReachDrawerComponent {
           title: 'Campaigns at break-even',
           description: `ROAS is ${roas.toFixed(2)}x on ${formatCurrency(totalSpend)} spend — not yet profitable. Fix creative and targeting before scaling budget`,
           priority: 'medium',
-          dueLabel: 'This month',
+
           actionType: 'investigate',
         });
       }
@@ -223,7 +223,7 @@ export class PaidSocialReachDrawerComponent {
             title: 'ROAS trending down 3 months straight',
             description: `ROAS fell from ${recent3[0].toFixed(2)}x to ${recent3[2].toFixed(2)}x over 3 months — investigate audience saturation and creative fatigue`,
             priority: 'medium',
-            dueLabel: 'This month',
+
             actionType: 'investigate',
           });
         }
@@ -235,7 +235,7 @@ export class PaidSocialReachDrawerComponent {
           title: 'Investigate reach decline',
           description: `Impressions dropped ${Math.abs(changePercentage).toFixed(1)}% MoM — review targeting, bid strategy, and platform algorithm changes`,
           priority: 'high',
-          dueLabel: 'Next campaign',
+
           actionType: 'investigate',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.html
@@ -53,7 +53,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
@@ -252,7 +252,7 @@ export class RevenueImpactDrawerComponent {
           title: 'Cut or pause losing paid campaigns',
           description: `Paid ROAS is ${paidMedia.roas.toFixed(2)}x — ${RevenueImpactDrawerComponent.formatRevenue(lost)} spent above revenue earned. Review top-spending campaigns and pause underperformers`,
           priority: 'high',
-          dueLabel: 'This week',
+
           actionType: 'decline',
         });
       } else if (paidMedia.adSpend > 0 && paidMedia.roas >= 0.8 && paidMedia.roas < 1) {
@@ -260,7 +260,7 @@ export class RevenueImpactDrawerComponent {
           title: 'Paid media at break-even',
           description: `ROAS is ${paidMedia.roas.toFixed(2)}x on ${RevenueImpactDrawerComponent.formatRevenue(paidMedia.adSpend)} spend — optimize creative and targeting before scaling`,
           priority: 'medium',
-          dueLabel: 'This month',
+
           actionType: 'investigate',
         });
       }
@@ -272,7 +272,7 @@ export class RevenueImpactDrawerComponent {
             title: 'Reduce channel concentration risk',
             description: `${RevenueImpactDrawerComponent.formatChannelLabel(top.channel)} drives ${top.percentage.toFixed(0)}% of paid impressions — one algorithm change could cut reach in half. Grow at least one alternate channel`,
             priority: 'high',
-            dueLabel: 'This quarter',
+
             actionType: 'decline',
           });
         } else if (top.percentage > 55) {
@@ -280,7 +280,7 @@ export class RevenueImpactDrawerComponent {
             title: 'Watch channel concentration',
             description: `${RevenueImpactDrawerComponent.formatChannelLabel(top.channel)} is ${top.percentage.toFixed(0)}% of paid impressions — diversify before it crosses 70%`,
             priority: 'medium',
-            dueLabel: 'This quarter',
+
             actionType: 'engagement',
           });
         }
@@ -297,7 +297,7 @@ export class RevenueImpactDrawerComponent {
             title: 'Rebalance project-level channel mix',
             description: `${heavilyConcentrated.length} projects get 80%+ of their paid reach from a single channel — rebalance to reduce per-project platform dependency`,
             priority: 'medium',
-            dueLabel: 'Next quarter',
+
             actionType: 'engagement',
           });
         }
@@ -313,7 +313,7 @@ export class RevenueImpactDrawerComponent {
               title: 'Event registration revenue over-concentrated',
               description: `${topEvt.channel} drove ${topShare.toFixed(0)}% of event-registration last-touch revenue (${RevenueImpactDrawerComponent.formatRevenue(topEvt.lastTouchRevenue ?? 0)}) — grow alternate acquisition paths for event revenue`,
               priority: 'medium',
-              dueLabel: 'Next quarter',
+
               actionType: 'engagement',
             });
           }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -95,7 +95,6 @@
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-                <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -219,7 +219,7 @@ export class SocialMediaDrawerComponent {
           title: `Increase posting on ${highEngageLowPost.platform}`,
           description: `${highEngageLowPost.engagementRate.toFixed(1)}% engagement rate but only ${highEngageLowPost.postsLast30Days} posts in 30 days`,
           priority: 'high',
-          dueLabel: 'This week',
+
           actionType: 'content',
         });
       }
@@ -229,7 +229,7 @@ export class SocialMediaDrawerComponent {
           title: 'Address follower decline',
           description: `Followers dropped ${Math.abs(changePercentage)}% — review content strategy and posting cadence`,
           priority: 'high',
-          dueLabel: 'This week',
+
           actionType: 'decline',
         });
       }
@@ -243,7 +243,7 @@ export class SocialMediaDrawerComponent {
             title: `Boost engagement on ${lowest.platform}`,
             description: `${formatNumber(lowest.followers)} followers but only ${lowest.engagementRate.toFixed(1)}% engagement — try interactive content`,
             priority: 'medium',
-            dueLabel: 'This month',
+
             actionType: 'engagement',
           });
         }
@@ -254,7 +254,7 @@ export class SocialMediaDrawerComponent {
           title: 'Continue growth strategy',
           description: `${formatNumber(totalFollowers)} followers across ${platforms.length} platforms${changePercentage > 0 ? ` — growing ${changePercentage}%` : ''}`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -80,7 +80,6 @@
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-                <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -192,7 +192,7 @@ export class WebsiteVisitsDrawerComponent {
             title: 'Investigate traffic decline',
             description: `Sessions dropped ~${decline}% over recent weeks — review traffic sources and content changes`,
             priority: 'high',
-            dueLabel: 'This month',
+
             actionType: 'decline',
           });
         }
@@ -207,7 +207,7 @@ export class WebsiteVisitsDrawerComponent {
             title: `Diversify traffic beyond ${sorted[0].domainGroup}`,
             description: `${topShare.toFixed(0)}% of sessions come from a single domain — expand content across other properties`,
             priority: 'medium',
-            dueLabel: 'This month',
+
             actionType: 'diversify',
           });
         }
@@ -221,7 +221,7 @@ export class WebsiteVisitsDrawerComponent {
             title: 'Improve internal linking',
             description: `Only ${pagesPerSession.toFixed(1)} pages per session — add cross-links to increase engagement`,
             priority: 'medium',
-            dueLabel: 'This month',
+
             actionType: 'optimize',
           });
         }
@@ -232,7 +232,7 @@ export class WebsiteVisitsDrawerComponent {
           title: 'Continue current strategy',
           description: `${formatNumber(totalSessions)} sessions with healthy traffic distribution`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2677,7 +2677,6 @@ export interface MarketingRecommendedAction {
   title: string;
   description: string;
   priority: 'high' | 'medium' | 'low';
-  dueLabel: string;
   actionType: MarketingActionType;
 }
 

--- a/packages/shared/src/utils/flywheel.utils.ts
+++ b/packages/shared/src/utils/flywheel.utils.ts
@@ -120,7 +120,7 @@ export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse
         title: 'Improve working group re-engagement path',
         description: `WG re-engagement at ${wgRate.toFixed(1)}% vs ${communityRate.toFixed(1)}% for community — attendees need clearer path to participate`,
         priority: 'high',
-        dueLabel: 'This quarter',
+
         actionType: 'conversion',
       });
     }
@@ -131,7 +131,7 @@ export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse
       title: 'Address re-engagement rate decline',
       description: `Re-engagement dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% MoM — review post-event follow-up effectiveness`,
       priority: 'high',
-      dueLabel: 'This month',
+
       actionType: 'decline',
     });
   }
@@ -141,7 +141,7 @@ export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse
       title: 'Add post-event engagement CTAs',
       description: `Only ${reengagement.reengagementRate.toFixed(1)}% re-engagement — add community join and working group prompts to event follow-ups`,
       priority: 'medium',
-      dueLabel: 'Next event',
+
       actionType: 'content',
     });
   }
@@ -152,7 +152,7 @@ export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse
       title: 'Continue flywheel optimization',
       description: `${reengagement.reengagementRate.toFixed(1)}% re-engagement rate${growthSuffix} across ${formatNumber(attendees)} attendees`,
       priority: 'low',
-      dueLabel: 'Ongoing',
+
       actionType: 'growth',
     });
   }


### PR DESCRIPTION
## Summary
- Removed `dueLabel` from `MarketingRecommendedAction` interface in `analytics-data.interface.ts`
- Removed `dueLabel` from all 12 ED drawer components (HTML templates and TS action builders)
- Removed `dueLabel` from `buildFlywheelRecommendedActions()` in `flywheel.utils.ts`

PR 1 of 2 for drawer polish work.

LFXV2-1468

## Test plan
- [ ] Verify all 12 ED drawers render without errors (no `dueLabel` binding crash)
- [ ] Verify recommended actions section no longer shows "Due:" labels
- [ ] Confirm no TypeScript compilation errors

Generated with [Claude Code](https://claude.ai/code)