### PR TITLE
refactor(shared): centralize insights base url

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.html
@@ -123,7 +123,7 @@
     <lfx-insights-handoff-section
       title="Looking for contributor details?"
       description="Individual contributor profiles, commit history, and detailed activity breakdowns are available in LFX Insights."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       data-testid="active-contributors-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/active-contributors-drawer/active-contributors-drawer.component.ts
@@ -8,7 +8,7 @@ import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_ACTIVE_CONTRIBUTORS_MONTHLY, DEFAULT_FOUNDATION_CONTRIBUTORS_DISTRIBUTION, lfxColors } from '@lfx-one/shared/constants';
-import { hexToRgba } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, hexToRgba } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
@@ -33,6 +33,7 @@ export class ActiveContributorsDrawerComponent {
   private readonly fb = inject(FormBuilder);
 
   // === Static Options ===
+  protected readonly insightsUrl = buildInsightsUrl();
   protected readonly timeRangeOptions = [{ label: 'Last 12 months', value: 'last-12-months' }];
 
   protected readonly trendChartOptions: ChartOptions<'line'> = {

--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
@@ -126,7 +126,7 @@
     <lfx-insights-handoff-section
       title="Looking for detailed event information?"
       description="Individual event details, attendee lists, and historical event data are available in LFX Insights."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       data-testid="events-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.ts
@@ -8,6 +8,7 @@ import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_EVENTS_ATTENDANCE_DISTRIBUTION, DEFAULT_FOUNDATION_EVENTS_QUARTERLY, lfxColors } from '@lfx-one/shared/constants';
+import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
@@ -32,6 +33,7 @@ export class EventsDrawerComponent {
   private readonly fb = inject(FormBuilder);
 
   // === Static Options ===
+  protected readonly insightsUrl = buildInsightsUrl();
   protected readonly timeRangeOptions = [{ label: 'Last 12 months', value: 'last-12-months' }];
 
   protected readonly quarterlyChartOptions: ChartOptions<'bar'> = {

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
@@ -123,7 +123,7 @@
     <lfx-insights-handoff-section
       title="Looking for detailed maintainer metrics?"
       description="Project-level maintainer activity, contribution patterns, and individual maintainer details are available in LFX Insights."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       data-testid="maintainers-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
@@ -8,7 +8,7 @@ import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_MAINTAINERS_DISTRIBUTION, DEFAULT_FOUNDATION_MAINTAINERS_MONTHLY, lfxColors } from '@lfx-one/shared/constants';
-import { hexToRgba } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, hexToRgba } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
@@ -33,6 +33,7 @@ export class MaintainersDrawerComponent {
   private readonly fb = inject(FormBuilder);
 
   // === Static Options ===
+  protected readonly insightsUrl = buildInsightsUrl();
   protected readonly timeRangeOptions = [{ label: 'Last 12 months', value: 'last-12-months' }];
 
   protected readonly trendChartOptions: ChartOptions<'line'> = {

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-active-contributors-drawer/org-active-contributors-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-active-contributors-drawer/org-active-contributors-drawer.component.html
@@ -90,7 +90,7 @@
     <lfx-insights-handoff-section
       title="Looking for detailed contributor metrics?"
       description="Operational metrics, individual contributor activity, and project-level breakdowns are available in the Organization Dashboard."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       buttonLabel="View Organization Dashboard"
       data-testid="org-active-contributors-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-active-contributors-drawer/org-active-contributors-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-active-contributors-drawer/org-active-contributors-drawer.component.ts
@@ -6,7 +6,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
-import { hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -29,6 +29,9 @@ export class OrgActiveContributorsDrawerComponent {
   private readonly accountContextService = inject(AccountContextService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
+
+  // === Static Data ===
+  protected readonly insightsUrl = buildInsightsUrl();
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-certified-employees-drawer/org-certified-employees-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-certified-employees-drawer/org-certified-employees-drawer.component.html
@@ -77,7 +77,7 @@
     <lfx-insights-handoff-section
       title="Looking for certification details?"
       description="Individual certification records, training enrollments, and detailed education analytics are available in the Organization Dashboard."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       buttonLabel="View Organization Dashboard"
       data-testid="org-certified-employees-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-certified-employees-drawer/org-certified-employees-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-certified-employees-drawer/org-certified-employees-drawer.component.ts
@@ -6,7 +6,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
-import { hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -29,6 +29,9 @@ export class OrgCertifiedEmployeesDrawerComponent {
   private readonly accountContextService = inject(AccountContextService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
+
+  // === Static Data ===
+  protected readonly insightsUrl = buildInsightsUrl();
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-dependency-drawer/org-dependency-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-dependency-drawer/org-dependency-drawer.component.html
@@ -64,7 +64,7 @@
     <lfx-insights-handoff-section
       title="Looking for detailed contribution metrics?"
       description="Detailed contribution patterns, activity breakdowns, and participation trends are available in LFX Insights."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       data-testid="org-dependency-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-dependency-drawer/org-dependency-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-dependency-drawer/org-dependency-drawer.component.ts
@@ -5,6 +5,7 @@ import { Component, computed, input, model, Signal } from '@angular/core';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
+import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -16,6 +17,9 @@ import type { FoundationCompanyBusFactorResponse } from '@lfx-one/shared/interfa
   templateUrl: './org-dependency-drawer.component.html',
 })
 export class OrgDependencyDrawerComponent {
+  // === Static Data ===
+  protected readonly insightsUrl = buildInsightsUrl();
+
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-event-attendees-drawer/org-event-attendees-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-event-attendees-drawer/org-event-attendees-drawer.component.html
@@ -56,7 +56,7 @@
     <lfx-insights-handoff-section
       title="Looking for event details?"
       description="Event-level participation details and attendee lists are available in the Organization Dashboard."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       buttonLabel="View Organization Dashboard"
       data-testid="org-event-attendees-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-event-attendees-drawer/org-event-attendees-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-event-attendees-drawer/org-event-attendees-drawer.component.ts
@@ -6,6 +6,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
+import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -27,6 +28,9 @@ export class OrgEventAttendeesDrawerComponent {
   private readonly accountContextService = inject(AccountContextService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
+
+  // === Static Data ===
+  protected readonly insightsUrl = buildInsightsUrl();
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-event-speakers-drawer/org-event-speakers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-event-speakers-drawer/org-event-speakers-drawer.component.html
@@ -56,7 +56,7 @@
     <lfx-insights-handoff-section
       title="Looking for speaker details?"
       description="Event-level speaker details and presentation information are available in the Organization Dashboard."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       buttonLabel="View Organization Dashboard"
       data-testid="org-event-speakers-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-event-speakers-drawer/org-event-speakers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-event-speakers-drawer/org-event-speakers-drawer.component.ts
@@ -6,6 +6,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
+import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -27,6 +28,9 @@ export class OrgEventSpeakersDrawerComponent {
   private readonly accountContextService = inject(AccountContextService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
+
+  // === Static Data ===
+  protected readonly insightsUrl = buildInsightsUrl();
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-maintainers-drawer/org-maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-maintainers-drawer/org-maintainers-drawer.component.html
@@ -140,7 +140,7 @@
     <lfx-insights-handoff-section
       title="Looking for maintainer details and activity?"
       description="Individual maintainer activity and project-level contribution details are available in the Organization Dashboard."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       buttonLabel="View Organization Dashboard"
       data-testid="org-maintainers-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-maintainers-drawer/org-maintainers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-maintainers-drawer/org-maintainers-drawer.component.ts
@@ -6,7 +6,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
-import { hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -30,6 +30,9 @@ export class OrgMaintainersDrawerComponent {
   private readonly accountContextService = inject(AccountContextService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
+
+  // === Static Data ===
+  protected readonly insightsUrl = buildInsightsUrl();
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-training-enrollments-drawer/org-training-enrollments-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-training-enrollments-drawer/org-training-enrollments-drawer.component.html
@@ -77,7 +77,7 @@
     <lfx-insights-handoff-section
       title="Looking for training details?"
       description="Individual training records and project-level training analytics are available in the Organization Dashboard."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       buttonLabel="View Organization Dashboard"
       data-testid="org-training-enrollments-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-training-enrollments-drawer/org-training-enrollments-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-training-enrollments-drawer/org-training-enrollments-drawer.component.ts
@@ -6,7 +6,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
-import { hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -29,6 +29,9 @@ export class OrgTrainingEnrollmentsDrawerComponent {
   private readonly accountContextService = inject(AccountContextService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
+
+  // === Static Data ===
+  protected readonly insightsUrl = buildInsightsUrl();
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.html
@@ -97,7 +97,7 @@
     <lfx-insights-handoff-section
       title="Looking for detailed project health metrics?"
       description="Project-level health diagnostics, activity patterns, and individual project metrics are available in LFX Insights."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       data-testid="project-health-scores-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
@@ -5,6 +5,7 @@ import { Component, computed, input, model, Signal } from '@angular/core';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
+import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -17,6 +18,8 @@ import type { FoundationHealthScoreDistributionResponse } from '@lfx-one/shared/
 })
 export class ProjectHealthScoresDrawerComponent {
   // === Static Options ===
+  protected readonly insightsUrl = buildInsightsUrl();
+
   protected readonly legendColors = {
     critical: lfxColors.red[500],
     unsteady: lfxColors.amber[400],

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
@@ -78,7 +78,7 @@
     <lfx-insights-handoff-section
       title="Looking for detailed membership information?"
       description="Member organization details, membership tiers, and historical membership data are available in LFX Insights."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       data-testid="total-members-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
@@ -7,6 +7,7 @@ import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_TOTAL_MEMBERS, lfxColors } from '@lfx-one/shared/constants';
+import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -22,6 +23,7 @@ export class TotalMembersDrawerComponent {
   private readonly fb = inject(FormBuilder);
 
   // === Static Options ===
+  protected readonly insightsUrl = buildInsightsUrl();
   protected readonly timeRangeOptions = [{ label: 'Last 12 months', value: 'last-12-months' }];
 
   // === Forms ===

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
@@ -223,7 +223,7 @@
     <lfx-insights-handoff-section
       title="Looking for detailed project metrics?"
       description="Project-level activity history, contribution patterns, and individual project analytics are available in LFX Insights."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       data-testid="total-projects-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
@@ -18,7 +18,7 @@ import {
   lfxColors,
   TOTAL_PROJECTS_DRAWER_ITEMS_PER_PAGE,
 } from '@lfx-one/shared/constants';
-import { hexToRgba } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, hexToRgba } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
@@ -56,6 +56,7 @@ export class TotalProjectsDrawerComponent {
   private readonly fb = inject(FormBuilder);
 
   // === Static Options ===
+  protected readonly insightsUrl = buildInsightsUrl();
   protected readonly timeRangeOptions = [{ label: 'Last 12 months', value: 'last-12-months' }];
   protected readonly viewOptions = [
     { label: 'Chart', value: 'chart' },

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-value-drawer/total-value-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-value-drawer/total-value-drawer.component.html
@@ -46,7 +46,7 @@
     <lfx-insights-handoff-section
       title="Looking for project details?"
       description="Individual project metrics, contribution history, and detailed analytics are available in LFX Insights."
-      link="https://insights.linuxfoundation.org"
+      [link]="insightsUrl"
       data-testid="total-value-drawer-insights-handoff"></lfx-insights-handoff-section>
 
     <!-- Disclaimer -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-value-drawer/total-value-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-value-drawer/total-value-drawer.component.ts
@@ -5,6 +5,7 @@ import { Component, computed, input, model, Signal } from '@angular/core';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
+import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -16,6 +17,9 @@ import type { FoundationValueConcentrationResponse } from '@lfx-one/shared/inter
   templateUrl: './total-value-drawer.component.html',
 })
 export class TotalValueDrawerComponent {
+  // === Static Data ===
+  protected readonly insightsUrl = buildInsightsUrl();
+
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);
 

--- a/apps/lfx-one/src/app/modules/dashboards/health-metrics/code-contribution-card/code-contribution-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/health-metrics/code-contribution-card/code-contribution-card.component.ts
@@ -5,6 +5,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, inject, input, PLATFORM_ID, signal } from '@angular/core';
 import { SkeletonModule } from 'primeng/skeleton';
 import { HEALTH_METRICS_CODE_CONTRIBUTION_DEFAULT_SUMMARY } from '@lfx-one/shared/constants';
+import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { downloadCardAsImage } from '@shared/utils/download-card.util';
@@ -118,7 +119,7 @@ export class CodeContributionCardComponent {
   protected readonly exploreMoreUrl = computed(() => {
     const slug = this.summaryData().projectSlug;
     if (!slug) return '';
-    return `https://insights.linuxfoundation.org/project/${slug}/contributors`;
+    return buildInsightsUrl(`/project/${slug}/contributors`);
   });
 
   public constructor() {

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -99,7 +99,7 @@
     <div class="flex flex-col items-center gap-3 mt-auto">
       <!-- LFX Insights -->
       <a
-        href="https://insights.linuxfoundation.org/"
+        [href]="insightsUrl"
         target="_blank"
         rel="noopener noreferrer"
         data-testid="lens-insights"

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
@@ -10,6 +10,7 @@ import { ImpersonationDialogComponent } from '@components/impersonation-dialog/i
 import { environment } from '@environments/environment';
 import { LENS_DEFAULT_ROUTES } from '@lfx-one/shared/constants';
 import { Lens } from '@lfx-one/shared/interfaces';
+import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
 import { UserService } from '@services/user.service';
 import { DialogService } from 'primeng/dynamicdialog';
@@ -35,6 +36,7 @@ export class LensSwitcherComponent {
   protected readonly lenses = this.lensService.availableLenses;
   protected readonly user = this.userService.user;
   protected readonly changelogUrl = environment.urls.changelog;
+  protected readonly insightsUrl = buildInsightsUrl();
   protected readonly userMenu = viewChild<Popover>('userMenu');
 
   protected readonly userInitials = this.userService.userInitials;

--- a/packages/shared/src/constants/links.config.ts
+++ b/packages/shared/src/constants/links.config.ts
@@ -5,4 +5,7 @@ export const LINKS_CONFIG = {
   EVENTS: {
     DISCOVER: 'https://events.linuxfoundation.org/',
   },
+  INSIGHTS: {
+    BASE: 'https://insights.linuxfoundation.org',
+  },
 };

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -21,3 +21,4 @@ export * from './badge.utils';
 export * from './marketing.utils';
 export * from './flywheel.utils';
 export * from './rewards.utils';
+export * from './insights.utils';

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -1,0 +1,12 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { LINKS_CONFIG } from '../constants/links.config';
+
+export function buildInsightsUrl(path: string = ''): string {
+  if (!path) {
+    return LINKS_CONFIG.INSIGHTS.BASE;
+  }
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return `${LINKS_CONFIG.INSIGHTS.BASE}${normalizedPath}`;
+}


### PR DESCRIPTION
## Summary

- Add `LINKS_CONFIG.INSIGHTS.BASE` + `buildInsightsUrl(path?: string)` helper to `@lfx-one/shared`
- Migrate all 16 hardcoded `https://insights.linuxfoundation.org` call-sites to consume the helper (14 dashboard drawers, the lens-switcher footer link, and the code-contribution-card \`exploreMoreUrl\` computed)
- Behavior-preserving — every URL destination is identical to before

## Why

Per the Insights team (Jonathan Reimer, Joana Maia), the handoff URLs were shipped as a consistent UI pattern but never got real deep-links wired up — every one points at the Insights homepage root. This PR consolidates the base URL so the follow-up work (remove handoffs for unsupported drawers; add deep-links for supported ones) is a one-line edit per call-site.

## Follow-ups (separate PRs)

- **#_stacked_** — remove the handoff section from 6 drawers Insights has no equivalent view for (events, training enrollments, event attendees, event speakers, certified employees, total members)
- **#_pending_** — deep-link the drawers Insights does support (active contributors, maintainers, total projects, project health scores, code-contribution-card), plus the 4 ambiguous \`org-*\` + total-value drawers once Joana confirms the URL map

## Test plan

- [ ] \`yarn format\` passes
- [ ] \`yarn lint\` passes
- [ ] \`yarn build\` passes
- [ ] Verify every \"Open in LFX Insights\" link on the Board Member dashboard still lands on the Insights homepage (no behavior change)
- [ ] Verify the lens-switcher footer Insights icon link still works
- [ ] Verify the Code Contribution card \"Explore more\" link still deep-links to \`/project/{slug}/contributors\`

🤖 Generated with [Claude Code](https://claude.ai/code)