### PR TITLE
fix(meetings): summary title and content in meeting summary

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.html
@@ -4,10 +4,7 @@
 <div class="flex flex-col gap-4">
   <!-- Title -->
   @if (title) {
-    <div data-testid="summary-title">
-      <h4 class="text-lg font-semibold text-gray-900">{{ title }}</h4>
-      <p class="text-sm text-gray-500">AI-generated meeting summary</p>
-    </div>
+    <p class="text-sm text-gray-500" data-testid="summary-title">AI-generated meeting summary</p>
   }
 
   <!-- Status -->

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.html
@@ -3,7 +3,7 @@
 
 <div class="flex flex-col gap-4">
   <!-- Title -->
-  @if (title) {
+  @if (hasTitle) {
     <p class="text-sm text-gray-500" data-testid="summary-title">AI-generated meeting summary</p>
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.html
@@ -2,6 +2,14 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-4">
+  <!-- Title -->
+  @if (title) {
+    <div data-testid="summary-title">
+      <h4 class="text-lg font-semibold text-gray-900">{{ title }}</h4>
+      <p class="text-sm text-gray-500">AI-generated meeting summary</p>
+    </div>
+  }
+
   <!-- Status -->
   <div class="flex items-center gap-2" data-testid="summary-status">
     @if (approved) {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.ts
@@ -17,7 +17,7 @@ export class MeetingSummaryModalComponent {
 
   public readonly summary: PastMeetingSummary = this.dialogConfig.data.summary;
   public readonly title: string = this.summary.summary_data?.title || '';
-  public readonly content: string = this.summary.summary_data?.edited_content || this.summary.summary_data?.content || '';
+  public readonly content: string = this.summary.summary_data?.edited_content ?? this.summary.summary_data?.content ?? '';
   public readonly approved: boolean = this.summary.approved || false;
   public readonly sections: SummarySection[] = this.parseSections(this.content);
   public readonly isStructured: boolean = this.sections.length > 0;

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.ts
@@ -16,6 +16,7 @@ export class MeetingSummaryModalComponent {
   private readonly dialogConfig = inject(DynamicDialogConfig);
 
   public readonly summary: PastMeetingSummary = this.dialogConfig.data.summary;
+  public readonly title: string = this.summary.summary_data?.title || '';
   public readonly content: string = this.summary.summary_data?.edited_content || this.summary.summary_data?.content || '';
   public readonly approved: boolean = this.summary.approved || false;
   public readonly sections: SummarySection[] = this.parseSections(this.content);

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.ts
@@ -16,7 +16,7 @@ export class MeetingSummaryModalComponent {
   private readonly dialogConfig = inject(DynamicDialogConfig);
 
   public readonly summary: PastMeetingSummary = this.dialogConfig.data.summary;
-  public readonly title: string = this.summary.summary_data?.title || '';
+  public readonly hasTitle: boolean = !!this.summary.summary_data?.title;
   public readonly content: string = this.summary.summary_data?.edited_content ?? this.summary.summary_data?.content ?? '';
   public readonly approved: boolean = this.summary.approved || false;
   public readonly sections: SummarySection[] = this.parseSections(this.content);

--- a/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts
@@ -122,7 +122,7 @@ export class PastMeetingDetailsComponent {
     if (!summary) return;
 
     this.dialogService.open(MeetingSummaryModalComponent, {
-      header: 'AI Summary',
+      header: summary.summary_data?.title || 'AI Summary',
       width: '700px',
       modal: true,
       closable: true,

--- a/packages/shared/src/interfaces/my-document.interface.ts
+++ b/packages/shared/src/interfaces/my-document.interface.ts
@@ -26,8 +26,7 @@ export interface GroupsIOArtifactQueryResult {
   link_url?: string;
   download_url?: string;
   media_type?: string;
-  last_posted_at?: string;
-  created_at?: string;
+  created_at: string;
 }
 
 /** Raw shape returned by query service for `v1_meeting_registrant` resource type */

--- a/packages/shared/src/interfaces/my-document.interface.ts
+++ b/packages/shared/src/interfaces/my-document.interface.ts
@@ -26,7 +26,8 @@ export interface GroupsIOArtifactQueryResult {
   link_url?: string;
   download_url?: string;
   media_type?: string;
-  created_at: string;
+  last_posted_at?: string;
+  created_at?: string;
 }
 
 /** Raw shape returned by query service for `v1_meeting_registrant` resource type */

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -293,8 +293,9 @@ export function buildJoinUrlWithParams(joinUrl: string, user?: User | null, opti
  * @returns V2 SummaryData object
  */
 function buildV2SummaryDataFromV1(v1Summary: V1PastMeetingSummary & { content?: string; edited_content?: string }): SummaryData {
-  // Indexer contract shape: flat content/edited_content fields — use directly
-  if (v1Summary.content || v1Summary.edited_content) {
+  // Indexer contract shape: flat content/edited_content fields — use directly.
+  // Use property presence ('in') not truthiness to correctly handle empty strings.
+  if ('content' in (v1Summary as object) || 'edited_content' in (v1Summary as object)) {
     return {
       title: v1Summary.summary_title || '',
       content: v1Summary.content || '',
@@ -352,8 +353,9 @@ function buildV2SummaryDataFromV1(v1Summary: V1PastMeetingSummary & { content?: 
  * - summary_end_time → summary_data.end_time
  */
 export function transformV1SummaryToV2(summary: PastMeetingSummary): PastMeetingSummary {
-  // If already has v2 format (uid and summary_data.content), return as-is
-  if (summary.uid && summary.summary_data?.content) {
+  // If already has v2 format (uid and summary_data present), return as-is.
+  // Check presence of summary_data, not value of content (which can be an empty string).
+  if (summary.uid && summary.summary_data) {
     return summary;
   }
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -297,9 +297,9 @@ function buildV2SummaryDataFromV1(v1Summary: V1PastMeetingSummary & { content?: 
   // Use property presence ('in') not truthiness to correctly handle empty strings.
   if ('content' in v1Summary || 'edited_content' in v1Summary) {
     return {
-      title: v1Summary.summary_title || '',
-      content: v1Summary.content || '',
-      edited_content: v1Summary.edited_content || '',
+      title: v1Summary.summary_title ?? '',
+      content: v1Summary.content ?? '',
+      edited_content: v1Summary.edited_content ?? '',
       doc_url: '',
       start_time: v1Summary.summary_start_time || '',
       end_time: v1Summary.summary_end_time || '',

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -292,11 +292,21 @@ export function buildJoinUrlWithParams(joinUrl: string, user?: User | null, opti
  * @param v1Summary - V1 summary object
  * @returns V2 SummaryData object
  */
-function buildV2SummaryDataFromV1(v1Summary: V1PastMeetingSummary): SummaryData {
-  // Build markdown content from v1 fields
-  const parts: string[] = [];
+function buildV2SummaryDataFromV1(v1Summary: V1PastMeetingSummary & { content?: string; edited_content?: string }): SummaryData {
+  // Indexer contract shape: flat content/edited_content fields — use directly
+  if (v1Summary.content || v1Summary.edited_content) {
+    return {
+      title: v1Summary.summary_title || '',
+      content: v1Summary.content || '',
+      edited_content: v1Summary.edited_content || '',
+      doc_url: '',
+      start_time: v1Summary.summary_start_time || '',
+      end_time: v1Summary.summary_end_time || '',
+    };
+  }
 
-  // Use edited content if available, otherwise use original
+  // Legacy V1 shape: build markdown content from structured fields
+  const parts: string[] = [];
   const overview = v1Summary.edited_summary_overview || v1Summary.summary_overview;
   const details = v1Summary.edited_summary_details || v1Summary.summary_details;
   const nextSteps = v1Summary.edited_next_steps || v1Summary.next_steps;
@@ -347,31 +357,28 @@ export function transformV1SummaryToV2(summary: PastMeetingSummary): PastMeeting
     return summary;
   }
 
-  // Cast to V1PastMeetingSummary for accessing v1-specific fields with type safety
-  const v1Summary = summary as unknown as V1PastMeetingSummary;
+  // Cast to raw shape to access both V1 fields and indexer-contract flat fields
+  // (content, edited_content, summary_title are indexer fields not in PastMeetingSummary or V1PastMeetingSummary)
+  const raw = summary as unknown as V1PastMeetingSummary & { content?: string; edited_content?: string };
 
   return {
-    // V2 fields - use v2 field or fall back to v1 equivalent
-    uid: summary.uid || v1Summary.id || '',
-    meeting_id: summary.meeting_id || v1Summary.meeting_id || '',
+    uid: summary.uid || raw.id || '',
+    meeting_id: summary.meeting_id || raw.meeting_id || '',
     past_meeting_id: summary.past_meeting_id || '',
     platform: summary.platform || 'Zoom',
-    approved: summary.approved ?? v1Summary.approved ?? false,
-    requires_approval: summary.requires_approval ?? v1Summary.requires_approval ?? false,
-    email_sent: summary.email_sent ?? v1Summary.email_sent ?? false,
-    password: summary.password || v1Summary.password || '',
+    approved: summary.approved ?? raw.approved ?? false,
+    requires_approval: summary.requires_approval ?? raw.requires_approval ?? false,
+    email_sent: summary.email_sent ?? raw.email_sent ?? false,
+    password: summary.password || raw.password || '',
 
-    // Transform summary_data from v1 fields
-    summary_data: buildV2SummaryDataFromV1(v1Summary),
+    summary_data: buildV2SummaryDataFromV1(raw),
 
-    // Build zoom_config from v1 fields if not present
     zoom_config: summary.zoom_config || {
-      meeting_id: v1Summary.meeting_id || '',
-      meeting_uuid: v1Summary.zoom_meeting_uuid || '',
+      meeting_id: raw.meeting_id || '',
+      meeting_uuid: raw.zoom_meeting_uuid || '',
     },
 
-    // Timestamps
-    created_at: summary.created_at || v1Summary.summary_created_time || '',
-    updated_at: summary.updated_at || v1Summary.summary_last_modified_time || v1Summary.modified_at || '',
+    created_at: summary.created_at || raw.summary_created_time || '',
+    updated_at: summary.updated_at || raw.summary_last_modified_time || raw.modified_at || '',
   };
 }

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -295,7 +295,7 @@ export function buildJoinUrlWithParams(joinUrl: string, user?: User | null, opti
 function buildV2SummaryDataFromV1(v1Summary: V1PastMeetingSummary & { content?: string; edited_content?: string }): SummaryData {
   // Indexer contract shape: flat content/edited_content fields — use directly.
   // Use property presence ('in') not truthiness to correctly handle empty strings.
-  if ('content' in (v1Summary as object) || 'edited_content' in (v1Summary as object)) {
+  if ('content' in v1Summary || 'edited_content' in v1Summary) {
     return {
       title: v1Summary.summary_title || '',
       content: v1Summary.content || '',
@@ -360,7 +360,7 @@ export function transformV1SummaryToV2(summary: PastMeetingSummary): PastMeeting
   }
 
   // Cast to raw shape to access both V1 fields and indexer-contract flat fields
-  // (content, edited_content, summary_title are indexer fields not in PastMeetingSummary or V1PastMeetingSummary)
+  // (content and edited_content are indexer-flat fields not present in PastMeetingSummary or V1PastMeetingSummary)
   const raw = summary as unknown as V1PastMeetingSummary & { content?: string; edited_content?: string };
 
   return {
@@ -373,7 +373,7 @@ export function transformV1SummaryToV2(summary: PastMeetingSummary): PastMeeting
     email_sent: summary.email_sent ?? raw.email_sent ?? false,
     password: summary.password || raw.password || '',
 
-    summary_data: buildV2SummaryDataFromV1(raw),
+    summary_data: summary.summary_data ?? buildV2SummaryDataFromV1(raw),
 
     zoom_config: summary.zoom_config || {
       meeting_id: raw.meeting_id || '',


### PR DESCRIPTION
- Rename `title: string` input to `hasTitle: boolean` in `MeetingSummaryModalComponent` — the string value was only used as a boolean gate; the actual title is already shown in the PrimeNG dialog header set by the caller
- Switch `||` to `??` for flat-indexer string fields in `buildV2SummaryDataFromV1` for consistency with the `'in'`-presence check and other `??` operators in this PR

Assisted by [Claude Code](https://claude.ai/claude-code)

# Overview

This PR fixes how AI-generated meeting summary titles and content are displayed in the meeting summary modal.

**Meeting Summary Modal — Title Input Refactor**
- Renamed `title: string` input to `hasTitle: boolean` in `MeetingSummaryModalComponent` — the string value was never rendered in the modal body (the actual title appears in the PrimeNG dialog header). Using a boolean makes the gate intent explicit. [[1]](apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.ts) [[2]](apps/lfx-one/src/app/modules/meetings/components/meeting-summary-modal/meeting-summary-modal.component.html)

**Meeting Utils — V1→V2 Summary Transform Fix**
- Fixed the flat-indexer detection in `buildV2SummaryDataFromV1` to use property presence (`'in'`) rather than truthiness, so intentionally empty `content` and `edited_content` strings are handled correctly.
- Switched `||` to `??` for flat-indexer string fields for consistency with the precision goal of the `'in'` check. [[1]](packages/shared/src/utils/meeting.utils.ts)

**Meeting Summary Modal — Content Display**
- Fixed how `edited_content` falls back to `content` using `??` (not `||`) so an intentionally empty `edited_content` string is preserved. [[1]](apps/lfx-one/src/app/modules/meetings/past-meeting-details/past-meeting-details.component.ts)

**Past Meeting Details — Summary Data Guard**
- The `transformV1SummaryToV2` function now uses `summary.summary_data ?? buildV2SummaryDataFromV1(raw)` so existing v2 `summary_data` is never overwritten when `uid` is present. [[1]](packages/shared/src/utils/meeting.utils.ts)