### PR TITLE
feat(dashboard): add marketing attribution backend and interfaces

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -107,7 +107,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -127,7 +127,7 @@ export class BrandHealthDrawerComponent {
           title: 'Address negative sentiment spike',
           description: `${sentiment.negative.toFixed(1)}% of mentions are negative — investigate top themes and coordinate response`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       }
@@ -137,7 +137,7 @@ export class BrandHealthDrawerComponent {
           title: 'Sentiment trending down',
           description: `Positive sentiment dropped ${Math.abs(sentimentMomChangePp).toFixed(1)}pp month-over-month — review recent coverage drivers`,
           priority: 'medium',
-          dueLabel: 'This month',
+
           actionType: 'engagement',
         });
       }
@@ -147,7 +147,7 @@ export class BrandHealthDrawerComponent {
           title: 'Maintain brand sentiment momentum',
           description: `${formatNumber(totalMentions)} mentions with ${sentiment.positive.toFixed(0)}% positive sentiment`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
@@ -87,7 +87,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
@@ -82,7 +82,7 @@ export class BrandReachDrawerComponent {
             title: 'Reduce platform concentration risk',
             description: `${top.name} holds ${topShare.toFixed(0)}% of ${formatNumber(totalSocialFollowers)} followers — a platform policy change could halve reach. Grow the next 2 largest channels`,
             priority: 'high',
-            dueLabel: 'This quarter',
+
             actionType: 'decline',
           });
         } else if (topShare > 55) {
@@ -90,7 +90,7 @@ export class BrandReachDrawerComponent {
             title: 'Watch platform concentration',
             description: `${top.name} is ${topShare.toFixed(0)}% of total followers — diversify before it crosses 70%`,
             priority: 'medium',
-            dueLabel: 'Next quarter',
+
             actionType: 'engagement',
           });
         }
@@ -102,7 +102,7 @@ export class BrandReachDrawerComponent {
           title: 'Expand platform footprint',
           description: `Active on only ${activePlatforms} platform${activePlatforms === 1 ? '' : 's'} — evaluate adding complementary networks to reduce single-network risk`,
           priority: 'medium',
-          dueLabel: 'This quarter',
+
           actionType: 'engagement',
         });
       }
@@ -116,7 +116,7 @@ export class BrandReachDrawerComponent {
             title: 'Web traffic over-reliant on one domain',
             description: `${topDomain.domain} drives ${topDomainShare.toFixed(0)}% of sessions — invest in secondary properties and cross-linking`,
             priority: 'medium',
-            dueLabel: 'This quarter',
+
             actionType: 'engagement',
           });
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -89,7 +89,6 @@
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-                <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -251,7 +251,7 @@ export class EmailCtrDrawerComponent {
           title: 'Test new call-to-action formats',
           description: `CTR dropped ${Math.abs(changePercentage)}% — experiment with button placement and copy in the next send`,
           priority: 'high',
-          dueLabel: 'Next send',
+
           actionType: 'optimize',
         });
       }
@@ -266,7 +266,7 @@ export class EmailCtrDrawerComponent {
             title: 'Optimize email subject lines',
             description: `Open rate declined from ${prevOpenRate.toFixed(1)}% to ${latestOpenRate.toFixed(1)}% — A/B test subject lines`,
             priority: latestOpenRate < prevOpenRate * 0.9 ? 'high' : 'medium',
-            dueLabel: 'Next send',
+
             actionType: 'content',
           });
         }
@@ -281,7 +281,7 @@ export class EmailCtrDrawerComponent {
             title: `Replicate "${best.campaignName}" approach`,
             description: `Top campaign has ${best.avgCtr.toFixed(1)}% CTR vs ${worst.avgCtr.toFixed(1)}% for "${worst.campaignName}" — apply winning format`,
             priority: 'medium',
-            dueLabel: 'This month',
+
             actionType: 'optimize',
           });
         }
@@ -292,7 +292,7 @@ export class EmailCtrDrawerComponent {
           title: 'Maintain current momentum',
           description: `CTR is trending up (+${changePercentage}%) — continue current content strategy`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -78,7 +78,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -205,7 +205,7 @@ export class EngagedCommunityDrawerComponent {
           title: 'Address community decline',
           description: `Engaged community dropped ${Math.abs(changePercentage).toFixed(1)}% vs last month — review engagement programs and onboarding flow`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       }
@@ -218,7 +218,7 @@ export class EngagedCommunityDrawerComponent {
             title: 'Grow working group participation',
             description: `Working groups hold only ${wgShare.toFixed(0)}% of engaged members (${formatNumber(breakdown.workingGroupMembers)}) — convert passive community members into active contributors`,
             priority: 'medium',
-            dueLabel: 'This quarter',
+
             actionType: 'engagement',
           });
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -128,7 +128,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
@@ -149,7 +149,7 @@ export class EventGrowthDrawerComponent {
           title: 'Reverse attendance decline',
           description: `Attendance dropped ${Math.abs(attendeeYoyChange).toFixed(1)}% YoY — review event mix, promotion windows, and channel performance`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       } else if (attendeeYoyChange <= -3) {
@@ -157,7 +157,7 @@ export class EventGrowthDrawerComponent {
           title: 'Attendance softening',
           description: `Attendance down ${Math.abs(attendeeYoyChange).toFixed(1)}% YoY — watch next event's registration pace`,
           priority: 'medium',
-          dueLabel: 'Next event',
+
           actionType: 'investigate',
         });
       }
@@ -168,7 +168,7 @@ export class EventGrowthDrawerComponent {
           title: 'Event revenue declining',
           description: `Total event revenue down ${Math.abs(revenueYoyChange).toFixed(1)}% YoY${revenuePerAttendeeText} — review sponsorship packages and ticket pricing`,
           priority: 'medium',
-          dueLabel: 'This quarter',
+
           actionType: 'revenue',
         });
       }
@@ -181,7 +181,7 @@ export class EventGrowthDrawerComponent {
             title: 'One event carries the portfolio',
             description: `${leadEvent.name} drives ${topShare.toFixed(0)}% of total attendance — a single weak year on this event would hit the whole portfolio`,
             priority: 'medium',
-            dueLabel: 'Next planning cycle',
+
             actionType: 'engagement',
           });
         }
