### PR TITLE
fix(ui): stop selector backdrop from blocking clicks when closed

### DIFF
--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -71,16 +71,16 @@
   </p-drawer>
 
   <!-- Selector backdrop — covers main content area when project/foundation selector is open -->
-  <div
-    class="hidden lg:block fixed inset-0 bg-black/10 z-30 transition-opacity duration-300"
-    [ngClass]="{
-      'top-12': userService.impersonating(),
-      'top-0': !userService.impersonating(),
-      'opacity-100 pointer-events-auto': selectorPanelOpen(),
-      'opacity-0 pointer-events-none': !selectorPanelOpen(),
-    }"
-    (click)="selectorPanelOpen.set(false)"
-    data-testid="selector-backdrop"></div>
+  @if (selectorPanelOpen()) {
+    <div
+      class="hidden lg:block fixed inset-0 bg-black/10 z-30 transition-opacity duration-300 opacity-100"
+      [ngClass]="{
+        'top-12': userService.impersonating(),
+        'top-0': !userService.impersonating(),
+      }"
+      (click)="selectorPanelOpen.set(false)"
+      data-testid="selector-backdrop"></div>
+  }
 
   <!-- Main Content Area -->
   <main class="flex-1 min-w-0 transition-all duration-300 lg:ml-[344px] flex flex-col" data-testid="main-content">

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -73,7 +73,7 @@
   <!-- Selector backdrop — covers main content area when project/foundation selector is open -->
   @if (selectorPanelOpen()) {
     <div
-      class="hidden lg:block fixed inset-0 bg-black/10 z-30 transition-opacity duration-300 opacity-100"
+      class="hidden lg:block fixed inset-0 bg-black/10 z-30"
       [ngClass]="{
         'top-12': userService.impersonating(),
         'top-0': !userService.impersonating(),


### PR DESCRIPTION
## Summary

- The project/foundation selector backdrop in `main-layout` was always rendered on desktop and toggled `pointer-events` via CSS based on `selectorPanelOpen()`.
- If that signal ever got stuck at `true` (e.g. the `<lfx-project-selector>` was torn down before `onPopoverHide` fired, leaving the parent model at `true`), the invisible backdrop silently swallowed every click on the page — no visible UI change, no JS error.
- Symptom reported: on `/profile`, the pencil edit button, the 3-dot action menus on work-experience / identities / affiliations, and the "Add work experience" / "Add identity" buttons all did nothing when clicked.
- Fix: render the backdrop conditionally with `@if (selectorPanelOpen())` so the element only exists in the DOM when it's actually meant to be active. Dropped the now-redundant `pointer-events-*` / `opacity-*` class toggles.

## Test plan

- [ ] `/profile` → pencil opens the edit dialog
- [ ] `/profile` → 3-dot menu on each work-experience row opens with Edit / Delete
- [ ] `/profile` → 3-dot menu on each identity row opens with Remove
- [ ] `/profile` → "Add work experience" opens the form dialog
- [ ] `/profile/identities` → "Add identity" opens the add-account dialog
- [ ] On a project- or foundation-lens page, opening the project/foundation selector still shows the dimmed backdrop, and clicking it closes the selector
- [ ] Switching lenses while the selector is open leaves subsequent clicks responsive (no stuck backdrop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)