### PR TITLE
feat(dashboard): add attribution and rewrite email drawer

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -12,8 +12,8 @@
   <ng-template #header>
     <div class="flex items-start justify-between gap-4 w-full" data-testid="email-ctr-drawer-header">
       <div class="flex flex-col gap-1 flex-1">
-        <h2 class="text-lg font-semibold text-gray-900" data-testid="email-ctr-drawer-title">Email Click-Through Rate</h2>
-        <p class="text-sm text-gray-500">Executive Director · Marketing view</p>
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="email-ctr-drawer-title">Campaign Performance</h2>
+        <p class="text-sm text-gray-500">Executive Director · Performance across channels</p>
       </div>
       <lfx-button
         icon="fa-light fa-xmark"
@@ -39,32 +39,7 @@
         <p-skeleton width="60%" height="1rem" />
       </div>
     } @else {
-      <!-- Summary Stats -->
-      <div class="flex gap-4" data-testid="email-ctr-drawer-stats">
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Current CTR</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ drawerData().currentCtr | number: '1.1-1' }}%</span>
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">vs 6-Month Avg</span>
-            @if (drawerData().changePercentage !== 0) {
-              <div class="flex items-center gap-2">
-                <span class="text-2xl font-semibold" [class]="drawerData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ drawerData().changePercentage > 0 ? '+' : '' }}{{ drawerData().changePercentage | number: '1.1-1' }}%
-                </span>
-                <i class="text-sm" [class]="drawerData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
-              </div>
-            } @else {
-              <span class="text-2xl font-semibold text-gray-500">0%</span>
-            }
-          </div>
-        </lfx-card>
-      </div>
-
-      <!-- FIRST FOLD: Needs Your Attention -->
+      <!-- Cross-Channel Insights -->
       @if (attentionActions().length > 0 || attentionInsights().length > 0) {
         <div class="flex flex-col gap-4 p-4 bg-red-50 border border-red-200 rounded-lg" data-testid="email-ctr-drawer-attention">
           <div class="flex items-center gap-2">
@@ -102,7 +77,6 @@
         </div>
       }
 
-      <!-- SECOND FOLD: Performing Well -->
       @if (performingActions().length > 0 || performingInsights().length > 0) {
         <div class="flex flex-col gap-4 p-4 bg-green-50 border border-green-200 rounded-lg" data-testid="email-ctr-drawer-performing">
           <div class="flex items-center gap-2">
@@ -137,56 +111,328 @@
         </div>
       }
 
-      <!-- Monthly Trend Chart -->
-      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-chart-section">
-        <div class="flex flex-col gap-1">
-          <h3 class="text-sm font-semibold text-gray-900">Monthly CTR Trend</h3>
-          <p class="text-sm text-gray-600">Email click-through rate over the last 6 months</p>
-        </div>
-        @if (drawerData().monthlyData.length > 0) {
-          <div class="h-[240px]" data-testid="email-ctr-drawer-chart">
-            <lfx-chart type="bar" [data]="chartData()" [options]="chartOptions" height="100%"></lfx-chart>
+      @if (attributionData().channels.length > 0) {
+        <div class="flex flex-col gap-5" data-testid="email-ctr-drawer-attribution-section">
+          <div class="flex items-center gap-2">
+            <i class="fa-light fa-chart-mixed text-indigo-500"></i>
+            <h3 class="text-base font-semibold text-gray-900">Marketing Attribution</h3>
           </div>
-        } @else {
-          <div class="text-center py-8 border border-slate-200 rounded-lg">
-            <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-            <p class="text-sm text-gray-500">No CTR data available</p>
+
+          <!-- Attribution Summary Stats -->
+          <div class="flex flex-wrap gap-4" data-testid="email-ctr-drawer-attribution-stats">
+            <lfx-card styleClass="flex-1 min-w-[100px]">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Total Sessions</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ formatCompact(attributionTotals().sessions) }}</span>
+              </div>
+            </lfx-card>
+            <lfx-card styleClass="flex-1 min-w-[100px]">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">First Touch</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ formatCurrency(attributionTotals().firstTouchRevenue) }}</span>
+              </div>
+            </lfx-card>
+            <lfx-card styleClass="flex-1 min-w-[100px]">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Last Touch</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ formatCurrency(attributionTotals().lastTouchRevenue) }}</span>
+              </div>
+            </lfx-card>
+            <lfx-card styleClass="flex-1 min-w-[100px]">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Linear</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ formatCurrency(attributionTotals().linearRevenue) }}</span>
+              </div>
+            </lfx-card>
+            <lfx-card styleClass="flex-1 min-w-[100px]">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Time Decay</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ formatCurrency(attributionTotals().timeDecayRevenue) }}</span>
+              </div>
+            </lfx-card>
+          </div>
+
+          <!-- Channel Attribution Table -->
+          <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-attribution-table">
+            <div class="flex flex-col gap-1">
+              <h3 class="text-sm font-semibold text-gray-900">Revenue by Channel</h3>
+              <p class="text-sm text-gray-600">Multi-touch attribution across marketing channels over the last 6 months</p>
+            </div>
+
+            <!-- Table Header -->
+            <div class="flex items-center py-2 px-1 text-[10px] font-semibold text-gray-500 uppercase tracking-wider border-b border-gray-200">
+              <span class="flex-[2] min-w-[120px]">Channel</span>
+              <span class="flex-1 text-right">Sessions</span>
+              <span class="flex-1 text-right">First Touch</span>
+              <span class="flex-1 text-right">Last Touch</span>
+              <span class="flex-1 text-right">Linear</span>
+              <span class="flex-1 text-right">Time Decay</span>
+              <span class="w-20 text-right">Rev/Session</span>
+            </div>
+
+            <!-- Channel Rows -->
+            @for (channel of attributionData().channels; track channel.channel) {
+              <div
+                class="flex items-center py-2.5 px-1 border-b border-gray-100 cursor-pointer hover:bg-gray-50 transition-colors"
+                (click)="toggleChannel(channel.channel)"
+                data-testid="email-ctr-drawer-attribution-channel-row">
+                <span class="flex-[2] min-w-[120px] text-sm font-semibold text-gray-900 truncate pr-2">{{ channel.channel }}</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(channel.sessions) }}</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCurrency(channel.firstTouchRevenue) }}</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCurrency(channel.lastTouchRevenue) }}</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCurrency(channel.linearRevenue) }}</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCurrency(channel.timeDecayRevenue) }}</span>
+                <span class="w-20 text-right text-sm font-semibold text-gray-900">{{ revPerSession(channel) }}</span>
+              </div>
+
+              <!-- Expanded Project Rows -->
+              @if (expandedChannels().has(channel.channel)) {
+                @for (project of attributionProjectsByChannel().get(channel.channel) ?? []; track project.projectName) {
+                  <div class="flex items-center py-2 px-1 pl-6 border-b border-gray-50 bg-gray-50" data-testid="email-ctr-drawer-attribution-project-row">
+                    <span class="flex-[2] min-w-[120px] text-xs text-gray-500 truncate pr-2" [title]="project.projectName">{{ project.projectName }}</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(project.sessions) }}</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCurrency(project.firstTouchRevenue) }}</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCurrency(project.lastTouchRevenue) }}</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCurrency(project.linearRevenue) }}</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCurrency(project.timeDecayRevenue) }}</span>
+                    <span class="w-20"></span>
+                  </div>
+                }
+              }
+            }
+
+            <!-- Total Row -->
+            <div class="flex items-center py-2.5 px-1 border-t-2 border-gray-300 font-bold">
+              <span class="flex-[2] min-w-[120px] text-sm text-gray-900">TOTAL</span>
+              <span class="flex-1 text-right text-sm text-gray-900">{{ formatCompact(attributionTotals().sessions) }}</span>
+              <span class="flex-1 text-right text-sm text-gray-900">{{ formatCurrency(attributionTotals().firstTouchRevenue) }}</span>
+              <span class="flex-1 text-right text-sm text-gray-900">{{ formatCurrency(attributionTotals().lastTouchRevenue) }}</span>
+              <span class="flex-1 text-right text-sm text-gray-900">{{ formatCurrency(attributionTotals().linearRevenue) }}</span>
+              <span class="flex-1 text-right text-sm text-gray-900">{{ formatCurrency(attributionTotals().timeDecayRevenue) }}</span>
+              <span class="w-20"></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Section Divider -->
+        <hr class="border-gray-200" />
+      }
+
+      <div class="flex flex-col gap-5" data-testid="email-ctr-drawer-paid-section">
+        <div class="flex items-center gap-2">
+          <i class="fa-light fa-bullhorn text-violet-500"></i>
+          <h3 class="text-base font-semibold text-gray-900">Paid Performance Marketing</h3>
+        </div>
+
+        <!-- Paid Summary Stats -->
+        <div class="flex flex-wrap gap-4" data-testid="email-ctr-drawer-paid-stats">
+          <lfx-card styleClass="flex-1 min-w-[100px]">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Spend</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalSpend() }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1 min-w-[100px]">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Revenue</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalRevenue() }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1 min-w-[100px]">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">ROAS</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ paidData().roas | number: '1.1-1' }}x</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1 min-w-[100px]">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Conversions</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ paidTotalConversions() }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1 min-w-[100px]">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Sessions</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ paidTotalSessions() }}</span>
+            </div>
+          </lfx-card>
+        </div>
+
+        <!-- Project Performance Table -->
+        @if ((paidData().projectBreakdown?.length ?? 0) > 0) {
+          <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-paid-projects-section">
+            <div class="flex flex-col gap-1">
+              <h3 class="text-sm font-semibold text-gray-900">Performance by Project</h3>
+              <p class="text-sm text-gray-600">Paid campaign performance grouped by project over the last 6 months</p>
+            </div>
+
+            <!-- Table Header -->
+            <div class="flex items-center py-2 px-1 text-[10px] font-semibold text-gray-500 uppercase tracking-wider border-b border-gray-200">
+              <span class="flex-[2] min-w-[120px]">Project / Campaign</span>
+              <span class="w-16 text-center">Funnel</span>
+              <span class="flex-1 text-right">Spend</span>
+              <span class="flex-1 text-right">Revenue</span>
+              <span class="w-14 text-right">ROAS</span>
+              <span class="flex-1 text-right">Conv.</span>
+              <span class="w-14 text-right">Conv %</span>
+              <span class="w-14 text-right">CPC</span>
+              <span class="w-20 text-right">Performance</span>
+            </div>
+
+            <!-- Project Rows -->
+            @for (project of paidData().projectBreakdown!; track project.projectName) {
+              <!-- Project Summary Row -->
+              <div
+                class="flex items-center py-2.5 px-1 border-b border-gray-100 cursor-pointer hover:bg-gray-50 transition-colors"
+                (click)="toggleProject(project.projectName)"
+                data-testid="email-ctr-drawer-project-row">
+                <span class="flex-[2] min-w-[120px] text-sm font-semibold text-gray-900 truncate pr-2">{{ project.projectName }}</span>
+                <span class="w-16 flex justify-center">
+                  @if (formatFunnelLabel(project.funnelStage)) {
+                    <lfx-tag [value]="formatFunnelLabel(project.funnelStage)" severity="secondary" [rounded]="true" />
+                  }
+                </span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(project.spend) | titlecase }}</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(project.revenue) | titlecase }}</span>
+                <span class="w-14 text-right text-sm font-semibold text-gray-900">{{ project.roas | number: '1.1-1' }}x</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(project.conversions) }}</span>
+                <span class="w-14 text-right text-sm font-semibold text-gray-900">{{ project.convRate | number: '1.1-1' }}%</span>
+                <span class="w-14 text-right text-sm font-semibold text-gray-900">${{ project.cpc | number: '1.2-2' }}</span>
+                <span class="w-20 flex justify-end">
+                  <lfx-tag [value]="project.performance" [severity]="getPerformanceSeverity(project.performance)" [rounded]="true" />
+                </span>
+              </div>
+
+              <!-- Expanded Campaign Rows -->
+              @if (expandedProjects().has(project.projectName)) {
+                @for (campaign of project.campaigns; track campaign.campaignName) {
+                  <div class="flex items-center py-2 px-1 pl-6 border-b border-gray-50 bg-gray-50" data-testid="email-ctr-drawer-paid-campaign-row">
+                    <span class="flex-[2] min-w-[120px] text-xs text-gray-500 truncate pr-2" [title]="campaign.campaignName">{{ campaign.campaignName }}</span>
+                    <span class="w-16 flex justify-center">
+                      @if (formatFunnelLabel(campaign.funnelStage)) {
+                        <lfx-tag [value]="formatFunnelLabel(campaign.funnelStage)" severity="secondary" [rounded]="true" />
+                      }
+                    </span>
+                    <span class="flex-1 text-right text-xs text-gray-600">${{ formatCompact(campaign.spend) }}</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">${{ formatCompact(campaign.revenue) }}</span>
+                    <span class="w-14 text-right text-xs text-gray-600">{{ campaign.roas | number: '1.1-1' }}x</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(campaign.conversions) }}</span>
+                    <span class="w-14 text-right text-xs text-gray-600">{{ campaign.convRate | number: '1.1-1' }}%</span>
+                    <span class="w-14 text-right text-xs text-gray-600">${{ campaign.cpc | number: '1.2-2' }}</span>
+                    <span class="w-20"></span>
+                  </div>
+                }
+              }
+            }
           </div>
         }
       </div>
 