@@ -195,7 +195,7 @@ export class EventGrowthDrawerComponent {
             title: 'Registrations falling 3 quarters straight',
             description: `Quarterly registrations fell from ${formatNumber(recent3[0].value)} to ${formatNumber(recent3[2].value)} — sustained decline, not a single bad event`,
             priority: 'high',
-            dueLabel: 'This quarter',
+
             actionType: 'decline',
           });
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -86,7 +86,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -108,7 +108,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -171,7 +171,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Reverse acquisition decline',
           description: `New member signups dropped ${Math.abs(changePercentage).toFixed(1)}% QoQ — review top-of-funnel channels, conversion paths, and outbound pipeline`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       } else if (changePercentage <= -5) {
@@ -179,7 +179,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Acquisition softening',
           description: `New member signups down ${Math.abs(changePercentage).toFixed(1)}% QoQ — watch next quarter's pipeline and renewal mix`,
           priority: 'medium',
-          dueLabel: 'Next quarter',
+
           actionType: 'investigate',
         });
       }
@@ -198,7 +198,6 @@ export class MemberAcquisitionDrawerComponent {
               title: 'Membership tier mix shifting down',
               description: `Revenue per new member fell ${declinePct.toFixed(0)}% (${formatCurrency(Math.abs(delta))}/member) — winning deals are smaller. Review tier positioning and sales qualification`,
               priority: 'high',
-              dueLabel: 'This quarter',
               actionType: 'revenue',
             });
           } else if (declinePct >= 5) {
@@ -206,7 +205,7 @@ export class MemberAcquisitionDrawerComponent {
               title: 'Watch tier mix trend',
               description: `Revenue per new member down ${declinePct.toFixed(0)}% QoQ — not yet urgent, but track whether next quarter's deals are smaller still`,
               priority: 'medium',
-              dueLabel: 'Next quarter',
+
               actionType: 'revenue',
             });
           }
@@ -337,7 +336,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Improve net revenue retention',
           description: `NRR at ${netRevenueRetention}% — significant revenue loss from existing members. Review downgrades and churn`,
           priority: 'high',
-          dueLabel: 'This quarter',
+
           actionType: 'revenue',
         });
       } else if (netRevenueRetention >= 90 && netRevenueRetention < 98) {
@@ -345,7 +344,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Monitor net revenue retention',
           description: `NRR at ${netRevenueRetention}% — revenue contraction from existing members. Explore upsell opportunities`,
           priority: 'medium',
-          dueLabel: 'Next quarter',
+
           actionType: 'revenue',
         });
       }
@@ -355,7 +354,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Address retention decline',
           description: `Renewal rate dropped ${Math.abs(changePercentage)}% — review member satisfaction and renewal outreach timing`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       }
@@ -365,7 +364,7 @@ export class MemberAcquisitionDrawerComponent {
           title: 'Maintain retention excellence',
           description: `${renewalRate}% renewal rate${netRevenueRetention > 100 ? ` with ${netRevenueRetention}% NRR` : ''}`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -84,7 +84,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -67,7 +67,7 @@ export class MemberRetentionDrawerComponent {
           title: 'Improve net revenue retention',
           description: `NRR at ${netRevenueRetention}% — significant revenue loss from existing members. Review downgrades and churn`,
           priority: 'high',
-          dueLabel: 'This quarter',
+
           actionType: 'revenue',
         });
       } else if (netRevenueRetention >= 90 && netRevenueRetention < 98) {
@@ -75,7 +75,7 @@ export class MemberRetentionDrawerComponent {
           title: 'Monitor net revenue retention',
           description: `NRR at ${netRevenueRetention}% — revenue contraction from existing members. Explore upsell opportunities`,
           priority: 'medium',
-          dueLabel: 'Next quarter',
+
           actionType: 'revenue',
         });
       }
@@ -86,7 +86,7 @@ export class MemberRetentionDrawerComponent {
           title: 'Address retention decline',
           description: `Renewal rate dropped ${Math.abs(changePercentage)}% — review member satisfaction and renewal outreach timing`,
           priority: 'high',
-          dueLabel: 'This month',
+
           actionType: 'decline',
         });
       }
@@ -96,7 +96,7 @@ export class MemberRetentionDrawerComponent {
           title: 'Maintain retention excellence',
           description: `${renewalRate}% renewal rate${netRevenueRetention > 100 ? ` with ${netRevenueRetention}% NRR` : ''}`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
@@ -98,7 +98,6 @@
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-                <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.ts
@@ -200,7 +200,7 @@ export class PaidSocialReachDrawerComponent {
           title: 'Cut or pause losing campaigns',
           description: `ROAS is ${roas.toFixed(2)}x — ${formatCurrency(lost)} spent above revenue earned. Pause bottom-performing campaigns before next cycle`,
           priority: 'high',
-          dueLabel: 'This week',
+
           actionType: 'decline',
         });
       } else if (totalSpend > 0 && roas >= 0.8 && roas < 1) {
@@ -208,7 +208,7 @@ export class PaidSocialReachDrawerComponent {
           title: 'Campaigns at break-even',
           description: `ROAS is ${roas.toFixed(2)}x on ${formatCurrency(totalSpend)} spend — not yet profitable. Fix creative and targeting before scaling budget`,
           priority: 'medium',
-          dueLabel: 'This month',
+
           actionType: 'investigate',
         });
       }
@@ -223,7 +223,7 @@ export class PaidSocialReachDrawerComponent {
             title: 'ROAS trending down 3 months straight',
             description: `ROAS fell from ${recent3[0].toFixed(2)}x to ${recent3[2].toFixed(2)}x over 3 months — investigate audience saturation and creative fatigue`,
             priority: 'medium',
-            dueLabel: 'This month',
+
             actionType: 'investigate',
           });
         }
@@ -235,7 +235,7 @@ export class PaidSocialReachDrawerComponent {
           title: 'Investigate reach decline',
           description: `Impressions dropped ${Math.abs(changePercentage).toFixed(1)}% MoM — review targeting, bid strategy, and platform algorithm changes`,
           priority: 'high',
-          dueLabel: 'Next campaign',
+
           actionType: 'investigate',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.html
@@ -53,7 +53,6 @@
                 }
               </div>
               <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-              <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
             </div>
           </div>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.ts
