### PR TITLE
feat(mailing-lists): add summary cards and public column

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -29,100 +29,12 @@
 
     <!-- Summary Stat Cards (Foundation/Project lens) -->
     @if (!isMeLens()) {
-      <div data-testid="committees-foundation-stats">
-        <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
-                <i class="fa-light fa-users-rectangle text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (committeesLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ totalCommittees() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Total Groups</p>
-              </div>
-            </div>
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
-                <i class="fa-light fa-globe text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (committeesLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ publicCommittees() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Public Groups</p>
-              </div>
-            </div>
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
-                <i class="fa-light fa-check-to-slot text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (committeesLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ activeVoting() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Voting Enabled Groups</p>
-              </div>
-            </div>
-          </div>
-        </lfx-card>
-      </div>
+      <lfx-stat-card-grid [cards]="foundationStatCards()" [loading]="committeesLoading()" data-testid="committees-foundation-stats" />
     }
 
     <!-- Summary Stat Cards (Me lens only) -->
     @if (isMeLens()) {
-      <div data-testid="committees-me-stats">
-        <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
-                <i class="fa-light fa-users-rectangle text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (myCommitteesLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ myTotalGroups() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Total Groups</p>
-              </div>
-            </div>
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
-                <i class="fa-light fa-globe text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (myCommitteesLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ myPublicGroups() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Public Groups</p>
-              </div>
-            </div>
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
-                <i class="fa-light fa-check-to-slot text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (myCommitteesLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ myActiveVoting() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Voting Enabled Groups</p>
-              </div>
-            </div>
-          </div>
-        </lfx-card>
-      </div>
+      <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" data-testid="committees-me-stats" />
     }
 
     <!-- My Groups Table (Me lens) -->

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -7,8 +7,9 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
 import { COMMITTEE_LABEL } from '@lfx-one/shared/constants';
-import { Committee, MyCommittee, ProjectContext } from '@lfx-one/shared/interfaces';
+import { Committee, MyCommittee, ProjectContext, StatCardItem } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
@@ -22,7 +23,7 @@ import { CommitteeTableComponent } from '../components/committee-table/committee
 
 @Component({
   selector: 'lfx-committee-dashboard',
-  imports: [ButtonComponent, CardComponent, CommitteeTableComponent, SkeletonModule, EmptyStateComponent],
+  imports: [ButtonComponent, CardComponent, CommitteeTableComponent, SkeletonModule, EmptyStateComponent, StatCardGridComponent],
   templateUrl: './committee-dashboard.component.html',
   styleUrl: './committee-dashboard.component.scss',
 })
