### PR TITLE
fix(meetings): stop treating maybe RSVPs as pending actions

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -523,9 +523,8 @@ export class MeetingsDashboardComponent {
     }
 
     if (pendingRsvpOnly) {
-      // Pending = no RSVP yet OR a non-committal "maybe". Matches the "needs response" semantics
-      // used by the pending-actions transformer.
-      filtered = filtered.filter((m) => !m.my_rsvp || m.my_rsvp.response_type === 'maybe');
+      // Pending = no RSVP recorded. accepted, declined, and maybe are all valid responses.
+      filtered = filtered.filter((m) => !m.my_rsvp);
     }
 
     return this.filterBySearchAndType(filtered, searchQuery, meetingType);

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -930,7 +930,7 @@ export class UserService {
    *   - Non-responded surveys (Snowflake)
    *   - Upcoming meetings within the next two weeks (Review Agenda action)
    *   - Active votes the user hasn't cast (Cast Vote action)
-   *   - Missing or "maybe" RSVPs for meetings in the 2-week window (Set RSVP action)
+   *   - Missing RSVPs for meetings in the 2-week window (Set RSVP action)
    * No meeting-type filter — a working-group meeting next week is as much a pending action as
    * a board meeting.
    */
@@ -1141,9 +1141,10 @@ export class UserService {
   }
 
   /**
-   * For each in-window meeting, emit a "Set RSVP" action when the user has no RSVP recorded or
-   * the recorded RSVP is "maybe". Per-occurrence RSVPs count as a response for the series — a
-   * user who has RSVPed any occurrence won't be nagged for a fresh top-level response.
+   * For each in-window meeting, emit a "Set RSVP" action when the user has no RSVP recorded.
+   * `accepted`, `declined`, and `maybe` are all valid responses — only missing RSVPs are pending.
+   * Per-occurrence RSVPs count as a response for the series — a user who has RSVPed any
+   * occurrence won't be nagged for a fresh top-level response.
    *
    * Before trusting an RSVP, require its `registrant_id` to be in the user's active registrant
    * set so historical RSVPs from removed registrations can't suppress a needed Set RSVP action
@@ -1154,22 +1155,17 @@ export class UserService {
 
     const inWindowMeetingIds = new Set(meetings.map((m) => m.id).filter((id): id is string => !!id));
 
-    // Keep the strongest signal per meeting: accepted/declined beats maybe beats nothing.
-    const responseByMeeting = new Map<string, MeetingRsvp>();
+    const respondedMeetingIds = new Set<string>();
     for (const rsvp of rsvps) {
       if (!rsvp.meeting_id || !inWindowMeetingIds.has(rsvp.meeting_id)) continue;
       if (!rsvp.registrant_id || !activeRegistrantIds.has(rsvp.registrant_id)) continue;
-      const existing = responseByMeeting.get(rsvp.meeting_id);
-      if (!existing || (existing.response_type === 'maybe' && rsvp.response_type !== 'maybe')) {
-        responseByMeeting.set(rsvp.meeting_id, rsvp);
-      }
+      respondedMeetingIds.add(rsvp.meeting_id);
     }
 
     const actions: PendingActionItem[] = [];
     for (const meeting of meetings) {
       if (!meeting.id) continue;
-      const rsvp = responseByMeeting.get(meeting.id);
-      if (rsvp && rsvp.response_type !== 'maybe') continue;
+      if (respondedMeetingIds.has(meeting.id)) continue;
       actions.push(this.createRsvpAction(meeting));
     }
     return actions;


### PR DESCRIPTION
## Summary

A "maybe" RSVP is a valid response — the user has answered — so it should not appear as pending. Before this fix, two places incorrectly nagged users who had already maybe-RSVPed:

- Dashboard **Pending Actions** panel kept emitting a "Set RSVP" action for meetings the user had already answered with "maybe".
- `/meetings` **Pending RSVP** filter chip (shipped in #553 / LFXV2-1545) surfaced maybe-responded meetings as still pending.

After this fix, pending = **no RSVP recorded at all**. `accepted`, `declined`, and `maybe` are all valid responses.

## Changes

- `apps/lfx-one/src/server/services/user.service.ts` — `transformMissingRsvpsToActions`: simplified to a `Set<meeting_id>` of any recorded response. Dropped the "strongest-response-wins" reducer since we only need existence now. Updated `getUserPendingActions` docstring and the transformer's own docstring.
- `apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts` — filter predicate simplified to `!m.my_rsvp`. Comment updated.

## Notes

- The strongest-response tiebreaker in `getUserMeetings` (line ~559) stays — it decides which `MeetingRsvp` to attach to `meeting.my_rsvp` when there are multiple, which is still a valid semantic for any future UI that displays the response type.
- No frontend type changes. No upstream contract changes.

LFXV2-1569