@@ -252,7 +252,7 @@ export class RevenueImpactDrawerComponent {
           title: 'Cut or pause losing paid campaigns',
           description: `Paid ROAS is ${paidMedia.roas.toFixed(2)}x — ${RevenueImpactDrawerComponent.formatRevenue(lost)} spent above revenue earned. Review top-spending campaigns and pause underperformers`,
           priority: 'high',
-          dueLabel: 'This week',
+
           actionType: 'decline',
         });
       } else if (paidMedia.adSpend > 0 && paidMedia.roas >= 0.8 && paidMedia.roas < 1) {
@@ -260,7 +260,7 @@ export class RevenueImpactDrawerComponent {
           title: 'Paid media at break-even',
           description: `ROAS is ${paidMedia.roas.toFixed(2)}x on ${RevenueImpactDrawerComponent.formatRevenue(paidMedia.adSpend)} spend — optimize creative and targeting before scaling`,
           priority: 'medium',
-          dueLabel: 'This month',
+
           actionType: 'investigate',
         });
       }
@@ -272,7 +272,7 @@ export class RevenueImpactDrawerComponent {
             title: 'Reduce channel concentration risk',
             description: `${RevenueImpactDrawerComponent.formatChannelLabel(top.channel)} drives ${top.percentage.toFixed(0)}% of paid impressions — one algorithm change could cut reach in half. Grow at least one alternate channel`,
             priority: 'high',
-            dueLabel: 'This quarter',
+
             actionType: 'decline',
           });
         } else if (top.percentage > 55) {
@@ -280,7 +280,7 @@ export class RevenueImpactDrawerComponent {
             title: 'Watch channel concentration',
             description: `${RevenueImpactDrawerComponent.formatChannelLabel(top.channel)} is ${top.percentage.toFixed(0)}% of paid impressions — diversify before it crosses 70%`,
             priority: 'medium',
-            dueLabel: 'This quarter',
+
             actionType: 'engagement',
           });
         }
@@ -297,7 +297,7 @@ export class RevenueImpactDrawerComponent {
             title: 'Rebalance project-level channel mix',
             description: `${heavilyConcentrated.length} projects get 80%+ of their paid reach from a single channel — rebalance to reduce per-project platform dependency`,
             priority: 'medium',
-            dueLabel: 'Next quarter',
+
             actionType: 'engagement',
           });
         }
@@ -313,7 +313,7 @@ export class RevenueImpactDrawerComponent {
               title: 'Event registration revenue over-concentrated',
               description: `${topEvt.channel} drove ${topShare.toFixed(0)}% of event-registration last-touch revenue (${RevenueImpactDrawerComponent.formatRevenue(topEvt.lastTouchRevenue ?? 0)}) — grow alternate acquisition paths for event revenue`,
               priority: 'medium',
-              dueLabel: 'Next quarter',
+
               actionType: 'engagement',
             });
           }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -95,7 +95,6 @@
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-                <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.ts
@@ -219,7 +219,7 @@ export class SocialMediaDrawerComponent {
           title: `Increase posting on ${highEngageLowPost.platform}`,
           description: `${highEngageLowPost.engagementRate.toFixed(1)}% engagement rate but only ${highEngageLowPost.postsLast30Days} posts in 30 days`,
           priority: 'high',
-          dueLabel: 'This week',
+
           actionType: 'content',
         });
       }
@@ -229,7 +229,7 @@ export class SocialMediaDrawerComponent {
           title: 'Address follower decline',
           description: `Followers dropped ${Math.abs(changePercentage)}% — review content strategy and posting cadence`,
           priority: 'high',
-          dueLabel: 'This week',
+
           actionType: 'decline',
         });
       }
@@ -243,7 +243,7 @@ export class SocialMediaDrawerComponent {
             title: `Boost engagement on ${lowest.platform}`,
             description: `${formatNumber(lowest.followers)} followers but only ${lowest.engagementRate.toFixed(1)}% engagement — try interactive content`,
             priority: 'medium',
-            dueLabel: 'This month',
+
             actionType: 'engagement',
           });
         }
@@ -254,7 +254,7 @@ export class SocialMediaDrawerComponent {
           title: 'Continue growth strategy',
           description: `${formatNumber(totalFollowers)} followers across ${platforms.length} platforms${changePercentage > 0 ? ` — growing ${changePercentage}%` : ''}`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -80,7 +80,6 @@
                   }
                 </div>
                 <p class="text-sm text-gray-500 mt-0.5">{{ action.description }}</p>
-                <p class="text-xs text-gray-400 mt-1">Due: {{ action.dueLabel }}</p>
               </div>
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -192,7 +192,7 @@ export class WebsiteVisitsDrawerComponent {
             title: 'Investigate traffic decline',
             description: `Sessions dropped ~${decline}% over recent weeks — review traffic sources and content changes`,
             priority: 'high',
-            dueLabel: 'This month',
+
             actionType: 'decline',
           });
         }
@@ -207,7 +207,7 @@ export class WebsiteVisitsDrawerComponent {
             title: `Diversify traffic beyond ${sorted[0].domainGroup}`,
             description: `${topShare.toFixed(0)}% of sessions come from a single domain — expand content across other properties`,
             priority: 'medium',
-            dueLabel: 'This month',
+
             actionType: 'diversify',
           });
         }
@@ -221,7 +221,7 @@ export class WebsiteVisitsDrawerComponent {
             title: 'Improve internal linking',
             description: `Only ${pagesPerSession.toFixed(1)} pages per session — add cross-links to increase engagement`,
             priority: 'medium',
-            dueLabel: 'This month',
+
             actionType: 'optimize',
           });
         }