-      <!-- Campaign Breakdown -->
-      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-campaigns-section">
-        <div class="flex flex-col gap-1">
-          <h3 class="text-sm font-semibold text-gray-900">CTR by Campaign</h3>
-          <p class="text-sm text-gray-600">Average click-through rate per campaign over the last 6 months</p>
+      <!-- Section Divider -->
+      <hr class="border-gray-200" />
+
+      <div class="flex flex-col gap-5" data-testid="email-ctr-drawer-email-section">
+        <div class="flex items-center gap-2">
+          <i class="fa-light fa-envelope text-blue-500"></i>
+          <h3 class="text-base font-semibold text-gray-900">Email Performance</h3>
         </div>
-        @if (drawerData().campaignGroups.length > 1) {
-          <div class="h-[240px]" data-testid="email-ctr-drawer-campaigns-chart">
-            <lfx-chart type="bar" [data]="campaignChartData()" [options]="campaignChartOptions" height="100%"></lfx-chart>
-          </div>
-        } @else {
-          <div class="text-center py-8 border border-slate-200 rounded-lg">
-            <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-            <p class="text-sm text-gray-500">No campaign breakdown available</p>
+
+        <!-- Email Summary Stats -->
+        <div class="flex flex-wrap gap-4" data-testid="email-ctr-drawer-stats">
+          <lfx-card styleClass="flex-1 min-w-[100px]">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Sends</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ emailTotalSends() }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1 min-w-[100px]">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Opens</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ emailTotalOpens() }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1 min-w-[100px]">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Open Rate</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ emailOpenRate() | number: '1.1-1' }}%</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1 min-w-[100px]">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Clicks</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ emailTotalClicks() }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1 min-w-[100px]">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">CTR</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ emailAvgCtr() | number: '1.1-1' }}%</span>
+            </div>
+          </lfx-card>
+        </div>
+
+        <!-- Campaign Insight Callout -->
+        @if (drawerData().campaignInsightText) {
+          <div class="flex items-start gap-3 p-3 bg-blue-50 border border-blue-200 rounded-lg" data-testid="email-ctr-drawer-campaign-insight">
+            <i class="fa-light fa-lightbulb text-blue-500 mt-0.5"></i>
+            <p class="text-sm text-blue-800">{{ drawerData().campaignInsightText }}</p>
           </div>
         }
-      </div>
 
