### PR TITLE
chore(events): add date validation to visa form and guard new request button

### DIFF
--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-request-list/event-request-list.component.ts
@@ -4,7 +4,6 @@
 import { ChangeDetectionStrategy, Component, Type, computed, inject, input, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { EventsService } from '@app/shared/services/events.service';
-import { UserService } from '@app/shared/services/user.service';
 import { EventRequestStatusSeverityPipe } from '@app/shared/pipes/event-request-status-severity.pipe';
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -12,7 +11,7 @@ import { DEFAULT_EVENTS_PAGE_SIZE, EMPTY_TRAVEL_FUND_REQUESTS_RESPONSE, EMPTY_VI
 import { PageChangeEvent, RequestType, VisaRequestsResponse } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
-import { catchError, combineLatest, defer, finalize, map, of, skip, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, finalize, of, skip, switchMap, tap } from 'rxjs';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { TravelFundApplicationDialogComponent } from '../travel-fund-application-dialog/travel-fund-application-dialog.component';
 import { VisaRequestApplicationDialogComponent } from '../visa-request-application-dialog/visa-request-application-dialog.component';
@@ -26,7 +25,6 @@ import { VisaRequestApplicationDialogComponent } from '../visa-request-applicati
 export class EventRequestListComponent {
   private readonly eventsService = inject(EventsService);
   private readonly dialogService = inject(DialogService);
-  private readonly userService = inject(UserService);
   private readonly messageService = inject(MessageService);
 
   public readonly requestType = input.required<RequestType>();
@@ -37,9 +35,7 @@ export class EventRequestListComponent {
   protected readonly sortField = signal<string>('APPLICATION_DATE');
   protected readonly sortOrder = signal<'ASC' | 'DESC'>('DESC');
   protected readonly page = signal<PageChangeEvent>({ offset: 0, pageSize: DEFAULT_EVENTS_PAGE_SIZE });
-  protected readonly isSalesforceIdLoading = signal(false);
   protected readonly requestsResponse: Signal<VisaRequestsResponse> = this.initRequests();
-  protected readonly isCreateEnabled: Signal<boolean> = this.initIsCreateEnabled();
 
   protected readonly rppOptions = computed<number[] | undefined>(() => (this.requestsResponse().total > 10 ? [10, 25, 50] : undefined));
 
@@ -82,7 +78,6 @@ export class EventRequestListComponent {
   }
 
   public openApplicationDialog(): void {
-    if (!this.isCreateEnabled()) return;
     this.dialogService.open(this.config().dialogComponent, {
       header: this.config().dialogHeader,
       width: '800px',
@@ -138,44 +133,6 @@ export class EventRequestListComponent {
         })
       ),
       { initialValue: EMPTY_VISA_REQUESTS_RESPONSE }
-    );
-  }
-
-  // Salesforce ID is required to create a new request
-  private initIsCreateEnabled(): Signal<boolean> {
-    if (this.userService.apiGatewayUserId()) {
-      return signal(true);
-    }
-
-    return toSignal(
-      defer(() => {
-        this.isSalesforceIdLoading.set(true);
-        return this.userService.getSalesforceId();
-      }).pipe(
-        map((profile) => {
-          if (profile?.id) {
-            this.userService.apiGatewayUserId.set(profile.id);
-            return true;
-          }
-
-          this.messageService.add({
-            severity: 'error',
-            summary: 'Error',
-            detail: 'Your account is missing the required Salesforce ID. Please contact support.',
-          });
-          return false;
-        }),
-        catchError(() => {
-          this.messageService.add({
-            severity: 'error',
-            summary: 'Error',
-            detail: 'Unable to verify your account. Please refresh the page.',
-          });
-          return of(false);
-        }),
-        finalize(() => this.isSalesforceIdLoading.set(false))
-      ),
-      { initialValue: false }
     );
   }
 }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-apply-form/visa-request-apply-form.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-apply-form/visa-request-apply-form.component.html
@@ -77,9 +77,15 @@
     </div>
     <div class="flex flex-col gap-1">
       <label class="text-sm font-medium text-gray-700">Passport Expiry Date <span class="text-red-500">*</span></label>
-      <lfx-calendar [form]="form" control="passportExpiryDate" placeholder="MM/DD/YYYY" styleClass="w-full" />
+      <lfx-calendar [form]="form" control="passportExpiryDate" placeholder="MM/DD/YYYY" styleClass="w-full" [minDate]="today" />
       @if (form.get('passportExpiryDate')?.invalid && form.get('passportExpiryDate')?.touched) {
-        <span class="text-xs text-red-500" data-testid="visa-apply-passport-expiry-error">Passport expiry date is required</span>
+        <span class="text-xs text-red-500" data-testid="visa-apply-passport-expiry-error">
+          @if (form.get('passportExpiryDate')?.hasError('pastDate')) {
+            Passport expiry date cannot be in the past
+          } @else {
+            Passport expiry date is required
+          }
+        </span>
       }
     </div>
   </div>
@@ -88,9 +94,15 @@
   <div class="grid grid-cols-2 gap-4">
     <div class="flex flex-col gap-1">
       <label class="text-sm font-medium text-gray-700">Date of Birth <span class="text-red-500">*</span></label>
-      <lfx-calendar [form]="form" control="birthDate" placeholder="MM/DD/YYYY" styleClass="w-full" dataTest="visa-apply-birth-date" />
+      <lfx-calendar [form]="form" control="birthDate" placeholder="MM/DD/YYYY" styleClass="w-full" dataTest="visa-apply-birth-date" [maxDate]="today" />
       @if (form.get('birthDate')?.invalid && form.get('birthDate')?.touched) {
-        <span class="text-xs text-red-500" data-testid="visa-apply-birth-date-error">Date of birth is required</span>
+        <span class="text-xs text-red-500" data-testid="visa-apply-birth-date-error">
+          @if (form.get('birthDate')?.hasError('futureDate')) {
+            Date of birth cannot be in the future
+          } @else {
+            Date of birth is required
+          }
+        </span>
       }
     </div>
     <div class="flex flex-col gap-1">

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-apply-form/visa-request-apply-form.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-apply-form/visa-request-apply-form.component.ts
@@ -3,7 +3,7 @@
 
 import { ChangeDetectionStrategy, Component, inject, output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { AbstractControl, NonNullableFormBuilder, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
+import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { UserService } from '@app/shared/services/user.service';
 import { CalendarComponent } from '@components/calendar/calendar.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
@@ -11,6 +11,7 @@ import { SelectComponent } from '@components/select/select.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
 import { ACCOMMODATION_PAID_BY_OPTIONS, ATTENDEE_TYPE_OPTIONS, COUNTRIES } from '@lfx-one/shared/constants';
 import { AttendeeAccommodationPaidBy, AttendeeType, VisaRequestApplicantInfo } from '@lfx-one/shared/interfaces';
+import { notFutureDateValidator, notPastDateValidator } from '@lfx-one/shared/validators';
 import { startWith } from 'rxjs';
 import { OrgSearchFieldComponent } from '../org-search-field/org-search-field.component';
 
@@ -27,14 +28,16 @@ export class VisaRequestApplyFormComponent {
   public readonly formValidityChange = output<boolean>();
   public readonly formChange = output<VisaRequestApplicantInfo>();
 
+  public readonly today = startOfDay(new Date());
+
   public readonly form = this.fb.group({
     firstName: ['', Validators.required],
     lastName: ['', Validators.required],
     email: [''],
     passportNumber: ['', Validators.required],
     citizenshipCountry: ['', Validators.required],
-    passportExpiryDate: [null as Date | null, [Validators.required, notPastDateValidator]],
-    birthDate: [null as Date | null, [Validators.required, notFutureDateValidator]],
+    passportExpiryDate: [null as Date | null, [Validators.required, notPastDateValidator(this.today)]],
+    birthDate: [null as Date | null, [Validators.required, notFutureDateValidator(this.today)]],
     embassyCity: ['', Validators.required],
     company: ['', Validators.required],
     organizationID: ['', Validators.required],
@@ -46,7 +49,6 @@ export class VisaRequestApplyFormComponent {
   public readonly countryOptions = [...COUNTRIES];
   public readonly attendeeTypeOptions = ATTENDEE_TYPE_OPTIONS;
   public readonly accommodationOptions = ACCOMMODATION_PAID_BY_OPTIONS;
-  public readonly today = startOfToday();
 
   public constructor() {
     this.form.get('email')?.disable();
@@ -74,32 +76,7 @@ export class VisaRequestApplyFormComponent {
   }
 }
 
-function startOfToday(): Date {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  return today;
-}
-
-function notFutureDateValidator(control: AbstractControl): ValidationErrors | null {
-  const value = control.value as Date | null;
-  if (!value) {
-    return null;
-  }
-
-  const date = new Date(value);
+function startOfDay(date: Date): Date {
   date.setHours(0, 0, 0, 0);
-
-  return date.getTime() > startOfToday().getTime() ? { futureDate: true } : null;
-}
-
-function notPastDateValidator(control: AbstractControl): ValidationErrors | null {
-  const value = control.value as Date | null;
-  if (!value) {
-    return null;
-  }
-
-  const date = new Date(value);
-  date.setHours(0, 0, 0, 0);
-
-  return date.getTime() < startOfToday().getTime() ? { pastDate: true } : null;
+  return date;
 }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-apply-form/visa-request-apply-form.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/visa-request-apply-form/visa-request-apply-form.component.ts
@@ -3,7 +3,7 @@
 
 import { ChangeDetectionStrategy, Component, inject, output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { NonNullableFormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AbstractControl, NonNullableFormBuilder, ReactiveFormsModule, ValidationErrors, Validators } from '@angular/forms';
 import { UserService } from '@app/shared/services/user.service';
 import { CalendarComponent } from '@components/calendar/calendar.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
@@ -33,8 +33,8 @@ export class VisaRequestApplyFormComponent {
     email: [''],
     passportNumber: ['', Validators.required],
     citizenshipCountry: ['', Validators.required],
-    passportExpiryDate: [null as Date | null, Validators.required],
-    birthDate: [null as Date | null, Validators.required],
+    passportExpiryDate: [null as Date | null, [Validators.required, notPastDateValidator]],
+    birthDate: [null as Date | null, [Validators.required, notFutureDateValidator]],
     embassyCity: ['', Validators.required],
     company: ['', Validators.required],
     organizationID: ['', Validators.required],
@@ -46,6 +46,7 @@ export class VisaRequestApplyFormComponent {
   public readonly countryOptions = [...COUNTRIES];
   public readonly attendeeTypeOptions = ATTENDEE_TYPE_OPTIONS;
   public readonly accommodationOptions = ACCOMMODATION_PAID_BY_OPTIONS;
+  public readonly today = startOfToday();
 
   public constructor() {
     this.form.get('email')?.disable();
@@ -71,4 +72,34 @@ export class VisaRequestApplyFormComponent {
   private buildFormValue(): VisaRequestApplicantInfo {
     return this.form.getRawValue() as VisaRequestApplicantInfo;
   }
+}
+
+function startOfToday(): Date {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
+}
+
+function notFutureDateValidator(control: AbstractControl): ValidationErrors | null {
+  const value = control.value as Date | null;
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+
+  return date.getTime() > startOfToday().getTime() ? { futureDate: true } : null;
+}
+
+function notPastDateValidator(control: AbstractControl): ValidationErrors | null {
+  const value = control.value as Date | null;
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  date.setHours(0, 0, 0, 0);
+
+  return date.getTime() < startOfToday().getTime() ? { pastDate: true } : null;
 }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -1,6 +1,5 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
-
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="my-events-dashboard">
   <div class="flex flex-col gap-6">
     <!-- Page Header -->
@@ -81,7 +80,7 @@
         @if (isRequestTab()) {
           <lfx-button
             [label]="requestButtonLabel()"
-            [icon]="isCreateEnabled() ? 'fa-light fa-plus' : 'fa-light fa-spinner-third fa-spin'"
+            [icon]="isSalesforceIdLoading() ? 'fa-light fa-spinner-third fa-spin' : 'fa-light fa-plus'"
             severity="primary"
             size="small"
             [disabled]="!isCreateEnabled()"

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -81,9 +81,10 @@
         @if (isRequestTab()) {
           <lfx-button
             [label]="requestButtonLabel()"
-            icon="fa-light fa-plus"
+            [icon]="isCreateEnabled() ? 'fa-light fa-plus' : 'fa-light fa-spinner-third fa-spin'"
             severity="primary"
             size="small"
+            [disabled]="!isCreateEnabled()"
             (onClick)="openCurrentRequestDialog()"
             data-testid="events-new-request-button" />
         }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -1,13 +1,16 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, signal, viewChild } from '@angular/core';
+import { Component, computed, inject, Signal, signal, viewChild } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { MY_EVENT_STATUS_OPTIONS, VISA_REQUEST_STATUS_OPTIONS } from '@lfx-one/shared/constants';
 import { EventTabId, FilterOption, FilterPillOption } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
 import { Tooltip } from 'primeng/tooltip';
+import { catchError, defer, finalize, map, of } from 'rxjs';
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
 import { EventsTopBarComponent } from '../components/events-top-bar/events-top-bar.component';
 import { EventsListComponent } from './components/events-list/events-list.component';
@@ -20,6 +23,7 @@ import { UserService } from '@app/shared/services/user.service';
 })
 export class MyEventsDashboardComponent {
   private readonly userService = inject(UserService);
+  private readonly messageService = inject(MessageService);
   private readonly eventsListRef = viewChild(EventsListComponent);
 
   protected readonly activeTab = signal<EventTabId>('upcoming');
@@ -58,7 +62,8 @@ export class MyEventsDashboardComponent {
   protected readonly nextEventName = computed(() => this.eventsListRef()?.nextEventName() ?? '');
   protected readonly upcomingCount = computed(() => this.eventsListRef()?.tabCounts().upcoming ?? 0);
 
-  protected readonly isCreateEnabled = computed(() => !!this.userService.apiGatewayUserId());
+  protected readonly isSalesforceIdLoading = signal(false);
+  protected readonly isCreateEnabled: Signal<boolean> = this.initIsCreateEnabled();
 
   protected onFoundationChange(value: string | null): void {
     this.selectedFoundation.set(value);
@@ -86,6 +91,7 @@ export class MyEventsDashboardComponent {
   }
 
   protected openCurrentRequestDialog(): void {
+    if (!this.isCreateEnabled()) return;
     this.eventsListRef()?.openCurrentRequestDialog();
   }
 
@@ -94,5 +100,42 @@ export class MyEventsDashboardComponent {
     this.selectedRole.set(null);
     this.selectedStatus.set(null);
     this.selectedSearchQuery.set('');
+  }
+
+  private initIsCreateEnabled(): Signal<boolean> {
+    if (this.userService.apiGatewayUserId()) {
+      return signal(true);
+    }
+
+    return toSignal(
+      defer(() => {
+        this.isSalesforceIdLoading.set(true);
+        return this.userService.getSalesforceId();
+      }).pipe(
+        map((profile) => {
+          if (profile?.id) {
+            this.userService.apiGatewayUserId.set(profile.id);
+            return true;
+          }
+
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error',
+            detail: 'Your account is missing the required Salesforce ID. Please contact support.',
+          });
+          return false;
+        }),
+        catchError(() => {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error',
+            detail: 'Unable to verify your account. Please refresh the page.',
+          });
+          return of(false);
+        }),
+        finalize(() => this.isSalesforceIdLoading.set(false))
+      ),
+      { initialValue: false }
+    );
   }
 }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, signal, viewChild } from '@angular/core';
+import { Component, computed, inject, signal, viewChild } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
@@ -11,6 +11,7 @@ import { Tooltip } from 'primeng/tooltip';
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
 import { EventsTopBarComponent } from '../components/events-top-bar/events-top-bar.component';
 import { EventsListComponent } from './components/events-list/events-list.component';
+import { UserService } from '@app/shared/services/user.service';
 
 @Component({
   selector: 'lfx-my-events-dashboard',
@@ -18,6 +19,7 @@ import { EventsListComponent } from './components/events-list/events-list.compon
   templateUrl: './my-events-dashboard.component.html',
 })
 export class MyEventsDashboardComponent {
+  private readonly userService = inject(UserService);
   private readonly eventsListRef = viewChild(EventsListComponent);
 
   protected readonly activeTab = signal<EventTabId>('upcoming');
@@ -55,6 +57,8 @@ export class MyEventsDashboardComponent {
   protected readonly attendedCount = computed(() => this.eventsListRef()?.attendedCount() ?? 0);
   protected readonly nextEventName = computed(() => this.eventsListRef()?.nextEventName() ?? '');
   protected readonly upcomingCount = computed(() => this.eventsListRef()?.tabCounts().upcoming ?? 0);
+
+  protected readonly isCreateEnabled = computed(() => !!this.userService.apiGatewayUserId());
 
   protected onFoundationChange(value: string | null): void {
     this.selectedFoundation.set(value);

--- a/packages/shared/src/validators/date.validators.ts
+++ b/packages/shared/src/validators/date.validators.ts
@@ -1,0 +1,28 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+export function notPastDateValidator(today: Date): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value as Date | null;
+    if (!value) return null;
+
+    const date = new Date(value);
+    date.setHours(0, 0, 0, 0);
+
+    return date.getTime() < today.getTime() ? { pastDate: true } : null;
+  };
+}
+
+export function notFutureDateValidator(today: Date): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value as Date | null;
+    if (!value) return null;
+
+    const date = new Date(value);
+    date.setHours(0, 0, 0, 0);
+
+    return date.getTime() > today.getTime() ? { futureDate: true } : null;
+  };
+}

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+export * from './date.validators';
 export * from './mailing-list.validators';
 export * from './meeting.validators';
 export * from './vote.validators';


### PR DESCRIPTION
## Summary

  - Added notPastDateValidator to passport expiry date and notFutureDateValidator to date of birth in the visa request form, with calendar minDate/maxDate constraints and distinct error messages for each failure
  case
  - Disabled the "New Request" button and shows a spinner until apiGatewayUserId is available, preventing premature form opens before user data has loaded