### PR TITLE
feat(meetings): add pending rsvp filter on me-lens meetings

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.html
@@ -5,6 +5,15 @@
   <!-- Time Filter Pills -->
   <lfx-filter-pills [options]="timeTabOptions" [selectedFilter]="timeFilter()" (filterChange)="onTimeTabChange($event)" data-testid="time-filter-tabs" />
 
+  <!-- Pending RSVP Filter Pills (Me lens, upcoming only) -->
+  @if (showPendingRsvpFilter()) {
+    <lfx-filter-pills
+      [options]="pendingRsvpPillOptions"
+      [selectedFilter]="pendingRsvpOnly() ? 'pending' : ''"
+      (filterChange)="onPendingRsvpPillChange()"
+      data-testid="pending-rsvp-filter-pills" />
+  }
+
   <!-- Search Input -->
   <div class="flex-1">
     <lfx-input-text

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/components/meetings-top-bar/meetings-top-bar.component.ts
@@ -21,17 +21,25 @@ export class MeetingsTopBarComponent {
   public showFoundationFilter = input<boolean>(false);
   public showProjectFilter = input<boolean>(false);
   public readonly timeFilter = input<'upcoming' | 'past'>('upcoming');
+  public readonly pendingRsvpOnly = input<boolean>(false);
+  public readonly showPendingRsvpFilter = input<boolean>(false);
   public readonly meetingTypeChange = output<string | null>();
   public readonly foundationFilterChange = output<string | null>();
   public readonly projectFilterChange = output<string | null>();
   public readonly searchQuery = input<string>('');
   public readonly searchQueryChange = output<string>();
   public readonly timeFilterChange = output<'upcoming' | 'past'>();
+  public readonly pendingRsvpOnlyChange = output<boolean>();
 
   public readonly timeTabOptions: FilterPillOption[] = [
     { id: 'upcoming', label: 'Upcoming' },
     { id: 'past', label: 'Past' },
   ];
+
+  // Single-pill toggle: when active (pendingRsvpOnly === true), selectedFilter === 'pending'
+  // and the pill highlights; when inactive, selectedFilter doesn't match any option so the pill
+  // renders gray. Clicking always fires 'pending', and the handler inverts the current state.
+  public readonly pendingRsvpPillOptions: FilterPillOption[] = [{ id: 'pending', label: 'Pending RSVP' }];
 
   public searchForm: FormGroup = new FormGroup({
     search: new FormControl(''),
@@ -72,5 +80,10 @@ export class MeetingsTopBarComponent {
 
   public onTimeTabChange(value: string): void {
     this.timeFilterChange.emit(value as 'upcoming' | 'past');
+  }
+
+  public onPendingRsvpPillChange(): void {
+    // Single pill — clicking always toggles the current state.
+    this.pendingRsvpOnlyChange.emit(!this.pendingRsvpOnly());
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -173,12 +173,15 @@
           [showFoundationFilter]="showFoundationFilter()"
           [showProjectFilter]="showProjectFilter()"
           [timeFilter]="timeFilter()"
+          [pendingRsvpOnly]="pendingRsvpOnly()"
+          [showPendingRsvpFilter]="activeLens() === 'me' && timeFilter() === 'upcoming'"
           (meetingTypeChange)="onMeetingTypeChange($event)"
           (foundationFilterChange)="onFoundationFilterChange($event)"
           (projectFilterChange)="onProjectFilterChange($event)"
           [searchQuery]="searchQuery()"
           (searchQueryChange)="searchQuery.set($event)"
-          (timeFilterChange)="onTimeFilterChange($event)" />
+          (timeFilterChange)="onTimeFilterChange($event)"
+          (pendingRsvpOnlyChange)="pendingRsvpOnly.set($event)" />
       }
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -71,6 +71,7 @@ export class MeetingsDashboardComponent {
   public meetingTypeOptions: Signal<{ label: string; value: string | null }[]>;
   public foundationFilter: WritableSignal<string | null>;
   public projectFilter: WritableSignal<string | null>;
+  public pendingRsvpOnly: WritableSignal<boolean>;
   public showFoundationFilter: Signal<boolean>;
   public showProjectFilter: Signal<boolean>;
   public foundationOptions: Signal<{ label: string; value: string | null }[]>;
@@ -134,6 +135,7 @@ export class MeetingsDashboardComponent {
     this.meetingTypeFilter = signal<string | null>(null);
     this.foundationFilter = signal<string | null>(null);
     this.projectFilter = signal<string | null>(null);
+    this.pendingRsvpOnly = signal<boolean>(false);
     this.hasMore = computed(() => this.activeLens() !== 'me' && (this.timeFilter() === 'past' ? !!this.pastPageToken() : !!this.upcomingPageToken()));
 
     // Initialize meeting type options
@@ -214,6 +216,7 @@ export class MeetingsDashboardComponent {
     this.timeFilter.set(value);
     this.foundationFilter.set(null);
     this.projectFilter.set(null);
+    this.pendingRsvpOnly.set(false);
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { time: value === 'past' ? 'past' : null },
@@ -227,6 +230,7 @@ export class MeetingsDashboardComponent {
     this.meetingTypeFilter.set(null);
     this.foundationFilter.set(null);
     this.projectFilter.set(null);
+    this.pendingRsvpOnly.set(false);
   }
 
   public loadMore(): void {
@@ -255,12 +259,13 @@ export class MeetingsDashboardComponent {
     const rawUserMeetings$ = toObservable(this.rawUserMeetings);
     const foundationFilter$ = toObservable(this.foundationFilter);
     const projectFilter$ = toObservable(this.projectFilter);
-    const meLens$ = combineLatest([lens$, timeFilter$, searchQuery$, meetingType$, rawUserMeetings$, foundationFilter$, projectFilter$]).pipe(
-      switchMap(([lens, timeFilter, searchQuery, meetingType, rawMeetings, foundation, project]) => {
+    const pendingRsvpOnly$ = toObservable(this.pendingRsvpOnly);
+    const meLens$ = combineLatest([lens$, timeFilter$, searchQuery$, meetingType$, rawUserMeetings$, foundationFilter$, projectFilter$, pendingRsvpOnly$]).pipe(
+      switchMap(([lens, timeFilter, searchQuery, meetingType, rawMeetings, foundation, project, pendingRsvpOnly]) => {
         if (lens !== 'me' || timeFilter !== 'upcoming') {
           return of<PageResult<Meeting>>({ data: [], page_token: undefined, reset: true });
         }
-        const filtered = this.filterMeLensMeetings(rawMeetings, searchQuery, meetingType, foundation, project);
+        const filtered = this.filterMeLensMeetings(rawMeetings, searchQuery, meetingType, foundation, project, pendingRsvpOnly);
         return of<PageResult<Meeting>>({ data: filtered, page_token: undefined, reset: true });
       })
     );
@@ -341,7 +346,8 @@ export class MeetingsDashboardComponent {
         if (lens !== 'me' || timeFilter !== 'past') {
           return of<PageResult<PastMeeting>>({ data: [], page_token: undefined, reset: true });
         }
-        const filtered = this.filterMeLensMeetings(rawPastMeetings, searchQuery, meetingType, foundation, project);
+        // Pending-RSVP chip is upcoming-only, so past-meeting filtering always passes `false`.
+        const filtered = this.filterMeLensMeetings(rawPastMeetings, searchQuery, meetingType, foundation, project, false);
         return of<PageResult<PastMeeting>>({ data: filtered, page_token: undefined, reset: true });
       })
     );
@@ -502,7 +508,8 @@ export class MeetingsDashboardComponent {
     searchQuery: string,
     meetingType: string | null,
     foundation: string | null,
-    project: string | null
+    project: string | null,
+    pendingRsvpOnly: boolean
   ): T[] {
     let filtered = items;
 
@@ -513,6 +520,12 @@ export class MeetingsDashboardComponent {
       // Sub-foundations (is_foundation: true with parent = this foundation) are their own
       // top-level filter entries, so exclude them and their children here.
       filtered = filtered.filter((m) => m.project_uid === foundation || (m.parent_project_uid === foundation && !m.is_foundation));
+    }
+
+    if (pendingRsvpOnly) {
+      // Pending = no RSVP yet OR a non-committal "maybe". Matches the "needs response" semantics
+      // used by the pending-actions transformer.
+      filtered = filtered.filter((m) => !m.my_rsvp || m.my_rsvp.response_type === 'maybe');
     }
 
     return this.filterBySearchAndType(filtered, searchQuery, meetingType);
@@ -703,6 +716,8 @@ export class MeetingsDashboardComponent {
   }
 
   private initIsFiltered(): Signal<boolean> {
-    return computed(() => !!this.debouncedSearchQuery() || !!this.meetingTypeFilter() || !!this.foundationFilter() || !!this.projectFilter());
+    return computed(
+      () => !!this.debouncedSearchQuery() || !!this.meetingTypeFilter() || !!this.foundationFilter() || !!this.projectFilter() || this.pendingRsvpOnly()
+    );
   }
 }

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -531,6 +531,48 @@ export class UserService {
 
     logger.debug(req, 'get_user_meetings', 'Fetched meetings from query service', { count: meetings.length });
 
+    // Enrich each meeting with the current user's RSVP (null when no response). Reuses the same
+    // query-service pattern that powers `getUserPendingActions` → `transformMissingRsvpsToActions`.
+    // Wrapped in try/catch so an RSVP-lookup failure degrades gracefully: meetings still return,
+    // `my_rsvp` stays undefined per row, the dashboard doesn't 500, and the Pending RSVP filter
+    // chip just shows the unfiltered list.
+    const rawUsername = await getUsernameFromAuth(req);
+    const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
+    const email = getEffectiveEmail(req) ?? '';
+
+    if ((email || username) && meetings.length > 0) {
+      try {
+        const [userRsvps, activeRegistrantIds] = await Promise.all([
+          this.fetchAllUserRsvps(req, email, username),
+          this.fetchUserActiveRegistrantIds(req, email, username),
+        ]);
+
+        // Strongest-response-wins (accepted/declined beats maybe beats nothing) — same logic as
+        // `transformMissingRsvpsToActions`. Drop RSVPs whose `registrant_id` isn't in the active
+        // set; otherwise stale RSVPs from removed registrations would falsely mark meetings as
+        // "responded".
+        const rsvpByMeeting = new Map<string, MeetingRsvp>();
+        for (const rsvp of userRsvps) {
+          if (!rsvp.meeting_id) continue;
+          if (!rsvp.registrant_id || !activeRegistrantIds.has(rsvp.registrant_id)) continue;
+          const existing = rsvpByMeeting.get(rsvp.meeting_id);
+          if (!existing || (existing.response_type === 'maybe' && rsvp.response_type !== 'maybe')) {
+            rsvpByMeeting.set(rsvp.meeting_id, rsvp);
+          }
+        }
+
+        for (const meeting of meetings) {
+          if (meeting.id) {
+            meeting.my_rsvp = rsvpByMeeting.get(meeting.id) ?? null;
+          }
+        }
+      } catch (error) {
+        logger.warning(req, 'get_user_meetings', 'RSVP enrichment failed, continuing without my_rsvp', {
+          err: error,
+        });
+      }
+    }
+
     // Drop past meetings; recurring meetings survive if any occurrence is still active.
     const upcomingMeetings = meetings.filter((meeting) => {
       if (meeting.occurrences && meeting.occurrences.length > 0) {

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -230,6 +230,9 @@ export interface Meeting {
   attended_count?: number;
   /** Meeting occurrences */
   occurrences: MeetingOccurrence[];
+  /** Current user's RSVP for this meeting (null when the user hasn't responded).
+   * Populated by /api/user/meetings only. Absent on other Meeting-returning endpoints. */
+  my_rsvp?: MeetingRsvp | null;
   /** Project name */
   project_name: string;
   /** Project slug */


### PR DESCRIPTION
## Summary

Adds a **Pending RSVP** pill to `/meetings` on the Me lens (upcoming tab) so users can quickly see invites awaiting a response. Click to toggle on/off — same styling as the existing Upcoming / Past pill.

**Ticket:** [LFXV2-1545](https://jira.linuxfoundation.org/browse/LFXV2-1545) (Approach B — minimal chip; not the richer dashboard integration)

## What's in the filter

"Pending" = the user hasn't RSVPed **or** their response is `maybe`. Matches the "needs response" semantics already used by the pending-actions aggregator, so the chip and the dashboard's Set RSVP action stay in agreement.

## Backend

- New field: `Meeting.my_rsvp?: MeetingRsvp | null` (response-only; populated by `/api/user/meetings`, absent on other Meeting-returning endpoints)
- `getUserMeetings` now enriches each meeting with the user's RSVP by reusing `fetchAllUserRsvps` + `fetchUserActiveRegistrantIds` — the same helpers already used by `getUserPendingActions`
- Active-registrant guard + strongest-response-wins logic mirrors `transformMissingRsvpsToActions` so stale RSVPs from removed registrations don't falsely mark a meeting as responded
- Wrapped in try/catch → `logger.warning` on failure; meetings still return and the chip falls back to showing all meetings

**No upstream Go service change required** — RSVP data is reached via the query service `v1_meeting_rsvp` type, which is already indexed per user.

## Frontend

- New `pendingRsvpOnly: WritableSignal<boolean>` in `MeetingsDashboardComponent`
- `filterMeLensMeetings()` takes a 6th param and drops meetings whose `my_rsvp` is set to `accepted`/`declined`
- Chip rendered via existing `lfx-filter-pills` primitive (same component as Upcoming/Past) — single-pill toggle mode
- Gated to Me lens + upcoming tab; resets on tab switch and on "Reset filters"

## Scope notes

- Me-lens only by design. Foundation/Project lens is for browsing project meetings rather than personal action, so the chip is not shown there.
- Client-side filter over already-loaded data — zero new API calls to toggle the pill.
- A small duplicate RSVP fetch exists between `getUserMeetings` and `getUserPendingActions` on Me-lens dashboard load; flagged for a future request-cache pass, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1545]: https://linuxfoundation.atlassian.net/browse/LFXV2-1545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