### PR TITLE
feat(dashboard): add marketing attribution backend and interfaces

### DIFF
--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -68,6 +68,7 @@ import {
   BrandReachResponse,
   BrandHealthResponse,
   RevenueImpactResponse,
+  MarketingAttributionResponse,
   MultiFoundationSummaryResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
@@ -1254,6 +1255,17 @@ export class AnalyticsService {
         })
       )
     );
+  }
+
+  /**
+   * Get marketing attribution data by channel with multi-touch revenue models.
+   * @param foundationSlug Foundation slug used to filter Snowflake queries
+   * @returns Observable emitting channel summary + project drill-down (or empty defaults on error)
+   */
+  public getMarketingAttribution(foundationSlug: string): Observable<MarketingAttributionResponse> {
+    return this.http
+      .get<MarketingAttributionResponse>('/api/analytics/marketing-attribution', { params: { foundationSlug } })
+      .pipe(catchError(() => of({ channels: [], projects: [] })));
   }
 
   /**

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2570,6 +2570,43 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/marketing-attribution
+   * Get channel-level marketing attribution with multi-touch revenue models
+   * Query params: foundationSlug (required)
+   */
+  public async getMarketingAttribution(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_marketing_attribution');
+
+    try {
+      const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_marketing_attribution',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_marketing_attribution',
+        });
+      }
+
+      const response = await this.projectService.getMarketingAttribution(foundationSlug);
+
+      logger.success(req, 'get_marketing_attribution', startTime, {
+        foundation_slug: foundationSlug,
+        channel_count: response.channels.length,
+        project_count: response.projects.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  /**
    * GET /api/analytics/multi-foundation-summary
    * Aggregate analytics across multiple foundations in a single request
    * Query params: slugs (required, comma-separated foundation slugs, max 25)

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -178,6 +178,7 @@ router.get('/event-growth', (req, res, next) => analyticsController.getEventGrow
 router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
 router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
 router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));
+router.get('/marketing-attribution', (req, res, next) => analyticsController.getMarketingAttribution(req, res, next));
 
 // Multi-foundation summary endpoint (multi-foundation dashboard)
 router.get('/multi-foundation-summary', (req, res, next) => analyticsController.getMultiFoundationSummary(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2257,12 +2257,12 @@ export class ProjectService {
                SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
                SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
                SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
-               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
-               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
-               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
-               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+               SUM(FIRST_TOUCH_REVENUE) AS FIRST_TOUCH_REVENUE,
+               SUM(LAST_TOUCH_REVENUE) AS LAST_TOUCH_REVENUE,
+               SUM(LINEAR_REVENUE) AS LINEAR_REVENUE,
+               SUM(TIME_DECAY_REVENUE) AS TIME_DECAY_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
-        WHERE SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        WHERE SESSION_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
         GROUP BY CHANNEL
         ORDER BY SESSIONS DESC
       `
@@ -2271,13 +2271,13 @@ export class ProjectService {
                SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
                SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
                SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
-               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
-               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
-               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
-               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+               SUM(FIRST_TOUCH_REVENUE) AS FIRST_TOUCH_REVENUE,
+               SUM(LAST_TOUCH_REVENUE) AS LAST_TOUCH_REVENUE,
+               SUM(LINEAR_REVENUE) AS LINEAR_REVENUE,
+               SUM(TIME_DECAY_REVENUE) AS TIME_DECAY_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
         WHERE FOUNDATION_SLUG = ?
-          AND SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+          AND SESSION_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
         GROUP BY CHANNEL
         ORDER BY SESSIONS DESC
       `;
@@ -2288,12 +2288,12 @@ export class ProjectService {
                SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
                SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
                SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
-               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
-               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
-               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
-               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+               SUM(FIRST_TOUCH_REVENUE) AS FIRST_TOUCH_REVENUE,
+               SUM(LAST_TOUCH_REVENUE) AS LAST_TOUCH_REVENUE,
+               SUM(LINEAR_REVENUE) AS LINEAR_REVENUE,
+               SUM(TIME_DECAY_REVENUE) AS TIME_DECAY_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
-        WHERE SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        WHERE SESSION_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
         GROUP BY PROJECT_NAME, CHANNEL
         ORDER BY CHANNEL, SESSIONS DESC
       `
@@ -2302,13 +2302,13 @@ export class ProjectService {
                SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
                SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
                SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
-               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
-               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
-               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
-               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+               SUM(FIRST_TOUCH_REVENUE) AS FIRST_TOUCH_REVENUE,
+               SUM(LAST_TOUCH_REVENUE) AS LAST_TOUCH_REVENUE,
+               SUM(LINEAR_REVENUE) AS LINEAR_REVENUE,
+               SUM(TIME_DECAY_REVENUE) AS TIME_DECAY_REVENUE
         FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
         WHERE FOUNDATION_SLUG = ?
-          AND SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+          AND SESSION_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
         GROUP BY PROJECT_NAME, CHANNEL
         ORDER BY CHANNEL, SESSIONS DESC
       `;
@@ -2405,7 +2405,18 @@ export class ProjectService {
           });
         }
       }
-      const channels = [...channelMap.values()].sort((a, b) => b.sessions - a.sessions);
+      // Round revenue after consolidation — rounding pre-aggregation causes penny drift
+      // when mapChannel() merges multiple raw channels into one UI label.
+      const roundRevenue = (item: MarketingAttributionChannel | MarketingAttributionProject): void => {
+        item.firstTouchRevenue = Math.round(item.firstTouchRevenue * 100) / 100;
+        item.lastTouchRevenue = Math.round(item.lastTouchRevenue * 100) / 100;
+        item.linearRevenue = Math.round(item.linearRevenue * 100) / 100;
+        item.timeDecayRevenue = Math.round(item.timeDecayRevenue * 100) / 100;
+      };
+
+      const channels = [...channelMap.values()];
+      channels.forEach(roundRevenue);
+      channels.sort((a, b) => b.sessions - a.sessions);
 
       // Map project rows with the same channel consolidation
       const attrProjectMap = new Map<string, MarketingAttributionProject>();
@@ -2439,7 +2450,9 @@ export class ProjectService {
           });
         }
       }
-      const projects = [...attrProjectMap.values()].sort((a, b) => b.sessions - a.sessions);
+      const projects = [...attrProjectMap.values()];
+      projects.forEach(roundRevenue);
+      projects.sort((a, b) => b.sessions - a.sessions);
 
       logger.debug(undefined, 'get_marketing_attribution', 'Marketing attribution data fetched', {
         foundation_slug: foundationSlug,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2378,7 +2378,7 @@ export class ProjectService {
       // Guard with ?? 0 — SUM() returns NULL when all values in the group are NULL.
       const channelMap = new Map<string, MarketingAttributionChannel>();
       for (const row of channelResult.rows) {
-        const label = mapChannel(row.CHANNEL);
+        const label = mapChannel(row.CHANNEL ?? 'Direct / Unknown');
         const existing = channelMap.get(label);
         if (existing) {
           existing.sessions += row.SESSIONS ?? 0;
@@ -2421,8 +2421,9 @@ export class ProjectService {
       // Map project rows with the same channel consolidation
       const attrProjectMap = new Map<string, MarketingAttributionProject>();
       for (const row of projectResult.rows) {
-        const label = mapChannel(row.CHANNEL);
-        const key = `${row.PROJECT_NAME}::${label}`;
+        const label = mapChannel(row.CHANNEL ?? 'Direct / Unknown');
+        const projectName = row.PROJECT_NAME ?? 'Unknown Project';
+        const key = `${projectName}::${label}`;
         const existing = attrProjectMap.get(key);
         if (existing) {
           existing.sessions += row.SESSIONS ?? 0;
@@ -2436,7 +2437,7 @@ export class ProjectService {
           existing.timeDecayRevenue += row.TIME_DECAY_REVENUE ?? 0;
         } else {
           attrProjectMap.set(key, {
-            projectName: row.PROJECT_NAME,
+            projectName,
             channel: label,
             sessions: row.SESSIONS ?? 0,
             pageViews: row.PAGE_VIEWS ?? 0,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2175,8 +2175,8 @@ export class ProjectService {
           return {
             projectName,
             funnelStage: formatFunnel(data.funnelStages),
-            spend: Math.round(data.spend),
-            revenue: Math.round(data.revenue),
+            spend: Math.round(data.spend * 100) / 100,
+            revenue: Math.round(data.revenue * 100) / 100,
             roas: projectRoas,
             conversions: data.conversions,
             convRate,
@@ -2191,8 +2191,8 @@ export class ProjectService {
               .map((c) => ({
                 campaignName: c.CAMPAIGN_NAME,
                 funnelStage: c.FUNNEL_STAGE ?? 'Unknown',
-                spend: Math.round(c.SPEND ?? 0),
-                revenue: Math.round(c.REVENUE ?? 0),
+                spend: Math.round((c.SPEND ?? 0) * 100) / 100,
+                revenue: Math.round((c.REVENUE ?? 0) * 100) / 100,
                 roas: c.ROAS ?? 0,
                 conversions: c.CONVERSIONS ?? 0,
                 convRate: c.CONV_RATE ?? 0,
@@ -2264,7 +2264,6 @@ export class ProjectService {
         FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
         WHERE SESSION_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
         GROUP BY CHANNEL
-        ORDER BY SESSIONS DESC
       `
         : `
         SELECT CHANNEL,
@@ -2279,7 +2278,6 @@ export class ProjectService {
         WHERE FOUNDATION_SLUG = ?
           AND SESSION_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
         GROUP BY CHANNEL
-        ORDER BY SESSIONS DESC
       `;
 
       const projectQuery = isUmbrella
@@ -2295,7 +2293,6 @@ export class ProjectService {
         FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
         WHERE SESSION_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
         GROUP BY PROJECT_NAME, CHANNEL
-        ORDER BY CHANNEL, SESSIONS DESC
       `
         : `
         SELECT PROJECT_NAME, CHANNEL,
@@ -2310,7 +2307,6 @@ export class ProjectService {
         WHERE FOUNDATION_SLUG = ?
           AND SESSION_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
         GROUP BY PROJECT_NAME, CHANNEL
-        ORDER BY CHANNEL, SESSIONS DESC
       `;
 
       const params = isUmbrella ? [] : [foundationSlug];

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -57,6 +57,9 @@ import {
   HealthMetricsDailyResponse,
   HealthMetricsRange,
   LifecycleStage,
+  MarketingAttributionChannel,
+  MarketingAttributionProject,
+  MarketingAttributionResponse,
   MemberAcquisitionResponse,
   MemberRetentionResponse,
   MembershipChurnPerTierSummaryResponse,
@@ -2033,12 +2036,45 @@ export class ProjectService {
       ORDER BY IMPRESSIONS DESC
     `;
 
-      const [impressionsResult, roasKpiResult, monthlyRoasResult, monthlyImpressionsResult, channelResult] = await Promise.all([
+      // Block 6: Project + campaign level performance breakdown (last 6 months)
+      const projectPerfQuery = `
+      SELECT
+        PROJECT_NAME, CAMPAIGN_NAME, FUNNEL_STAGE,
+        SUM(SPEND) AS SPEND, SUM(LINEAR_REVENUE) AS REVENUE,
+        ROUND(DIV0(SUM(LINEAR_REVENUE), SUM(SPEND)), 2) AS ROAS,
+        SUM(CONV) AS CONVERSIONS,
+        ROUND(DIV0(SUM(CONV), NULLIF(SUM(CLICKS), 0)) * 100, 2) AS CONV_RATE,
+        ROUND(DIV0(SUM(SPEND), NULLIF(SUM(CLICKS), 0)), 2) AS CPC,
+        SUM(SESSIONS) AS SESSIONS,
+        SUM(IMPRESSIONS) AS IMPRESSIONS,
+        SUM(CLICKS) AS CLICKS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.PAID_SOCIAL_REACH_BY_PROJECT_CHANNEL_MONTH
+      WHERE FOUNDATION_SLUG = ?
+        AND CAMPAIGN_MONTH >= DATEADD('MONTH', -6, DATE_TRUNC('MONTH', CURRENT_DATE()))
+      GROUP BY PROJECT_NAME, CAMPAIGN_NAME, FUNNEL_STAGE
+      ORDER BY SPEND DESC
+    `;
+
+      const [impressionsResult, roasKpiResult, monthlyRoasResult, monthlyImpressionsResult, channelResult, projectPerfResult] = await Promise.all([
         this.snowflakeService.execute<{ TOTAL_IMPRESSIONS: number; TOTAL_SPEND: number; TOTAL_REVENUE: number }>(impressionsQuery, [foundationSlug]),
         this.snowflakeService.execute<{ ROAS: number; ROAS_MOM_PCT: number }>(roasKpiQuery, [foundationSlug]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; ROAS: number }>(monthlyRoasQuery, [foundationSlug]),
         this.snowflakeService.execute<{ CAMPAIGN_MONTH: string; IMPRESSIONS: number }>(monthlyImpressionsQuery, [foundationSlug]),
         this.snowflakeService.execute<{ CHANNEL: string; IMPRESSIONS: number }>(channelQuery, [foundationSlug]),
+        this.snowflakeService.execute<{
+          PROJECT_NAME: string;
+          CAMPAIGN_NAME: string;
+          FUNNEL_STAGE: string;
+          SPEND: number;
+          REVENUE: number;
+          ROAS: number;
+          CONVERSIONS: number;
+          CONV_RATE: number;
+          CPC: number;
+          SESSIONS: number;
+          IMPRESSIONS: number;
+          CLICKS: number;
+        }>(projectPerfQuery, [foundationSlug]),
       ]);
 
       const totalReach = impressionsResult.rows[0]?.TOTAL_IMPRESSIONS ?? 0;
@@ -2074,6 +2110,98 @@ export class ProjectService {
         totalImpressions: row.IMPRESSIONS,
       }));
 
+      // Shape project breakdown with nested campaigns
+      const projectMap = new Map<
+        string,
+        {
+          spend: number;
+          revenue: number;
+          conversions: number;
+          impressions: number;
+          clicks: number;
+          sessions: number;
+          funnelStages: Set<string>;
+          campaigns: typeof projectPerfResult.rows;
+        }
+      >();
+      for (const row of projectPerfResult.rows) {
+        const existing = projectMap.get(row.PROJECT_NAME) ?? {
+          spend: 0,
+          revenue: 0,
+          conversions: 0,
+          impressions: 0,
+          clicks: 0,
+          sessions: 0,
+          funnelStages: new Set<string>(),
+          campaigns: [] as typeof projectPerfResult.rows,
+        };
+        existing.spend += row.SPEND ?? 0;
+        existing.revenue += row.REVENUE ?? 0;
+        existing.conversions += row.CONVERSIONS ?? 0;
+        existing.impressions += row.IMPRESSIONS ?? 0;
+        existing.clicks += row.CLICKS ?? 0;
+        existing.sessions += row.SESSIONS ?? 0;
+        if (row.FUNNEL_STAGE) {
+          existing.funnelStages.add(row.FUNNEL_STAGE);
+        }
+        existing.campaigns.push(row);
+        projectMap.set(row.PROJECT_NAME, existing);
+      }
+
+      const getPaidPerformance = (projectRoas: number): string => {
+        if (projectRoas >= 2) return 'EXCELLENT';
+        if (projectRoas >= 1) return 'GOOD';
+        if (projectRoas > 0) return 'POOR';
+        return 'NO REVENUE';
+      };
+
+      const formatFunnel = (stages: Set<string>): string => {
+        const priority = ['BoFU', 'MoFU', 'ToFU', 'ToFU2', 'Unknown'];
+        for (const p of priority) {
+          if (stages.has(p)) return p;
+        }
+        return [...stages][0] ?? 'Unknown';
+      };
+
+      const projectBreakdown = Array.from(projectMap.entries())
+        .filter(([, data]) => data.spend > 0)
+        .map(([projectName, data]) => {
+          const projectRoas = data.spend > 0 ? Math.round((data.revenue / data.spend) * 100) / 100 : 0;
+          const convRate = data.clicks > 0 ? Math.round((data.conversions / data.clicks) * 10000) / 100 : 0;
+          const cpc = data.clicks > 0 ? Math.round((data.spend / data.clicks) * 100) / 100 : 0;
+          return {
+            projectName,
+            funnelStage: formatFunnel(data.funnelStages),
+            spend: Math.round(data.spend),
+            revenue: Math.round(data.revenue),
+            roas: projectRoas,
+            conversions: data.conversions,
+            convRate,
+            cpc,
+            sessions: data.sessions,
+            impressions: data.impressions,
+            clicks: data.clicks,
+            performance: getPaidPerformance(projectRoas),
+            campaigns: data.campaigns
+              .sort((a, b) => (b.SPEND ?? 0) - (a.SPEND ?? 0))
+              .slice(0, 10)
+              .map((c) => ({
+                campaignName: c.CAMPAIGN_NAME,
+                funnelStage: c.FUNNEL_STAGE ?? 'Unknown',
+                spend: Math.round(c.SPEND ?? 0),
+                revenue: Math.round(c.REVENUE ?? 0),
+                roas: c.ROAS ?? 0,
+                conversions: c.CONVERSIONS ?? 0,
+                convRate: c.CONV_RATE ?? 0,
+                cpc: c.CPC ?? 0,
+                sessions: c.SESSIONS ?? 0,
+                impressions: c.IMPRESSIONS ?? 0,
+                clicks: c.CLICKS ?? 0,
+              })),
+          };
+        })
+        .sort((a, b) => b.spend - a.spend);
+
       return {
         totalReach,
         roas: Math.round(roas * 100) / 100,
@@ -2085,6 +2213,7 @@ export class ProjectService {
         monthlyLabels,
         monthlyRoas,
         channelGroups,
+        projectBreakdown,
       };
     } catch (error) {
       logger.warning(undefined, 'get_social_reach', 'Failed to fetch social reach data, returning defaults', {
@@ -2103,6 +2232,224 @@ export class ProjectService {
         monthlyRoas: [],
         channelGroups: [],
       };
+    }
+  }
+
+  /**
+   * Get marketing attribution data from ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION.
+   * Returns channel-level summary and project × channel drill-down for the last 6 months.
+   * @param foundationSlug - Foundation slug or 'tlf' for umbrella aggregation
+   * @returns Channel summary + project drill-down
+   */
+  public async getMarketingAttribution(foundationSlug: string): Promise<MarketingAttributionResponse> {
+    const startTime = Date.now();
+    logger.debug(undefined, 'get_marketing_attribution', 'Fetching marketing attribution from Snowflake', { foundation_slug: foundationSlug });
+
+    try {
+      const isUmbrella = foundationSlug === 'tlf';
+
+      const channelQuery = isUmbrella
+        ? `
+        SELECT CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY CHANNEL
+        ORDER BY SESSIONS DESC
+      `
+        : `
+        SELECT CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE FOUNDATION_SLUG = ?
+          AND SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY CHANNEL
+        ORDER BY SESSIONS DESC
+      `;
+
+      const projectQuery = isUmbrella
+        ? `
+        SELECT PROJECT_NAME, CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY PROJECT_NAME, CHANNEL
+        ORDER BY CHANNEL, SESSIONS DESC
+      `
+        : `
+        SELECT PROJECT_NAME, CHANNEL,
+               SUM(SESSIONS) AS SESSIONS, SUM(PAGE_VIEWS) AS PAGE_VIEWS,
+               SUM(UNIQUE_VISITORS) AS UNIQUE_VISITORS, SUM(NEW_VISITORS) AS NEW_VISITORS,
+               SUM(RETURNING_VISITORS) AS RETURNING_VISITORS,
+               ROUND(SUM(FIRST_TOUCH_REVENUE), 2) AS FIRST_TOUCH_REVENUE,
+               ROUND(SUM(LAST_TOUCH_REVENUE), 2) AS LAST_TOUCH_REVENUE,
+               ROUND(SUM(LINEAR_REVENUE), 2) AS LINEAR_REVENUE,
+               ROUND(SUM(TIME_DECAY_REVENUE), 2) AS TIME_DECAY_REVENUE
+        FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION
+        WHERE FOUNDATION_SLUG = ?
+          AND SESSION_MONTH >= DATEADD(MONTH, -6, CURRENT_DATE())
+        GROUP BY PROJECT_NAME, CHANNEL
+        ORDER BY CHANNEL, SESSIONS DESC
+      `;
+
+      const params = isUmbrella ? [] : [foundationSlug];
+
+      interface ChannelRow {
+        CHANNEL: string;
+        SESSIONS: number;
+        PAGE_VIEWS: number;
+        UNIQUE_VISITORS: number;
+        NEW_VISITORS: number;
+        RETURNING_VISITORS: number;
+        FIRST_TOUCH_REVENUE: number;
+        LAST_TOUCH_REVENUE: number;
+        LINEAR_REVENUE: number;
+        TIME_DECAY_REVENUE: number;
+      }
+
+      interface ProjectRow {
+        PROJECT_NAME: string;
+        CHANNEL: string;
+        SESSIONS: number;
+        PAGE_VIEWS: number;
+        UNIQUE_VISITORS: number;
+        NEW_VISITORS: number;
+        RETURNING_VISITORS: number;
+        FIRST_TOUCH_REVENUE: number;
+        LAST_TOUCH_REVENUE: number;
+        LINEAR_REVENUE: number;
+        TIME_DECAY_REVENUE: number;
+      }
+
+      const [channelResult, projectResult] = await Promise.all([
+        this.snowflakeService.execute<ChannelRow>(channelQuery, params),
+        this.snowflakeService.execute<ProjectRow>(projectQuery, params),
+      ]);
+
+      // Map Snowflake channels to consolidated UI labels:
+      //   Paid Search + Social → "Paid Performance"
+      //   Email / HubSpot → "Email"
+      //   Internal / Banner → "Internal & Banner"
+      //   Organic Search → "Organic"
+      //   Other Tracked → "Other"
+      //   Direct / Unknown → "Direct & Unknown"
+      const mapChannel = (raw: string): string => {
+        switch (raw) {
+          case 'Paid Search':
+          case 'Social':
+            return 'Paid Performance';
+          case 'Email / HubSpot':
+            return 'Email';
+          case 'Internal / Banner':
+            return 'Internal & Banner';
+          case 'Organic Search':
+            return 'Organic';
+          case 'Other Tracked':
+            return 'Other';
+          case 'Direct / Unknown':
+            return 'Direct & Unknown';
+          default:
+            return raw;
+        }
+      };
+
+      // Aggregate channel rows that map to the same UI label
+      const channelMap = new Map<string, MarketingAttributionChannel>();
+      for (const row of channelResult.rows) {
+        const label = mapChannel(row.CHANNEL);
+        const existing = channelMap.get(label);
+        if (existing) {
+          existing.sessions += row.SESSIONS;
+          existing.pageViews += row.PAGE_VIEWS;
+          existing.uniqueVisitors += row.UNIQUE_VISITORS;
+          existing.newVisitors += row.NEW_VISITORS;
+          existing.returningVisitors += row.RETURNING_VISITORS;
+          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE;
+          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE;
+          existing.linearRevenue += row.LINEAR_REVENUE;
+          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE;
+        } else {
+          channelMap.set(label, {
+            channel: label,
+            sessions: row.SESSIONS,
+            pageViews: row.PAGE_VIEWS,
+            uniqueVisitors: row.UNIQUE_VISITORS,
+            newVisitors: row.NEW_VISITORS,
+            returningVisitors: row.RETURNING_VISITORS,
+            firstTouchRevenue: row.FIRST_TOUCH_REVENUE,
+            lastTouchRevenue: row.LAST_TOUCH_REVENUE,
+            linearRevenue: row.LINEAR_REVENUE,
+            timeDecayRevenue: row.TIME_DECAY_REVENUE,
+          });
+        }
+      }
+      const channels = [...channelMap.values()].sort((a, b) => b.sessions - a.sessions);
+
+      // Map project rows with the same channel consolidation
+      const attrProjectMap = new Map<string, MarketingAttributionProject>();
+      for (const row of projectResult.rows) {
+        const label = mapChannel(row.CHANNEL);
+        const key = `${row.PROJECT_NAME}::${label}`;
+        const existing = attrProjectMap.get(key);
+        if (existing) {
+          existing.sessions += row.SESSIONS;
+          existing.pageViews += row.PAGE_VIEWS;
+          existing.uniqueVisitors += row.UNIQUE_VISITORS;
+          existing.newVisitors += row.NEW_VISITORS;
+          existing.returningVisitors += row.RETURNING_VISITORS;
+          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE;
+          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE;
+          existing.linearRevenue += row.LINEAR_REVENUE;
+          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE;
+        } else {
+          attrProjectMap.set(key, {
+            projectName: row.PROJECT_NAME,
+            channel: label,
+            sessions: row.SESSIONS,
+            pageViews: row.PAGE_VIEWS,
+            uniqueVisitors: row.UNIQUE_VISITORS,
+            newVisitors: row.NEW_VISITORS,
+            returningVisitors: row.RETURNING_VISITORS,
+            firstTouchRevenue: row.FIRST_TOUCH_REVENUE,
+            lastTouchRevenue: row.LAST_TOUCH_REVENUE,
+            linearRevenue: row.LINEAR_REVENUE,
+            timeDecayRevenue: row.TIME_DECAY_REVENUE,
+          });
+        }
+      }
+      const projects = [...attrProjectMap.values()].sort((a, b) => b.sessions - a.sessions);
+
+      logger.debug(undefined, 'get_marketing_attribution', 'Marketing attribution data fetched', {
+        foundation_slug: foundationSlug,
+        channel_count: channels.length,
+        project_count: projects.length,
+        duration_ms: Date.now() - startTime,
+      });
+
+      return { channels, projects };
+    } catch (error) {
+      logger.error(undefined, 'get_marketing_attribution', startTime, error instanceof Error ? error : new Error(String(error)), {
+        foundation_slug: foundationSlug,
+      });
+      throw error;
     }
   }
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2037,6 +2037,9 @@ export class ProjectService {
     `;
 
       // Block 6: Project + campaign level performance breakdown (last 6 months)
+      // Uses LINEAR_REVENUE (not FIRST_TOUCH) — the per-campaign drill-down uses linear
+      // attribution to distribute credit fairly across touchpoints, while the top-level
+      // KPI (Blocks 1–2) uses first-touch for the headline ROAS.
       const projectPerfQuery = `
       SELECT
         PROJECT_NAME, CAMPAIGN_NAME, FUNNEL_STAGE,
@@ -2371,33 +2374,34 @@ export class ProjectService {
         }
       };
 
-      // Aggregate channel rows that map to the same UI label
+      // Aggregate channel rows that map to the same UI label.
+      // Guard with ?? 0 — SUM() returns NULL when all values in the group are NULL.
       const channelMap = new Map<string, MarketingAttributionChannel>();
       for (const row of channelResult.rows) {
         const label = mapChannel(row.CHANNEL);
         const existing = channelMap.get(label);
         if (existing) {
-          existing.sessions += row.SESSIONS;
-          existing.pageViews += row.PAGE_VIEWS;
-          existing.uniqueVisitors += row.UNIQUE_VISITORS;
-          existing.newVisitors += row.NEW_VISITORS;
-          existing.returningVisitors += row.RETURNING_VISITORS;
-          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE;
-          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE;
-          existing.linearRevenue += row.LINEAR_REVENUE;
-          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE;
+          existing.sessions += row.SESSIONS ?? 0;
+          existing.pageViews += row.PAGE_VIEWS ?? 0;
+          existing.uniqueVisitors += row.UNIQUE_VISITORS ?? 0;
+          existing.newVisitors += row.NEW_VISITORS ?? 0;
+          existing.returningVisitors += row.RETURNING_VISITORS ?? 0;
+          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE ?? 0;
+          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE ?? 0;
+          existing.linearRevenue += row.LINEAR_REVENUE ?? 0;
+          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE ?? 0;
         } else {
           channelMap.set(label, {
             channel: label,
-            sessions: row.SESSIONS,
-            pageViews: row.PAGE_VIEWS,
-            uniqueVisitors: row.UNIQUE_VISITORS,
-            newVisitors: row.NEW_VISITORS,
-            returningVisitors: row.RETURNING_VISITORS,
-            firstTouchRevenue: row.FIRST_TOUCH_REVENUE,
-            lastTouchRevenue: row.LAST_TOUCH_REVENUE,
-            linearRevenue: row.LINEAR_REVENUE,
-            timeDecayRevenue: row.TIME_DECAY_REVENUE,
+            sessions: row.SESSIONS ?? 0,
+            pageViews: row.PAGE_VIEWS ?? 0,
+            uniqueVisitors: row.UNIQUE_VISITORS ?? 0,
+            newVisitors: row.NEW_VISITORS ?? 0,
+            returningVisitors: row.RETURNING_VISITORS ?? 0,
+            firstTouchRevenue: row.FIRST_TOUCH_REVENUE ?? 0,
+            lastTouchRevenue: row.LAST_TOUCH_REVENUE ?? 0,
+            linearRevenue: row.LINEAR_REVENUE ?? 0,
+            timeDecayRevenue: row.TIME_DECAY_REVENUE ?? 0,
           });
         }
       }
@@ -2410,28 +2414,28 @@ export class ProjectService {
         const key = `${row.PROJECT_NAME}::${label}`;
         const existing = attrProjectMap.get(key);
         if (existing) {
-          existing.sessions += row.SESSIONS;
-          existing.pageViews += row.PAGE_VIEWS;
-          existing.uniqueVisitors += row.UNIQUE_VISITORS;
-          existing.newVisitors += row.NEW_VISITORS;
-          existing.returningVisitors += row.RETURNING_VISITORS;
-          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE;
-          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE;
-          existing.linearRevenue += row.LINEAR_REVENUE;
-          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE;
+          existing.sessions += row.SESSIONS ?? 0;
+          existing.pageViews += row.PAGE_VIEWS ?? 0;
+          existing.uniqueVisitors += row.UNIQUE_VISITORS ?? 0;
+          existing.newVisitors += row.NEW_VISITORS ?? 0;
+          existing.returningVisitors += row.RETURNING_VISITORS ?? 0;
+          existing.firstTouchRevenue += row.FIRST_TOUCH_REVENUE ?? 0;
+          existing.lastTouchRevenue += row.LAST_TOUCH_REVENUE ?? 0;
+          existing.linearRevenue += row.LINEAR_REVENUE ?? 0;
+          existing.timeDecayRevenue += row.TIME_DECAY_REVENUE ?? 0;
         } else {
           attrProjectMap.set(key, {
             projectName: row.PROJECT_NAME,
             channel: label,
-            sessions: row.SESSIONS,
-            pageViews: row.PAGE_VIEWS,
-            uniqueVisitors: row.UNIQUE_VISITORS,
-            newVisitors: row.NEW_VISITORS,
-            returningVisitors: row.RETURNING_VISITORS,
-            firstTouchRevenue: row.FIRST_TOUCH_REVENUE,
-            lastTouchRevenue: row.LAST_TOUCH_REVENUE,
-            linearRevenue: row.LINEAR_REVENUE,
-            timeDecayRevenue: row.TIME_DECAY_REVENUE,
+            sessions: row.SESSIONS ?? 0,
+            pageViews: row.PAGE_VIEWS ?? 0,
+            uniqueVisitors: row.UNIQUE_VISITORS ?? 0,
+            newVisitors: row.NEW_VISITORS ?? 0,
+            returningVisitors: row.RETURNING_VISITORS ?? 0,
+            firstTouchRevenue: row.FIRST_TOUCH_REVENUE ?? 0,
+            lastTouchRevenue: row.LAST_TOUCH_REVENUE ?? 0,
+            linearRevenue: row.LINEAR_REVENUE ?? 0,
+            timeDecayRevenue: row.TIME_DECAY_REVENUE ?? 0,
           });
         }
       }

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2726,6 +2726,42 @@ export interface SocialReachChannelGroup {
 }
 
 /**
+ * Per-campaign paid performance data (nested under project)
+ */
+export interface PaidCampaignPerformance {
+  campaignName: string;
+  funnelStage: string;
+  spend: number;
+  revenue: number;
+  roas: number;
+  conversions: number;
+  convRate: number;
+  cpc: number;
+  sessions: number;
+  impressions: number;
+  clicks: number;
+}
+
+/**
+ * Project-level paid performance breakdown
+ */
+export interface PaidProjectBreakdown {
+  projectName: string;
+  funnelStage: string;
+  spend: number;
+  revenue: number;
+  roas: number;
+  conversions: number;
+  convRate: number;
+  cpc: number;
+  sessions: number;
+  impressions: number;
+  clicks: number;
+  performance: string;
+  campaigns: PaidCampaignPerformance[];
+}
+
+/**
  * API response for Paid Social query (ROAS + impressions)
  */
 export interface SocialReachResponse {
@@ -2739,6 +2775,7 @@ export interface SocialReachResponse {
   monthlyLabels: string[];
   monthlyRoas: number[];
   channelGroups: SocialReachChannelGroup[];
+  projectBreakdown?: PaidProjectBreakdown[];
 }
 
 // ============================================
@@ -2813,6 +2850,35 @@ export interface EmailCtrCampaignGroup {
 }
 
 /**
+ * Individual campaign performance from EMAIL_CAMPAIGN_PERFORMANCE Snowflake model
+ */
+export interface EmailCampaignPerformance {
+  campaignName: string;
+  emailType: string;
+  sends: number;
+  opens: number;
+  clicks: number;
+  openRate: number;
+  ctr: number;
+  ctrStatus: string;
+}
+
+/**
+ * Aggregated email type breakdown (grouped by EMAIL_TYPE)
+ */
+export interface EmailTypeBreakdown {
+  emailType: string;
+  campaignCount: number;
+  totalSends: number;
+  totalOpens: number;
+  totalClicks: number;
+  openRate: number;
+  ctr: number;
+  performance: string;
+  campaigns: EmailCampaignPerformance[];
+}
+
+/**
  * API response for Email CTR query
  */
 export interface EmailCtrResponse {
@@ -2824,6 +2890,8 @@ export interface EmailCtrResponse {
   campaignGroups: EmailCtrCampaignGroup[];
   monthlySends: number[];
   monthlyOpens: number[];
+  emailTypeBreakdown?: EmailTypeBreakdown[];
+  campaignInsightText?: string;
 }
 
 // ============================================
@@ -3211,6 +3279,54 @@ export interface RevenueImpactResponse {
   eventRegistrationAttribution: EventRegistrationAttribution;
 }
 
+// ============================================
+// Marketing Attribution (Campaign Performance Drawer)
+// ============================================
+
+/**
+ * Channel-level aggregation from ANALYTICS.PLATINUM_LFX_ONE.MARKETING_ATTRIBUTION.
+ * One row per channel with session, visitor, and multi-touch revenue totals.
+ */
+export interface MarketingAttributionChannel {
+  channel: string;
+  sessions: number;
+  pageViews: number;
+  uniqueVisitors: number;
+  newVisitors: number;
+  returningVisitors: number;
+  firstTouchRevenue: number;
+  lastTouchRevenue: number;
+  linearRevenue: number;
+  timeDecayRevenue: number;
+}
+
+/**
+ * Project × channel drill-down row.
+ * Shown when expanding a channel row in the attribution table.
+ */
+export interface MarketingAttributionProject {
+  projectName: string;
+  channel: string;
+  sessions: number;
+  pageViews: number;
+  uniqueVisitors: number;
+  newVisitors: number;
+  returningVisitors: number;
+  firstTouchRevenue: number;
+  lastTouchRevenue: number;
+  linearRevenue: number;
+  timeDecayRevenue: number;
+}
+
+/**
+ * Full response for the marketing attribution endpoint.
+ * Combines channel summary + project drill-down data.
+ */
+export interface MarketingAttributionResponse {
+  channels: MarketingAttributionChannel[];
+  projects: MarketingAttributionProject[];
+}
+
 /**
  * Aggregated response for all ED Evolution dashboard API calls.
  * Used by buildEdEvolutionMetrics() to convert API data into card UI models.
@@ -3224,4 +3340,5 @@ export interface EdEvolutionData {
   brandReach: BrandReachResponse;
   brandHealth: BrandHealthResponse;
   revenueImpact: RevenueImpactResponse;
+  attribution?: MarketingAttributionResponse;
 }


### PR DESCRIPTION
## Summary
- Add MarketingAttribution interfaces to shared package
- Add getMarketingAttribution Snowflake query with channel consolidation
- Extend getSocialReach with per-project campaign breakdown
- Add marketing-attribution controller endpoint and route
- Add frontend analytics service method
- Add null guards to attribution aggregation

Replaces #549 (auto-closed when base branch was deleted on #547 merge).

LFXV2-1468

## Related PRs

**Must merge alongside #550** — the two PRs form a stacked pair:
- This PR (#552) adds the backend queries, shared interfaces, and frontend service methods
- #550 adds the drawer UI that consumes these interfaces

Interface additions on this branch whose **backend population lives on #550**:
- `EmailCtrResponse.emailTypeBreakdown?` / `campaignInsightText?` — populated by the email CTR drawer rewrite on #550
- `EdEvolutionData.attribution?` — wired into the overview aggregator on #550

## Test plan
- [ ] Verify `/api/analytics/marketing-attribution?foundationSlug=tlf` returns channel data
- [ ] Verify attribution data loads in email CTR drawer
- [ ] Verify channel summary and project drill-down revenue totals reconcile (no penny drift after consolidation)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>