@@ -80,6 +81,10 @@ export class CommitteeDashboardComponent {
   public myPublicGroups: Signal<number>;
   public myActiveVoting: Signal<number>;
 
+  // Stat card arrays for the shared <lfx-stat-card-grid> component
+  public foundationStatCards: Signal<StatCardItem[]>;
+  public myStatCards: Signal<StatCardItem[]>;
+
   private searchTerm: Signal<string>;
 
   public constructor() {
@@ -113,6 +118,23 @@ export class CommitteeDashboardComponent {
     this.myTotalGroups = computed(() => this.myCommittees().length);
     this.myPublicGroups = computed(() => this.myCommittees().filter((c) => c.public).length);
     this.myActiveVoting = computed(() => this.myCommittees().filter((c) => c.enable_voting).length);
+
+    // Stat card arrays consumed by <lfx-stat-card-grid>
+    this.foundationStatCards = computed<StatCardItem[]>(() => [
+      { value: this.totalCommittees(), label: 'Total Groups', icon: 'fa-light fa-users-rectangle', iconContainerClass: 'bg-gray-200 text-gray-500' },
+      { value: this.publicCommittees(), label: 'Public Groups', icon: 'fa-light fa-globe', iconContainerClass: 'bg-blue-100 text-blue-600' },
+      { value: this.activeVoting(), label: 'Voting Enabled Groups', icon: 'fa-light fa-check-to-slot', iconContainerClass: 'bg-emerald-100 text-emerald-600' },
+    ]);
+    this.myStatCards = computed<StatCardItem[]>(() => [
+      { value: this.myTotalGroups(), label: 'Total Groups', icon: 'fa-light fa-users-rectangle', iconContainerClass: 'bg-gray-200 text-gray-500' },
+      { value: this.myPublicGroups(), label: 'Public Groups', icon: 'fa-light fa-globe', iconContainerClass: 'bg-blue-100 text-blue-600' },
+      {
+        value: this.myActiveVoting(),
+        label: 'Voting Enabled Groups',
+        icon: 'fa-light fa-check-to-slot',
+        iconContainerClass: 'bg-emerald-100 text-emerald-600',
+      },
+    ]);
   }
 
   public openCreateDialog(): void {

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
@@ -96,15 +96,16 @@
           <th>Name</th>
           <th>List Email</th>
           <th class="min-w-[300px]">Description</th>
-          <th>Visibility</th>
+          <th>Public</th>
           <th>Posting</th>
           <th>Linked {{ committeeLabel.plural }}</th>
           <th>Subscribers</th>
         } @else {
-          <!-- PMO View Headers (4-5 columns depending on board member) -->
+          <!-- PMO View Headers (5-6 columns depending on board member) -->
           <th>Mailing List</th>
           <th class="min-w-[300px]">Description</th>
           <th>Linked {{ committeeLabel.plural }}</th>
+          <th>Public</th>
           <th>Subscribers</th>
           @if (!isBoardMember()) {
             <th></th>
@@ -148,14 +149,20 @@
 
           <!-- Description Column -->
           <td>
-            <div class="line-clamp-2 text-sm text-gray-700">
+            <div class="max-w-[300px] line-clamp-2 text-sm text-gray-700">
               {{ (mailingList.description | stripHtml) || '-' }}
             </div>
           </td>
 
-          <!-- Visibility Column -->
+          <!-- Public Column -->
           <td>
-            <lfx-tag [value]="mailingList.public ? 'Public' : 'Private'" [severity]="mailingList.public | mailingListVisibilitySeverity"> </lfx-tag>
+            @if (mailingList.public) {
+              <span class="inline-flex items-center" pTooltip="Public mailing list" tooltipPosition="top" tabindex="0" aria-label="Public mailing list">
+                <i class="fa-solid fa-circle-check w-4 h-4 text-emerald-600" aria-hidden="true"></i>
+              </span>
+            } @else {
+              <span class="text-gray-400 text-xs" aria-label="Private mailing list">&mdash;</span>
+            }
           </td>
 
           <!-- Posting Column -->
@@ -208,7 +215,7 @@
 
           <!-- Description Column -->
           <td>
-            <div class="line-clamp-2 text-sm text-gray-700">
+            <div class="max-w-[300px] line-clamp-2 text-sm text-gray-700">
               {{ (mailingList.description | stripHtml) || '-' }}
             </div>
           </td>
@@ -239,6 +246,17 @@
             }
           </td>
 
+          <!-- Public Column -->
+          <td>
+            @if (mailingList.public) {
+              <span class="inline-flex items-center" pTooltip="Public mailing list" tooltipPosition="top" tabindex="0" aria-label="Public mailing list">
+                <i class="fa-solid fa-circle-check w-4 h-4 text-emerald-600" aria-hidden="true"></i>
+              </span>
+            } @else {
+              <span class="text-gray-400 text-xs" aria-label="Private mailing list">&mdash;</span>
+            }
+          </td>
+
           <!-- Subscribers Column -->
           <td [attr.data-testid]="'mailing-list-subscribers-' + mailingList.uid">
             <span class="text-sm text-gray-700">{{ mailingList.subscriber_count }}</span>
@@ -266,7 +284,7 @@
     <!-- Empty Message Template -->
     <ng-template #emptymessage>
       <tr>
-        <td [attr.colspan]="isMaintainer() ? 7 : isBoardMember() ? 4 : 5">
+        <td [attr.colspan]="isMaintainer() ? 7 : isBoardMember() ? 5 : 6">
           @if (isFiltered()) {
             <lfx-empty-state
               [withCard]="false"

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts
@@ -17,7 +17,6 @@ import { COMMITTEE_LABEL, MAILING_LIST_LABEL, MAILING_LIST_MAX_VISIBLE_GROUPS } 
 import { FilterOption, GroupsIOMailingList } from '@lfx-one/shared/interfaces';
 import { GroupEmailPipe } from '@pipes/group-email.pipe';
 import { MailingListTypeLabelPipe } from '@pipes/mailing-list-type-label.pipe';
-import { MailingListVisibilitySeverityPipe } from '@pipes/mailing-list-visibility-severity.pipe';
 import { RemainingGroupsTooltipPipe } from '@pipes/remaining-groups-tooltip.pipe';
 import { SliceLinkedGroupsPipe } from '@pipes/slice-linked-groups.pipe';
 import { StripHtmlPipe } from '@pipes/strip-html.pipe';
@@ -37,7 +36,6 @@ import { TooltipModule } from 'primeng/tooltip';
     TooltipModule,
     RouterLink,
     GroupEmailPipe,
-    MailingListVisibilitySeverityPipe,
     MailingListTypeLabelPipe,
     RemainingGroupsTooltipPipe,
     SliceLinkedGroupsPipe,

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
@@ -62,6 +62,104 @@
       </p>
     </div>
 
+    <!-- Summary Stat Cards (Foundation/Project lens) -->
+    @if (!isMeLens()) {
+      <div class="mb-6" data-testid="mailing-lists-foundation-stats">
+        <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+          <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+            <div class="flex items-center gap-3 p-4">
+              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
+                <i class="fa-light fa-envelope text-xl"></i>
+              </div>
+              <div class="flex flex-col gap-0.5">
+                @if (mailingListsLoading()) {
+                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                } @else {
+                  <p class="text-xl font-medium text-gray-900">{{ totalMailingLists() }}</p>
+                }
+                <p class="text-sm font-normal text-gray-900">Total Mailing Lists</p>
+              </div>
+            </div>
+            <div class="flex items-center gap-3 p-4">
+              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+                <i class="fa-light fa-users text-xl"></i>
+              </div>
+              <div class="flex flex-col gap-0.5">
+                @if (mailingListsLoading()) {
+                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                } @else {
+                  <p class="text-xl font-medium text-gray-900">{{ totalSubscribers() }}</p>
+                }
+                <p class="text-sm font-normal text-gray-900">Total Subscribers</p>
+              </div>
+            </div>
+            <div class="flex items-center gap-3 p-4">
+              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
+                <i class="fa-light fa-globe text-xl"></i>
+              </div>
+              <div class="flex flex-col gap-0.5">
+                @if (mailingListsLoading()) {
+                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                } @else {
+                  <p class="text-xl font-medium text-gray-900">{{ publicMailingLists() }}</p>
+                }
+                <p class="text-sm font-normal text-gray-900">Public Lists</p>
+              </div>
+            </div>
+          </div>
+        </lfx-card>
+      </div>
+    }
+
+    <!-- Summary Stat Cards (Me lens only) -->
+    @if (isMeLens()) {
+      <div class="mb-6" data-testid="mailing-lists-me-stats">
+        <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+          <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+            <div class="flex items-center gap-3 p-4">
+              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
+                <i class="fa-light fa-envelope text-xl"></i>
+              </div>
+              <div class="flex flex-col gap-0.5">
+                @if (myMailingListsLoading()) {
+                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                } @else {
+                  <p class="text-xl font-medium text-gray-900">{{ myTotalMailingLists() }}</p>
+                }
+                <p class="text-sm font-normal text-gray-900">Total Mailing Lists</p>
+              </div>
+            </div>
+            <div class="flex items-center gap-3 p-4">
+              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+                <i class="fa-light fa-newspaper text-xl"></i>
+              </div>
+              <div class="flex flex-col gap-0.5">
+                @if (myMailingListsLoading()) {
+                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                } @else {
+                  <p class="text-xl font-medium text-gray-900">{{ myOnDigest() }}</p>
+                }
+                <p class="text-sm font-normal text-gray-900">On Digest</p>
+              </div>
+            </div>
+            <div class="flex items-center gap-3 p-4">
+              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
+                <i class="fa-light fa-globe text-xl"></i>
+              </div>
+              <div class="flex flex-col gap-0.5">
+                @if (myMailingListsLoading()) {
+                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
+                } @else {
+                  <p class="text-xl font-medium text-gray-900">{{ myPublicMailingLists() }}</p>
+                }
+                <p class="text-sm font-normal text-gray-900">Public Lists</p>
+              </div>
+            </div>
+          </div>
+        </lfx-card>
+      </div>
+    }
+
     <!-- Content Area -->
     <div class="min-h-[400px]">
       @if (!isMeLens() && mailingLists().length === 0 && project()?.uid) {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html
@@ -64,99 +64,15 @@
 
     <!-- Summary Stat Cards (Foundation/Project lens) -->
     @if (!isMeLens()) {
-      <div class="mb-6" data-testid="mailing-lists-foundation-stats">
-        <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
-                <i class="fa-light fa-envelope text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (mailingListsLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ totalMailingLists() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Total Mailing Lists</p>
-              </div>
-            </div>
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
-                <i class="fa-light fa-users text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (mailingListsLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ totalSubscribers() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Total Subscribers</p>
-              </div>
-            </div>
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
-                <i class="fa-light fa-globe text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (mailingListsLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ publicMailingLists() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Public Lists</p>
-              </div>
-            </div>
-          </div>
-        </lfx-card>
+      <div class="mb-6">
+        <lfx-stat-card-grid [cards]="foundationStatCards()" [loading]="mailingListsLoading()" data-testid="mailing-lists-foundation-stats" />
       </div>
     }
 
     <!-- Summary Stat Cards (Me lens only) -->
     @if (isMeLens()) {
-      <div class="mb-6" data-testid="mailing-lists-me-stats">
-        <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
-          <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-gray-200 text-gray-500 flex-shrink-0">
-                <i class="fa-light fa-envelope text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (myMailingListsLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ myTotalMailingLists() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Total Mailing Lists</p>
-              </div>
-            </div>
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
-                <i class="fa-light fa-newspaper text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (myMailingListsLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ myOnDigest() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">On Digest</p>
-              </div>
-            </div>
-            <div class="flex items-center gap-3 p-4">
-              <div class="flex items-center justify-center w-11 h-11 rounded-full bg-emerald-100 text-emerald-600 flex-shrink-0">
-                <i class="fa-light fa-globe text-xl"></i>
-              </div>
-              <div class="flex flex-col gap-0.5">
-                @if (myMailingListsLoading()) {
-                  <p class="text-xl font-medium text-gray-400">&mdash;</p>
-                } @else {
-                  <p class="text-xl font-medium text-gray-900">{{ myPublicMailingLists() }}</p>
-                }
-                <p class="text-sm font-normal text-gray-900">Public Lists</p>
-              </div>
-            </div>
-          </div>
-        </lfx-card>
+      <div class="mb-6">
+        <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myMailingListsLoading()" data-testid="mailing-lists-me-stats" />
       </div>
     }
 

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -7,9 +7,18 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
 import { COMMITTEE_LABEL, MAILING_LIST_LABEL } from '@lfx-one/shared/constants';
 import { MailingListMemberDeliveryMode } from '@lfx-one/shared/enums';
-import { CommitteeReference, FilterOption, GroupsIOMailingList, GroupsIOService, MyMailingList, ProjectContext } from '@lfx-one/shared/interfaces';
+import {
+  CommitteeReference,
+  FilterOption,
+  GroupsIOMailingList,
+  GroupsIOService,
+  MyMailingList,
+  ProjectContext,
+  StatCardItem,
+} from '@lfx-one/shared/interfaces';
 import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
 import { PersonaService } from '@services/persona.service';
@@ -23,7 +32,7 @@ import { MailingListTableComponent } from '../components/mailing-list-table/mail
 
 @Component({
   selector: 'lfx-mailing-list-dashboard',
-  imports: [ButtonComponent, CardComponent, MailingListTableComponent, ReactiveFormsModule, EmptyStateComponent],
+  imports: [ButtonComponent, CardComponent, MailingListTableComponent, ReactiveFormsModule, EmptyStateComponent, StatCardGridComponent],
   templateUrl: './mailing-list-dashboard.component.html',
   styleUrl: './mailing-list-dashboard.component.scss',
 })
@@ -83,6 +92,9 @@ export class MailingListDashboardComponent {
   public readonly myTotalMailingLists: Signal<number> = this.initMyTotalMailingLists();
   public readonly myPublicMailingLists: Signal<number> = this.initMyPublicMailingLists();
   public readonly myOnDigest: Signal<number> = this.initMyOnDigest();
+  // Stat card arrays consumed by <lfx-stat-card-grid>
+  public readonly foundationStatCards: Signal<StatCardItem[]> = this.initFoundationStatCards();
+  public readonly myStatCards: Signal<StatCardItem[]> = this.initMyStatCards();
   public readonly availableServices: Signal<GroupsIOService[]> = this.initServices();
   public readonly hasNoServices: Signal<boolean> = this.initHasNoServices();
 
@@ -297,6 +309,22 @@ export class MailingListDashboardComponent {
 
   private initMyOnDigest(): Signal<number> {
     return computed(() => this.myMailingLists().filter((ml) => ml.my_delivery_mode === MailingListMemberDeliveryMode.DIGEST).length);
+  }
+
+  private initFoundationStatCards(): Signal<StatCardItem[]> {
+    return computed<StatCardItem[]>(() => [
+      { value: this.totalMailingLists(), label: 'Total Mailing Lists', icon: 'fa-light fa-envelope', iconContainerClass: 'bg-gray-200 text-gray-500' },
+      { value: this.totalSubscribers(), label: 'Total Subscribers', icon: 'fa-light fa-users', iconContainerClass: 'bg-blue-100 text-blue-600' },
+      { value: this.publicMailingLists(), label: 'Public Lists', icon: 'fa-light fa-globe', iconContainerClass: 'bg-emerald-100 text-emerald-600' },
+    ]);
+  }
+
+  private initMyStatCards(): Signal<StatCardItem[]> {
+    return computed<StatCardItem[]>(() => [
+      { value: this.myTotalMailingLists(), label: 'Total Mailing Lists', icon: 'fa-light fa-envelope', iconContainerClass: 'bg-gray-200 text-gray-500' },
+      { value: this.myOnDigest(), label: 'On Digest', icon: 'fa-light fa-newspaper', iconContainerClass: 'bg-blue-100 text-blue-600' },
+      { value: this.myPublicMailingLists(), label: 'Public Lists', icon: 'fa-light fa-globe', iconContainerClass: 'bg-emerald-100 text-emerald-600' },
+    ]);
   }
 
   private initServices(): Signal<GroupsIOService[]> {

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -8,6 +8,7 @@ import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { COMMITTEE_LABEL, MAILING_LIST_LABEL } from '@lfx-one/shared/constants';
+import { MailingListMemberDeliveryMode } from '@lfx-one/shared/enums';
 import { CommitteeReference, FilterOption, GroupsIOMailingList, GroupsIOService, MyMailingList, ProjectContext } from '@lfx-one/shared/interfaces';
 import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
@@ -78,6 +79,10 @@ export class MailingListDashboardComponent {
   );
   public readonly totalMailingLists: Signal<number> = this.initTotalMailingLists();
   public readonly publicMailingLists: Signal<number> = this.initPublicMailingLists();
+  public readonly totalSubscribers: Signal<number> = this.initTotalSubscribers();
+  public readonly myTotalMailingLists: Signal<number> = this.initMyTotalMailingLists();
+  public readonly myPublicMailingLists: Signal<number> = this.initMyPublicMailingLists();
+  public readonly myOnDigest: Signal<number> = this.initMyOnDigest();
   public readonly availableServices: Signal<GroupsIOService[]> = this.initServices();
   public readonly hasNoServices: Signal<boolean> = this.initHasNoServices();
 
@@ -276,6 +281,22 @@ export class MailingListDashboardComponent {
 
   private initPublicMailingLists(): Signal<number> {
     return computed(() => this.mailingLists().filter((ml) => ml.public).length);
+  }
+
+  private initTotalSubscribers(): Signal<number> {
+    return computed(() => this.mailingLists().reduce((sum, ml) => sum + (ml.subscriber_count ?? 0), 0));
+  }
+
+  private initMyTotalMailingLists(): Signal<number> {
+    return computed(() => this.myMailingLists().length);
+  }
+
+  private initMyPublicMailingLists(): Signal<number> {
+    return computed(() => this.myMailingLists().filter((ml) => ml.public).length);
+  }
+
+  private initMyOnDigest(): Signal<number> {
+    return computed(() => this.myMailingLists().filter((ml) => ml.my_delivery_mode === MailingListMemberDeliveryMode.DIGEST).length);
   }
 
   private initServices(): Signal<GroupsIOService[]> {

--- a/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.html
+++ b/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.html
@@ -1,0 +1,22 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+  <div class="grid w-full grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-gray-200">
+    @for (card of cards(); track card.label) {
+      <div class="flex items-center gap-3 p-4" [attr.data-testid]="'stat-card-' + card.label">
+        <div class="flex items-center justify-center w-11 h-11 rounded-full flex-shrink-0" [class]="card.iconContainerClass">
+          <i [class]="card.icon + ' text-xl'" aria-hidden="true"></i>
+        </div>
+        <div class="flex flex-col gap-0.5">
+          @if (loading()) {
+            <p class="text-xl font-medium text-gray-400">&mdash;</p>
+          } @else {
+            <p class="text-xl font-medium text-gray-900">{{ card.value }}</p>
+          }
+          <p class="text-sm font-normal text-gray-900">{{ card.label }}</p>
+        </div>
+      </div>
+    }
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.scss
+++ b/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.ts
+++ b/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input } from '@angular/core';
+import { CardComponent } from '@components/card/card.component';
+import { StatCardItem } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-stat-card-grid',
+  imports: [CardComponent],
+  templateUrl: './stat-card-grid.component.html',
+  styleUrl: './stat-card-grid.component.scss',
+})
+export class StatCardGridComponent {
+  public readonly cards = input.required<StatCardItem[]>();
+  public readonly loading = input<boolean>(false);
+}

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -201,6 +201,11 @@ export class MailingListService {
       })
     );
 
+    // Enrich the committees array with committee names. The groupsio_mailing_list index
+    // emits committees as { uid } only, so without this pass the Linked Groups column on
+    // the foundation/project-lens table would render empty tags (same fix as Me lens).
+    await this.enrichCommitteeNames(req, mailingLists);
+
     // Enrich with service data
     mailingLists = await this.enrichWithServices(req, mailingLists);
 
@@ -736,7 +741,7 @@ export class MailingListService {
    * (chunked at 100 UIDs), then mutates each list's `committees` entries in place with the
    * resolved name. On fetch failure, names are left unset — callers render a fallback.
    */
-  private async enrichCommitteeNames(req: Request, lists: MyMailingList[]): Promise<void> {
+  private async enrichCommitteeNames(req: Request, lists: GroupsIOMailingList[]): Promise<void> {
     const uniqueCommitteeUids = Array.from(
       new Set(
         lists

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -143,3 +143,6 @@ export * from './transaction.interface';
 
 // Supabase interfaces
 export * from './supabase.interface';
+
+// Stat card interfaces
+export * from './stat-card.interface';

--- a/packages/shared/src/interfaces/stat-card.interface.ts
+++ b/packages/shared/src/interfaces/stat-card.interface.ts
@@ -1,0 +1,18 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * A single cell in an `lfx-stat-card-grid`.
+ * @description Shared shape used by dashboards that surface a row of summary
+ * counts (committee dashboard, mailing-list dashboard, etc.).
+ */
+export interface StatCardItem {
+  /** Numeric or string value rendered at the top of the cell (replaced by an em-dash while loading). */
+  value: number | string;
+  /** Short descriptive label rendered below the value (e.g., "Total Groups"). */
+  label: string;
+  /** Font Awesome class string for the icon (e.g., "fa-light fa-envelope"). */
+  icon: string;
+  /** Tailwind class string applied to the icon's rounded container (bg + text color). */
+  iconContainerClass: string;
+}


### PR DESCRIPTION
## Summary

Mirrors the Groups (committees) dashboard UX on the Mailing Lists page:

- **Three summary stat cards** at the top of `/mailing-lists`, wrapped in a single `lfx-card` (same layout as the Groups dashboard). Foundation/project lens shows **Total Mailing Lists**, **Total Subscribers** (sum over `subscriber_count`), and **Public Lists**. Me lens shows **Total Mailing Lists**, **On Digest** (`my_delivery_mode === 'digest'`), and **Public Lists**. All counts are derived by `computed()` signals over already-loaded data — no new API calls.
- **Public column** in the mailing-list table, rendered like the Groups *Voting* column: emerald `fa-circle-check` when public, em-dash when private, with `aria-label` + tooltip. Present in both the maintainer view (replaces the previous `lfx-tag` Visibility column) and the non-maintainer / PMO view (new column between *Linked Groups* and *Subscribers*).
- **Description column** is now clamped to `max-w-[300px]` + `line-clamp-2` so long descriptions don't stretch the column (matches the committee-table pattern).

## Bug fix included

- **Foundation/project-lens linked-group names were rendering empty** because `getMailingLists` was skipping the `enrichCommitteeNames` pass that the Me-lens flow already runs. The query-service `groupsio_mailing_list` index emits committees as `{ uid }` only, so without enrichment the Linked Groups column renders empty tags. Fix: call `enrichCommitteeNames` right after the initial fetch in `getMailingLists`, same order as Me lens, and widen the helper's parameter type so both flows share it. Trade-off: one extra batched query-service round-trip on foundation/project dashboard loads (matches the cost Me lens already pays).

## Changes

- `apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts` — 4 new `computed()` signals (`totalSubscribers`, `myTotalMailingLists`, `myPublicMailingLists`, `myOnDigest`) via private init methods; imports `MailingListMemberDeliveryMode` for the Digest comparison.
- `apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.html` — two mirrored `@if` blocks (one per lens) rendering the three summary cards with em-dash loading fallback.
- `apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html` — `Visibility` tag → `Public` icon column in maintainer view; new `Public` icon column in non-maintainer view; description cell gets `max-w-[300px]`; empty-message `colspan` updated.
- `apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.ts` — removed the now-unused `MailingListVisibilitySeverityPipe` import.
- `apps/lfx-one/src/server/services/mailing-list.service.ts` — `getMailingLists` now calls `enrichCommitteeNames` after the fetch; helper parameter type widened from `MyMailingList[]` to `GroupsIOMailingList[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)