-      <!-- Reach vs Opens -->
-      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-reach-section">
-        <div class="flex flex-col gap-1">
-          <h3 class="text-sm font-semibold text-gray-900">Campaign Reach vs Opens</h3>
-          <p class="text-sm text-gray-600">Monthly email sends compared to opens over the last 6 months</p>
-        </div>
-        @if (drawerData().monthlySends.length > 0) {
-          <div class="h-[240px]" data-testid="email-ctr-drawer-reach-chart">
-            <lfx-chart type="bar" [data]="reachVsOpensChartData()" [options]="reachVsOpensChartOptions" height="100%"></lfx-chart>
-          </div>
-        } @else {
-          <div class="text-center py-8 border border-slate-200 rounded-lg">
-            <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-            <p class="text-sm text-gray-500">No reach data available</p>
+        <!-- Campaign Performance by Type -->
+        @if ((drawerData().emailTypeBreakdown?.length ?? 0) > 0) {
+          <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-campaigns-section">
+            <div class="flex flex-col gap-1">
+              <h3 class="text-sm font-semibold text-gray-900">Campaign Performance by Type</h3>
+              <p class="text-sm text-gray-600">Email performance grouped by campaign type over the last 6 months</p>
+            </div>
+
+            <!-- Table Header -->
+            <div class="flex items-center py-2 px-1 text-[10px] font-semibold text-gray-500 uppercase tracking-wider border-b border-gray-200">
+              <span class="flex-[2] min-w-[120px]">Type / Campaign</span>
+              <span class="flex-1 text-right">Sends</span>
+              <span class="flex-1 text-right">Opens</span>
+              <span class="flex-1 text-right">Open Rate</span>
+              <span class="flex-1 text-right">Clicks</span>
+              <span class="flex-1 text-right">CTR</span>
+              <span class="w-24 text-right">Performance</span>
+            </div>
+
+            <!-- Type Rows -->
+            @for (type of drawerData().emailTypeBreakdown!; track type.emailType) {
+              <!-- Type Summary Row -->
+              <div
+                class="flex items-center py-2.5 px-1 border-b border-gray-100 cursor-pointer hover:bg-gray-50 transition-colors"
+                (click)="toggleType(type.emailType)"
+                data-testid="email-ctr-drawer-type-row">
+                <span class="flex-[2] min-w-[120px]">
+                  <lfx-tag [value]="type.emailType | titlecase" severity="warn" [rounded]="true" />
+                </span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(type.totalSends) }}</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(type.totalOpens) }}</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ type.openRate | number: '1.1-1' }}%</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(type.totalClicks) }}</span>
+                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ type.ctr | number: '1.1-1' }}%</span>
+                <span class="w-24 flex justify-end">
+                  <lfx-tag [value]="type.performance" [severity]="getPerformanceSeverity(type.performance)" [rounded]="true" />
+                </span>
+              </div>
+
+              <!-- Expanded Campaign Rows -->
+              @if (expandedTypes().has(type.emailType)) {
+                @for (campaign of type.campaigns; track campaign.campaignName) {
+                  <div class="flex items-center py-2 px-1 pl-6 border-b border-gray-50 bg-gray-50" data-testid="email-ctr-drawer-campaign-row">
+                    <span class="flex-[2] min-w-[120px] text-xs text-gray-500 truncate pr-2" [title]="campaign.campaignName">{{ campaign.campaignName }}</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(campaign.sends) }}</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(campaign.opens) }}</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ campaign.openRate | number: '1.1-1' }}%</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(campaign.clicks) }}</span>
+                    <span class="flex-1 text-right text-xs text-gray-600">{{ campaign.ctr | number: '1.1-1' }}%</span>
+                    <span class="w-24"></span>
+                  </div>
+                }
+              }
+            }
           </div>
         }
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.scss
@@ -1,2 +1,0 @@
-// Copyright The Linux Foundation and each contributor to LFX.
-// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -1,14 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DecimalPipe } from '@angular/common';
+import { DecimalPipe, TitleCasePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
-import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { createBarChartOptions, createHorizontalBarChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { formatCurrency, formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MarketingActionIconPipe } from '@pipes/marketing-action-icon.pipe';
@@ -17,30 +16,31 @@ import { catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
 
-import type { ChartData, ChartOptions } from 'chart.js';
-import type { EmailCtrResponse, MarketingKeyInsight, MarketingRecommendedAction } from '@lfx-one/shared/interfaces';
-import { splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import type {
+  EmailCtrResponse,
+  MarketingAttributionChannel,
+  MarketingAttributionProject,
+  MarketingAttributionResponse,
+  MarketingKeyInsight,
+  MarketingRecommendedAction,
+  PaidCampaignPerformance,
+  SocialReachResponse,
+} from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-email-ctr-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule, ChartComponent, SkeletonModule, TagComponent, MarketingActionIconPipe],
+  imports: [ButtonComponent, CardComponent, DecimalPipe, DrawerModule, SkeletonModule, TagComponent, TitleCasePipe, MarketingActionIconPipe],
   templateUrl: './email-ctr-drawer.component.html',
-  styleUrl: './email-ctr-drawer.component.scss',
 })
 export class EmailCtrDrawerComponent {
-  // === Services ===
   private readonly analyticsService = inject(AnalyticsService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly messageService = inject(MessageService);
 
-  // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);
-
-  // === WritableSignals ===
   protected readonly drawerLoading = signal(false);
 
-  // === Computed Signals (lazy-loaded data) ===
   protected readonly drawerData: Signal<EmailCtrResponse> = this.initDrawerData();
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
@@ -53,121 +53,159 @@ export class EmailCtrDrawerComponent {
   protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
-  protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
-  protected readonly campaignChartData: Signal<ChartData<'bar'>> = this.initCampaignChartData();
-  protected readonly reachVsOpensChartData: Signal<ChartData<'bar'>> = this.initReachVsOpensChartData();
+  protected readonly expandedTypes = signal<Set<string>>(new Set());
 
-  protected readonly chartOptions: ChartOptions<'bar'> = createBarChartOptions({
-    plugins: {
-      legend: { display: false },
-      tooltip: {
-        ...DASHBOARD_TOOLTIP_CONFIG,
-        callbacks: {
-          label: (ctx) => ` ${(ctx.parsed.y ?? 0).toFixed(2)}% CTR`,
-        },
-      },
-    },
-    scales: {
-      x: {
-        display: true,
-        grid: { display: false },
-        border: { display: true, color: lfxColors.gray[300] },
-        ticks: { color: lfxColors.gray[500], font: { size: 11 } },
-      },
-      y: {
-        display: true,
-        grid: { color: lfxColors.gray[200], lineWidth: 1 },
-        border: { display: false },
-        ticks: {
-          color: lfxColors.gray[500],
-          font: { size: 11 },
-          callback: (value) => `${Number(value).toFixed(1)}%`,
-        },
-      },
-    },
-    datasets: {
-      bar: { barPercentage: 0.7, categoryPercentage: 0.9 },
-    },
+  protected readonly emailTotalSends: Signal<string> = computed(() => {
+    const types = this.drawerData().emailTypeBreakdown ?? [];
+    return formatNumber(types.reduce((sum, t) => sum + t.totalSends, 0));
+  });
+  protected readonly emailTotalOpens: Signal<string> = computed(() => {
+    const types = this.drawerData().emailTypeBreakdown ?? [];
+    return formatNumber(types.reduce((sum, t) => sum + t.totalOpens, 0));
+  });
+  protected readonly emailTotalClicks: Signal<string> = computed(() => {
+    const types = this.drawerData().emailTypeBreakdown ?? [];
+    return formatNumber(types.reduce((sum, t) => sum + t.totalClicks, 0));
+  });
+  protected readonly emailOpenRate: Signal<number> = computed(() => {
+    const types = this.drawerData().emailTypeBreakdown ?? [];
+    const sends = types.reduce((sum, t) => sum + t.totalSends, 0);
+    const opens = types.reduce((sum, t) => sum + t.totalOpens, 0);
+    return sends > 0 ? Math.round(((opens * 100.0) / sends) * 10) / 10 : 0;
+  });
+  protected readonly emailAvgCtr: Signal<number> = computed(() => {
+    const types = this.drawerData().emailTypeBreakdown ?? [];
+    const sends = types.reduce((sum, t) => sum + t.totalSends, 0);
+    const clicks = types.reduce((sum, t) => sum + t.totalClicks, 0);
+    return sends > 0 ? Math.round(((clicks * 100.0) / sends) * 10) / 10 : 0;
   });
 
-  protected readonly campaignChartOptions: ChartOptions<'bar'> = createHorizontalBarChartOptions({
-    plugins: {
-      legend: { display: false },
-      tooltip: {
-        ...DASHBOARD_TOOLTIP_CONFIG,
-        callbacks: {
-          label: (ctx) => ` ${(ctx.parsed.x ?? 0).toFixed(2)}% CTR`,
-        },
-      },
-    },
-    scales: {
-      x: {
-        display: true,
-        grid: { color: lfxColors.gray[200], lineWidth: 1 },
-        border: { display: true, color: lfxColors.gray[300] },
-        ticks: {
-          color: lfxColors.gray[500],
-          font: { size: 11 },
-          callback: (value) => `${Number(value).toFixed(1)}%`,
-        },
-      },
-      y: {
-        display: true,
-        grid: { display: false },
-        border: { display: false },
-        ticks: { color: lfxColors.gray[600], font: { size: 12 } },
-      },
-    },
+  protected readonly paidData: Signal<SocialReachResponse> = this.initPaidData();
+  protected readonly formattedTotalSpend: Signal<string> = computed(() => formatCurrency(this.paidData().totalSpend));
+  protected readonly formattedTotalRevenue: Signal<string> = computed(() => formatCurrency(this.paidData().totalRevenue));
+  protected readonly paidTotalConversions: Signal<string> = computed(() => {
+    const projects = this.paidData().projectBreakdown ?? [];
+    return formatNumber(projects.reduce((sum, p) => sum + p.conversions, 0));
+  });
+  protected readonly paidTotalSessions: Signal<string> = computed(() => {
+    const projects = this.paidData().projectBreakdown ?? [];
+    return formatNumber(projects.reduce((sum, p) => sum + p.sessions, 0));
+  });
+  protected readonly expandedProjects = signal<Set<string>>(new Set());
+
+  protected readonly funnelAggregates: Signal<FunnelAggregates> = computed(() => {
+    const projects = this.paidData().projectBreakdown ?? [];
+    const campaigns: PaidCampaignPerformance[] = projects.flatMap((p) => p.campaigns);
+
+    const aggregate = (stages: string[]): FunnelTierMetrics => {
+      const matched = campaigns.filter((c) => stages.includes(c.funnelStage));
+      return {
+        count: matched.length,
+        spend: matched.reduce((s, c) => s + c.spend, 0),
+        revenue: matched.reduce((s, c) => s + c.revenue, 0),
+        impressions: matched.reduce((s, c) => s + c.impressions, 0),
+        clicks: matched.reduce((s, c) => s + c.clicks, 0),
+        sessions: matched.reduce((s, c) => s + c.sessions, 0),
+        conversions: matched.reduce((s, c) => s + c.conversions, 0),
+      };
+    };
+
+    const tofu = aggregate(['ToFU', 'ToFU2']);
+    const mofu = aggregate(['MoFU']);
+    const bofu = aggregate(['BoFU']);
+
+    return { tofu, mofu, bofu };
   });
 
-  protected readonly reachVsOpensChartOptions: ChartOptions<'bar'> = createBarChartOptions({
-    plugins: {
-      legend: {
-        display: true,
-        position: 'bottom',
-        labels: { color: lfxColors.gray[600], font: { size: 11 }, boxWidth: 12, padding: 16 },
-      },
-      tooltip: {
-        ...DASHBOARD_TOOLTIP_CONFIG,
-        callbacks: {
-          label: (ctx) => ` ${ctx.dataset.label}: ${(ctx.parsed.y ?? 0).toLocaleString()}`,
-        },
-      },
-    },
-    scales: {
-      x: {
-        display: true,
-        grid: { display: false },
-        border: { display: true, color: lfxColors.gray[300] },
-        ticks: { color: lfxColors.gray[500], font: { size: 11 } },
-      },
-      y: {
-        display: true,
-        grid: { color: lfxColors.gray[200], lineWidth: 1 },
-        border: { display: false },
-        ticks: {
-          color: lfxColors.gray[500],
-          font: { size: 11 },
-          callback: (value) => {
-            const num = Number(value);
-            if (num >= 999_950) return `${(num / 1_000_000).toFixed(1)}M`;
-            if (num >= 1_000) return `${(num / 1_000).toFixed(0)}K`;
-            return String(num);
-          },
-        },
-      },
-    },
-    datasets: {
-      bar: { barPercentage: 0.7, categoryPercentage: 0.9 },
-    },
+  protected readonly attributionData: Signal<MarketingAttributionResponse> = this.initAttributionData();
+  protected readonly expandedChannels = signal<Set<string>>(new Set());
+  protected readonly attributionProjectsByChannel: Signal<Map<string, MarketingAttributionProject[]>> = computed(() => {
+    const grouped = new Map<string, MarketingAttributionProject[]>();
+    for (const p of this.attributionData().projects) {
+      const list = grouped.get(p.channel) ?? [];
+      list.push(p);
+      grouped.set(p.channel, list);
+    }
+    return grouped;
+  });
+  protected readonly attributionTotals: Signal<{
+    sessions: number;
+    linearRevenue: number;
+    firstTouchRevenue: number;
+    lastTouchRevenue: number;
+    timeDecayRevenue: number;
+  }> = computed(() => {
+    const channels = this.attributionData().channels;
+    return {
+      sessions: channels.reduce((s, c) => s + c.sessions, 0),
+      linearRevenue: channels.reduce((s, c) => s + c.linearRevenue, 0),
+      firstTouchRevenue: channels.reduce((s, c) => s + c.firstTouchRevenue, 0),
+      lastTouchRevenue: channels.reduce((s, c) => s + c.lastTouchRevenue, 0),
+      timeDecayRevenue: channels.reduce((s, c) => s + c.timeDecayRevenue, 0),
+    };
   });
 
-  // === Protected Methods ===
+  protected readonly formatCurrency = formatCurrency;
+
   protected onClose(): void {
     this.visible.set(false);
   }
 
-  // === Private Initializers ===
+  protected toggleType(emailType: string): void {
+    const current = this.expandedTypes();
+    const next = new Set(current);
+    if (next.has(emailType)) {
+      next.delete(emailType);
+    } else {
+      next.add(emailType);
+    }
+    this.expandedTypes.set(next);
+  }
+
+  protected formatCompact(value: number): string {
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+    return value.toLocaleString();
+  }
+
+  protected getPerformanceSeverity(performance: string): 'danger' | 'warn' | 'success' | 'secondary' {
+    if (performance === 'LOW OPENS' || performance === 'LOW CLICKS' || performance === 'POOR' || performance === 'NO REVENUE') return 'danger';
+    if (performance === 'GOOD') return 'warn';
+    if (performance === 'EXCELLENT' || performance === 'STRONG') return 'success';
+    return 'secondary';
+  }
+
+  protected toggleProject(projectName: string): void {
+    const current = this.expandedProjects();
+    const next = new Set(current);
+    if (next.has(projectName)) {
+      next.delete(projectName);
+    } else {
+      next.add(projectName);
+    }
+    this.expandedProjects.set(next);
+  }
+
+  protected formatFunnelLabel(stage: string): string {
+    const labels: Record<string, string> = { BoFU: 'BOTTOM', MoFU: 'MIDDLE', ToFU: 'TOP', ToFU2: 'TOP', Unknown: '' };
+    return labels[stage] ?? stage;
+  }
+
+  protected toggleChannel(channel: string): void {
+    const current = this.expandedChannels();
+    const next = new Set(current);
+    if (next.has(channel)) {
+      next.delete(channel);
+    } else {
+      next.add(channel);
+    }
+    this.expandedChannels.set(next);
+  }
+
+  protected revPerSession(channel: MarketingAttributionChannel): string {
+    return channel.sessions > 0 ? `$${(channel.linearRevenue / channel.sessions).toFixed(2)}` : '—';
+  }
+
   private initDrawerData(): Signal<EmailCtrResponse> {
     const defaultValue: EmailCtrResponse = {
       currentCtr: 0,
@@ -207,92 +245,137 @@ export class EmailCtrDrawerComponent {
     );
   }
 
-  private initChartData(): Signal<ChartData<'bar'>> {
-    return computed(() => {
-      const { monthlyData, monthlyLabels } = this.drawerData();
-      return {
-        labels: monthlyLabels,
-        datasets: [
-          {
-            data: monthlyData,
-            backgroundColor: lfxColors.blue[500],
-            borderRadius: 4,
-          },
-        ],
-      };
-    });
-  }
-
-  private initCampaignChartData(): Signal<ChartData<'bar'>> {
-    return computed(() => {
-      const { campaignGroups } = this.drawerData();
-      const sorted = [...campaignGroups].sort((a, b) => b.avgCtr - a.avgCtr);
-      return {
-        labels: sorted.map((c) => c.campaignName),
-        datasets: [
-          {
-            data: sorted.map((c) => c.avgCtr),
-            backgroundColor: [lfxColors.blue[700], lfxColors.blue[500], lfxColors.blue[400], lfxColors.blue[300], lfxColors.blue[200]],
-            borderRadius: { topLeft: 0, bottomLeft: 0, topRight: 4, bottomRight: 4 },
-            borderSkipped: 'start',
-          },
-        ],
-      };
-    });
-  }
-
   private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
     return computed(() => {
-      const { changePercentage, campaignGroups, monthlySends, monthlyOpens } = this.drawerData();
-      const actions: MarketingRecommendedAction[] = [];
+      const email = this.drawerData();
+      const paid = this.paidData();
+      const attribution = this.attributionData();
 
-      if (changePercentage < 0) {
-        actions.push({
-          title: 'Test new call-to-action formats',
-          description: `CTR dropped ${Math.abs(changePercentage)}% — experiment with button placement and copy in the next send`,
+      // Collect best action per section (attribution, paid, email) — max 3 total
+      const attrActions: MarketingRecommendedAction[] = [];
+      const paidActions: MarketingRecommendedAction[] = [];
+      const emailActions: MarketingRecommendedAction[] = [];
+
+      // --- Attribution ---
+      const marketingChannelNames = new Set(['Email', 'Paid Performance', 'Internal & Banner']);
+      const marketingChannels = attribution.channels.filter((c) => marketingChannelNames.has(c.channel));
+      if (marketingChannels.length > 0) {
+        const emailChannel = marketingChannels.find((c) => c.channel === 'Email');
+        const bannerChannel = marketingChannels.find((c) => c.channel === 'Internal & Banner');
+        const zeroCostUnused: string[] = [];
+        if (emailChannel && emailChannel.sessions === 0) zeroCostUnused.push('Email');
+        if (bannerChannel && bannerChannel.sessions === 0) zeroCostUnused.push('Internal & Banner');
+
+        if (zeroCostUnused.length > 0) {
+          attrActions.push({
+            title: `Leverage ${zeroCostUnused.join(' and ')} for more reach`,
+            description: `${zeroCostUnused.join(' and ')} ${zeroCostUnused.length > 1 ? 'are' : 'is'} not driving sessions — activate these zero-cost channels to complement paid`,
+            priority: 'medium',
+            actionType: 'growth',
+          });
+        }
+
+        if (attrActions.length === 0) {
+          const totalMktSessions = marketingChannels.reduce((s, c) => s + c.sessions, 0);
+          const lowChannels = marketingChannels.filter((c) => totalMktSessions > 0 && (c.sessions / totalMktSessions) * 100 < 10 && c.sessions > 0);
+          if (lowChannels.length > 0) {
+            attrActions.push({
+              title: `Scale up ${lowChannels.map((c) => c.channel).join(' and ')}`,
+              description: `These channels are active but contributing less than 10% of marketing sessions — increase activity to boost reach`,
+              priority: 'medium',
+              actionType: 'growth',
+            });
+          }
+        }
+      }
+
+      // --- Paid (funnel-aware, impressions-based) — pick highest-priority ---
+      const funnel = this.funnelAggregates();
+
+      if (funnel.tofu.count > 0 && funnel.tofu.impressions === 0 && funnel.tofu.spend > 0) {
+        paidActions.push({
+          title: 'Awareness campaigns generating no impressions',
+          description: `${funnel.tofu.count} awareness campaign${funnel.tofu.count > 1 ? 's' : ''} with ${formatCurrency(funnel.tofu.spend)} spend but zero impressions — review ad targeting`,
           priority: 'high',
-
           actionType: 'optimize',
         });
       }
 
-      if (monthlySends.length >= 2 && monthlyOpens.length >= 2) {
-        const latestOpenRate =
-          monthlySends[monthlySends.length - 1] > 0 ? (monthlyOpens[monthlyOpens.length - 1] / monthlySends[monthlySends.length - 1]) * 100 : 0;
-        const prevOpenRate =
-          monthlySends[monthlySends.length - 2] > 0 ? (monthlyOpens[monthlyOpens.length - 2] / monthlySends[monthlySends.length - 2]) * 100 : 0;
-        if (latestOpenRate < prevOpenRate) {
-          actions.push({
-            title: 'Optimize email subject lines',
-            description: `Open rate declined from ${prevOpenRate.toFixed(1)}% to ${latestOpenRate.toFixed(1)}% — A/B test subject lines`,
-            priority: latestOpenRate < prevOpenRate * 0.9 ? 'high' : 'medium',
-
-            actionType: 'content',
-          });
-        }
-      }
-
-      if (campaignGroups.length > 1) {
-        const sorted = [...campaignGroups].sort((a, b) => b.avgCtr - a.avgCtr);
-        const best = sorted[0];
-        const worst = sorted[sorted.length - 1];
-        if (best.avgCtr > worst.avgCtr * 1.5) {
-          actions.push({
-            title: `Replicate "${best.campaignName}" approach`,
-            description: `Top campaign has ${best.avgCtr.toFixed(1)}% CTR vs ${worst.avgCtr.toFixed(1)}% for "${worst.campaignName}" — apply winning format`,
+      if (paidActions.length === 0 && funnel.mofu.count > 0 && funnel.mofu.spend > 0) {
+        const ctr = funnel.mofu.impressions > 0 ? (funnel.mofu.clicks / funnel.mofu.impressions) * 100 : 0;
+        if (ctr > 0 && ctr < 1) {
+          paidActions.push({
+            title: 'Low click-through on engagement campaigns',
+            description: `Engagement CTR at ${ctr.toFixed(2)}% — test new ad creative or refine audience targeting`,
             priority: 'medium',
-
             actionType: 'optimize',
           });
         }
       }
 
-      if (changePercentage >= 0 && actions.length === 0) {
+      if (paidActions.length === 0 && paid.monthlyData.length >= 3) {
+        const recent3 = paid.monthlyData.slice(-3);
+        if (recent3[0] > recent3[1] && recent3[1] > recent3[2]) {
+          paidActions.push({
+            title: 'Investigate declining paid impressions',
+            description: 'Impressions dropped for 3 consecutive months — review budget pacing and bid strategy',
+            priority: 'medium',
+            actionType: 'content',
+          });
+        }
+      }
+
+      // --- Email — pick highest-priority ---
+      if (email.changePercentage < 0) {
+        emailActions.push({
+          title: 'Test new call-to-action formats',
+          description: `Email CTR dropped ${Math.abs(email.changePercentage).toFixed(1)}% — experiment with button placement and copy`,
+          priority: email.changePercentage < -10 ? 'high' : 'medium',
+          actionType: 'optimize',
+        });
+      }
+
+      if (emailActions.length === 0 && email.monthlySends.length >= 2 && email.monthlyOpens.length >= 2) {
+        const latestOpenRate =
+          email.monthlySends[email.monthlySends.length - 1] > 0
+            ? (email.monthlyOpens[email.monthlyOpens.length - 1] / email.monthlySends[email.monthlySends.length - 1]) * 100
+            : 0;
+        const prevOpenRate =
+          email.monthlySends[email.monthlySends.length - 2] > 0
+            ? (email.monthlyOpens[email.monthlyOpens.length - 2] / email.monthlySends[email.monthlySends.length - 2]) * 100
+            : 0;
+        if (latestOpenRate < prevOpenRate) {
+          emailActions.push({
+            title: 'Optimize email subject lines',
+            description: `Open rate declined from ${prevOpenRate.toFixed(1)}% to ${latestOpenRate.toFixed(1)}% — A/B test subject lines`,
+            priority: latestOpenRate < prevOpenRate * 0.9 ? 'high' : 'medium',
+            actionType: 'content',
+          });
+        }
+      }
+
+      if (emailActions.length === 0 && (email.emailTypeBreakdown?.length ?? 0) >= 2) {
+        const types = email.emailTypeBreakdown!;
+        const bestCtr = [...types].sort((a, b) => b.ctr - a.ctr)[0];
+        const worstCtr = [...types].sort((a, b) => a.ctr - b.ctr)[0];
+        if (bestCtr.ctr > worstCtr.ctr * 2 && worstCtr.totalSends > 100) {
+          emailActions.push({
+            title: `Revamp ${worstCtr.emailType.toLowerCase()} email strategy`,
+            description: `${worstCtr.emailType} emails average ${worstCtr.ctr.toFixed(1)}% CTR vs ${bestCtr.ctr.toFixed(1)}% for ${bestCtr.emailType} — apply winning patterns`,
+            priority: 'medium',
+            actionType: 'content',
+          });
+        }
+      }
+
+      // Combine — 1 per section, max 3
+      const actions = [...attrActions.slice(0, 1), ...paidActions.slice(0, 1), ...emailActions.slice(0, 1)];
+
+      if (actions.length === 0) {
         actions.push({
           title: 'Maintain current momentum',
-          description: `CTR is trending up (+${changePercentage}%) — continue current content strategy`,
+          description: 'All channels performing well — continue current strategy and monitor for shifts',
           priority: 'low',
-
           actionType: 'growth',
         });
       }
@@ -303,82 +386,176 @@ export class EmailCtrDrawerComponent {
 
   private initKeyInsights(): Signal<MarketingKeyInsight[]> {
     return computed(() => {
-      const { currentCtr, changePercentage, monthlyData, campaignGroups, monthlySends, monthlyOpens } = this.drawerData();
-      const insights: MarketingKeyInsight[] = [];
+      const email = this.drawerData();
+      const paid = this.paidData();
+      const attribution = this.attributionData();
 
-      if (currentCtr === 0 && monthlyData.length === 0) {
-        return insights;
-      }
+      // Collect best insight per section (attribution, paid, email) — max 3 total
+      const attrInsights: MarketingKeyInsight[] = [];
+      const paidInsights: MarketingKeyInsight[] = [];
+      const emailInsights: MarketingKeyInsight[] = [];
 
-      // CTR trend insight
-      if (changePercentage < -10) {
-        insights.push({ text: `CTR dropped ${Math.abs(changePercentage)}% vs 6-month avg — significant decline`, type: 'warning' });
-      } else if (changePercentage < 0) {
-        insights.push({ text: `CTR declined ${Math.abs(changePercentage)}% vs 6-month avg`, type: 'warning' });
-      } else if (changePercentage > 10) {
-        insights.push({ text: `CTR grew ${changePercentage}% vs 6-month avg — strong improvement`, type: 'driver' });
-      } else if (changePercentage > 0) {
-        insights.push({ text: `CTR up ${changePercentage}% vs 6-month avg`, type: 'info' });
-      }
+      // --- Attribution — pick 1 best ---
+      if (attribution.channels.length > 0) {
+        const totalSessions = attribution.channels.reduce((s, c) => s + c.sessions, 0);
+        const totalLinearRevenue = attribution.channels.reduce((s, c) => s + c.linearRevenue, 0);
 
-      // Open rate insight
-      if (monthlySends.length > 0 && monthlyOpens.length > 0) {
-        const totalSends = monthlySends.reduce((sum, v) => sum + v, 0);
-        const totalOpens = monthlyOpens.reduce((sum, v) => sum + v, 0);
-        if (totalSends > 0) {
-          const avgOpenRate = (totalOpens / totalSends) * 100;
-          insights.push({ text: `Average open rate: ${avgOpenRate.toFixed(1)}% across ${totalSends.toLocaleString()} sends`, type: 'info' });
+        if (totalLinearRevenue > 0) {
+          const revPerSession = totalLinearRevenue / totalSessions;
+          attrInsights.push({
+            text: `${formatNumber(totalSessions)} total sessions driving ${EmailCtrDrawerComponent.formatRevenue(totalLinearRevenue)} attributed revenue ($${revPerSession.toFixed(2)}/session)`,
+            type: 'driver',
+          });
+        } else if (totalSessions > 0) {
+          attrInsights.push({ text: `${formatNumber(totalSessions)} total sessions across ${attribution.channels.length} channels`, type: 'info' });
         }
       }
 
-      // Campaign spread insight
-      if (campaignGroups.length > 1) {
-        const ctrs = campaignGroups.map((c) => c.avgCtr);
-        const max = Math.max(...ctrs);
-        const min = Math.min(...ctrs);
-        if (max > min * 2) {
-          insights.push({ text: `Wide CTR spread across campaigns (${min.toFixed(1)}%–${max.toFixed(1)}%)`, type: 'warning' });
+      // --- Paid (funnel-aware, impressions-based) — pick 1 best ---
+      const funnel = this.funnelAggregates();
+      const totalPaidImpressions = funnel.tofu.impressions + funnel.mofu.impressions + funnel.bofu.impressions;
+
+      if (totalPaidImpressions > 0) {
+        paidInsights.push({
+          text: `Paid campaigns: ${formatNumber(totalPaidImpressions)} impressions across ${funnel.tofu.count + funnel.mofu.count + funnel.bofu.count} campaigns (${formatCurrency(funnel.tofu.spend + funnel.mofu.spend + funnel.bofu.spend)} spend)`,
+          type: totalPaidImpressions > 10_000 ? 'driver' : 'info',
+        });
+      }
+
+      if (paidInsights.length === 0 && funnel.tofu.count > 0) {
+        if (funnel.tofu.impressions > 0) {
+          paidInsights.push({
+            text: `Awareness: ${formatNumber(funnel.tofu.impressions)} impressions across ${funnel.tofu.count} campaign${funnel.tofu.count > 1 ? 's' : ''} (${formatCurrency(funnel.tofu.spend)} spend)`,
+            type: funnel.tofu.impressions > 10_000 ? 'driver' : 'info',
+          });
+        } else if (funnel.tofu.spend > 0) {
+          paidInsights.push({
+            text: `Awareness: ${funnel.tofu.count} campaign${funnel.tofu.count > 1 ? 's' : ''} active but no impressions recorded`,
+            type: 'warning',
+          });
+        }
+      }
+
+      if (paidInsights.length === 0 && funnel.mofu.count > 0) {
+        const ctr = funnel.mofu.impressions > 0 ? (funnel.mofu.clicks / funnel.mofu.impressions) * 100 : 0;
+        if (funnel.mofu.clicks > 0) {
+          paidInsights.push({
+            text: `Engagement: ${formatNumber(funnel.mofu.clicks)} clicks at ${ctr.toFixed(1)}% CTR across ${funnel.mofu.count} campaign${funnel.mofu.count > 1 ? 's' : ''}`,
+            type: ctr >= 2 ? 'driver' : 'info',
+          });
+        }
+      }
+
+      if (paidInsights.length === 0 && paid.totalReach > 0 && paid.monthlyData.length >= 2) {
+        const prev = paid.monthlyData[paid.monthlyData.length - 2];
+        const curr = paid.monthlyData[paid.monthlyData.length - 1];
+        if (prev > 0) {
+          const paidMom = ((curr - prev) / prev) * 100;
+          if (paidMom > 20) {
+            paidInsights.push({ text: `Paid impressions surged ${paidMom.toFixed(0)}% MoM — ${formatNumber(curr)} last month`, type: 'driver' });
+          } else if (paidMom < -20) {
+            paidInsights.push({ text: `Paid impressions dropped ${Math.abs(paidMom).toFixed(0)}% MoM`, type: 'warning' });
+          }
+        }
+      }
+
+      // --- Email — pick 1 best ---
+      if (email.currentCtr > 0 || email.monthlyData.length > 0) {
+        if (email.changePercentage > 10) {
+          emailInsights.push({ text: `Email CTR grew ${email.changePercentage.toFixed(1)}% vs 6-month avg — strong improvement`, type: 'driver' });
+        } else if (email.changePercentage < -10) {
+          emailInsights.push({ text: `Email CTR dropped ${Math.abs(email.changePercentage).toFixed(1)}% vs 6-month avg`, type: 'warning' });
+        } else if (email.changePercentage !== 0) {
+          emailInsights.push({
+            text: `Email CTR ${email.changePercentage > 0 ? 'up' : 'down'} ${Math.abs(email.changePercentage).toFixed(1)}% vs 6-month avg`,
+            type: email.changePercentage > 0 ? 'info' : 'warning',
+          });
+        }
+      }
+
+      if (emailInsights.length === 0 && (email.emailTypeBreakdown?.length ?? 0) > 0) {
+        const types = email.emailTypeBreakdown!;
+        const excellent = types.filter((t) => t.performance === 'EXCELLENT' || t.performance === 'STRONG');
+        if (excellent.length > 0) {
+          const names = excellent.map((t) => t.emailType.toLowerCase()).join(', ');
+          emailInsights.push({ text: `${names} emails are performing well across opens and clicks`, type: 'driver' });
         } else {
-          insights.push({ text: `CTR consistent across campaigns (${min.toFixed(1)}%–${max.toFixed(1)}%)`, type: 'info' });
+          const lowOpens = types.filter((t) => t.performance === 'LOW OPENS');
+          if (lowOpens.length > 0) {
+            const names = lowOpens.map((t) => t.emailType.toLowerCase()).join(', ');
+            emailInsights.push({ text: `${names} emails have low open rates — review subject lines and send times`, type: 'warning' });
+          }
         }
       }
 
-      // Monthly trend consistency
-      if (monthlyData.length >= 3) {
-        const recent3 = monthlyData.slice(-3);
-        const isConsistentlyDecreasing = recent3[0] > recent3[1] && recent3[1] > recent3[2];
-        const isConsistentlyIncreasing = recent3[0] < recent3[1] && recent3[1] < recent3[2];
-        if (isConsistentlyDecreasing) {
-          insights.push({ text: 'CTR declining for 3 consecutive months', type: 'warning' });
-        } else if (isConsistentlyIncreasing) {
-          insights.push({ text: 'CTR improving for 3 consecutive months', type: 'driver' });
-        }
-      }
-
-      return insights;
+      // Combine — 1 per section, max 3
+      return [...attrInsights.slice(0, 1), ...paidInsights.slice(0, 1), ...emailInsights.slice(0, 1)];
     });
   }
 
-  private initReachVsOpensChartData(): Signal<ChartData<'bar'>> {
-    return computed(() => {
-      const { monthlySends, monthlyOpens, monthlyLabels } = this.drawerData();
-      return {
-        labels: monthlyLabels,
-        datasets: [
-          {
-            label: 'Reach (Sends)',
-            data: monthlySends,
-            backgroundColor: lfxColors.blue[500],
-            borderRadius: 4,
-          },
-          {
-            label: 'Opens',
-            data: monthlyOpens,
-            backgroundColor: lfxColors.blue[300],
-            borderRadius: 4,
-          },
-        ],
-      };
-    });
+  private initPaidData(): Signal<SocialReachResponse> {
+    const defaultValue: SocialReachResponse = {
+      totalReach: 0,
+      roas: 0,
+      totalSpend: 0,
+      totalRevenue: 0,
+      changePercentage: 0,
+      trend: 'up',
+      monthlyData: [],
+      monthlyLabels: [],
+      monthlyRoas: [],
+      channelGroups: [],
+    };
+
+    const visible$ = toObservable(this.visible);
+    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.slug || ''));
+
+    return toSignal(
+      combineLatest([visible$, foundation$]).pipe(
+        filter(([isVisible, slug]) => isVisible && !!slug),
+        map(([, slug]) => slug),
+        switchMap((foundationSlug) => this.analyticsService.getSocialReach(foundationSlug).pipe(catchError(() => of(defaultValue))))
+      ),
+      { initialValue: defaultValue }
+    );
   }
+
+  private initAttributionData(): Signal<MarketingAttributionResponse> {
+    const defaultValue: MarketingAttributionResponse = { channels: [], projects: [] };
+
+    const visible$ = toObservable(this.visible);
+    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.slug || ''));
+
+    return toSignal(
+      combineLatest([visible$, foundation$]).pipe(
+        filter(([isVisible, slug]) => isVisible && !!slug),
+        map(([, slug]) => slug),
+        switchMap((foundationSlug) => this.analyticsService.getMarketingAttribution(foundationSlug).pipe(catchError(() => of(defaultValue))))
+      ),
+      { initialValue: defaultValue }
+    );
+  }
+
+  private static formatRevenue(value: number): string {
+    if (value <= 0) return '—';
+    if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
+    return `$${value.toLocaleString()}`;
+  }
+}
+
+interface FunnelTierMetrics {
+  count: number;
+  spend: number;
+  revenue: number;
+  impressions: number;
+  clicks: number;
+  sessions: number;
+  conversions: number;
+}
+
+interface FunnelAggregates {
+  tofu: FunnelTierMetrics;
+  mofu: FunnelTierMetrics;
+  bofu: FunnelTierMetrics;
 }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -151,6 +151,28 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
     projectBreakdown: [],
     eventRegistrationAttribution: { channelBreakdown: [], monthlyTrend: [] },
   },
+  emailCtr: {
+    currentCtr: 0,
+    changePercentage: 0,
+    trend: 'up' as const,
+    monthlyData: [],
+    monthlyLabels: [],
+    campaignGroups: [],
+    monthlySends: [],
+    monthlyOpens: [],
+  },
+  paidCampaign: {
+    totalReach: 0,
+    roas: 0,
+    totalSpend: 0,
+    totalRevenue: 0,
+    changePercentage: 0,
+    trend: 'up' as const,
+    monthlyData: [],
+    monthlyLabels: [],
+    monthlyRoas: [],
+    channelGroups: [],
+  },
 };
 
 @Component({
@@ -307,6 +329,8 @@ export class MarketingOverviewComponent {
             brandReach: safe('brandReach', this.analyticsService.getBrandReach(slug)),
             brandHealth: safe('brandHealth', this.analyticsService.getBrandHealth(slug)),
             revenueImpact: safe('revenueImpact', this.analyticsService.getRevenueImpact(slug)),
+            emailCtr: safe('emailCtr', this.analyticsService.getEmailCtr(slug)),
+            paidCampaign: safe('paidCampaign', this.analyticsService.getSocialReach(slug)),
           })
         )
       ),

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -68,6 +68,7 @@ import {
   BrandReachResponse,
   BrandHealthResponse,
   RevenueImpactResponse,
+  MarketingAttributionResponse,
   MultiFoundationSummaryResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
@@ -1254,6 +1255,17 @@ export class AnalyticsService {
         })
       )
     );
+  }
+
+  /**
+   * Get marketing attribution data by channel with multi-touch revenue models.
+   * @param foundationSlug Foundation slug used to filter Snowflake queries
+   * @returns Observable emitting channel summary + project drill-down (or empty defaults on error)
+   */
+  public getMarketingAttribution(foundationSlug: string): Observable<MarketingAttributionResponse> {
+    return this.http
+      .get<MarketingAttributionResponse>('/api/analytics/marketing-attribution', { params: { foundationSlug } })
+      .pipe(catchError(() => of({ channels: [], projects: [] })));
   }
 
   /**

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2570,6 +2570,43 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/marketing-attribution
+   * Get channel-level marketing attribution with multi-touch revenue models
+   * Query params: foundationSlug (required)
+   */
+  public async getMarketingAttribution(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_marketing_attribution');
+
+    try {
+      const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_marketing_attribution',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_marketing_attribution',
+        });
+      }
+
+      const response = await this.projectService.getMarketingAttribution(foundationSlug);
+
+      logger.success(req, 'get_marketing_attribution', startTime, {
+        foundation_slug: foundationSlug,
+        channel_count: response.channels.length,
+        project_count: response.projects.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  /**
    * GET /api/analytics/multi-foundation-summary
    * Aggregate analytics across multiple foundations in a single request
    * Query params: slugs (required, comma-separated foundation slugs, max 25)

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -178,6 +178,7 @@ router.get('/event-growth', (req, res, next) => analyticsController.getEventGrow
 router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
 router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
 router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));
+router.get('/marketing-attribution', (req, res, next) => analyticsController.getMarketingAttribution(req, res, next));
 
 // Multi-foundation summary endpoint (multi-foundation dashboard)
 router.get('/multi-foundation-summary', (req, res, next) => analyticsController.getMultiFoundationSummary(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -57,6 +57,9 @@ import {
   HealthMetricsDailyResponse,
   HealthMetricsRange,
   LifecycleStage,
+  MarketingAttributionChannel,
+  MarketingAttributionProject,
+  MarketingAttributionResponse,
   MemberAcquisitionResponse,
   MemberRetentionResponse,
   MembershipChurnPerTierSummaryResponse,
@@ -2033,12 +2036,45 @@ export class ProjectService {
       ORDER BY IMPRESSIONS DESC
     `;
 
-      const [impressionsResult, roasKpiResult, monthlyRoasResult, monthlyImpressionsResult, channelResult] = await Promise.all([
+      // Block 6: Project + campaign level performance breakdown (last 6 months)
+      const projectPerfQuery = `
+      SELECT
+        PROJECT_NAME, CAMPAIGN_NAME, FUNNEL_STAGE,
+        SUM(SPEND) AS SPEND, SUM(LINEAR_REVENUE) AS REVENUE,
+        ROUND(DIV0(SUM(LINEAR_REVENUE), SUM(SPEND)), 2) AS ROAS,
+        SUM(CONV) AS CONVERSIONS,
+        ROUND(DIV0(SUM(CONV), NULLIF(SUM(CLICKS), 0)) * 100, 2) AS CONV_RATE,
+        ROUND(DIV0(SUM(SPEND), NULLIF(SUM(CLICKS), 0)), 2) AS CPC,
+        SUM(SESSIONS) AS SESSIONS,
+        SUM(IMPRESSIONS) AS IMPRESSIONS,
+        SUM(CLICKS) AS CLICKS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
+      WHERE FOUNDATION_SLUG = ?
+        AND CAMPAIGN_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
+      GROUP BY PROJECT_NAME, CAMPAIGN_NAME, FUNNEL_STAGE
+      ORDER BY SPEND DESC
+    `;
+
+      const [impressionsResult, roasKpiResult, monthlyRoasResult, monthlyImpressionsResult, channelResult, projectPerfResult] = await Promise.all([
         this.snowflakeService.execute<{ TOTAL_IMPRESSIONS: number; TOTAL_SPEND: number; TOTAL_REVENUE: number }>(impressionsQuery, [foundationSlug]),
         this.snowflakeService.execute<{ ROAS: number; ROAS_MOM_PCT: number }>(roasKpiQuery, [foundationSlug]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; ROAS: number }>(monthlyRoasQuery, [foundationSlug]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; IMPRESSIONS: number }>(monthlyImpressionsQuery, [foundationSlug]),
         this.snowflakeService.execute<{ CHANNEL: string; IMPRESSIONS: number }>(channelQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          PROJECT_NAME: string;
+          CAMPAIGN_NAME: string;
+          FUNNEL_STAGE: string;
+          SPEND: number;
+          REVENUE: number;
+          ROAS: number;
+          CONVERSIONS: number;
+          CONV_RATE: number;
+          CPC: number;
+          SESSIONS: number;
+          IMPRESSIONS: number;
+          CLICKS: number;
+        }>(projectPerfQuery, [foundationSlug]),
       ]);
 
       const totalReach = impressionsResult.rows[0]?.TOTAL_IMPRESSIONS ?? 0;
@@ -2074,6 +2110,98 @@ export class ProjectService {
         totalImpressions: row.IMPRESSIONS,
       }));
 
+      // Shape project breakdown with nested campaigns
+      const projectMap = new Map<
+        string,
+        {
+          spend: number;
+          revenue: number;
+          conversions: number;
+          impressions: number;
+          clicks: number;
+          sessions: number;
+          funnelStages: Set<string>;
+          campaigns: typeof projectPerfResult.rows;
+        }
+      >();
+      for (const row of projectPerfResult.rows) {
+        const existing = projectMap.get(row.PROJECT_NAME) ?? {
+          spend: 0,
+          revenue: 0,
+          conversions: 0,
+          impressions: 0,
+          clicks: 0,
+          sessions: 0,
+          funnelStages: new Set<string>(),
+          campaigns: [] as typeof projectPerfResult.rows,
+        };
+        existing.spend += row.SPEND ?? 0;
+        existing.revenue += row.REVENUE ?? 0;
+        existing.conversions += row.CONVERSIONS ?? 0;
+        existing.impressions += row.IMPRESSIONS ?? 0;
+        existing.clicks += row.CLICKS ?? 0;
+        existing.sessions += row.SESSIONS ?? 0;
+        if (row.FUNNEL_STAGE) {
+          existing.funnelStages.add(row.FUNNEL_STAGE);
+        }
+        existing.campaigns.push(row);
+        projectMap.set(row.PROJECT_NAME, existing);
+      }
+
+      const getPaidPerformance = (projectRoas: number): string => {
+        if (projectRoas >= 2) return 'EXCELLENT';
+        if (projectRoas >= 1) return 'GOOD';
+        if (projectRoas > 0) return 'POOR';
+        return 'NO REVENUE';
+      };
+
+      const formatFunnel = (stages: Set<string>): string => {
+        const priority = ['BoFU', 'MoFU', 'ToFU', 'ToFU2', 'Unknown'];
+        for (const p of priority) {
+          if (stages.has(p)) return p;
+        }
+        return [...stages][0] ?? 'Unknown';
+      };
+
+      const projectBreakdown = Array.from(projectMap.entries())
+        .filter(([, data]) => data.spend > 0)
+        .map(([projectName, data]) => {
+          const projectRoas = data.spend > 0 ? Math.round((data.revenue / data.spend) * 100) / 100 : 0;
+          const convRate = data.clicks > 0 ? Math.round((data.conversions / data.clicks) * 10000) / 100 : 0;
+          const cpc = data.clicks > 0 ? Math.round((data.spend / data.clicks) * 100) / 100 : 0;
+          return {
+            projectName,
+            funnelStage: formatFunnel(data.funnelStages),
+            spend: Math.round(data.spend),
+            revenue: Math.round(data.revenue),
+            roas: projectRoas,
+            conversions: data.conversions,
+            convRate,
+            cpc,
+            sessions: data.sessions,
+            impressions: data.impressions,
+            clicks: data.clicks,
+            performance: getPaidPerformance(projectRoas),
+            campaigns: data.campaigns
+              .sort((a, b) => (b.SPEND ?? 0) - (a.SPEND ?? 0))
+              .slice(0, 10)
+              .map((c) => ({
+                campaignName: c.CAMPAIGN_NAME,
+                funnelStage: c.FUNNEL_STAGE ?? 'Unknown',
+                spend: Math.round(c.SPEND ?? 0),
+                revenue: Math.round(c.REVENUE ?? 0),
+                roas: c.ROAS ?? 0,
+                conversions: c.CONVERSIONS ?? 0,
+                convRate: c.CONV_RATE ?? 0,
+                cpc: c.CPC ?? 0,
+                sessions: c.SESSIONS ?? 0,
+                impressions: c.IMPRESSIONS ?? 0,
+                clicks: c.CLICKS ?? 0,
+              })),
+          };
+        })
+        .sort((a, b) => b.spend - a.spend);
+
       return {
         totalReach,
         roas: Math.round(roas * 100) / 100,
@@ -2085,6 +2213,7 @@ export class ProjectService {
         monthlyLabels,
         monthlyRoas,
         channelGroups,
+        projectBreakdown,
       };
     } catch (error) {
       logger.warning(undefined, 'get_social_reach', 'Failed to fetch social reach data, returning defaults', {
@@ -4520,6 +4649,224 @@ export class ProjectService {
       };
     } catch (error) {
       logger.error(undefined, 'get_revenue_impact', startTime, error instanceof Error ? error : new Error(String(error)), {
+        foundation_slug: foundationSlug,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Get marketing attribution data from ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION.
+   * Returns channel-level summary and project × channel drill-down for the last 6 months.
+   * @param foundationSlug - Foundation slug or 'tlf' for umbrella aggregation
+   * @returns Channel summary + project drill-down
+   */
+  public async getMarketingAttribution(foundationSlug: string): Promise<MarketingAttributionResponse> {
+    const startTime = Date.now();
+    logger.debug(undefined, 'get_marketing_attribution', 'Fetching marketing attribution from Snowflake', { foundation_slug: foundationSlug });
+
+    try {
+      const isUmbrella = foundationSlug === 'tlf';
+
+      const channelQuery = isUmbrella
+        ? `
+        SELECT CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY CHANNEL
+        ORDER BY SESSIONS DESC
+      `
+        : `
+        SELECT CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE FOUNDATION_SLUG = ?
+          AND SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY CHANNEL
+        ORDER BY SESSIONS DESC
+      `;
+
+      const projectQuery = isUmbrella
+        ? `
+        SELECT PROJECT_NAME, CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY PROJECT_NAME, CHANNEL
+        ORDER BY CHANNEL, SESSIONS DESC
+      `
+        : `
+        SELECT PROJECT_NAME, CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE FOUNDATION_SLUG = ?
+          AND SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY PROJECT_NAME, CHANNEL
+        ORDER BY CHANNEL, SESSIONS DESC
+      `;
+
+      const params = isUmbrella ? [] : [foundationSlug];
+
+      interface ChannelRow {
+        CHANNEL: string;
+        SESSIONS: number;
+        PAGE_VIEWS: number;
+        UNIQUE_VISITORS: number;
+        NEW_VISITORS: number;
+        RETURNING_VISITORS: number;
+        FIRST_TOUCH_REVENUE: number;
+        LAST_TOUCH_REVENUE: number;
+        LINEAR_REVENUE: number;
+        TIME_DECAY_REVENUE: number;
+      }
+
+      interface ProjectRow {
+        PROJECT_NAME: string;
+        CHANNEL: string;
+        SESSIONS: number;
+        PAGE_VIEWS: number;
+        UNIQUE_VISITORS: number;
+        NEW_VISITORS: number;
+        RETURNING_VISITORS: number;
+        FIRST_TOUCH_REVENUE: number;
+        LAST_TOUCH_REVENUE: number;
+        LINEAR_REVENUE: number;
+        TIME_DECAY_REVENUE: number;
+      }
+
+      const [channelResult, projectResult] = await Promise.all([
+        this.snowflakeService.execute<ChannelRow>(channelQuery, params),
+        this.snowflakeService.execute<ProjectRow>(projectQuery, params),
+      ]);
+
+      // Map Snowflake channels to consolidated UI labels:
+      //   Paid Search + Social → "Paid Performance"
+      //   Email / HubSpot → "Email"
+      //   Internal / Banner → "Internal & Banner"
+      //   Organic Search → "Organic"
+      //   Other Tracked → "Other"
+      //   Direct / Unknown → "Direct & Unknown"
+      const mapChannel = (raw: string): string => {
+        switch (raw) {
+          case 'Paid Search':
+          case 'Social':
+            return 'Paid Performance';
+          case 'Email / HubSpot':
+            return 'Email';
+          case 'Internal / Banner':
+            return 'Internal & Banner';
+          case 'Organic Search':
+            return 'Organic';
+          case 'Other Tracked':
+            return 'Other';
+          case 'Direct / Unknown':
+            return 'Direct & Unknown';
+          default:
+            return raw;
+        }
+      };
+
+      // Aggregate channel rows that map to the same UI label
+      const channelMap = new Map<string, MarketingAttributionChannel>();
+      for (const row of channelResult.rows) {
+        const label = mapChannel(row.CHANNEL);
+        const existing = channelMap.get(label);
+        if (existing) {
+          existing.sessions += row.SESSIONS;
+          existing.pageViews += row.PAGE_VIEWS;
+          existing.uniqueVisitors += row.UNIQUE_VISITORS;
+          existing.newVisitors += row.NEW_VISITORS;
+          existing.returningVisitors += row.RETURNING_VISITORS;
+          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE;
+          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE;
+          existing.linearRevenue += row.LINEAR_REVENUE;
+          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE;
+        } else {
+          channelMap.set(label, {
+            channel: label,
+            sessions: row.SESSIONS,
+            pageViews: row.PAGE_VIEWS,
+            uniqueVisitors: row.UNIQUE_VISITORS,
+            newVisitors: row.NEW_VISITORS,
+            returningVisitors: row.RETURNING_VISITORS,
+            firstTouchRevenue: row.FIRST_TOUCH_REVENUE,
+            lastTouchRevenue: row.LAST_TOUCH_REVENUE,
+            linearRevenue: row.LINEAR_REVENUE,
+            timeDecayRevenue: row.TIME_DECAY_REVENUE,
+          });
+        }
+      }
+      const channels = [...channelMap.values()].sort((a, b) => b.sessions - a.sessions);
+
+      // Map project rows with the same channel consolidation
+      const projectMap = new Map<string, MarketingAttributionProject>();
+      for (const row of projectResult.rows) {
+        const label = mapChannel(row.CHANNEL);
+        const key = `${row.PROJECT_NAME}::${label}`;
+        const existing = projectMap.get(key);
+        if (existing) {
+          existing.sessions += row.SESSIONS;
+          existing.pageViews += row.PAGE_VIEWS;
+          existing.uniqueVisitors += row.UNIQUE_VISITORS;
+          existing.newVisitors += row.NEW_VISITORS;
+          existing.returningVisitors += row.RETURNING_VISITORS;
+          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE;
+          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE;
+          existing.linearRevenue += row.LINEAR_REVENUE;
+          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE;
+        } else {
+          projectMap.set(key, {
+            projectName: row.PROJECT_NAME,
+            channel: label,
+            sessions: row.SESSIONS,
+            pageViews: row.PAGE_VIEWS,
+            uniqueVisitors: row.UNIQUE_VISITORS,
+            newVisitors: row.NEW_VISITORS,
+            returningVisitors: row.RETURNING_VISITORS,
+            firstTouchRevenue: row.FIRST_TOUCH_REVENUE,
+            lastTouchRevenue: row.LAST_TOUCH_REVENUE,
+            linearRevenue: row.LINEAR_REVENUE,
+            timeDecayRevenue: row.TIME_DECAY_REVENUE,
+          });
+        }
+      }
+      const projects = [...projectMap.values()].sort((a, b) => b.sessions - a.sessions);
+
+      logger.debug(undefined, 'get_marketing_attribution', 'Marketing attribution data fetched', {
+        foundation_slug: foundationSlug,
+        channel_count: channels.length,
+        project_count: projects.length,
+        duration_ms: Date.now() - startTime,
+      });
+
+      return { channels, projects };
+    } catch (error) {
+      logger.error(undefined, 'get_marketing_attribution', startTime, error instanceof Error ? error : new Error(String(error)), {
         foundation_slug: foundationSlug,
       });
       throw error;

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -817,8 +817,8 @@ function eventAttrMonthlyRevenueSeries(rows: { month: string; lastTouchRevenue: 
     .map((m) => byMonth.get(m) ?? 0);
 }
 
-/** Compute MoM change display from event-attribution monthly revenue series */
-function eventAttrMomChange(series: number[]): string | undefined {
+/** Compute MoM change display from a monthly numeric series (last vs second-to-last). */
+function seriesMomChange(series: number[]): string | undefined {
   if (series.length < 2) return undefined;
   const prev = series[series.length - 2];
   const curr = series[series.length - 1];
@@ -826,15 +826,19 @@ function eventAttrMomChange(series: number[]): string | undefined {
   return formatMomChange(((curr - prev) / prev) * 100);
 }
 
-/** Compute trend direction from event-attribution monthly revenue series.
- *  Uses the same MoM % formula as eventAttrMomChange so the color matches the displayed text. */
-function eventAttrTrendDirection(series: number[]): 'up' | 'down' | 'neutral' | undefined {
+/** Compute trend direction from a monthly numeric series.
+ *  Uses the same MoM % formula as seriesMomChange so the color matches the displayed text. */
+function seriesTrendDirection(series: number[]): 'up' | 'down' | 'neutral' | undefined {
   if (series.length < 2) return undefined;
   const prev = series[series.length - 2];
   const curr = series[series.length - 1];
   if (prev === 0) return undefined;
   return trendFromChange(((curr - prev) / prev) * 100);
 }
+
+// Legacy aliases — kept so existing call sites compile without a rename pass.
+const eventAttrMomChange = seriesMomChange;
+const eventAttrTrendDirection = seriesTrendDirection;
 
 /**
  * Build ED Evolution dashboard cards from live API data.
@@ -847,9 +851,46 @@ function eventAttrTrendDirection(series: number[]): 'up' | 'down' | 'neutral' | 
  * Emerald/red are reserved for delta indicators (up/down), never sparkline stroke.
  */
 export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricCard[] {
-  const { flywheel, memberAcquisition, memberRetention, engagedCommunity, eventGrowth, brandReach, brandHealth, revenueImpact } = data;
+  const { flywheel, memberAcquisition, memberRetention, engagedCommunity, eventGrowth, brandReach, brandHealth, revenueImpact, emailCtr, paidCampaign } = data;
+
+  // Pre-compute email open rate for the Campaign Performance card
+  const emailTotalSends = emailCtr.monthlySends.reduce((sum, v) => sum + v, 0);
+  const emailTotalOpens = emailCtr.monthlyOpens.reduce((sum, v) => sum + v, 0);
+  const emailOpenRate = emailTotalSends > 0 ? (emailTotalOpens / emailTotalSends) * 100 : 0;
 
   return [
+    // === Campaign Performance (dual-signal: Email Opens + Paid Impressions) ===
+    {
+      title: 'Campaign Performance',
+      icon: 'fa-light fa-chart-mixed',
+      chartType: 'line',
+      category: 'memberships',
+      testId: 'ed-evo-campaign-performance',
+      description: 'Email opens and paid impressions with MoM trends.',
+      customContentType: 'dual-signal',
+      dualSignals: [
+        protoDualSignal(
+          `Email · ${emailCtr.currentCtr.toFixed(1)}% CTR · ${emailOpenRate.toFixed(0)}% Open`,
+          formatNumber(emailTotalOpens) + ' opens',
+          emailCtr.monthlyOpens,
+          lfxColors.blue[500],
+          seriesMomChange(emailCtr.monthlyOpens),
+          seriesTrendDirection(emailCtr.monthlyOpens)
+        ),
+        protoDualSignal(
+          `Paid · ${formatCurrency(paidCampaign.totalSpend)} spend`,
+          formatNumber(paidCampaign.totalReach) + ' impressions',
+          paidCampaign.monthlyData,
+          lfxColors.violet[500],
+          seriesMomChange(paidCampaign.monthlyData),
+          seriesTrendDirection(paidCampaign.monthlyData)
+        ),
+      ],
+      caption: trendWindow(Math.max(emailCtr.monthlyOpens.length, paidCampaign.monthlyData.length)),
+      tooltipText: 'Email opens with CTR and open rate. Paid campaign impressions with total spend.',
+      drawerType: DashboardDrawerType.MarketingEmailCtr,
+    } as DashboardMetricCard,
+
     // === North Star (4 cards — retention merged into Member Growth drawer) ===
     {
       title: 'Flywheel Re-engagement',

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2726,6 +2726,42 @@ export interface SocialReachChannelGroup {
 }
 
 /**
+ * Per-campaign paid performance data (nested under project)
+ */
+export interface PaidCampaignPerformance {
+  campaignName: string;
+  funnelStage: string;
+  spend: number;
+  revenue: number;
+  roas: number;
+  conversions: number;
+  convRate: number;
+  cpc: number;
+  sessions: number;
+  impressions: number;
+  clicks: number;
+}
+
+/**
+ * Project-level paid performance breakdown
+ */
+export interface PaidProjectBreakdown {
+  projectName: string;
+  funnelStage: string;
+  spend: number;
+  revenue: number;
+  roas: number;
+  conversions: number;
+  convRate: number;
+  cpc: number;
+  sessions: number;
+  impressions: number;
+  clicks: number;
+  performance: string;
+  campaigns: PaidCampaignPerformance[];
+}
+
+/**
  * API response for Paid Social query (ROAS + impressions)
  */
 export interface SocialReachResponse {
@@ -2739,6 +2775,7 @@ export interface SocialReachResponse {
   monthlyLabels: string[];
   monthlyRoas: number[];
   channelGroups: SocialReachChannelGroup[];
+  projectBreakdown?: PaidProjectBreakdown[];
 }
 
 // ============================================
@@ -2813,6 +2850,35 @@ export interface EmailCtrCampaignGroup {
 }
 
 /**
+ * Individual campaign performance from EMAIL_CAMPAIGN_PERFORMANCE Snowflake model
+ */
+export interface EmailCampaignPerformance {
+  campaignName: string;
+  emailType: string;
+  sends: number;
+  opens: number;
+  clicks: number;
+  openRate: number;
+  ctr: number;
+  ctrStatus: string;
+}
+
+/**
+ * Aggregated email type breakdown (grouped by EMAIL_TYPE)
+ */
+export interface EmailTypeBreakdown {
+  emailType: string;
+  campaignCount: number;
+  totalSends: number;
+  totalOpens: number;
+  totalClicks: number;
+  openRate: number;
+  ctr: number;
+  performance: string;
+  campaigns: EmailCampaignPerformance[];
+}
+
+/**
  * API response for Email CTR query
  */
 export interface EmailCtrResponse {
@@ -2824,6 +2890,49 @@ export interface EmailCtrResponse {
   campaignGroups: EmailCtrCampaignGroup[];
   monthlySends: number[];
   monthlyOpens: number[];
+  emailTypeBreakdown?: EmailTypeBreakdown[];
+  campaignInsightText?: string;
+}
+
+// ============================================
+// Marketing Metrics Card (Executive Director Dashboard)
+// ============================================
+
+/**
+ * Email campaign section data for the Marketing Metrics card
+ */
+export interface MarketingMetricsEmailSection {
+  ctr: string;
+  changeLabel: string;
+  trend: 'up' | 'down' | 'neutral';
+  totalSends: number;
+  totalOpens: number;
+  openRate: string;
+  monthlyData: number[];
+  monthlyLabels: string[];
+}
+
+/**
+ * Paid campaign section data for the Marketing Metrics card
+ */
+export interface MarketingMetricsPaidSection {
+  impressions: string;
+  changeLabel: string;
+  trend: 'up' | 'down' | 'neutral';
+  roas: string;
+  totalSpend: string;
+  totalRevenue: string;
+  monthlyData: number[];
+  monthlyLabels: string[];
+}
+
+/**
+ * Composite data for the Marketing Metrics card.
+ * Pre-formatted for template binding — no formatting in the template.
+ */
+export interface MarketingMetricsCardData {
+  email: MarketingMetricsEmailSection;
+  paid: MarketingMetricsPaidSection;
 }
 
 // ============================================
@@ -3211,6 +3320,54 @@ export interface RevenueImpactResponse {
   eventRegistrationAttribution: EventRegistrationAttribution;
 }
 
+// ============================================
+// Marketing Attribution (Campaign Performance Drawer)
+// ============================================
+
+/**
+ * Channel-level aggregation from ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION.
+ * One row per channel with session, visitor, and multi-touch revenue totals.
+ */
+export interface MarketingAttributionChannel {
+  channel: string;
+  sessions: number;
+  pageViews: number;
+  uniqueVisitors: number;
+  newVisitors: number;
+  returningVisitors: number;
+  firstTouchRevenue: number;
+  lastTouchRevenue: number;
+  linearRevenue: number;
+  timeDecayRevenue: number;
+}
+
+/**
+ * Project × channel drill-down row.
+ * Shown when expanding a channel row in the attribution table.
+ */
+export interface MarketingAttributionProject {
+  projectName: string;
+  channel: string;
+  sessions: number;
+  pageViews: number;
+  uniqueVisitors: number;
+  newVisitors: number;
+  returningVisitors: number;
+  firstTouchRevenue: number;
+  lastTouchRevenue: number;
+  linearRevenue: number;
+  timeDecayRevenue: number;
+}
+
+/**
+ * Full response for the marketing attribution endpoint.
+ * Combines channel summary + project drill-down data.
+ */
+export interface MarketingAttributionResponse {
+  channels: MarketingAttributionChannel[];
+  projects: MarketingAttributionProject[];
+}
+
 /**
  * Aggregated response for all ED Evolution dashboard API calls.
  * Used by buildEdEvolutionMetrics() to convert API data into card UI models.
@@ -3224,4 +3381,6 @@ export interface EdEvolutionData {
   brandReach: BrandReachResponse;
   brandHealth: BrandHealthResponse;
   revenueImpact: RevenueImpactResponse;
+  emailCtr: EmailCtrResponse;
+  paidCampaign: SocialReachResponse;
 }


### PR DESCRIPTION
## Summary
- Add `getMarketingAttribution` Snowflake query endpoint (controller, route, service) with multi-touch attribution (first touch, last touch, linear, time decay) and channel consolidation
- Extend `getSocialReach` with per-project paid campaign breakdown including funnel-stage, ROAS, conversions, CPC, and impressions/clicks
- Rewrite email CTR drawer as a unified **Campaign Performance** drawer with three data sections: Marketing Attribution (channel table), Paid Performance (project/campaign table with funnel tags), and Email Performance (type/campaign table with performance badges)
- Add Campaign Performance card to ED dashboard with dual-signal sparkline (Email Opens + Paid Impressions)
- Add shared interfaces: `PaidCampaignPerformance`, `PaidProjectBreakdown`, `EmailCampaignPerformance`, `EmailTypeBreakdown`, `MarketingAttributionChannel`, `MarketingAttributionProject`, `MarketingAttributionResponse`

## Test plan
- [ ] Verify the Campaign Performance card renders on the ED dashboard with email opens and paid impressions sparklines
- [ ] Open the Campaign Performance drawer and verify all three sections load: Attribution, Paid, Email
- [ ] Expand channel rows in the attribution table to see per-project breakdown
- [ ] Expand project rows in the paid table to see per-campaign breakdown with funnel stage tags
- [ ] Expand email type rows to see individual campaign performance
- [ ] Verify cross-channel insights (attention/performing) render correctly based on data
- [ ] Confirm the drawer loads paid and attribution data independently (no blocking)
- [ ] Test with `tlf` foundation slug to ensure umbrella-level queries work

Generated with [Claude Code](https://claude.ai/claude-code)