### PR TITLE
fix(ui): make filter tabs responsive and truncate long labels in groups pages

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
@@ -89,9 +89,18 @@ export class CommitteeTableComponent {
   protected readonly categoryTabOptions = computed<FilterPillOption[]>(() =>
     this.categoryOptions().map((opt) => ({
       id: opt.value ?? 'all',
-      label: opt.label ?? 'All',
+      label: this.truncateTabLabel(opt.label ?? 'All'),
+      fullLabel: opt.label ?? 'All',
     }))
   );
+
+  private truncateTabLabel(label: string): string {
+    const match = label.match(/^(.+) \((\d+)\)$/);
+    if (!match) return label;
+    const [, name, count] = match;
+    if (name.length <= 20) return label;
+    return `${name.slice(0, 20)}...(${count})`;
+  }
 
   protected onRowSelect(event: { data: Committee }): void {
     this.rowClick.emit(event.data);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
@@ -87,20 +87,16 @@ export class CommitteeTableComponent {
   protected readonly rppOptions = computed<number[] | undefined>(() => (this.committees().length > 10 ? [10, 25, 50] : undefined));
 
   protected readonly categoryTabOptions = computed<FilterPillOption[]>(() =>
-    this.categoryOptions().map((opt) => ({
-      id: opt.value ?? 'all',
-      label: this.truncateTabLabel(opt.label ?? 'All'),
-      fullLabel: opt.label ?? 'All',
-    }))
+    this.categoryOptions().map((opt) => {
+      const fullLabel = opt.label ?? 'All';
+      const truncatedLabel = this.truncateTabLabel(fullLabel);
+      return {
+        id: opt.value ?? 'all',
+        label: truncatedLabel,
+        fullLabel: truncatedLabel !== fullLabel ? fullLabel : undefined,
+      };
+    })
   );
-
-  private truncateTabLabel(label: string): string {
-    const match = label.match(/^(.+) \((\d+)\)$/);
-    if (!match) return label;
-    const [, name, count] = match;
-    if (name.length <= 20) return label;
-    return `${name.slice(0, 20)}...(${count})`;
-  }
 
   protected onRowSelect(event: { data: Committee }): void {
     this.rowClick.emit(event.data);
@@ -116,5 +112,13 @@ export class CommitteeTableComponent {
     this.searchForm().patchValue({ search: '', category: null, votingStatus: null, foundationFilter: null, projectFilter: null });
     this.foundationFilterChange.emit(null);
     this.projectFilterChange.emit(null);
+  }
+
+  private truncateTabLabel(label: string): string {
+    const match = label.match(/^(.+) \((\d+)\)$/);
+    if (!match) return label;
+    const [, name, count] = match;
+    if (name.length <= 20) return label;
+    return `${name.slice(0, 20)}...(${count})`;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -4,7 +4,6 @@
 <div
   class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden flex flex-col justify-between hover:border-blue-400 transition-colors h-full"
   data-testid="dashboard-meeting-card">
-
   <!-- Card header strip (shown when cardLabel is set) -->
   @if (cardLabel()) {
     <div
@@ -37,10 +36,7 @@
         [class.border-gray-200]="cardVariant() === 'neutral'"
         [class.border-blue-200]="cardVariant() === 'accent'">
         <!-- Month strip -->
-        <div
-          class="flex items-center justify-center py-0.5"
-          [class.bg-gray-200]="cardVariant() === 'neutral'"
-          [class.bg-blue-500]="cardVariant() === 'accent'">
+        <div class="flex items-center justify-center py-0.5" [class.bg-gray-200]="cardVariant() === 'neutral'" [class.bg-blue-500]="cardVariant() === 'accent'">
           <span
             class="text-[10px] font-semibold uppercase tracking-wider"
             [class.text-gray-500]="cardVariant() === 'neutral'"
@@ -49,10 +45,7 @@
           </span>
         </div>
         <!-- Day number -->
-        <div
-          class="h-11 flex items-center justify-center"
-          [class.bg-gray-50]="cardVariant() === 'neutral'"
-          [class.bg-blue-50]="cardVariant() === 'accent'">
+        <div class="h-11 flex items-center justify-center" [class.bg-gray-50]="cardVariant() === 'neutral'" [class.bg-blue-50]="cardVariant() === 'accent'">
           <span
             class="font-display font-light text-3xl leading-none"
             [class.text-gray-900]="cardVariant() === 'neutral'"
@@ -150,9 +143,7 @@
 
       <!-- Description snippet -->
       @if (meetingDescription()) {
-        <p
-          class="text-[10px] text-gray-500 truncate"
-          data-testid="dashboard-meeting-card-description">
+        <p class="text-[10px] text-gray-500 truncate" data-testid="dashboard-meeting-card-description">
           {{ meetingDescription() }}
         </p>
       }

--- a/apps/lfx-one/src/app/shared/components/card-tabs-bar/card-tabs-bar.component.html
+++ b/apps/lfx-one/src/app/shared/components/card-tabs-bar/card-tabs-bar.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex items-center justify-between px-5 py-4 border-b border-gray-200" data-testid="card-tabs-bar">
+<div class="flex items-start justify-between px-5 py-4 border-b border-gray-200" data-testid="card-tabs-bar">
   <lfx-filter-pills [options]="options()" [selectedFilter]="selectedFilter()" (filterChange)="filterChange.emit($event)" />
   <ng-content />
 </div>

--- a/apps/lfx-one/src/app/shared/components/filter-pills/filter-pills.component.html
+++ b/apps/lfx-one/src/app/shared/components/filter-pills/filter-pills.component.html
@@ -12,8 +12,9 @@
           : 'px-3 py-1 rounded-full text-sm transition-colors bg-gray-100 text-gray-700 hover:bg-gray-200'
       "
       [pTooltip]="option.fullLabel || ''"
-      [tooltipDisabled]="!option.fullLabel"
+      [tooltipDisabled]="!option.fullLabel || option.fullLabel === option.label"
       tooltipPosition="top"
+      [attr.aria-label]="option.fullLabel || option.label"
       [attr.data-testid]="'filter-pill-' + option.id">
       {{ option.label }}
     </button>

--- a/apps/lfx-one/src/app/shared/components/filter-pills/filter-pills.component.html
+++ b/apps/lfx-one/src/app/shared/components/filter-pills/filter-pills.component.html
@@ -1,7 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="flex items-center gap-2">
+<div class="flex flex-wrap items-center gap-2">
   @for (option of options(); track option.id) {
     <button
       type="button"
@@ -11,6 +11,9 @@
           ? 'px-3 py-1 rounded-full text-sm transition-colors bg-blue-500 text-white'
           : 'px-3 py-1 rounded-full text-sm transition-colors bg-gray-100 text-gray-700 hover:bg-gray-200'
       "
+      [pTooltip]="option.fullLabel || ''"
+      [tooltipDisabled]="!option.fullLabel"
+      tooltipPosition="top"
       [attr.data-testid]="'filter-pill-' + option.id">
       {{ option.label }}
     </button>

--- a/apps/lfx-one/src/app/shared/components/filter-pills/filter-pills.component.ts
+++ b/apps/lfx-one/src/app/shared/components/filter-pills/filter-pills.component.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, input, output } from '@angular/core';
+import { TooltipModule } from 'primeng/tooltip';
 import { FilterPillOption } from '@lfx-one/shared/interfaces';
 
 /** @deprecated Use FilterPillOption from @lfx-one/shared/interfaces instead */
@@ -9,7 +10,7 @@ export type FilterOption = FilterPillOption;
 
 @Component({
   selector: 'lfx-filter-pills',
-  imports: [],
+  imports: [TooltipModule],
   templateUrl: './filter-pills.component.html',
 })
 export class FilterPillsComponent {

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -302,8 +302,10 @@ export interface HealthMetricsSummaryCard {
 export interface FilterPillOption {
   /** Unique filter identifier used for category filtering */
   id: string;
-  /** Display label for the filter pill */
+  /** Display label for the filter pill (may be truncated) */
   label: string;
+  /** Full untruncated label shown as tooltip */
+  fullLabel?: string;
 }
 
 /**


### PR DESCRIPTION
## What
Fixes filter tab pills overflowing on narrow viewports across all `lfx-card-tabs-bar` consumers (committees, votes, surveys, transactions, documents, events).

On the My Groups and Groups pages specifically, committee category tab labels longer than 20 characters are truncated to `Name...(N)` format, keeping the count readable, with the full label shown as a tooltip on hover.

## How
- Add `flex-wrap` to `filter-pills` so pills wrap to a new line instead of overflowing
- Change `card-tabs-bar` outer alignment to `items-start` so `ng-content` slots (e.g. CTA buttons) align to the top when pills wrap to multiple lines
- Truncate committee category tab labels >20 chars via a `truncateTabLabel()` method in `committee-table`
- Add `fullLabel?: string` to `FilterPillOption` interface and wire it to `pTooltip` in `filter-pills`

## Checklist
- [x] License headers on modified files
- [x] No new dependencies
- [x] Responsive wrapping tested visually

🤖 Generated with [Claude Code](https://claude.ai/code)