### PR TITLE
feat(committees): show project or foundation name in subtitle

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -21,7 +21,7 @@
       <p class="mt-1 text-sm text-gray-500" data-testid="dashboard-hero-description">
         {{
           isMeLens()
-            ? project()?.uid
+            ? project()?.name
               ? committeeLabel.plural + ' you are a member of in ' + project()?.name + '.'
               : committeeLabel.plural + ' you are a member of across all foundations and projects.'
             : 'Manage ' + committeeLabel.plural.toLowerCase() + ' and governance for your project.'

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -22,7 +22,7 @@
         {{
           isMeLens()
             ? project()?.uid
-              ? committeeLabel.plural + ' you are a member of in this ' + (isFoundationContext() ? 'foundation' : 'project') + '.'
+              ? committeeLabel.plural + ' you are a member of in ' + project()?.name + '.'
               : committeeLabel.plural + ' you are a member of across all foundations and projects.'
             : 'Manage ' + committeeLabel.plural.toLowerCase() + ' and governance for your project.'
         }}


### PR DESCRIPTION
# Summary

This pull request updates the committee dashboard header message to provide more specific context to users. Instead of displaying a generic message about the foundation or project, the header now includes the actual project name when listing committees a user is a member of.

User interface improvement:

* Updated the committee dashboard header in `committee-dashboard.component.html` to display the specific project name instead of a generic reference to "this foundation" or "project" when listing committees that the user is a member of.