@@ -232,7 +232,7 @@ export class WebsiteVisitsDrawerComponent {
           title: 'Continue current strategy',
           description: `${formatNumber(totalSessions)} sessions with healthy traffic distribution`,
           priority: 'low',
-          dueLabel: 'Ongoing',
+
           actionType: 'growth',
         });
       }

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -68,6 +68,7 @@ import {
   BrandReachResponse,
   BrandHealthResponse,
   RevenueImpactResponse,
+  MarketingAttributionResponse,
   MultiFoundationSummaryResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
@@ -1254,6 +1255,17 @@ export class AnalyticsService {
         })
       )
     );
+  }
+
+  /**
+   * Get marketing attribution data by channel with multi-touch revenue models.
+   * @param foundationSlug Foundation slug used to filter Snowflake queries
+   * @returns Observable emitting channel summary + project drill-down (or empty defaults on error)
+   */
+  public getMarketingAttribution(foundationSlug: string): Observable<MarketingAttributionResponse> {
+    return this.http
+      .get<MarketingAttributionResponse>('/api/analytics/marketing-attribution', { params: { foundationSlug } })
+      .pipe(catchError(() => of({ channels: [], projects: [] })));
   }
 
   /**

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2570,6 +2570,43 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/marketing-attribution
+   * Get channel-level marketing attribution with multi-touch revenue models
+   * Query params: foundationSlug (required)
+   */
+  public async getMarketingAttribution(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_marketing_attribution');
+
+    try {
+      const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_marketing_attribution',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_marketing_attribution',
+        });
+      }
+
+      const response = await this.projectService.getMarketingAttribution(foundationSlug);
+
+      logger.success(req, 'get_marketing_attribution', startTime, {
+        foundation_slug: foundationSlug,
+        channel_count: response.channels.length,
+        project_count: response.projects.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  /**
    * GET /api/analytics/multi-foundation-summary
    * Aggregate analytics across multiple foundations in a single request
    * Query params: slugs (required, comma-separated foundation slugs, max 25)

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -178,6 +178,7 @@ router.get('/event-growth', (req, res, next) => analyticsController.getEventGrow
 router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
 router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
 router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));
+router.get('/marketing-attribution', (req, res, next) => analyticsController.getMarketingAttribution(req, res, next));
 
 // Multi-foundation summary endpoint (multi-foundation dashboard)
 router.get('/multi-foundation-summary', (req, res, next) => analyticsController.getMultiFoundationSummary(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -57,6 +57,9 @@ import {
   HealthMetricsDailyResponse,
   HealthMetricsRange,
   LifecycleStage,
+  MarketingAttributionChannel,
+  MarketingAttributionProject,
+  MarketingAttributionResponse,
   MemberAcquisitionResponse,
   MemberRetentionResponse,
   MembershipChurnPerTierSummaryResponse,
@@ -2033,12 +2036,45 @@ export class ProjectService {
       ORDER BY IMPRESSIONS DESC
     `;
 
-      const [impressionsResult, roasKpiResult, monthlyRoasResult, monthlyImpressionsResult, channelResult] = await Promise.all([
+      // Block 6: Project + campaign level performance breakdown (last 6 months)
+      const projectPerfQuery = `
+      SELECT
+        PROJECT_NAME, CAMPAIGN_NAME, FUNNEL_STAGE,
+        SUM(SPEND) AS SPEND, SUM(LINEAR_REVENUE) AS REVENUE,
+        ROUND(DIV0(SUM(LINEAR_REVENUE), SUM(SPEND)), 2) AS ROAS,
+        SUM(CONV) AS CONVERSIONS,
+        ROUND(DIV0(SUM(CONV), NULLIF(SUM(CLICKS), 0)) * 100, 2) AS CONV_RATE,
+        ROUND(DIV0(SUM(SPEND), NULLIF(SUM(CLICKS), 0)), 2) AS CPC,
+        SUM(SESSIONS) AS SESSIONS,
+        SUM(IMPRESSIONS) AS IMPRESSIONS,
+        SUM(CLICKS) AS CLICKS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
+      WHERE FOUNDATION_SLUG = ?
+        AND CAMPAIGN_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
+      GROUP BY PROJECT_NAME, CAMPAIGN_NAME, FUNNEL_STAGE
+      ORDER BY SPEND DESC
+    `;
+
+      const [impressionsResult, roasKpiResult, monthlyRoasResult, monthlyImpressionsResult, channelResult, projectPerfResult] = await Promise.all([
         this.snowflakeService.execute<{ TOTAL_IMPRESSIONS: number; TOTAL_SPEND: number; TOTAL_REVENUE: number }>(impressionsQuery, [foundationSlug]),
         this.snowflakeService.execute<{ ROAS: number; ROAS_MOM_PCT: number }>(roasKpiQuery, [foundationSlug]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; ROAS: number }>(monthlyRoasQuery, [foundationSlug]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; IMPRESSIONS: number }>(monthlyImpressionsQuery, [foundationSlug]),
         this.snowflakeService.execute<{ CHANNEL: string; IMPRESSIONS: number }>(channelQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          PROJECT_NAME: string;
+          CAMPAIGN_NAME: string;
+          FUNNEL_STAGE: string;
+          SPEND: number;
+          REVENUE: number;
+          ROAS: number;
+          CONVERSIONS: number;
+          CONV_RATE: number;
+          CPC: number;
+          SESSIONS: number;
+          IMPRESSIONS: number;
+          CLICKS: number;
+        }>(projectPerfQuery, [foundationSlug]),
       ]);
 
       const totalReach = impressionsResult.rows[0]?.TOTAL_IMPRESSIONS ?? 0;
@@ -2074,6 +2110,98 @@ export class ProjectService {
         totalImpressions: row.IMPRESSIONS,
       }));
 
+      // Shape project breakdown with nested campaigns
+      const projectMap = new Map<
+        string,
+        {
+          spend: number;
+          revenue: number;
+          conversions: number;
+          impressions: number;
+          clicks: number;
+          sessions: number;
+          funnelStages: Set<string>;
+          campaigns: typeof projectPerfResult.rows;
+        }
+      >();
+      for (const row of projectPerfResult.rows) {
+        const existing = projectMap.get(row.PROJECT_NAME) ?? {
+          spend: 0,
+          revenue: 0,
+          conversions: 0,
+          impressions: 0,
+          clicks: 0,
+          sessions: 0,
+          funnelStages: new Set<string>(),
+          campaigns: [] as typeof projectPerfResult.rows,
+        };
+        existing.spend += row.SPEND ?? 0;
+        existing.revenue += row.REVENUE ?? 0;
+        existing.conversions += row.CONVERSIONS ?? 0;
+        existing.impressions += row.IMPRESSIONS ?? 0;
+        existing.clicks += row.CLICKS ?? 0;
+        existing.sessions += row.SESSIONS ?? 0;
+        if (row.FUNNEL_STAGE) {
+          existing.funnelStages.add(row.FUNNEL_STAGE);
+        }
+        existing.campaigns.push(row);
+        projectMap.set(row.PROJECT_NAME, existing);
+      }
+
+      const getPaidPerformance = (projectRoas: number): string => {
+        if (projectRoas >= 2) return 'EXCELLENT';
+        if (projectRoas >= 1) return 'GOOD';
+        if (projectRoas > 0) return 'POOR';
+        return 'NO REVENUE';
+      };
+
+      const formatFunnel = (stages: Set<string>): string => {
+        const priority = ['BoFU', 'MoFU', 'ToFU', 'ToFU2', 'Unknown'];
+        for (const p of priority) {
+          if (stages.has(p)) return p;
+        }
+        return [...stages][0] ?? 'Unknown';
+      };
+
+      const projectBreakdown = Array.from(projectMap.entries())
+        .filter(([, data]) => data.spend > 0)
+        .map(([projectName, data]) => {
+          const projectRoas = data.spend > 0 ? Math.round((data.revenue / data.spend) * 100) / 100 : 0;
+          const convRate = data.clicks > 0 ? Math.round((data.conversions / data.clicks) * 10000) / 100 : 0;
+          const cpc = data.clicks > 0 ? Math.round((data.spend / data.clicks) * 100) / 100 : 0;
+          return {
+            projectName,
+            funnelStage: formatFunnel(data.funnelStages),
+            spend: Math.round(data.spend),
+            revenue: Math.round(data.revenue),
+            roas: projectRoas,
+            conversions: data.conversions,
+            convRate,
+            cpc,
+            sessions: data.sessions,
+            impressions: data.impressions,
+            clicks: data.clicks,
+            performance: getPaidPerformance(projectRoas),
+            campaigns: data.campaigns
+              .sort((a, b) => (b.SPEND ?? 0) - (a.SPEND ?? 0))
+              .slice(0, 10)
+              .map((c) => ({
+                campaignName: c.CAMPAIGN_NAME,
+                funnelStage: c.FUNNEL_STAGE ?? 'Unknown',
+                spend: Math.round(c.SPEND ?? 0),
+                revenue: Math.round(c.REVENUE ?? 0),
+                roas: c.ROAS ?? 0,
+                conversions: c.CONVERSIONS ?? 0,
+                convRate: c.CONV_RATE ?? 0,
+                cpc: c.CPC ?? 0,
+                sessions: c.SESSIONS ?? 0,
+                impressions: c.IMPRESSIONS ?? 0,
+                clicks: c.CLICKS ?? 0,
+              })),
+          };
+        })
+        .sort((a, b) => b.spend - a.spend);
+
       return {
         totalReach,
         roas: Math.round(roas * 100) / 100,
@@ -2085,6 +2213,7 @@ export class ProjectService {
         monthlyLabels,
         monthlyRoas,
         channelGroups,
+        projectBreakdown,
       };
     } catch (error) {
       logger.warning(undefined, 'get_social_reach', 'Failed to fetch social reach data, returning defaults', {
@@ -2103,6 +2232,224 @@ export class ProjectService {
         monthlyRoas: [],
         channelGroups: [],
       };
+    }
+  }
+
+  /**
+   * Get marketing attribution data from ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION.
+   * Returns channel-level summary and project × channel drill-down for the last 6 months.
+   * @param foundationSlug - Foundation slug or 'tlf' for umbrella aggregation
+   * @returns Channel summary + project drill-down
+   */
+  public async getMarketingAttribution(foundationSlug: string): Promise<MarketingAttributionResponse> {
+    const startTime = Date.now();
+    logger.debug(undefined, 'get_marketing_attribution', 'Fetching marketing attribution from Snowflake', { foundation_slug: foundationSlug });
+
+    try {
+      const isUmbrella = foundationSlug === 'tlf';
+
+      const channelQuery = isUmbrella
+        ? `
+        SELECT CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY CHANNEL
+        ORDER BY SESSIONS DESC
+      `
+        : `
+        SELECT CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE FOUNDATION_SLUG = ?
+          AND SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY CHANNEL
+        ORDER BY SESSIONS DESC
+      `;
+
+      const projectQuery = isUmbrella
+        ? `
+        SELECT PROJECT_NAME, CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY PROJECT_NAME, CHANNEL
+        ORDER BY CHANNEL, SESSIONS DESC
+      `
+        : `
+        SELECT PROJECT_NAME, CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE FOUNDATION_SLUG = ?
+          AND SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY PROJECT_NAME, CHANNEL
+        ORDER BY CHANNEL, SESSIONS DESC
+      `;
+
+      const params = isUmbrella ? [] : [foundationSlug];
+
+      interface ChannelRow {
+        CHANNEL: string;
+        SESSIONS: number;
+        PAGE_VIEWS: number;
+        UNIQUE_VISITORS: number;
+        NEW_VISITORS: number;
+        RETURNING_VISITORS: number;
+        FIRST_TOUCH_REVENUE: number;
+        LAST_TOUCH_REVENUE: number;
+        LINEAR_REVENUE: number;
+        TIME_DECAY_REVENUE: number;
+      }
+
+      interface ProjectRow {
+        PROJECT_NAME: string;
+        CHANNEL: string;
+        SESSIONS: number;
+        PAGE_VIEWS: number;
+        UNIQUE_VISITORS: number;
+        NEW_VISITORS: number;
+        RETURNING_VISITORS: number;
+        FIRST_TOUCH_REVENUE: number;
+        LAST_TOUCH_REVENUE: number;
+        LINEAR_REVENUE: number;
+        TIME_DECAY_REVENUE: number;
+      }
+
+      const [channelResult, projectResult] = await Promise.all([
+        this.snowflakeService.execute<ChannelRow>(channelQuery, params),
+        this.snowflakeService.execute<ProjectRow>(projectQuery, params),
+      ]);
+
+      // Map Snowflake channels to consolidated UI labels:
+      //   Paid Search + Social → "Paid Performance"
+      //   Email / HubSpot → "Email"
+      //   Internal / Banner → "Internal & Banner"
+      //   Organic Search → "Organic"
+      //   Other Tracked → "Other"
+      //   Direct / Unknown → "Direct & Unknown"
+      const mapChannel = (raw: string): string => {
+        switch (raw) {
+          case 'Paid Search':
+          case 'Social':
+            return 'Paid Performance';
+          case 'Email / HubSpot':
+            return 'Email';
+          case 'Internal / Banner':
+            return 'Internal & Banner';
+          case 'Organic Search':
+            return 'Organic';
+          case 'Other Tracked':
+            return 'Other';
+          case 'Direct / Unknown':
+            return 'Direct & Unknown';
+          default:
+            return raw;
+        }
+      };
+
+      // Aggregate channel rows that map to the same UI label
+      const channelMap = new Map<string, MarketingAttributionChannel>();
+      for (const row of channelResult.rows) {
+        const label = mapChannel(row.CHANNEL);
+        const existing = channelMap.get(label);
+        if (existing) {
+          existing.sessions += row.SESSIONS;
+          existing.pageViews += row.PAGE_VIEWS;
+          existing.uniqueVisitors += row.UNIQUE_VISITORS;
+          existing.newVisitors += row.NEW_VISITORS;
+          existing.returningVisitors += row.RETURNING_VISITORS;
+          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE;
+          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE;
+          existing.linearRevenue += row.LINEAR_REVENUE;
+          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE;
+        } else {
+          channelMap.set(label, {
+            channel: label,
+            sessions: row.SESSIONS,
+            pageViews: row.PAGE_VIEWS,
+            uniqueVisitors: row.UNIQUE_VISITORS,
+            newVisitors: row.NEW_VISITORS,
+            returningVisitors: row.RETURNING_VISITORS,
+            firstTouchRevenue: row.FIRST_TOUCH_REVENUE,
+            lastTouchRevenue: row.LAST_TOUCH_REVENUE,
+            linearRevenue: row.LINEAR_REVENUE,
+            timeDecayRevenue: row.TIME_DECAY_REVENUE,
+          });
+        }
+      }
+      const channels = [...channelMap.values()].sort((a, b) => b.sessions - a.sessions);
+
+      // Map project rows with the same channel consolidation
+      const attrProjectMap = new Map<string, MarketingAttributionProject>();
+      for (const row of projectResult.rows) {
+        const label = mapChannel(row.CHANNEL);
+        const key = `${row.PROJECT_NAME}::${label}`;
+        const existing = attrProjectMap.get(key);
+        if (existing) {
+          existing.sessions += row.SESSIONS;
+          existing.pageViews += row.PAGE_VIEWS;
+          existing.uniqueVisitors += row.UNIQUE_VISITORS;
+          existing.newVisitors += row.NEW_VISITORS;
+          existing.returningVisitors += row.RETURNING_VISITORS;
+          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE;
+          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE;
+          existing.linearRevenue += row.LINEAR_REVENUE;
+          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE;
+        } else {
+          attrProjectMap.set(key, {
+            projectName: row.PROJECT_NAME,
+            channel: label,
+            sessions: row.SESSIONS,
+            pageViews: row.PAGE_VIEWS,
+            uniqueVisitors: row.UNIQUE_VISITORS,
+            newVisitors: row.NEW_VISITORS,
+            returningVisitors: row.RETURNING_VISITORS,
+            firstTouchRevenue: row.FIRST_TOUCH_REVENUE,
+            lastTouchRevenue: row.LAST_TOUCH_REVENUE,
+            linearRevenue: row.LINEAR_REVENUE,
+            timeDecayRevenue: row.TIME_DECAY_REVENUE,
+          });
+        }
+      }
+      const projects = [...attrProjectMap.values()].sort((a, b) => b.sessions - a.sessions);
+
+      logger.debug(undefined, 'get_marketing_attribution', 'Marketing attribution data fetched', {
+        foundation_slug: foundationSlug,
+        channel_count: channels.length,
+        project_count: projects.length,
+        duration_ms: Date.now() - startTime,
+      });
+
+      return { channels, projects };
+    } catch (error) {
+      logger.error(undefined, 'get_marketing_attribution', startTime, error instanceof Error ? error : new Error(String(error)), {
+        foundation_slug: foundationSlug,
+      });
+      throw error;
     }
   }
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2037,6 +2037,9 @@ export class ProjectService {
     `;
 
       // Block 6: Project + campaign level performance breakdown (last 6 months)
+      // Uses LINEAR_REVENUE (not FIRST_TOUCH) — the per-campaign drill-down uses linear
+      // attribution to distribute credit fairly across touchpoints, while the top-level
+      // KPI (Blocks 1–2) uses first-touch for the headline ROAS.
       const projectPerfQuery = `
       SELECT
         PROJECT_NAME, CAMPAIGN_NAME, FUNNEL_STAGE,
@@ -2371,33 +2374,34 @@ export class ProjectService {
         }
       };
 
-      // Aggregate channel rows that map to the same UI label
+      // Aggregate channel rows that map to the same UI label.
+      // Guard with ?? 0 — SUM() returns NULL when all values in the group are NULL.
       const channelMap = new Map<string, MarketingAttributionChannel>();
       for (const row of channelResult.rows) {
         const label = mapChannel(row.CHANNEL);
         const existing = channelMap.get(label);
         if (existing) {
-          existing.sessions += row.SESSIONS;
-          existing.pageViews += row.PAGE_VIEWS;
-          existing.uniqueVisitors += row.UNIQUE_VISITORS;
-          existing.newVisitors += row.NEW_VISITORS;
-          existing.returningVisitors += row.RETURNING_VISITORS;
-          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE;
-          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE;
-          existing.linearRevenue += row.LINEAR_REVENUE;
-          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE;
+          existing.sessions += row.SESSIONS ?? 0;
+          existing.pageViews += row.PAGE_VIEWS ?? 0;
+          existing.uniqueVisitors += row.UNIQUE_VISITORS ?? 0;
+          existing.newVisitors += row.NEW_VISITORS ?? 0;
+          existing.returningVisitors += row.RETURNING_VISITORS ?? 0;
+          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE ?? 0;
+          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE ?? 0;
+          existing.linearRevenue += row.LINEAR_REVENUE ?? 0;
+          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE ?? 0;
         } else {
           channelMap.set(label, {
             channel: label,
-            sessions: row.SESSIONS,
-            pageViews: row.PAGE_VIEWS,
-            uniqueVisitors: row.UNIQUE_VISITORS,
-            newVisitors: row.NEW_VISITORS,
-            returningVisitors: row.RETURNING_VISITORS,
-            firstTouchRevenue: row.FIRST_TOUCH_REVENUE,
-            lastTouchRevenue: row.LAST_TOUCH_REVENUE,
-            linearRevenue: row.LINEAR_REVENUE,
-            timeDecayRevenue: row.TIME_DECAY_REVENUE,
+            sessions: row.SESSIONS ?? 0,
+            pageViews: row.PAGE_VIEWS ?? 0,
+            uniqueVisitors: row.UNIQUE_VISITORS ?? 0,
+            newVisitors: row.NEW_VISITORS ?? 0,
+            returningVisitors: row.RETURNING_VISITORS ?? 0,
+            firstTouchRevenue: row.FIRST_TOUCH_REVENUE ?? 0,
+            lastTouchRevenue: row.LAST_TOUCH_REVENUE ?? 0,
+            linearRevenue: row.LINEAR_REVENUE ?? 0,
+            timeDecayRevenue: row.TIME_DECAY_REVENUE ?? 0,
           });
         }
       }
@@ -2410,28 +2414,28 @@ export class ProjectService {
         const key = `${row.PROJECT_NAME}::${label}`;
         const existing = attrProjectMap.get(key);
         if (existing) {
-          existing.sessions += row.SESSIONS;
-          existing.pageViews += row.PAGE_VIEWS;
-          existing.uniqueVisitors += row.UNIQUE_VISITORS;
-          existing.newVisitors += row.NEW_VISITORS;
-          existing.returningVisitors += row.RETURNING_VISITORS;
-          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE;
-          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE;
-          existing.linearRevenue += row.LINEAR_REVENUE;
-          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE;
+          existing.sessions += row.SESSIONS ?? 0;
+          existing.pageViews += row.PAGE_VIEWS ?? 0;
+          existing.uniqueVisitors += row.UNIQUE_VISITORS ?? 0;
+          existing.newVisitors += row.NEW_VISITORS ?? 0;
+          existing.returningVisitors += row.RETURNING_VISITORS ?? 0;
+          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE ?? 0;
+          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE ?? 0;
+          existing.linearRevenue += row.LINEAR_REVENUE ?? 0;
+          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE ?? 0;
         } else {
           attrProjectMap.set(key, {
             projectName: row.PROJECT_NAME,
             channel: label,
-            sessions: row.SESSIONS,
-            pageViews: row.PAGE_VIEWS,
-            uniqueVisitors: row.UNIQUE_VISITORS,
-            newVisitors: row.NEW_VISITORS,
-            returningVisitors: row.RETURNING_VISITORS,
-            firstTouchRevenue: row.FIRST_TOUCH_REVENUE,
-            lastTouchRevenue: row.LAST_TOUCH_REVENUE,
-            linearRevenue: row.LINEAR_REVENUE,
-            timeDecayRevenue: row.TIME_DECAY_REVENUE,
+            sessions: row.SESSIONS ?? 0,
+            pageViews: row.PAGE_VIEWS ?? 0,
+            uniqueVisitors: row.UNIQUE_VISITORS ?? 0,
+            newVisitors: row.NEW_VISITORS ?? 0,
+            returningVisitors: row.RETURNING_VISITORS ?? 0,
+            firstTouchRevenue: row.FIRST_TOUCH_REVENUE ?? 0,
+            lastTouchRevenue: row.LAST_TOUCH_REVENUE ?? 0,
+            linearRevenue: row.LINEAR_REVENUE ?? 0,
+            timeDecayRevenue: row.TIME_DECAY_REVENUE ?? 0,
           });
         }
       }

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2726,6 +2726,42 @@ export interface SocialReachChannelGroup {
 }
 
 /**
+ * Per-campaign paid performance data (nested under project)
+ */
+export interface PaidCampaignPerformance {
+  campaignName: string;
+  funnelStage: string;
+  spend: number;
+  revenue: number;
+  roas: number;
+  conversions: number;
+  convRate: number;
+  cpc: number;
+  sessions: number;
+  impressions: number;
+  clicks: number;
+}
+
+/**
+ * Project-level paid performance breakdown
+ */
+export interface PaidProjectBreakdown {
+  projectName: string;
+  funnelStage: string;
+  spend: number;
+  revenue: number;
+  roas: number;
+  conversions: number;
+  convRate: number;
+  cpc: number;
+  sessions: number;
+  impressions: number;
+  clicks: number;
+  performance: string;
+  campaigns: PaidCampaignPerformance[];
+}
+
+/**
  * API response for Paid Social query (ROAS + impressions)
  */
 export interface SocialReachResponse {
@@ -2739,6 +2775,7 @@ export interface SocialReachResponse {
   monthlyLabels: string[];
   monthlyRoas: number[];
   channelGroups: SocialReachChannelGroup[];
+  projectBreakdown?: PaidProjectBreakdown[];
 }
 
 // ============================================
@@ -2813,6 +2850,35 @@ export interface EmailCtrCampaignGroup {
 }
 
 /**
+ * Individual campaign performance from EMAIL_CAMPAIGN_PERFORMANCE Snowflake model
+ */
+export interface EmailCampaignPerformance {
+  campaignName: string;
+  emailType: string;
+  sends: number;
+  opens: number;
+  clicks: number;
+  openRate: number;
+  ctr: number;
+  ctrStatus: string;
+}
+
+/**
+ * Aggregated email type breakdown (grouped by EMAIL_TYPE)
+ */
+export interface EmailTypeBreakdown {
+  emailType: string;
+  campaignCount: number;
+  totalSends: number;
+  totalOpens: number;
+  totalClicks: number;
+  openRate: number;
+  ctr: number;
+  performance: string;
+  campaigns: EmailCampaignPerformance[];
+}
+
+/**
  * API response for Email CTR query
  */
 export interface EmailCtrResponse {
@@ -2824,6 +2890,8 @@ export interface EmailCtrResponse {
   campaignGroups: EmailCtrCampaignGroup[];
   monthlySends: number[];
   monthlyOpens: number[];
+  emailTypeBreakdown?: EmailTypeBreakdown[];
+  campaignInsightText?: string;
 }
 
 // ============================================
@@ -3211,6 +3279,54 @@ export interface RevenueImpactResponse {
   eventRegistrationAttribution: EventRegistrationAttribution;
 }
 
+// ============================================
+// Marketing Attribution (Campaign Performance Drawer)
+// ============================================
+
+/**
+ * Channel-level aggregation from ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION.
+ * One row per channel with session, visitor, and multi-touch revenue totals.
+ */
+export interface MarketingAttributionChannel {
+  channel: string;
+  sessions: number;
+  pageViews: number;
+  uniqueVisitors: number;
+  newVisitors: number;
+  returningVisitors: number;
+  firstTouchRevenue: number;
+  lastTouchRevenue: number;
+  linearRevenue: number;
+  timeDecayRevenue: number;
+}
+
+/**
+ * Project × channel drill-down row.
+ * Shown when expanding a channel row in the attribution table.
+ */
+export interface MarketingAttributionProject {
+  projectName: string;
+  channel: string;
+  sessions: number;
+  pageViews: number;
+  uniqueVisitors: number;
+  newVisitors: number;
+  returningVisitors: number;
+  firstTouchRevenue: number;
+  lastTouchRevenue: number;
+  linearRevenue: number;
+  timeDecayRevenue: number;
+}
+
+/**
+ * Full response for the marketing attribution endpoint.
+ * Combines channel summary + project drill-down data.
+ */
+export interface MarketingAttributionResponse {
+  channels: MarketingAttributionChannel[];
+  projects: MarketingAttributionProject[];
+}
+
 /**
  * Aggregated response for all ED Evolution dashboard API calls.
  * Used by buildEdEvolutionMetrics() to convert API data into card UI models.
@@ -3224,4 +3340,5 @@ export interface EdEvolutionData {
   brandReach: BrandReachResponse;
   brandHealth: BrandHealthResponse;
   revenueImpact: RevenueImpactResponse;
+  attribution?: MarketingAttributionResponse;
 }

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2677,7 +2677,6 @@ export interface MarketingRecommendedAction {
   title: string;
   description: string;
   priority: 'high' | 'medium' | 'low';
-  dueLabel: string;
   actionType: MarketingActionType;
 }
 

--- a/packages/shared/src/utils/flywheel.utils.ts
+++ b/packages/shared/src/utils/flywheel.utils.ts
@@ -120,7 +120,7 @@ export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse
         title: 'Improve working group re-engagement path',
         description: `WG re-engagement at ${wgRate.toFixed(1)}% vs ${communityRate.toFixed(1)}% for community — attendees need clearer path to participate`,
         priority: 'high',
-        dueLabel: 'This quarter',
+
         actionType: 'conversion',
       });
     }
@@ -131,7 +131,7 @@ export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse
       title: 'Address re-engagement rate decline',
       description: `Re-engagement dropped ${Math.abs(reengagement.reengagementMomChange).toFixed(1)}% MoM — review post-event follow-up effectiveness`,
       priority: 'high',
-      dueLabel: 'This month',
+
       actionType: 'decline',
     });
   }
@@ -141,7 +141,7 @@ export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse
       title: 'Add post-event engagement CTAs',
       description: `Only ${reengagement.reengagementRate.toFixed(1)}% re-engagement — add community join and working group prompts to event follow-ups`,
       priority: 'medium',
-      dueLabel: 'Next event',
+
       actionType: 'content',
     });
   }
@@ -152,7 +152,7 @@ export function buildFlywheelRecommendedActions(data: FlywheelConversionResponse
       title: 'Continue flywheel optimization',
       description: `${reengagement.reengagementRate.toFixed(1)}% re-engagement rate${growthSuffix} across ${formatNumber(attendees)} attendees`,
       priority: 'low',
-      dueLabel: 'Ongoing',
+
       actionType: 'growth',
     });
   }


### PR DESCRIPTION
## Summary
- Add `MarketingAttribution` shared interfaces (`MarketingAttributionChannel`, `MarketingAttributionProject`, `MarketingAttributionResponse`) plus `PaidCampaignPerformance`, `PaidProjectBreakdown`, `EmailCampaignPerformance`, `EmailTypeBreakdown`
- Add `projectBreakdown` to `SocialReachResponse` and `emailTypeBreakdown`/`campaignInsightText` to `EmailCtrResponse`
- Add `getMarketingAttribution` Snowflake query in `project.service.ts` with channel consolidation (e.g. Paid Search + Social -> "Paid Performance")
- Extend `getSocialReach` with Block 6 per-project/campaign breakdown query
- Add `/marketing-attribution` controller endpoint, route, and frontend analytics service method

## Stacking
- **Base**: PR #547 (`fix/LFXV2-1468-drawer-cleanup`)
- **Next**: PR 2b will wire the attribution data into drawer components

## Test plan
- [ ] `yarn lint && yarn build` pass cleanly
- [ ] Verify new `/api/analytics/marketing-attribution?foundationSlug=tlf` endpoint returns `{ channels, projects }`
- [ ] Verify `/api/analytics/social-reach?foundationSlug=tlf` now includes `projectBreakdown` array
- [ ] Confirm no changes to drawer components, marketing-overview, or dashboard-metrics.constants

LFXV2-1468

🤖 Generated with [Claude Code](https://claude.ai/claude-code)