### PR TITLE
feat(meetings): surface past-meeting attendance counts in drawers

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -373,7 +373,7 @@
               severity="secondary"
               styleClass="w-full"
               data-testid="view-guests-button"
-              (click)="onRegistrantsToggle()">
+              (click)="showRegistrants.set(!showRegistrants())">
             </lfx-button>
             @if (canToggleRsvpView()) {
               <lfx-button

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -280,7 +280,9 @@
                 [showAddButton]="!pastMeeting()"
                 [additionalRegistrantsCount]="additionalRegistrantsCount()"
                 (addClicked)="showRegistrants.set(true)"
-                (currentUserHasRsvpChanged)="userHasRsvp.set($event)">
+                (currentUserHasRsvpChanged)="userHasRsvp.set($event)"
+                (pastParticipantCountsChange)="onPastParticipantCountsChange($event)"
+                (pastParticipantsLoaded)="onPastParticipantsLoaded($event)">
               </lfx-meeting-rsvp-details>
             }
           } @placeholder {
@@ -425,7 +427,7 @@
             @if (pastMeeting()) {
               <div class="flex flex-col">
                 <h1>Meeting Participants</h1>
-                <span class="text-base text-gray-500">{{ meeting().participant_count || 0 }} participants</span>
+                <span class="text-base text-gray-500">{{ pastAttendedCount() }} attended / {{ pastParticipantCount() }} invited</span>
               </div>
             } @else if (meeting().committees && meeting().committees!.length > 0) {
               <div class="flex flex-col">
@@ -446,6 +448,8 @@
           [meeting]="meeting()"
           [pastMeeting]="pastMeeting()"
           [visible]="showRegistrants()"
+          [initialPastParticipants]="pastParticipants()"
+          [initialPastParticipantsLoading]="pastParticipantsLoading()"
           [showAddRegistrant]="!pastMeeting()"
           (registrantsCountChange)="additionalRegistrantsCount.set($event)">
         </lfx-meeting-registrants-display>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -47,6 +47,7 @@ import {
   MEETING_TYPE_CONFIGS,
   PastMeeting,
   PastMeetingAttachment,
+  PastMeetingParticipant,
   PastMeetingRecording,
   PastMeetingSummary,
   TagSeverity,
@@ -123,6 +124,14 @@ export class MeetingCardComponent implements OnInit {
   public recording: WritableSignal<PastMeetingRecording | null> = signal(null);
   public summary: WritableSignal<PastMeetingSummary | null> = signal(null);
   public additionalRegistrantsCount: WritableSignal<number> = signal(0);
+  // Past-meeting attendance counts forwarded by <lfx-meeting-rsvp-details> from its lazy-loaded
+  // participants list. The project/foundation list endpoint does not enrich the meeting object
+  // with `attended_count` / `participant_count`, so the drawer header reads from these signals
+  // instead of `meeting().*_count` (which would always render 0/0 in the dashboard).
+  public pastAttendedCount: WritableSignal<number> = signal(0);
+  public pastParticipantCount: WritableSignal<number> = signal(0);
+  public pastParticipants: WritableSignal<PastMeetingParticipant[]> = signal([]);
+  public pastParticipantsLoading: WritableSignal<boolean> = signal(false);
   public attachments: Signal<(MeetingAttachment | PastMeetingAttachment)[]> = signal([]);
   public materialsDrawerVisible = signal(false);
 
@@ -230,6 +239,8 @@ export class MeetingCardComponent implements OnInit {
   public ngOnInit(): void {
     this.attachments = this.initAttachments();
     if (this.pastMeeting()) {
+      this.pastParticipantsLoading.set(true);
+      this.initPastParticipantCountFallback();
       this.initRecording();
       this.initSummary();
     }
@@ -241,6 +252,16 @@ export class MeetingCardComponent implements OnInit {
 
   public onRsvpViewToggle(): void {
     this.showMyRsvp.set(!this.showMyRsvp());
+  }
+
+  public onPastParticipantCountsChange(event: { total: number; attended: number }): void {
+    this.pastAttendedCount.set(event.attended);
+    this.pastParticipantCount.set(event.total);
+  }
+
+  public onPastParticipantsLoaded(participants: PastMeetingParticipant[]): void {
+    this.pastParticipants.set(participants);
+    this.pastParticipantsLoading.set(false);
   }
 
   public openMaterialsDrawer(): void {
@@ -524,6 +545,18 @@ export class MeetingCardComponent implements OnInit {
         { initialValue: null }
       );
     });
+  }
+
+  private initPastParticipantCountFallback(): void {
+    const meeting = this.meetingInput();
+
+    if ('attended_count' in meeting && typeof meeting.attended_count === 'number') {
+      this.pastAttendedCount.set(meeting.attended_count);
+    }
+
+    if ('participant_count' in meeting && typeof meeting.participant_count === 'number') {
+      this.pastParticipantCount.set(meeting.participant_count);
+    }
   }
 
   private initTotalResourcesCount(): Signal<number> {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -11,6 +11,7 @@ import {
   inject,
   Injector,
   input,
+  model,
   OnInit,
   output,
   runInInjectionContext,
@@ -97,6 +98,7 @@ import { PublicRegistrationModalComponent } from '../../components/public-regist
   templateUrl: './meeting-card.component.html',
 })
 export class MeetingCardComponent implements OnInit {
+  // === Services ===
   private readonly projectService = inject(ProjectService);
   private readonly meetingService = inject(MeetingService);
   private readonly dialogService = inject(DialogService);
@@ -104,79 +106,83 @@ export class MeetingCardComponent implements OnInit {
   private readonly injector = inject(Injector);
   private readonly clipboard = inject(Clipboard);
   private readonly userService = inject(UserService);
-
   private readonly destroyRef = inject(DestroyRef);
+
+  // === Internal Streams ===
   private readonly refreshAttachments$ = new BehaviorSubject<void>(undefined);
 
+  // === Inputs ===
   public readonly meetingInput = input.required<Meeting | PastMeeting>();
   public readonly occurrenceInput = input<MeetingOccurrence | null>(null);
   public readonly pastMeeting = input<boolean>(false);
   public readonly loading = input<boolean>(false);
   public readonly showBorder = input<boolean>(false);
 
-  public showRegistrants: WritableSignal<boolean> = signal(false);
-  public showMyRsvp: WritableSignal<boolean> = signal(false);
+  // === Outputs ===
+  public readonly meetingDeleted = output<void>();
+
+  // === Static / Injected Refs ===
+  public readonly project = this.projectService.project;
+  public readonly committeeLabel = COMMITTEE_LABEL;
+  public readonly authenticated: Signal<boolean> = this.userService.authenticated;
+
+  // === Model Signals (two-way binding) ===
+  protected readonly showRegistrants = model<boolean>(false);
+  protected readonly materialsDrawerVisible = model<boolean>(false);
+
+  // === WritableSignals ===
+  protected readonly showMyRsvp = signal(false);
   // Set by <lfx-meeting-rsvp-details> after it resolves its registrants/rsvps data.
   // Drives the "Set My RSVP" / "Update My RSVP" label on the toggle button.
-  public userHasRsvp: WritableSignal<boolean> = signal(false);
-  public meeting: WritableSignal<Meeting | PastMeeting> = signal({} as Meeting | PastMeeting);
-  public occurrence: WritableSignal<MeetingOccurrence | null> = signal(null);
-  public recording: WritableSignal<PastMeetingRecording | null> = signal(null);
-  public summary: WritableSignal<PastMeetingSummary | null> = signal(null);
-  public additionalRegistrantsCount: WritableSignal<number> = signal(0);
+  protected readonly userHasRsvp = signal(false);
+  protected readonly meeting: WritableSignal<Meeting | PastMeeting> = signal({} as Meeting | PastMeeting);
+  protected readonly occurrence: WritableSignal<MeetingOccurrence | null> = signal(null);
+  protected readonly recording: WritableSignal<PastMeetingRecording | null> = signal(null);
+  protected readonly summary: WritableSignal<PastMeetingSummary | null> = signal(null);
+  protected readonly additionalRegistrantsCount = signal(0);
   // Past-meeting attendance counts forwarded by <lfx-meeting-rsvp-details> from its lazy-loaded
   // participants list. The project/foundation list endpoint does not enrich the meeting object
   // with `attended_count` / `participant_count`, so the drawer header reads from these signals
   // instead of `meeting().*_count` (which would always render 0/0 in the dashboard).
-  public pastAttendedCount: WritableSignal<number> = signal(0);
-  public pastParticipantCount: WritableSignal<number> = signal(0);
-  public pastParticipants: WritableSignal<PastMeetingParticipant[]> = signal([]);
-  public pastParticipantsLoading: WritableSignal<boolean> = signal(false);
-  public attachments: Signal<(MeetingAttachment | PastMeetingAttachment)[]> = signal([]);
-  public materialsDrawerVisible = signal(false);
+  protected readonly pastAttendedCount = signal(0);
+  protected readonly pastParticipantCount = signal(0);
+  protected readonly pastParticipants: WritableSignal<PastMeetingParticipant[]> = signal([]);
+  protected readonly pastParticipantsLoading = signal(false);
+  protected attachments: Signal<(MeetingAttachment | PastMeetingAttachment)[]> = signal([]);
 
-  // Computed values for template
-  public readonly summaryContent: Signal<string | null> = this.initSummaryContent();
-  public readonly summaryApproved: Signal<boolean> = this.initSummaryApproved();
-  public readonly hasSummary: Signal<boolean> = this.initHasSummary();
-  public readonly recordingShareUrl: Signal<string | null> = this.initRecordingShareUrl();
-  public readonly hasRecording: Signal<boolean> = this.initHasRecording();
-  public readonly totalResourcesCount: Signal<number> = this.initTotalResourcesCount();
-  public readonly enabledFeaturesCount: Signal<number> = this.initEnabledFeaturesCount();
-  public readonly meetingTypeBadge: Signal<{
+  // === Computed Signals ===
+  protected readonly summaryContent: Signal<string | null> = this.initSummaryContent();
+  protected readonly summaryApproved: Signal<boolean> = this.initSummaryApproved();
+  protected readonly hasSummary: Signal<boolean> = this.initHasSummary();
+  protected readonly recordingShareUrl: Signal<string | null> = this.initRecordingShareUrl();
+  protected readonly hasRecording: Signal<boolean> = this.initHasRecording();
+  protected readonly totalResourcesCount: Signal<number> = this.initTotalResourcesCount();
+  protected readonly enabledFeaturesCount: Signal<number> = this.initEnabledFeaturesCount();
+  protected readonly meetingTypeBadge: Signal<{
     severity: TagSeverity;
     styleClass: string;
     icon?: string;
     text: string;
   } | null> = this.initMeetingTypeBadge();
-  public readonly containerClass: Signal<string> = this.initContainerClass();
-  public readonly rsvpToggleLabel: Signal<string> = this.initRsvpToggleLabel();
-  public readonly currentOccurrence: Signal<MeetingOccurrence | null> = this.initCurrentOccurrence();
-  public readonly meetingStartTime: Signal<string | null> = this.initMeetingStartTime();
-  public readonly canJoinMeeting: Signal<boolean> = this.initCanJoinMeeting();
-  public readonly joinUrl: Signal<string | null>;
-  public readonly authenticated: Signal<boolean> = this.userService.authenticated;
-
-  public readonly meetingDetailUrl: Signal<string> = this.initMeetingDetailUrl();
-
-  // Computed signals for invited/registration status to ensure reactivity after registration
-  public readonly isInvited: Signal<boolean> = computed(() => this.meeting().invited ?? false);
-  public readonly canRegisterForMeeting: Signal<boolean> = computed(
+  protected readonly containerClass: Signal<string> = this.initContainerClass();
+  protected readonly rsvpToggleLabel: Signal<string> = this.initRsvpToggleLabel();
+  protected readonly currentOccurrence: Signal<MeetingOccurrence | null> = this.initCurrentOccurrence();
+  protected readonly meetingStartTime: Signal<string | null> = this.initMeetingStartTime();
+  protected readonly canJoinMeeting: Signal<boolean> = this.initCanJoinMeeting();
+  protected readonly joinUrl: Signal<string | null>;
+  protected readonly meetingDetailUrl: Signal<string> = this.initMeetingDetailUrl();
+  protected readonly isInvited: Signal<boolean> = computed(() => this.meeting().invited ?? false);
+  protected readonly canRegisterForMeeting: Signal<boolean> = computed(
     () => !this.isInvited() && !this.meeting().restricted && this.meeting().visibility === 'public'
   );
-  // Computed signal to check if user can toggle between RSVP Details and RSVP Button Group
   // True when user is both an organizer AND invited to the meeting (for non-past meetings)
-  public readonly canToggleRsvpView: Signal<boolean> = computed(() => !!this.meeting().organizer && this.isInvited() && !this.pastMeeting());
+  protected readonly canToggleRsvpView: Signal<boolean> = computed(() => !!this.meeting().organizer && this.isInvited() && !this.pastMeeting());
+  protected readonly meetingTitle: Signal<string> = this.initMeetingTitle();
+  protected readonly meetingDescription: Signal<string> = this.initMeetingDescription();
+  protected readonly hasAiCompanion: Signal<boolean> = this.initHasAiCompanion();
+  protected readonly joinQueryParams: Signal<Record<string, string>> = this.initJoinQueryParams();
 
-  public readonly meetingTitle: Signal<string> = this.initMeetingTitle();
-  public readonly meetingDescription: Signal<string> = this.initMeetingDescription();
-  public readonly hasAiCompanion: Signal<boolean> = this.initHasAiCompanion();
-  public readonly joinQueryParams: Signal<Record<string, string>> = this.initJoinQueryParams();
-
-  public readonly meetingDeleted = output<void>();
-  public readonly project = this.projectService.project;
-  public readonly committeeLabel = COMMITTEE_LABEL;
-
+  // === Constructor ===
   public constructor() {
     effect(() => {
       if (!this.meeting()?.id) {
@@ -246,29 +252,26 @@ export class MeetingCardComponent implements OnInit {
     }
   }
 
-  public onRegistrantsToggle(): void {
-    this.showRegistrants.set(!this.showRegistrants());
+  // === Protected Methods (template handlers) ===
+  protected onRsvpViewToggle(): void {
+    this.showMyRsvp.update((v) => !v);
   }
 
-  public onRsvpViewToggle(): void {
-    this.showMyRsvp.set(!this.showMyRsvp());
-  }
-
-  public onPastParticipantCountsChange(event: { total: number; attended: number }): void {
+  protected onPastParticipantCountsChange(event: { total: number; attended: number }): void {
     this.pastAttendedCount.set(event.attended);
     this.pastParticipantCount.set(event.total);
   }
 
-  public onPastParticipantsLoaded(participants: PastMeetingParticipant[]): void {
+  protected onPastParticipantsLoaded(participants: PastMeetingParticipant[]): void {
     this.pastParticipants.set(participants);
     this.pastParticipantsLoading.set(false);
   }
 
-  public openMaterialsDrawer(): void {
+  protected openMaterialsDrawer(): void {
     this.materialsDrawerVisible.set(true);
   }
 
-  public copyMeetingLink(): void {
+  protected copyMeetingLink(): void {
     const meeting = this.meeting();
     const meetingUrl: URL = new URL(environment.urls.home + '/meetings/' + meeting.id);
 
@@ -284,7 +287,7 @@ export class MeetingCardComponent implements OnInit {
     });
   }
 
-  public registerForMeeting(): void {
+  protected registerForMeeting(): void {
     const meeting = this.meeting();
     const user = this.userService.user();
 
@@ -309,7 +312,7 @@ export class MeetingCardComponent implements OnInit {
     });
   }
 
-  public downloadAttachment(attachment: MeetingAttachment | PastMeetingAttachment): void {
+  protected downloadAttachment(attachment: MeetingAttachment | PastMeetingAttachment): void {
     const meetingId = this.meeting().id;
     const download$ = this.pastMeeting()
       ? this.meetingService.getPastMeetingAttachmentDownloadUrl(meetingId, attachment.uid)
@@ -331,7 +334,7 @@ export class MeetingCardComponent implements OnInit {
     });
   }
 
-  public openRecordingModal(): void {
+  protected openRecordingModal(): void {
     if (!this.recordingShareUrl()) {
       return;
     }
@@ -349,7 +352,7 @@ export class MeetingCardComponent implements OnInit {
     });
   }
 
-  public openSummaryModal(): void {
+  protected openSummaryModal(): void {
     if (!this.summaryContent() || !this.summary()?.uid) {
       return;
     }
@@ -387,7 +390,7 @@ export class MeetingCardComponent implements OnInit {
     });
   }
 
-  public deleteMeeting(): void {
+  protected deleteMeeting(): void {
     const meeting = this.meeting();
     if (!meeting) return;
 
@@ -424,6 +427,7 @@ export class MeetingCardComponent implements OnInit {
     }
   }
 
+  // === Private Helpers ===
   private getLargestSessionShareUrl(recording: PastMeetingRecording): string | null {
     if (!recording.sessions || recording.sessions.length === 0) {
       return null;
@@ -511,6 +515,7 @@ export class MeetingCardComponent implements OnInit {
       .subscribe();
   }
 
+  // === Private Initializers ===
   private initAttachments(): Signal<(MeetingAttachment | PastMeetingAttachment)[]> {
     return runInInjectionContext(this.injector, () => {
       const id = this.meetingInput().id;

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -32,12 +32,21 @@ export class MeetingRegistrantsDisplayComponent {
   public readonly visible: InputSignal<boolean> = input<boolean>(false);
   public readonly showAddRegistrant: InputSignal<boolean> = input<boolean>(false);
   public readonly myMeetingRegistrants: InputSignal<boolean> = input<boolean>(false);
+  // Gates the past-meeting participants self-fetch. When the parent (e.g. the public meeting-join
+  // page) knows the viewer does not have full access, it can pass `false` so the child skips the
+  // network call entirely and the drawer header / body stay consistent. Defaults to `true` so
+  // existing callers (meeting-card on the dashboard) keep their previous behavior.
+  public readonly pastMeetingFullAccess: InputSignal<boolean> = input<boolean>(true);
   // Externally-managed mode: when the parent already owns the registrants list (e.g. on the
   // meeting join page) it can pass it in here to avoid a duplicate fetch on drawer open. The
   // child uses the seed as its source and emits refreshRequested when the data needs to be
   // re-pulled (e.g. after adding a guest). Pass `null` (default) to keep the legacy self-fetch
   // behavior used by meeting-card.
   public readonly initialRegistrants: InputSignal<MeetingRegistrant[] | null> = input<MeetingRegistrant[] | null>(null);
+  // Same externally-managed pattern for past-meeting participants; allows parent components
+  // to reuse already-fetched participant data and avoid a duplicate fetch when opening drawers.
+  public readonly initialPastParticipants: InputSignal<PastMeetingParticipant[] | null> = input<PastMeetingParticipant[] | null>(null);
+  public readonly initialPastParticipantsLoading: InputSignal<boolean> = input<boolean>(false);
   public readonly initialRegistrantsLoading: InputSignal<boolean> = input<boolean>(false);
 
   public readonly registrantsCountChange: OutputEmitterRef<number> = output<number>();
@@ -46,8 +55,16 @@ export class MeetingRegistrantsDisplayComponent {
   private readonly internalLoading: WritableSignal<boolean> = signal(true);
   private readonly refresh$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   private readonly externallyManaged: Signal<boolean> = computed(() => this.initialRegistrants() !== null);
+  private readonly externallyManagedPast: Signal<boolean> = computed(() => this.pastMeeting() && this.initialPastParticipants() !== null);
   private readonly internalRegistrants: Signal<MeetingRegistrant[]> = this.initRegistrantsList();
-  public readonly pastMeetingParticipants: Signal<PastMeetingParticipant[]> = this.initPastMeetingParticipantsList();
+  private readonly internalPastMeetingParticipants: Signal<PastMeetingParticipant[]> = this.initPastMeetingParticipantsList();
+  public readonly pastMeetingParticipants: Signal<PastMeetingParticipant[]> = computed(() => {
+    if (this.externallyManagedPast()) {
+      const seed = this.initialPastParticipants() ?? [];
+      return [...seed].sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as PastMeetingParticipant[];
+    }
+    return this.internalPastMeetingParticipants();
+  });
   public readonly registrants: Signal<MeetingRegistrant[]> = computed(() => {
     if (this.externallyManaged()) {
       const seed = this.initialRegistrants() ?? [];
@@ -56,8 +73,11 @@ export class MeetingRegistrantsDisplayComponent {
     return this.internalRegistrants();
   });
   public readonly registrantsLoading: Signal<boolean> = computed(() => {
-    // Past-meeting participants are always fetched internally (parent does not prefetch them),
-    // so fall back to the internal loader regardless of externally-managed mode.
+    if (this.externallyManagedPast()) {
+      return this.initialPastParticipantsLoading();
+    }
+    // Upcoming meetings can be externally managed by the parent. Past meetings can now also be
+    // externally managed via initialPastParticipants.
     if (this.externallyManaged() && !this.pastMeeting()) {
       return this.initialRegistrantsLoading();
     }
@@ -111,8 +131,18 @@ export class MeetingRegistrantsDisplayComponent {
 
     effect(() => {
       if (!this.visible()) return;
-      // Past-meeting participants always self-fetch.
+      // Past-meeting participants always self-fetch — but skip when the parent has signalled the
+      // viewer lacks full access, so the body matches the header instead of leaking a 401-shaped
+      // empty list with a spinner.
       if (this.pastMeeting()) {
+        if (this.externallyManagedPast()) {
+          this.internalLoading.set(false);
+          return;
+        }
+        if (!this.pastMeetingFullAccess()) {
+          this.internalLoading.set(false);
+          return;
+        }
         this.internalLoading.set(true);
         this.refresh$.next(true);
         return;
@@ -238,7 +268,9 @@ export class MeetingRegistrantsDisplayComponent {
     return toSignal(
       this.refresh$.pipe(
         takeUntilDestroyed(),
-        filter((refresh) => refresh && this.pastMeeting()),
+        // Skip when the viewer lacks full access — the server would reject the call and we'd just
+        // catch into an empty array, so don't even try.
+        filter((refresh) => refresh && this.pastMeeting() && this.pastMeetingFullAccess() && !this.externallyManagedPast()),
         switchMap(() => {
           this.internalLoading.set(true);
           return this.meetingService

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, DestroyRef, effect, inject, input, InputSignal, output, OutputEmitterRef, Signal, signal, WritableSignal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, InputSignal, output, OutputEmitterRef, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { AvatarComponent } from '@components/avatar/avatar.component';
@@ -13,7 +13,23 @@ import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
 import { TooltipModule } from 'primeng/tooltip';
-import { BehaviorSubject, catchError, debounceTime, filter, finalize, map, of, pairwise, startWith, switchMap, take, tap } from 'rxjs';
+import {
+  catchError,
+  combineLatest,
+  debounceTime,
+  distinctUntilChanged,
+  filter,
+  finalize,
+  map,
+  merge,
+  of,
+  pairwise,
+  startWith,
+  Subject,
+  switchMap,
+  take,
+  tap,
+} from 'rxjs';
 
 import { RegistrantFormComponent } from '../registrant-form/registrant-form.component';
 
@@ -23,10 +39,12 @@ import { RegistrantFormComponent } from '../registrant-form/registrant-form.comp
   templateUrl: './meeting-registrants-display.component.html',
 })
 export class MeetingRegistrantsDisplayComponent {
+  // === Services ===
   private readonly meetingService = inject(MeetingService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
 
+  // === Inputs ===
   public readonly meeting: InputSignal<Meeting | PastMeeting> = input.required<Meeting | PastMeeting>();
   public readonly pastMeeting: InputSignal<boolean> = input<boolean>(false);
   public readonly visible: InputSignal<boolean> = input<boolean>(false);
@@ -49,30 +67,61 @@ export class MeetingRegistrantsDisplayComponent {
   public readonly initialPastParticipantsLoading: InputSignal<boolean> = input<boolean>(false);
   public readonly initialRegistrantsLoading: InputSignal<boolean> = input<boolean>(false);
 
+  // === Outputs ===
   public readonly registrantsCountChange: OutputEmitterRef<number> = output<number>();
   public readonly refreshRequested: OutputEmitterRef<number> = output<number>();
 
-  private readonly internalLoading: WritableSignal<boolean> = signal(true);
-  private readonly refresh$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  // === Static Options ===
+  protected readonly rsvpFilterOptions = [
+    { label: 'All RSVPs', value: 'all' },
+    { label: 'Accepted', value: 'yes' },
+    { label: 'Declined', value: 'no' },
+    { label: 'Pending', value: 'pending' },
+  ];
+
+  // === Forms ===
+  protected addRegistrantForm: FormGroup;
+  protected readonly searchControl: FormControl<string> = new FormControl<string>('', { nonNullable: true });
+  protected readonly rsvpFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
+  protected readonly groupFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
+  protected readonly filterForm: FormGroup = new FormGroup({
+    rsvpFilter: this.rsvpFilterControl,
+    groupFilter: this.groupFilterControl,
+  });
+
+  // === Internal Streams ===
+  // Manual triggers (refresh button, post-add refetch) merge with the visibility-driven trigger
+  // inside the init* pipelines below.
+  private readonly manualRefresh$ = new Subject<void>();
+
+  // === WritableSignals ===
+  // Initialized to `false` — the lazy-load pipelines flip it to `true` via `tap` when a fetch
+  // actually starts. The drawer is closed on initial render, so there is no upfront work to mask.
+  private readonly internalLoading = signal(false);
+  protected readonly additionalRegistrantsCount = signal(0);
+  protected readonly showAddForm = signal(false);
+  protected readonly submitting = signal(false);
+
+  // === Computed Signals ===
   private readonly externallyManaged: Signal<boolean> = computed(() => this.initialRegistrants() !== null);
   private readonly externallyManagedPast: Signal<boolean> = computed(() => this.pastMeeting() && this.initialPastParticipants() !== null);
   private readonly internalRegistrants: Signal<MeetingRegistrant[]> = this.initRegistrantsList();
   private readonly internalPastMeetingParticipants: Signal<PastMeetingParticipant[]> = this.initPastMeetingParticipantsList();
-  public readonly pastMeetingParticipants: Signal<PastMeetingParticipant[]> = computed(() => {
+  protected readonly pastMeetingParticipants: Signal<PastMeetingParticipant[]> = computed(() => {
     if (this.externallyManagedPast()) {
       const seed = this.initialPastParticipants() ?? [];
       return [...seed].sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as PastMeetingParticipant[];
     }
     return this.internalPastMeetingParticipants();
   });
-  public readonly registrants: Signal<MeetingRegistrant[]> = computed(() => {
+  protected readonly registrants: Signal<MeetingRegistrant[]> = computed(() => {
     if (this.externallyManaged()) {
       const seed = this.initialRegistrants() ?? [];
       return [...seed].sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as MeetingRegistrant[];
     }
     return this.internalRegistrants();
   });
-  public readonly registrantsLoading: Signal<boolean> = computed(() => {
+  protected readonly registrantsLoading: Signal<boolean> = computed(() => {
     if (this.externallyManagedPast()) {
       return this.initialPastParticipantsLoading();
     }
@@ -83,77 +132,19 @@ export class MeetingRegistrantsDisplayComponent {
     }
     return this.internalLoading();
   });
-  public readonly additionalRegistrantsCount: WritableSignal<number> = signal(0);
-  public readonly showAddForm = signal(false);
-  public readonly submitting = signal(false);
+  protected readonly groupFilterOptions = this.initGroupFilterOptions();
+  protected readonly hasCommittees = this.initHasCommittees();
+  protected readonly searchQuery: Signal<string> = toSignal(this.searchControl.valueChanges.pipe(startWith(''), debounceTime(300)), { initialValue: '' });
+  protected readonly rsvpFilter: Signal<string> = toSignal(this.rsvpFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
+  protected readonly groupFilter: Signal<string> = toSignal(this.groupFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
+  protected readonly filteredRegistrants = this.initFilteredRegistrants();
+  protected readonly filteredPastParticipants = this.initFilteredPastParticipants();
 
-  // Add registrant form
-  public addRegistrantForm: FormGroup;
-
-  // Search and filter controls
-  public readonly searchControl: FormControl<string> = new FormControl<string>('', { nonNullable: true });
-  public readonly rsvpFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
-  public readonly groupFilterControl: FormControl<string> = new FormControl<string>('all', { nonNullable: true });
-  public readonly filterForm: FormGroup = new FormGroup({
-    rsvpFilter: this.rsvpFilterControl,
-    groupFilter: this.groupFilterControl,
-  });
-
-  // Filter options
-  public readonly rsvpFilterOptions = [
-    { label: 'All RSVPs', value: 'all' },
-    { label: 'Accepted', value: 'yes' },
-    { label: 'Declined', value: 'no' },
-    { label: 'Pending', value: 'pending' },
-  ];
-
-  // Group (Committee) filter options computed from meeting committees
-  public readonly groupFilterOptions = this.initGroupFilterOptions();
-
-  // Check if meeting has committees
-  public readonly hasCommittees = this.initHasCommittees();
-
-  // Search query signal from form control
-  public readonly searchQuery: Signal<string> = toSignal(this.searchControl.valueChanges.pipe(startWith(''), debounceTime(300)), { initialValue: '' });
-
-  // Filter signals from form controls
-  public readonly rsvpFilter: Signal<string> = toSignal(this.rsvpFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
-  public readonly groupFilter: Signal<string> = toSignal(this.groupFilterControl.valueChanges.pipe(startWith('all')), { initialValue: 'all' });
-
-  // Filtered registrants based on search and filters
-  public readonly filteredRegistrants = this.initFilteredRegistrants();
-
-  // Filtered past meeting participants based on search
-  public readonly filteredPastParticipants = this.initFilteredPastParticipants();
-
+  // === Constructor ===
   public constructor() {
     this.addRegistrantForm = this.meetingService.createRegistrantFormGroup(false);
 
-    effect(() => {
-      if (!this.visible()) return;
-      // Past-meeting participants always self-fetch — but skip when the parent has signalled the
-      // viewer lacks full access, so the body matches the header instead of leaking a 401-shaped
-      // empty list with a spinner.
-      if (this.pastMeeting()) {
-        if (this.externallyManagedPast()) {
-          this.internalLoading.set(false);
-          return;
-        }
-        if (!this.pastMeetingFullAccess()) {
-          this.internalLoading.set(false);
-          return;
-        }
-        this.internalLoading.set(true);
-        this.refresh$.next(true);
-        return;
-      }
-      // Externally-managed: parent owns the registrants list, no internal fetch needed.
-      if (this.externallyManaged()) return;
-      this.internalLoading.set(true);
-      this.refresh$.next(true);
-    });
-
-    // Reset inline add form when drawer closes (open → closed transition)
+    // Reset inline add form when drawer closes (open → closed transition).
     toObservable(this.visible)
       .pipe(
         pairwise(),
@@ -168,10 +159,11 @@ export class MeetingRegistrantsDisplayComponent {
 
   // === Public Methods ===
   public refresh(): void {
-    this.refresh$.next(true);
+    this.manualRefresh$.next();
   }
 
-  public toggleAddForm(): void {
+  // === Protected Methods (template handlers) ===
+  protected toggleAddForm(): void {
     const isShowing = this.showAddForm();
     this.showAddForm.set(!isShowing);
     if (isShowing) {
@@ -179,7 +171,7 @@ export class MeetingRegistrantsDisplayComponent {
     }
   }
 
-  public onAddRegistrant(): void {
+  protected onAddRegistrant(): void {
     if (this.submitting()) return;
 
     if (this.addRegistrantForm.valid) {
@@ -202,7 +194,7 @@ export class MeetingRegistrantsDisplayComponent {
                 // Self-managed mode: optimistically increment locally (query indexing is async).
                 this.additionalRegistrantsCount.update((c) => c + response.summary.successful);
                 this.registrantsCountChange.emit(this.additionalRegistrantsCount());
-                this.refresh$.next(true);
+                this.manualRefresh$.next();
               }
               this.addRegistrantForm.reset();
             } else {
@@ -223,70 +215,78 @@ export class MeetingRegistrantsDisplayComponent {
     }
   }
 
-  public onUserSelectedFromSearch(): void {
+  protected onUserSelectedFromSearch(): void {
     this.onAddRegistrant();
   }
 
+  // === Private Initializers ===
   private initRegistrantsList(): Signal<MeetingRegistrant[]> {
-    return toSignal(
-      toObservable(this.myMeetingRegistrants).pipe(
-        takeUntilDestroyed(),
-        switchMap((useMyEndpoint) =>
-          this.refresh$.pipe(
-            // Skip when externally-managed (parent supplies the list) or when the meeting is past
-            // (handled by initPastMeetingParticipantsList).
-            filter((refresh) => refresh && !this.pastMeeting() && !this.externallyManaged()),
-            switchMap(() => {
-              this.internalLoading.set(true);
-              // Use access-controlled endpoint for meeting join page, regular endpoint for organizer views
-              const registrantsObservable = useMyEndpoint
-                ? this.meetingService.getMyMeetingRegistrants(this.meeting().id, true)
-                : this.meetingService.getMeetingRegistrants(this.meeting().id, true);
+    // Trigger sources: drawer becoming visible (only for upcoming, self-managed mode) and explicit
+    // manual refreshes (post-add refetch, public refresh()).
+    const visibleTrigger$ = combineLatest([toObservable(this.visible), toObservable(this.myMeetingRegistrants)]).pipe(
+      filter(([visible]) => visible && !this.pastMeeting() && !this.externallyManaged()),
+      distinctUntilChanged(([prevVisible, prevUseMy], [currVisible, currUseMy]) => prevVisible === currVisible && prevUseMy === currUseMy)
+    );
 
-              return registrantsObservable.pipe(
-                catchError(() => of([])),
-                map((registrants) => registrants.sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as MeetingRegistrant[]),
-                tap((registrants) => {
-                  const baseCount = (this.meeting().individual_registrants_count || 0) + (this.meeting().committee_members_count || 0);
-                  const fetchedAdditional = Math.max(0, (registrants?.length || 0) - baseCount);
-                  // Never decrease below the current optimistic count (async indexing may lag)
-                  const additionalCount = Math.max(fetchedAdditional, this.additionalRegistrantsCount());
-                  this.additionalRegistrantsCount.set(additionalCount);
-                  this.registrantsCountChange.emit(additionalCount);
-                }),
-                finalize(() => this.internalLoading.set(false))
-              );
-            })
-          )
-        )
+    return toSignal(
+      merge(visibleTrigger$.pipe(map(() => undefined)), this.manualRefresh$).pipe(
+        takeUntilDestroyed(),
+        // Re-check guards on every emission — externallyManaged can flip at runtime.
+        filter(() => !this.pastMeeting() && !this.externallyManaged()),
+        tap(() => this.internalLoading.set(true)),
+        switchMap(() => {
+          // Use access-controlled endpoint for meeting join page, regular endpoint for organizer views.
+          const registrantsObservable = this.myMeetingRegistrants()
+            ? this.meetingService.getMyMeetingRegistrants(this.meeting().id, true)
+            : this.meetingService.getMeetingRegistrants(this.meeting().id, true);
+
+          return registrantsObservable.pipe(
+            map((registrants) => registrants.sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as MeetingRegistrant[]),
+            tap((registrants) => {
+              const baseCount = (this.meeting().individual_registrants_count || 0) + (this.meeting().committee_members_count || 0);
+              const fetchedAdditional = Math.max(0, registrants.length - baseCount);
+              // Never decrease below the current optimistic count (async indexing may lag).
+              const additionalCount = Math.max(fetchedAdditional, this.additionalRegistrantsCount());
+              this.additionalRegistrantsCount.set(additionalCount);
+              this.registrantsCountChange.emit(additionalCount);
+            }),
+            catchError(() => of([] as MeetingRegistrant[])),
+            finalize(() => this.internalLoading.set(false))
+          );
+        })
       ),
-      { initialValue: [] }
+      { initialValue: [] as MeetingRegistrant[] }
     );
   }
 
   private initPastMeetingParticipantsList(): Signal<PastMeetingParticipant[]> {
+    // Past-meeting fetch is gated by visibility, the past-meeting flag, full-access permission,
+    // and the externally-managed seed not being present. Re-check guards on every emission so a
+    // late-flipping `pastMeetingFullAccess` (e.g. after the access check resolves on the public
+    // meeting-join page) can still drive the fetch.
+    const visibleTrigger$ = toObservable(this.visible).pipe(
+      filter((visible) => visible && this.pastMeeting() && this.pastMeetingFullAccess() && !this.externallyManagedPast()),
+      distinctUntilChanged()
+    );
+
     return toSignal(
-      this.refresh$.pipe(
+      merge(visibleTrigger$.pipe(map(() => undefined)), this.manualRefresh$).pipe(
         takeUntilDestroyed(),
-        // Skip when the viewer lacks full access — the server would reject the call and we'd just
-        // catch into an empty array, so don't even try.
-        filter((refresh) => refresh && this.pastMeeting() && this.pastMeetingFullAccess() && !this.externallyManagedPast()),
-        switchMap(() => {
-          this.internalLoading.set(true);
-          return this.meetingService
-            .getPastMeetingParticipants(this.meeting().id)
-            .pipe(catchError(() => of([])))
-            .pipe(
-              map((participants) => participants.sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as PastMeetingParticipant[]),
-              finalize(() => this.internalLoading.set(false))
-            );
-        })
+        filter(() => this.pastMeeting() && this.pastMeetingFullAccess() && !this.externallyManagedPast()),
+        tap(() => this.internalLoading.set(true)),
+        switchMap(() =>
+          this.meetingService.getPastMeetingParticipants(this.meeting().id).pipe(
+            map((participants) => participants.sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as PastMeetingParticipant[]),
+            catchError(() => of([] as PastMeetingParticipant[])),
+            finalize(() => this.internalLoading.set(false))
+          )
+        )
       ),
-      { initialValue: [] }
+      { initialValue: [] as PastMeetingParticipant[] }
     );
   }
 
-  private initGroupFilterOptions() {
+  private initGroupFilterOptions(): Signal<{ label: string; value: string }[]> {
     return computed(() => {
       const meeting = this.meeting();
       const committees = (meeting as Meeting).committees || [];
@@ -303,14 +303,14 @@ export class MeetingRegistrantsDisplayComponent {
     });
   }
 
-  private initHasCommittees() {
+  private initHasCommittees(): Signal<boolean> {
     return computed(() => {
       const meeting = this.meeting();
       return ((meeting as Meeting).committees?.length || 0) > 0;
     });
   }
 
-  private initFilteredRegistrants() {
+  private initFilteredRegistrants(): Signal<MeetingRegistrant[]> {
     return computed(() => {
       const registrants = this.registrants();
       const query = this.searchQuery().toLowerCase().trim();
@@ -318,7 +318,6 @@ export class MeetingRegistrantsDisplayComponent {
       const group = this.groupFilter();
 
       return registrants.filter((registrant) => {
-        // Search filter
         const matchesSearch =
           !query ||
           registrant.first_name?.toLowerCase().includes(query) ||
@@ -326,24 +325,20 @@ export class MeetingRegistrantsDisplayComponent {
           registrant.email?.toLowerCase().includes(query) ||
           registrant.org_name?.toLowerCase().includes(query);
 
-        // RSVP filter (must match display logic in template)
+        // RSVP filter (must match display logic in template).
         let matchesRsvp = true;
         if (rsvp !== 'all') {
           if (rsvp === 'yes') {
-            // Accepted: rsvp.response_type === 'accepted' OR invite_accepted === true
             matchesRsvp = registrant.rsvp?.response_type === 'accepted' || registrant.invite_accepted === true;
           } else if (rsvp === 'no') {
-            // Declined: rsvp.response_type === 'declined' OR invite_accepted === false
             matchesRsvp = registrant.rsvp?.response_type === 'declined' || registrant.invite_accepted === false;
           } else if (rsvp === 'pending') {
-            // Pending: NOT accepted AND NOT declined (includes maybe and no response)
             const isAccepted = registrant.rsvp?.response_type === 'accepted' || registrant.invite_accepted === true;
             const isDeclined = registrant.rsvp?.response_type === 'declined' || registrant.invite_accepted === false;
             matchesRsvp = !isAccepted && !isDeclined;
           }
         }
 
-        // Group (Committee) filter
         const matchesGroup = group === 'all' || registrant.committee_uid === group;
 
         return matchesSearch && matchesRsvp && matchesGroup;
@@ -351,7 +346,7 @@ export class MeetingRegistrantsDisplayComponent {
     });
   }
 
-  private initFilteredPastParticipants() {
+  private initFilteredPastParticipants(): Signal<PastMeetingParticipant[]> {
     return computed(() => {
       const participants = this.pastMeetingParticipants();
       const query = this.searchQuery().toLowerCase().trim();

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, inject, input, InputSignal, output, signal, Signal, WritableSignal } from '@angular/core';
+import { Component, computed, effect, inject, input, InputSignal, output, signal, Signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import {
@@ -42,6 +42,13 @@ export class MeetingRsvpDetailsComponent {
   // Emits whether the current user has any RSVP on this meeting, derived from the already-fetched
   // registrants/rsvps data. Parent card uses this to flip "Set My RSVP" → "Update My RSVP".
   public readonly currentUserHasRsvpChanged = output<boolean>();
+  // Emits past-meeting attendance counts as soon as the lazy-loaded participants resolve.
+  // Parent (meeting-card) uses this to populate the registrants drawer header without re-fetching,
+  // since the project/foundation list endpoint does not enrich `participant_count` / `attended_count`.
+  public readonly pastParticipantCountsChange = output<{ total: number; attended: number }>();
+  // Emits the resolved past-meeting participants list so parents can reuse it (e.g. drawer list)
+  // and avoid a second fetch for the same endpoint.
+  public readonly pastParticipantsLoaded = output<PastMeetingParticipant[]>();
   public readonly disabled: InputSignal<boolean> = input<boolean>(false);
   public readonly disabledMessage: InputSignal<string> = input<string>('RSVP not available for this meeting');
 
@@ -49,9 +56,9 @@ export class MeetingRsvpDetailsComponent {
   // Private source: one observable, two derived signals. Consolidates registrants + RSVPs
   // into a single HTTP call for the Me lens (where the backend doesn't populate counts),
   // and falls back to a direct RSVP fetch for the non-Me lens where counts are already populated.
-  private readonly upcomingData: Signal<{ rsvps: MeetingRsvp[]; registrants: MeetingRegistrant[] }> = this.initializeUpcomingData();
+  private readonly upcomingData: Signal<{ rsvps: MeetingRsvp[]; registrants: MeetingRegistrant[] }> = this.initUpcomingData();
   public readonly rsvps: Signal<MeetingRsvp[]> = computed(() => this.upcomingData().rsvps);
-  public readonly pastParticipants: Signal<PastMeetingParticipant[]> = this.initializePastParticipants();
+  public readonly pastParticipants: Signal<PastMeetingParticipant[]> = this.initPastParticipants();
   public readonly registrants: Signal<MeetingRegistrant[]> = computed(() => this.upcomingData().registrants);
   // Tracks across both rsvps data AND user identity; re-emits whenever either changes so the
   // parent card's "Set My RSVP" / "Update My RSVP" label stays in sync with login/impersonation.
@@ -60,16 +67,16 @@ export class MeetingRsvpDetailsComponent {
     if (!email) return false;
     return this.upcomingData().rsvps.some((r) => r.email?.toLowerCase() === email);
   });
-  public readonly rsvpCounts: Signal<RsvpCounts> = this.initializeRsvpCounts();
+  public readonly rsvpCounts: Signal<RsvpCounts> = this.initRsvpCounts();
   public readonly acceptedCount: Signal<number> = computed(() => this.rsvpCounts().accepted);
   public readonly maybeCount: Signal<number> = computed(() => this.rsvpCounts().maybe);
   public readonly declinedCount: Signal<number> = computed(() => this.rsvpCounts().declined);
-  public readonly meetingRegistrantCount: Signal<number> = this.initializeMeetingRegistrantCount();
-  public readonly attendedCount: Signal<number> = this.initializeAttendedCount();
-  public readonly attendancePercentage: Signal<number> = this.initializeAttendancePercentage();
+  public readonly meetingRegistrantCount: Signal<number> = this.initMeetingRegistrantCount();
+  public readonly attendedCount: Signal<number> = this.initAttendedCount();
+  public readonly attendancePercentage: Signal<number> = this.initAttendancePercentage();
   public readonly showPoorAttendanceWarning: Signal<boolean> = computed(() => this.pastMeeting() && this.attendancePercentage() < 50);
-  public readonly backgroundClasses: Signal<string> = this.initializeBackgroundClasses();
-  public readonly borderClasses: Signal<string> = this.initializeBorderClasses();
+  public readonly backgroundClasses: Signal<string> = this.initBackgroundClasses();
+  public readonly borderClasses: Signal<string> = this.initBorderClasses();
   public readonly headerTextClasses: Signal<string> = computed(() => (this.showPoorAttendanceWarning() ? 'text-amber-600' : 'text-gray-600'));
   public readonly summaryTextClasses: Signal<string> = computed(() => (this.showPoorAttendanceWarning() ? 'text-amber-900' : 'text-gray-900'));
 
@@ -78,9 +85,20 @@ export class MeetingRsvpDetailsComponent {
     toObservable(this.currentUserHasRsvp)
       .pipe(distinctUntilChanged(), takeUntilDestroyed())
       .subscribe((v) => this.currentUserHasRsvpChanged.emit(v));
+
+    // Forward past-meeting attendance counts to the parent whenever the lazy-loaded participants
+    // resolve. Only emits in past-meeting mode so the upcoming-meeting path stays untouched.
+    effect(() => {
+      if (!this.pastMeeting() || this.loading()) return;
+      const participants = this.pastParticipants();
+      const total = participants.length;
+      const attended = this.attendedCount();
+      this.pastParticipantsLoaded.emit(participants);
+      this.pastParticipantCountsChange.emit({ total, attended });
+    });
   }
 
-  private initializeUpcomingData(): Signal<{ rsvps: MeetingRsvp[]; registrants: MeetingRegistrant[] }> {
+  private initUpcomingData(): Signal<{ rsvps: MeetingRsvp[]; registrants: MeetingRegistrant[] }> {
     return toSignal(
       toObservable(this.meeting).pipe(
         tap(() => {
@@ -120,7 +138,7 @@ export class MeetingRsvpDetailsComponent {
     );
   }
 
-  private initializePastParticipants(): Signal<PastMeetingParticipant[]> {
+  private initPastParticipants(): Signal<PastMeetingParticipant[]> {
     return toSignal(
       toObservable(this.meeting).pipe(
         tap(() => {
@@ -149,7 +167,7 @@ export class MeetingRsvpDetailsComponent {
     return meeting.individual_registrants_count !== undefined || meeting.committee_members_count !== undefined;
   }
 
-  private initializeRsvpCounts(): Signal<RsvpCounts> {
+  private initRsvpCounts(): Signal<RsvpCounts> {
     return computed(() => {
       const rsvps = this.rsvps();
       const occurrence = this.currentOccurrence();
@@ -158,7 +176,7 @@ export class MeetingRsvpDetailsComponent {
     });
   }
 
-  private initializeMeetingRegistrantCount(): Signal<number> {
+  private initMeetingRegistrantCount(): Signal<number> {
     return computed(() => {
       const meeting = this.meeting();
       const additionalCount = this.additionalRegistrantsCount();
@@ -175,14 +193,14 @@ export class MeetingRsvpDetailsComponent {
     });
   }
 
-  private initializeAttendedCount(): Signal<number> {
+  private initAttendedCount(): Signal<number> {
     return computed(() => {
       if (!this.pastMeeting()) return 0;
       return this.pastParticipants().filter((p) => p.is_attended).length;
     });
   }
 
-  private initializeAttendancePercentage(): Signal<number> {
+  private initAttendancePercentage(): Signal<number> {
     return computed(() => {
       const total = this.meetingRegistrantCount();
       if (total === 0) {
@@ -197,7 +215,7 @@ export class MeetingRsvpDetailsComponent {
     });
   }
 
-  private initializeBackgroundClasses(): Signal<string> {
+  private initBackgroundClasses(): Signal<string> {
     return computed(() => {
       if (this.showPoorAttendanceWarning()) {
         return 'bg-amber-50';
@@ -206,7 +224,7 @@ export class MeetingRsvpDetailsComponent {
     });
   }
 
-  private initializeBorderClasses(): Signal<string> {
+  private initBorderClasses(): Signal<string> {
     return computed(() => {
       if (this.showPoorAttendanceWarning()) {
         return 'border border-amber-200';

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -493,6 +493,8 @@
             [position]="drawerPosition()"
             styleClass="xl:w-1/4 lg:w-1/3 md:w-5/12 sm:w-1/2 w-full"
             [modal]="true"
+            [dismissible]="false"
+            appendTo="body"
             [showCloseIcon]="false"
             data-testid="meeting-registrants-drawer">
             <ng-template #header>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -504,7 +504,7 @@
                   @if (isPastMeeting()) {
                     <div class="flex flex-col">
                       <h1>Meeting Participants</h1>
-                      <span class="text-base text-gray-500">{{ participantCount() }} participants</span>
+                      <span class="text-base text-gray-500">{{ attendedCount() }} attended / {{ participantCount() }} invited</span>
                     </div>
                   } @else if (meeting().committees && meeting().committees.length > 0) {
                     <div class="flex flex-col">
@@ -526,6 +526,7 @@
             <lfx-meeting-registrants-display
               [meeting]="meeting()"
               [pastMeeting]="isPastMeeting()"
+              [pastMeetingFullAccess]="pastMeetingFullAccess()"
               [showAddRegistrant]="!!meeting().organizer && !isPastMeeting()"
               [myMeetingRegistrants]="true"
               [initialRegistrants]="registrants()"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -533,6 +533,8 @@
               [myMeetingRegistrants]="true"
               [initialRegistrants]="registrants()"
               [initialRegistrantsLoading]="registrantsLoading()"
+              [initialPastParticipants]="isPastMeeting() ? pastMeetingParticipants() : null"
+              [initialPastParticipantsLoading]="pastMeetingParticipantsLoading()"
               [visible]="showRegistrants()"
               (refreshRequested)="onRegistrantsRefreshRequested($event)">
             </lfx-meeting-registrants-display>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -211,6 +211,9 @@ export class MeetingJoinComponent implements OnInit {
   });
   // Past meeting participants (fetched from API for attendance stats)
   protected pastMeetingParticipants: Signal<PastMeetingParticipant[]>;
+  // Tracks the in-flight state of the past-participants fetch so the registrants drawer can
+  // show a loading indicator while reusing the parent-owned list (avoids a duplicate fetch).
+  protected readonly pastMeetingParticipantsLoading: WritableSignal<boolean> = signal(false);
   // Past meeting attendance stats (derived from participants)
   protected participantCount = computed(() => this.pastMeetingParticipants().length);
   protected attendedCount = computed(() => this.pastMeetingParticipants().filter((p) => p.is_attended).length);
@@ -1053,8 +1056,15 @@ export class MeetingJoinComponent implements OnInit {
     return toSignal(
       combineLatest([toObservable(this.pastMeetingFullAccess), toObservable(this.meeting)]).pipe(
         switchMap(([hasAccess, meeting]) => {
-          if (!hasAccess || !meeting?.id || !this.authenticated()) return of([] as PastMeetingParticipant[]);
-          return this.meetingService.getPastMeetingParticipants(meeting.id).pipe(catchError(() => of([] as PastMeetingParticipant[])));
+          if (!hasAccess || !meeting?.id || !this.authenticated()) {
+            this.pastMeetingParticipantsLoading.set(false);
+            return of([] as PastMeetingParticipant[]);
+          }
+          this.pastMeetingParticipantsLoading.set(true);
+          return this.meetingService.getPastMeetingParticipants(meeting.id).pipe(
+            catchError(() => of([] as PastMeetingParticipant[])),
+            finalize(() => this.pastMeetingParticipantsLoading.set(false))
+          );
         })
       ),
       { initialValue: [] }


### PR DESCRIPTION
# Summary

This pull request improves how past meeting participant data and attendance counts are handled and displayed in the meetings dashboard. The changes make it possible for parent components to receive, manage, and display accurate attendance information for past meetings without redundant network requests or inconsistent UI states. The most important changes are grouped below.

**Enhancements to Past Meeting Attendance Handling**

* The `MeetingCardComponent` now tracks and displays accurate past meeting attendance and participant counts using new signals (`pastAttendedCount`, `pastParticipantCount`, etc.), which are updated via events from child components instead of relying on incomplete data from the backend. This ensures the dashboard shows correct attended/invited numbers for past meetings. [[1]](diffhunk://#diff-55048cc825e1b4ed2849f0e190086861082224f67bfc6ab1b4c0784e99caa120R127-R134) [[2]](diffhunk://#diff-55048cc825e1b4ed2849f0e190086861082224f67bfc6ab1b4c0784e99caa120R242-R243) [[3]](diffhunk://#diff-55048cc825e1b4ed2849f0e190086861082224f67bfc6ab1b4c0784e99caa120R257-R266) [[4]](diffhunk://#diff-55048cc825e1b4ed2849f0e190086861082224f67bfc6ab1b4c0784e99caa120R550-R561) [[5]](diffhunk://#diff-d4e75d83ec09795107b5f8a2079625bcb281fde286a5bbee19de6d19aed989b2L428-R430)
* The `MeetingRsvpDetailsComponent` emits new events (`pastParticipantCountsChange` and `pastParticipantsLoaded`) when past participant data is loaded, allowing parent components to update their UI and avoid duplicate data fetching. [[1]](diffhunk://#diff-bffe6d19ff42729f01e02d8d4ebefc91f5dc0583cfe98b06d57b1c22b9fb0a6fR45-R61) [[2]](diffhunk://#diff-bffe6d19ff42729f01e02d8d4ebefc91f5dc0583cfe98b06d57b1c22b9fb0a6fR88-R101) [[3]](diffhunk://#diff-d4e75d83ec09795107b5f8a2079625bcb281fde286a5bbee19de6d19aed989b2L283-R285)

**Externally-Managed Past Participants in Registrants Drawer**

* The `MeetingRegistrantsDisplayComponent` now supports externally-managed past participant data through new inputs (`initialPastParticipants`, `initialPastParticipantsLoading`). This allows parent components to pass in already-fetched participant lists and loading states, preventing unnecessary network calls and keeping the drawer header/body consistent. [[1]](diffhunk://#diff-bb1da901fd8b8b6725effd971187b6d4974d2a7ea0ffede84d06dcc239402f1eR35-R49) [[2]](diffhunk://#diff-bb1da901fd8b8b6725effd971187b6d4974d2a7ea0ffede84d06dcc239402f1eR58-R67) [[3]](diffhunk://#diff-bb1da901fd8b8b6725effd971187b6d4974d2a7ea0ffede84d06dcc239402f1eL59-R80) [[4]](diffhunk://#diff-d4e75d83ec09795107b5f8a2079625bcb281fde286a5bbee19de6d19aed989b2R451-R452)
* Logic in `MeetingRegistrantsDisplayComponent` is updated to skip fetching past participants if the parent signals the viewer lacks access, or if the data is already provided, improving performance and avoiding UI inconsistencies. [[1]](diffhunk://#diff-bb1da901fd8b8b6725effd971187b6d4974d2a7ea0ffede84d06dcc239402f1eL114-R145) [[2]](diffhunk://#diff-bb1da901fd8b8b6725effd971187b6d4974d2a7ea0ffede84d06dcc239402f1eL241-R273)

**Code Cleanups and Refactoring**

* Several private method names in `MeetingRsvpDetailsComponent` have been standardized from `initialize*` to `init*` for clarity and consistency. [[1]](diffhunk://#diff-bffe6d19ff42729f01e02d8d4ebefc91f5dc0583cfe98b06d57b1c22b9fb0a6fR45-R61) [[2]](diffhunk://#diff-bffe6d19ff42729f01e02d8d4ebefc91f5dc0583cfe98b06d57b1c22b9fb0a6fL63-R79) [[3]](diffhunk://#diff-bffe6d19ff42729f01e02d8d4ebefc91f5dc0583cfe98b06d57b1c22b9fb0a6fL123-R141) [[4]](diffhunk://#diff-bffe6d19ff42729f01e02d8d4ebefc91f5dc0583cfe98b06d57b1c22b9fb0a6fL152-R170) [[5]](diffhunk://#diff-bffe6d19ff42729f01e02d8d4ebefc91f5dc0583cfe98b06d57b1c22b9fb0a6fL161-R179) [[6]](diffhunk://#diff-bffe6d19ff42729f01e02d8d4ebefc91f5dc0583cfe98b06d57b1c22b9fb0a6fL178-R203)

These changes together provide a more robust, efficient, and consistent experience when viewing past meeting attendance and participants in the dashboard.