### PR TITLE
refactor(dashboards): drop insights handoff for unsupported drawers

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
@@ -121,12 +121,5 @@
         </div>
       }
     </div>
-
-    <!-- Insights Handoff -->
-    <lfx-insights-handoff-section
-      title="Looking for detailed event information?"
-      description="Individual event details, attendee lists, and historical event data are available in LFX Insights."
-      [link]="insightsUrl"
-      data-testid="events-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.ts
@@ -5,10 +5,8 @@ import { Component, computed, inject, input, model, signal, Signal } from '@angu
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ChartComponent } from '@components/chart/chart.component';
-import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_EVENTS_ATTENDANCE_DISTRIBUTION, DEFAULT_FOUNDATION_EVENTS_QUARTERLY, lfxColors } from '@lfx-one/shared/constants';
-import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
@@ -23,7 +21,7 @@ import type {
 
 @Component({
   selector: 'lfx-events-drawer',
-  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, InsightsHandoffSectionComponent],
+  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule],
   templateUrl: './events-drawer.component.html',
 })
 export class EventsDrawerComponent {
@@ -33,7 +31,6 @@ export class EventsDrawerComponent {
   private readonly fb = inject(FormBuilder);
 
   // === Static Options ===
-  protected readonly insightsUrl = buildInsightsUrl();
   protected readonly timeRangeOptions = [{ label: 'Last 12 months', value: 'last-12-months' }];
 
   protected readonly quarterlyChartOptions: ChartOptions<'bar'> = {

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-certified-employees-drawer/org-certified-employees-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-certified-employees-drawer/org-certified-employees-drawer.component.html
@@ -72,13 +72,5 @@
         }
       </div>
     }
-
-    <!-- Insights Handoff -->
-    <lfx-insights-handoff-section
-      title="Looking for certification details?"
-      description="Individual certification records, training enrollments, and detailed education analytics are available in the Organization Dashboard."
-      [link]="insightsUrl"
-      buttonLabel="View Organization Dashboard"
-      data-testid="org-certified-employees-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-certified-employees-drawer/org-certified-employees-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-certified-employees-drawer/org-certified-employees-drawer.component.ts
@@ -4,9 +4,8 @@
 import { Component, computed, inject, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
-import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
-import { buildInsightsUrl, hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
+import { hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -21,7 +20,7 @@ const DEFAULT_DISTRIBUTION: OrgCertifiedEmployeesDistributionResponse = { progra
 
 @Component({
   selector: 'lfx-org-certified-employees-drawer',
-  imports: [DrawerModule, ChartComponent, InsightsHandoffSectionComponent],
+  imports: [DrawerModule, ChartComponent],
   templateUrl: './org-certified-employees-drawer.component.html',
 })
 export class OrgCertifiedEmployeesDrawerComponent {
@@ -29,9 +28,6 @@ export class OrgCertifiedEmployeesDrawerComponent {
   private readonly accountContextService = inject(AccountContextService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
-
-  // === Static Data ===
-  protected readonly insightsUrl = buildInsightsUrl();
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-event-attendees-drawer/org-event-attendees-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-event-attendees-drawer/org-event-attendees-drawer.component.html
@@ -51,13 +51,5 @@
         </div>
       }
     </div>
-
-    <!-- Insights Handoff -->
-    <lfx-insights-handoff-section
-      title="Looking for event details?"
-      description="Event-level participation details and attendee lists are available in the Organization Dashboard."
-      [link]="insightsUrl"
-      buttonLabel="View Organization Dashboard"
-      data-testid="org-event-attendees-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-event-attendees-drawer/org-event-attendees-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-event-attendees-drawer/org-event-attendees-drawer.component.ts
@@ -4,9 +4,7 @@
 import { Component, computed, inject, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
-import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
-import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -20,7 +18,7 @@ const DEFAULT_MONTHLY: OrgEventAttendeesMonthlyResponse = { monthlyData: [], mon
 
 @Component({
   selector: 'lfx-org-event-attendees-drawer',
-  imports: [DrawerModule, ChartComponent, InsightsHandoffSectionComponent],
+  imports: [DrawerModule, ChartComponent],
   templateUrl: './org-event-attendees-drawer.component.html',
 })
 export class OrgEventAttendeesDrawerComponent {
@@ -28,9 +26,6 @@ export class OrgEventAttendeesDrawerComponent {
   private readonly accountContextService = inject(AccountContextService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
-
-  // === Static Data ===
-  protected readonly insightsUrl = buildInsightsUrl();
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-event-speakers-drawer/org-event-speakers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-event-speakers-drawer/org-event-speakers-drawer.component.html
@@ -51,13 +51,5 @@
         </div>
       }
     </div>
-
-    <!-- Insights Handoff -->
-    <lfx-insights-handoff-section
-      title="Looking for speaker details?"
-      description="Event-level speaker details and presentation information are available in the Organization Dashboard."
-      [link]="insightsUrl"
-      buttonLabel="View Organization Dashboard"
-      data-testid="org-event-speakers-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-event-speakers-drawer/org-event-speakers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-event-speakers-drawer/org-event-speakers-drawer.component.ts
@@ -4,9 +4,7 @@
 import { Component, computed, inject, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
-import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
-import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -20,7 +18,7 @@ const DEFAULT_MONTHLY: OrgEventSpeakersMonthlyResponse = { monthlyData: [], mont
 
 @Component({
   selector: 'lfx-org-event-speakers-drawer',
-  imports: [DrawerModule, ChartComponent, InsightsHandoffSectionComponent],
+  imports: [DrawerModule, ChartComponent],
   templateUrl: './org-event-speakers-drawer.component.html',
 })
 export class OrgEventSpeakersDrawerComponent {
@@ -28,9 +26,6 @@ export class OrgEventSpeakersDrawerComponent {
   private readonly accountContextService = inject(AccountContextService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
-
-  // === Static Data ===
-  protected readonly insightsUrl = buildInsightsUrl();
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-training-enrollments-drawer/org-training-enrollments-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-training-enrollments-drawer/org-training-enrollments-drawer.component.html
@@ -72,13 +72,5 @@
         }
       </div>
     }
-
-    <!-- Insights Handoff -->
-    <lfx-insights-handoff-section
-      title="Looking for training details?"
-      description="Individual training records and project-level training analytics are available in the Organization Dashboard."
-      [link]="insightsUrl"
-      buttonLabel="View Organization Dashboard"
-      data-testid="org-training-enrollments-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/org-training-enrollments-drawer/org-training-enrollments-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/org-training-enrollments-drawer/org-training-enrollments-drawer.component.ts
@@ -4,9 +4,8 @@
 import { Component, computed, inject, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
-import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { lfxColors } from '@lfx-one/shared/constants';
-import { buildInsightsUrl, hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
+import { hexToRgba, wrapLabel } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -21,7 +20,7 @@ const DEFAULT_DISTRIBUTION: OrgTrainingEnrollmentsDistributionResponse = { proje
 
 @Component({
   selector: 'lfx-org-training-enrollments-drawer',
-  imports: [DrawerModule, ChartComponent, InsightsHandoffSectionComponent],
+  imports: [DrawerModule, ChartComponent],
   templateUrl: './org-training-enrollments-drawer.component.html',
 })
 export class OrgTrainingEnrollmentsDrawerComponent {
@@ -29,9 +28,6 @@ export class OrgTrainingEnrollmentsDrawerComponent {
   private readonly accountContextService = inject(AccountContextService);
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
-
-  // === Static Data ===
-  protected readonly insightsUrl = buildInsightsUrl();
 
   // === Model Signals (two-way binding) ===
   public readonly visible = model<boolean>(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
@@ -73,12 +73,5 @@
         </div>
       }
     </div>
-
-    <!-- Insights Handoff -->
-    <lfx-insights-handoff-section
-      title="Looking for detailed membership information?"
-      description="Member organization details, membership tiers, and historical membership data are available in LFX Insights."
-      [link]="insightsUrl"
-      data-testid="total-members-drawer-insights-handoff"></lfx-insights-handoff-section>
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
@@ -4,10 +4,8 @@
 import { Component, computed, inject, input, model, Signal } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ChartComponent } from '@components/chart/chart.component';
-import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_TOTAL_MEMBERS, lfxColors } from '@lfx-one/shared/constants';
-import { buildInsightsUrl } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { ChartData, ChartOptions } from 'chart.js';
@@ -15,7 +13,7 @@ import type { FoundationTotalMembersResponse } from '@lfx-one/shared/interfaces'
 
 @Component({
   selector: 'lfx-total-members-drawer',
-  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, InsightsHandoffSectionComponent],
+  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule],
   templateUrl: './total-members-drawer.component.html',
 })
 export class TotalMembersDrawerComponent {
@@ -23,7 +21,6 @@ export class TotalMembersDrawerComponent {
   private readonly fb = inject(FormBuilder);
 
   // === Static Options ===
-  protected readonly insightsUrl = buildInsightsUrl();
   protected readonly timeRangeOptions = [{ label: 'Last 12 months', value: 'last-12-months' }];
 
   // === Forms ===


### PR DESCRIPTION
## Summary

Remove the \"Open in LFX Insights\" handoff section from 6 drawers whose data has no equivalent view in LFX Insights:

- Events
- Training Enrollments
- Event Attendees
- Event Speakers
- Certified Employees
- Total Members

This data is collected in CDP but is not treated as collaborations/contributions, so Insights has no matching view. Linking to the Insights root on these drawers was worse than having no link.

## Why

Per Jonathan Reimer + Joana Maia (LFX Insights team). See the authoritative URL map: https://docs.google.com/spreadsheets/d/1Ab6E-yGkRM-am5Kx7gV09DqKOZO37GQdAlZD8C_qmGA/edit

## Follow-ups

A third PR will deep-link the drawers Insights DOES support (Active Contributors, Maintainers, Total Projects, Project Health Scores, Code Contribution card) plus the 4 ambiguous \`org-*\` / total-value drawers once Joana confirms the URL map. That PR will be a one-line-per-drawer change thanks to the \`buildInsightsUrl()\` helper shipped in #559.

## Dependencies

Stacks on #559. PR 2's base branch = \`refactor/insights-base-url\`. Merge #559 first, then retarget this PR to \`main\`.

## Test plan

- [ ] \`yarn format\` / \`yarn lint\` / \`yarn build\` pass
- [ ] Open the 6 affected drawers and verify the handoff section is gone; all other drawer content (charts, tables, tooltips) renders as before
- [ ] Open the remaining 8 drawers (active-contributors, maintainers, total-projects, project-health-scores, total-value, org-active-contributors, org-maintainers, org-dependency) and verify the handoff section is still present and still opens \`https://insights.linuxfoundation.org\`

🤖 Generated with [Claude Code](https://claude.ai/code)