### PR TITLE
perf(dashboards): aggregate pending actions via fga-direct grants

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -190,7 +190,7 @@ export class CommitteeOverviewComponent {
   }
 
   public handlePendingActionClick(item: PendingActionItem): void {
-    if (item.type === 'Cast Vote') {
+    if (item.type === 'Vote') {
       const vote = this.pendingVotes().find((v) => v.uid === item.buttonLink);
       if (vote) {
         this.selectedVoteId.set(vote.uid);
@@ -355,7 +355,7 @@ export class CommitteeOverviewComponent {
   private initPendingActionItems(): Signal<PendingActionItem[]> {
     return computed(() => {
       const voteItems: PendingActionItem[] = this.pendingVotes().map((vote) => ({
-        type: 'Cast Vote',
+        type: 'Vote',
         badge: this.committee().name,
         text: vote.name,
         icon: 'fa-light fa-check-to-slot',
@@ -367,7 +367,7 @@ export class CommitteeOverviewComponent {
           : undefined,
       }));
       const surveyItems: PendingActionItem[] = this.pendingSurveys().map((survey) => ({
-        type: 'Submit Feedback',
+        type: 'Survey',
         badge: this.committee().name,
         text: survey.survey_title,
         icon: 'fa-light fa-chart-simple',
@@ -384,7 +384,7 @@ export class CommitteeOverviewComponent {
   private initPendingActionsViewAllTab(): Signal<'votes' | 'surveys'> {
     return computed(() => {
       const overflow = this.pendingActionItems().slice(2);
-      const hasVotes = overflow.some((item) => item.type === 'Cast Vote');
+      const hasVotes = overflow.some((item) => item.type === 'Vote');
       return hasVotes ? 'votes' : 'surveys';
     });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -16,13 +16,18 @@
         {{ cardLabel() }}
       </span>
       @if (viewAllRouterLink()) {
-        <a
-          [routerLink]="viewAllRouterLink()"
-          [queryParams]="viewAllQueryParams()"
-          class="text-xs text-[#009aff] hover:underline"
-          data-testid="dashboard-meeting-card-view-all">
-          View all
-        </a>
+        <div class="flex items-center gap-2">
+          @if (overlappingCount() > 0) {
+            <span class="text-[11px] text-gray-600" data-testid="dashboard-meeting-card-overlap-hint"> +{{ overlappingCount() }} overlapping · </span>
+          }
+          <a
+            [routerLink]="viewAllRouterLink()"
+            [queryParams]="viewAllQueryParams()"
+            class="text-xs text-[#009aff] hover:underline"
+            data-testid="dashboard-meeting-card-view-all">
+            View all
+          </a>
+        </div>
       }
     </div>
   }
@@ -153,7 +158,7 @@
     @defer (on idle) {
       <button
         type="button"
-        [cdkCopyToClipboard]="meetingDetailHref()"
+        [cdkCopyToClipboard]="meetingDetailClipboardUrl()"
         class="shrink-0 w-7 h-7 flex items-center justify-center rounded-full hover:bg-gray-100 transition-colors text-gray-500 mt-1"
         pTooltip="Copy meeting link"
         tooltipPosition="top"

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { ClipboardModule } from '@angular/cdk/clipboard';
-import { Component, computed, inject, input, Signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Component, computed, inject, input, PLATFORM_ID, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { Params, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
@@ -31,6 +32,7 @@ import { catchError, combineLatest, map, of, switchMap } from 'rxjs';
 export class DashboardMeetingCardComponent {
   private readonly meetingService = inject(MeetingService);
   private readonly userService = inject(UserService);
+  private readonly platformId = inject(PLATFORM_ID);
 
   public readonly meeting = input.required<Meeting>();
   public readonly occurrence = input<MeetingOccurrence | null>(null);
@@ -50,6 +52,8 @@ export class DashboardMeetingCardComponent {
   public readonly viewAllRouterLink = input<string | null>(null);
   /** Query params for the "View all" router link. */
   public readonly viewAllQueryParams = input<Params>({});
+  /** Count of other meetings whose time range overlaps this one. When > 0, the card header shows a "+N overlapping" hint before the "View all" link. */
+  public readonly overlappingCount = input<number>(0);
   /** Optional recording URL override — when set, skips the API call and renders the "Watch recording" button directly. */
   public readonly recordingUrl = input<string | null>(null);
 
@@ -69,6 +73,7 @@ export class DashboardMeetingCardComponent {
   public readonly meetingDetailUrl: Signal<string> = this.initMeetingDetailUrl();
   public readonly meetingDetailQueryParams: Signal<Record<string, string>> = this.initMeetingDetailQueryParams();
   public readonly meetingDetailHref: Signal<string> = this.initMeetingDetailHref();
+  public readonly meetingDetailClipboardUrl: Signal<string> = this.initMeetingDetailClipboardUrl();
   public readonly recordingShareUrl: Signal<string | null> = this.initRecordingShareUrl();
 
   // New signals for the Figma card design
@@ -215,6 +220,16 @@ export class DashboardMeetingCardComponent {
       const params = this.meetingDetailQueryParams();
       const queryString = new URLSearchParams(params).toString();
       return queryString ? `${url}?${queryString}` : url;
+    });
+  }
+
+  private initMeetingDetailClipboardUrl(): Signal<string> {
+    return computed(() => {
+      const href = this.meetingDetailHref();
+      if (!isPlatformBrowser(this.platformId)) return href;
+      const override = this.detailUrl();
+      if (override && /^https?:\/\//i.test(override)) return href;
+      return `${window.location.origin}${href}`;
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -226,6 +226,10 @@ export class DashboardMeetingCardComponent {
   private initMeetingDetailClipboardUrl(): Signal<string> {
     return computed(() => {
       const href = this.meetingDetailHref();
+      // SSR fallback: `window` is undefined during server rendering, so we return the relative
+      // path. The copy-link button sits behind a `@defer` block, so in practice the clipboard
+      // write only runs in the browser where `window.location.origin` resolves — but if that
+      // `@defer` is ever removed, preserve this guard so SSR snapshots don't copy a relative URL.
       if (!isPlatformBrowser(this.platformId)) return href;
       const override = this.detailUrl();
       if (override && /^https?:\/\//i.test(override)) return href;

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.html
@@ -83,7 +83,8 @@
           [occurrence]="item.occurrence"
           cardLabel="NEXT MEETING"
           cardVariant="accent"
-          viewAllRouterLink="/meetings" />
+          viewAllRouterLink="/meetings"
+          [overlappingCount]="overlappingNextCount()" />
       } @else {
         <div
           class="rounded-2xl border border-blue-100 shadow-sm overflow-hidden flex-1 flex items-center justify-center gap-4 px-5 py-10"

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
@@ -26,8 +26,6 @@ export class MyMeetingsComponent {
   private readonly projectContextService = inject(ProjectContextService);
   private readonly lensService = inject(LensService);
 
-  private static readonly bufferMs = 40 * 60 * 1000; // 40 minutes
-
   protected readonly activeLens = this.lensService.activeLens;
   protected readonly upcomingLoading = signal(true);
   protected readonly pastLoading = signal(true);
@@ -38,11 +36,17 @@ export class MyMeetingsComponent {
   private readonly rawMeetings = this.initRawMeetings();
   private readonly rawPastMeetings = this.initRawPastMeetings();
 
+  // Computed: Active (not-ended) meeting entries sorted by start time
+  private readonly activeEntries: Signal<MeetingWithOccurrence[]> = this.initActiveEntries();
+
   // Computed: Next upcoming meeting (with occurrence expansion)
   protected readonly nextMeeting: Signal<MeetingWithOccurrence | null> = this.initNextMeeting();
 
   // Computed: Last past meeting
   protected readonly lastMeeting: Signal<PastMeeting | null> = this.initLastMeeting();
+
+  // Count of other meetings whose time range overlaps the displayed Next Meeting
+  protected readonly overlappingNextCount: Signal<number> = this.initOverlappingNextCount();
 
   // Text based on lens
   protected readonly sectionTitle = computed(() => (this.activeLens() === 'me' ? 'My Meetings' : 'Meetings'));
@@ -62,7 +66,7 @@ export class MyMeetingsComponent {
   private initRawPastMeetings() {
     return this.initLensSwitchedData<PastMeeting>(
       this.pastLoading,
-      () => this.userService.getUserPastMeetings(),
+      () => this.userService.getUserLatestPastMeetings(),
       (uid) => this.meetingService.getPastMeetingsByProject(uid)
     );
   }
@@ -107,7 +111,7 @@ export class MyMeetingsComponent {
     );
   }
 
-  private initNextMeeting(): Signal<MeetingWithOccurrence | null> {
+  private initActiveEntries(): Signal<MeetingWithOccurrence[]> {
     return computed(() => {
       const meetings = this.rawMeetings();
       const now = Date.now();
@@ -117,14 +121,14 @@ export class MyMeetingsComponent {
         if (meeting.occurrences && meeting.occurrences.length > 0) {
           for (const occurrence of getActiveOccurrences(meeting.occurrences)) {
             const startMs = new Date(occurrence.start_time).getTime();
-            const endMs = startMs + occurrence.duration * 60 * 1000 + MyMeetingsComponent.bufferMs;
+            const endMs = startMs + occurrence.duration * 60 * 1000;
             if (endMs >= now) {
               entries.push({ meeting, occurrence, sortTime: startMs, trackId: `${meeting.id}-${occurrence.occurrence_id}` });
             }
           }
         } else {
           const startMs = new Date(meeting.start_time).getTime();
-          const endMs = startMs + meeting.duration * 60 * 1000 + MyMeetingsComponent.bufferMs;
+          const endMs = startMs + meeting.duration * 60 * 1000;
           if (endMs >= now) {
             entries.push({
               meeting,
@@ -143,22 +147,42 @@ export class MyMeetingsComponent {
       }
 
       entries.sort((a, b) => a.sortTime - b.sortTime);
+      return entries;
+    });
+  }
+
+  private initNextMeeting(): Signal<MeetingWithOccurrence | null> {
+    return computed(() => {
+      const entries = this.activeEntries();
+      const now = Date.now();
+      const imminentWindowMs = 10 * 60 * 1000;
+
+      const imminent = entries.find((entry) => entry.sortTime > now && entry.sortTime - now <= imminentWindowMs);
+      if (imminent) return imminent;
+
+      const inProgress = entries.find((entry) => entry.sortTime <= now);
+      if (inProgress) return inProgress;
+
       return entries[0] ?? null;
     });
   }
 
-  private initLastMeeting(): Signal<PastMeeting | null> {
+  private initOverlappingNextCount(): Signal<number> {
     return computed(() => {
-      const pastMeetings = this.rawPastMeetings();
-      if (pastMeetings.length === 0) {
-        return null;
-      }
-
-      // Sort by scheduled_start_time descending (most recent first)
-      const sorted = [...pastMeetings].sort((a, b) =>
-        (b.scheduled_start_time ?? b.start_time ?? '').localeCompare(a.scheduled_start_time ?? a.start_time ?? '')
-      );
-      return sorted[0] ?? null;
+      const next = this.nextMeeting();
+      if (!next) return 0;
+      const nextStart = next.sortTime;
+      const nextEnd = nextStart + next.occurrence.duration * 60 * 1000;
+      return this.activeEntries().filter((entry) => {
+        if (entry === next) return false;
+        const entryStart = entry.sortTime;
+        const entryEnd = entryStart + entry.occurrence.duration * 60 * 1000;
+        return entryStart < nextEnd && entryEnd > nextStart;
+      }).length;
     });
+  }
+
+  private initLastMeeting(): Signal<PastMeeting | null> {
+    return computed(() => this.rawPastMeetings()[0] ?? null);
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.ts
@@ -183,6 +183,27 @@ export class MyMeetingsComponent {
   }
 
   private initLastMeeting(): Signal<PastMeeting | null> {
-    return computed(() => this.rawPastMeetings()[0] ?? null);
+    return computed(() => {
+      // The backend `v1_past_meeting` index includes meetings as soon as they START (not end),
+      // so both the Me-lens fast-path and the project-lens `getPastMeetingsByProject` stream can
+      // contain in-progress meetings at the top. The Me-lens service already filters those out
+      // upstream, but the project-lens path doesn't — so we re-apply the filter client-side here
+      // to keep both lenses consistent. rawPastMeetings is already sorted newest-first.
+      const now = Date.now();
+      return (
+        this.rawPastMeetings().find((meeting) => {
+          if (meeting.scheduled_end_time) {
+            const scheduledEnd = new Date(meeting.scheduled_end_time).getTime();
+            if (!Number.isNaN(scheduledEnd)) return scheduledEnd < now;
+          }
+          const startIso = meeting.scheduled_start_time ?? meeting.start_time;
+          if (!startIso) return false;
+          const startMs = new Date(startIso).getTime();
+          const duration = Number(meeting.duration);
+          if (Number.isNaN(startMs) || Number.isNaN(duration)) return false;
+          return startMs + duration * 60 * 1000 < now;
+        }) ?? null
+      );
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -22,8 +22,8 @@
           [attr.data-testid]="'dashboard-pending-actions-item-' + item.type">
           <!-- Label + text -->
           <div class="flex items-center gap-3 min-w-0 flex-1">
-            <div class="w-24 shrink-0">
-              <lfx-tag [value]="item.type" [severity]="item.severity" [icon]="item.icon" />
+            <div class="w-32 shrink-0">
+              <lfx-tag [value]="item.type" [severity]="item.severity" [icon]="item.icon" styleClass="whitespace-nowrap" />
             </div>
             <p class="text-sm font-medium text-gray-900 truncate" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
               {{ item.text }}

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -31,7 +31,7 @@ import { ProjectService } from '@services/project.service';
 import { SurveyService } from '@services/survey.service';
 import { UserService } from '@services/user.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { BehaviorSubject, catchError, combineLatest, filter, forkJoin, map, of, switchMap, take, tap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
 
 import { CardComponent } from '@components/card/card.component';
 import { TableComponent } from '@components/table/table.component';
@@ -236,19 +236,8 @@ export class MultiPersonaDashboardComponent {
       this.refresh$.pipe(
         switchMap(() => {
           this.pendingActionsLoading.set(true);
-          return toObservable(this.userFoundations).pipe(take(1));
-        }),
-        switchMap((foundations) => {
-          if (foundations.length === 0) {
-            this.pendingActionsLoading.set(false);
-            return of([]);
-          }
-          const persona = this.personaService.currentPersona();
-          return forkJoin(
-            foundations.map((f) =>
-              this.projectService.getPendingActions(f.projectSlug, f.projectUid, persona).pipe(catchError(() => of([] as PendingActionItem[])))
-            )
-          ).pipe(map((results) => results.flat()));
+          // Single unscoped request — the backend aggregates across all of the user's FGA grants.
+          return this.projectService.getPendingActions().pipe(catchError(() => of([] as PendingActionItem[])));
         }),
         // Windowing (dismiss filtering + display cap) is owned by PendingActionsComponent.
         // Pass the raw aggregated list and let the child render the top 5 unhidden items.

--- a/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/user-dashboard/user-dashboard.component.ts
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, inject, Signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { isBoardScopedPersona, PendingActionItem } from '@lfx-one/shared/interfaces';
 import { PersonaService } from '@services/persona.service';
-import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { SkeletonModule } from 'primeng/skeleton';
 import { BehaviorSubject, catchError, of, switchMap } from 'rxjs';
@@ -22,7 +21,6 @@ import { RecentProgressComponent } from '../components/recent-progress/recent-pr
   styleUrl: './user-dashboard.component.scss',
 })
 export class UserDashboardComponent {
-  private readonly projectContextService = inject(ProjectContextService);
   private readonly personaService = inject(PersonaService);
   private readonly projectService = inject(ProjectService);
 
@@ -71,24 +69,10 @@ export class UserDashboardComponent {
   }
 
   private initPendingActions(): Signal<PendingActionItem[]> {
-    const project$ = toObservable(this.projectContextService.activeContext);
-
     return toSignal(
       this.refresh$.pipe(
         takeUntilDestroyed(),
-        switchMap(() =>
-          project$.pipe(
-            switchMap((project) => {
-              if (!project?.slug || !project?.uid) {
-                return of([] as PendingActionItem[]);
-              }
-
-              return this.projectService
-                .getPendingActions(project.slug, project.uid, this.personaService.currentPersona())
-                .pipe(catchError(() => of([] as PendingActionItem[])));
-            })
-          )
-        )
+        switchMap(() => this.projectService.getPendingActions().pipe(catchError(() => of([] as PendingActionItem[]))))
       ),
       { initialValue: [] }
     );

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -1089,14 +1089,19 @@ export class MeetingJoinComponent implements OnInit {
   private initializeParentProject(): Signal<Project | null> {
     return toSignal(
       toObservable(this.project).pipe(
-        filter((p) => !!p?.parent_uid),
-        distinctUntilChanged((a, b) => a?.parent_uid === b?.parent_uid),
-        switchMap((p) =>
-          this.projectService.getProject(p!.parent_uid!, false).pipe(
+        map((p) => p?.parent_uid ?? null),
+        distinctUntilChanged(),
+        switchMap((parentUid) => {
+          if (!parentUid) {
+            // Top-level (or unknown) project — explicitly clear any stale foundation context
+            // instead of suppressing the emission, which would leave the previous parent cached.
+            return of(null);
+          }
+          return this.projectService.getProject(parentUid, false).pipe(
             map((parent) => (parent?.slug === ROOT_PROJECT_SLUG ? null : parent)),
             catchError(() => of(null))
-          )
-        )
+          );
+        })
       ),
       { initialValue: null }
     );

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -35,6 +35,7 @@ import {
   PastMeetingSummary,
   Project,
   PublicPastMeetingResponse,
+  ROOT_PROJECT_SLUG,
   TagSeverity,
   User,
 } from '@lfx-one/shared';
@@ -1090,7 +1091,12 @@ export class MeetingJoinComponent implements OnInit {
       toObservable(this.project).pipe(
         filter((p) => !!p?.parent_uid),
         distinctUntilChanged((a, b) => a?.parent_uid === b?.parent_uid),
-        switchMap((p) => this.projectService.getProject(p!.parent_uid!, false).pipe(catchError(() => of(null))))
+        switchMap((p) =>
+          this.projectService.getProject(p!.parent_uid!, false).pipe(
+            map((parent) => (parent?.slug === ROOT_PROJECT_SLUG ? null : parent)),
+            catchError(() => of(null))
+          )
+        )
       ),
       { initialValue: null }
     );

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -403,15 +403,7 @@ export class MeetingsDashboardComponent {
     return toSignal(
       merge(meLens$, firstPage$, nextPage$).pipe(
         tap((response) => this.pastPageToken.set(response.page_token)),
-        scan((acc: PastMeeting[], response: PageResult<PastMeeting>) => {
-          // TODO: Remove client-side sorting once API supports sorting by scheduled_start_time
-          const sorted = response.data.sort((a, b) => {
-            const timeA = new Date(a.scheduled_start_time ?? a.start_time).getTime();
-            const timeB = new Date(b.scheduled_start_time ?? b.start_time).getTime();
-            return timeB - timeA;
-          });
-          return response.reset ? sorted : [...acc, ...sorted];
-        }, [])
+        scan((acc: PastMeeting[], response: PageResult<PastMeeting>) => (response.reset ? response.data : [...acc, ...response.data]), [])
       ),
       { initialValue: [] }
     );

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -149,11 +149,7 @@ export class MeetingService {
   }
 
   public getPastMeetingsByProject(uid: string): Observable<PastMeeting[]> {
-    const params = new HttpParams().set('tags', `project_uid:${uid}`);
-
-    // TODO: Add sort parameter once API supports sorting by scheduled_start_time
-    // When implemented, add: params = params.set('sort', 'scheduled_start_time_desc');
-    // This will enable backend sorting instead of client-side sorting in the component
+    const params = new HttpParams().set('tags', `project_uid:${uid}`).set('sort', 'name_desc');
 
     return this.getPastMeetings(params).pipe(map((response) => response.data));
   }
@@ -189,7 +185,7 @@ export class MeetingService {
     searchName?: string,
     filters?: string[]
   ): Observable<PaginatedResponse<PastMeeting>> {
-    let params = new HttpParams().set('tags', `project_uid:${uid}`);
+    let params = new HttpParams().set('tags', `project_uid:${uid}`).set('sort', 'name_desc');
     if (pageToken) {
       params = params.set('page_token', pageToken);
     }

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -75,14 +75,20 @@ export class ProjectService {
   }
 
   /**
-   * Get all pending actions (surveys + meetings) for the current user
-   * @param projectSlug - Project slug for survey filtering
-   * @param projectUid - Project UID for meeting filtering
-   * @param persona - User persona type (default: 'board-member')
+   * Get all pending actions (surveys + meetings + votes + RSVPs) for the current user.
+   * Omit all arguments to run unscoped across all of the user's FGA grants (Me-lens — one
+   * request instead of N project-scoped fan-outs). Provide `projectSlug` and `projectUid` to
+   * scope to a single project (project/foundation-lens dashboards).
+   * @param projectSlug - Optional project slug for survey filtering
+   * @param projectUid - Optional project UID for meeting/vote filtering
+   * @param persona - Optional persona for telemetry (no longer drives behavior)
    * @returns Observable of pending action items
    */
-  public getPendingActions(projectSlug: string, projectUid: string, persona: string = 'board-member'): Observable<PendingActionItem[]> {
-    const params = new HttpParams().set('projectSlug', projectSlug).set('projectUid', projectUid).set('persona', persona);
+  public getPendingActions(projectSlug?: string, projectUid?: string, persona?: string): Observable<PendingActionItem[]> {
+    let params = new HttpParams();
+    if (projectSlug) params = params.set('projectSlug', projectSlug);
+    if (projectUid) params = params.set('projectUid', projectUid);
+    if (persona) params = params.set('persona', persona);
 
     return this.http.get<PendingActionItem[]>('/api/user/pending-actions', { params }).pipe(
       catchError((error) => {

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -51,8 +51,10 @@ export class UserService {
   // to the refresh subjects. A fresh Subject is created for each new chain.
   private userMeetingsDestroy$ = new Subject<void>();
   private userPastMeetingsDestroy$ = new Subject<void>();
+  private userLatestPastMeetingsDestroy$ = new Subject<void>();
   private userMeetings$: Observable<Meeting[]> | null = null;
   private userPastMeetings$: Observable<PastMeeting[]> | null = null;
+  private userLatestPastMeetings$: Observable<PastMeeting[]> | null = null;
 
   public constructor() {
     // Invalidate cached user-scoped observables when the authenticated user or
@@ -74,8 +76,11 @@ export class UserService {
         this.userMeetingsDestroy$ = new Subject<void>();
         this.userPastMeetingsDestroy$.next();
         this.userPastMeetingsDestroy$ = new Subject<void>();
+        this.userLatestPastMeetingsDestroy$.next();
+        this.userLatestPastMeetingsDestroy$ = new Subject<void>();
         this.userMeetings$ = null;
         this.userPastMeetings$ = null;
+        this.userLatestPastMeetings$ = null;
       });
   }
 
@@ -154,14 +159,7 @@ export class UserService {
       const destroy$ = this.userMeetingsDestroy$;
       this.userMeetings$ = this.userMeetingsRefresh$.pipe(
         startWith(undefined),
-        switchMap(() =>
-          this.http.get<Meeting[]>('/api/user/meetings').pipe(
-            catchError((error) => {
-              console.error('Failed to load user meetings:', error);
-              return of([]);
-            })
-          )
-        ),
+        switchMap(() => this.http.get<Meeting[]>('/api/user/meetings')),
         takeUntil(destroy$),
         shareReplay({ bufferSize: 1, refCount: false })
       );
@@ -178,19 +176,31 @@ export class UserService {
       const destroy$ = this.userPastMeetingsDestroy$;
       this.userPastMeetings$ = this.userPastMeetingsRefresh$.pipe(
         startWith(undefined),
-        switchMap(() =>
-          this.http.get<PastMeeting[]>('/api/user/past-meetings').pipe(
-            catchError((error) => {
-              console.error('Failed to load user past meetings:', error);
-              return of([]);
-            })
-          )
-        ),
+        switchMap(() => this.http.get<PastMeeting[]>('/api/user/past-meetings')),
         takeUntil(destroy$),
         shareReplay({ bufferSize: 1, refCount: false })
       );
     }
     return this.userPastMeetings$;
+  }
+
+  /**
+   * Gets up to 5 of the user's most recent past meetings via the fast-path endpoint.
+   * Uses query service sort=name_desc + page_size=5, and filters out meetings whose
+   * scheduled end time has not yet passed. Returns an empty array when the user has no
+   * truly past meetings.
+   */
+  public getUserLatestPastMeetings(): Observable<PastMeeting[]> {
+    if (!this.userLatestPastMeetings$) {
+      const destroy$ = this.userLatestPastMeetingsDestroy$;
+      this.userLatestPastMeetings$ = this.userPastMeetingsRefresh$.pipe(
+        startWith(undefined),
+        switchMap(() => this.http.get<PastMeeting[]>('/api/user/latest-past-meetings')),
+        takeUntil(destroy$),
+        shareReplay({ bufferSize: 1, refCount: false })
+      );
+    }
+    return this.userLatestPastMeetings$;
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -186,9 +186,10 @@ export class UserService {
 
   /**
    * Gets up to 5 of the user's most recent past meetings via the fast-path endpoint.
-   * Uses query service sort=name_desc + page_size=5, and filters out meetings whose
-   * scheduled end time has not yet passed. Returns an empty array when the user has no
-   * truly past meetings.
+   * The backend uses `sort=name_desc` and over-fetches (page_size=10) so it can drop ongoing
+   * meetings from the top of the sort and still return up to 5 truly-past rows in a single
+   * request. Returns an empty array when the user has no truly past meetings, or fewer than 5
+   * rows when many concurrently-ongoing meetings sit at the head of the sort.
    */
   public getUserLatestPastMeetings(): Observable<PastMeeting[]> {
     if (!this.userLatestPastMeetings$) {

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -193,6 +193,9 @@ export class UserService {
   public getUserLatestPastMeetings(): Observable<PastMeeting[]> {
     if (!this.userLatestPastMeetings$) {
       const destroy$ = this.userLatestPastMeetingsDestroy$;
+      // Shares `userPastMeetingsRefresh$` with `getUserPastMeetings()` on purpose — the two
+      // caches represent different slices of the same underlying data, so `refreshUserPastMeetings()`
+      // invalidates both together and they re-fetch in lockstep.
       this.userLatestPastMeetings$ = this.userPastMeetingsRefresh$.pipe(
         startWith(undefined),
         switchMap(() => this.http.get<PastMeeting[]>('/api/user/latest-past-meetings')),

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -1,7 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { PersonaType } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
@@ -19,9 +18,16 @@ export class UserController {
    * GET /api/user/pending-actions - Get all pending actions for the authenticated user
    */
   public async getPendingActions(req: Request, res: Response, next: NextFunction): Promise<void> {
+    // projectUid/projectSlug/persona are optional. When omitted, the aggregator runs
+    // user-scoped across the user's FGA grants instead of project-scoped.
+    const persona = req.query['persona'] as string | undefined;
+    const projectUid = req.query['projectUid'] as string | undefined;
+    const projectSlug = req.query['projectSlug'] as string | undefined;
+
     const startTime = logger.startOperation(req, 'get_pending_actions', {
-      persona: req.query['persona'],
-      project_uid: req.query['projectUid'],
+      ...(persona !== undefined && { persona }),
+      ...(projectUid !== undefined && { project_uid: projectUid }),
+      ...(projectSlug !== undefined && { project_slug: projectSlug }),
     });
 
     try {
@@ -29,45 +35,6 @@ export class UserController {
       const userEmail = getEffectiveEmail(req);
       if (!userEmail) {
         const validationError = ServiceValidationError.forField('email', 'User email not found in authentication context', {
-          operation: 'get_pending_actions',
-          service: 'user_controller',
-          path: req.path,
-        });
-
-        next(validationError);
-        return;
-      }
-
-      // Extract and validate persona
-      const persona = req.query['persona'] as PersonaType | undefined;
-      if (!persona) {
-        const validationError = ServiceValidationError.forField('persona', 'persona query parameter is required', {
-          operation: 'get_pending_actions',
-          service: 'user_controller',
-          path: req.path,
-        });
-
-        next(validationError);
-        return;
-      }
-
-      // Extract and validate projectUid
-      const projectUid = req.query['projectUid'] as string | undefined;
-      if (!projectUid) {
-        const validationError = ServiceValidationError.forField('projectUid', 'projectUid query parameter is required', {
-          operation: 'get_pending_actions',
-          service: 'user_controller',
-          path: req.path,
-        });
-
-        next(validationError);
-        return;
-      }
-
-      // Extract and validate projectSlug (needed for Snowflake surveys query)
-      const projectSlug = req.query['projectSlug'] as string | undefined;
-      if (!projectSlug) {
-        const validationError = ServiceValidationError.forField('projectSlug', 'projectSlug query parameter is required', {
           operation: 'get_pending_actions',
           service: 'user_controller',
           path: req.path,
@@ -99,14 +66,14 @@ export class UserController {
         limit = Math.min(parsed, 100);
       }
 
-      // Get pending actions from service — persona is validated above for API-contract stability
-      // but is no longer consumed by the aggregator (pending actions are persona-agnostic now).
+      // persona is accepted for telemetry but no longer consumed by the aggregator
+      // (pending actions are persona-agnostic).
       const pendingActions = await this.userService.getPendingActions(req, projectUid, userEmail, projectSlug, limit);
 
       logger.success(req, 'get_pending_actions', startTime, {
-        persona,
-        project_uid: projectUid,
-        project_slug: projectSlug,
+        ...(persona !== undefined && { persona }),
+        ...(projectUid !== undefined && { project_uid: projectUid }),
+        ...(projectSlug !== undefined && { project_slug: projectSlug }),
         action_count: pendingActions.length,
         ...(limit !== undefined && { limit }),
       });
@@ -195,6 +162,53 @@ export class UserController {
         project_uid: projectUid,
         foundation_uid: foundationUid,
         past_meeting_count: pastMeetings.length,
+      });
+
+      // Private, revalidate-every-time — see getUserMeetings for full rationale.
+      res.set('Cache-Control', 'private, no-cache');
+      res.json(pastMeetings);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/user/latest-past-meetings - Get up to 5 most-recent past meetings for the authenticated user
+   * Returns an array of up to 5 past meetings the user has direct FGA access to with
+   * `scheduled_end_time` in the past. Uses query service sort=name_desc + page_size=5 instead of
+   * paginating the full history.
+   * @query projectUid - Optional project UID to filter meetings
+   * @query foundation_uid - Optional foundation UID to filter meetings (OR across child projects)
+   */
+  public async getUserLatestPastMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_user_latest_past_meetings', {
+      project_uid: req.query['projectUid'],
+      foundation_uid: req.query['foundation_uid'],
+    });
+
+    try {
+      const projectUid = req.query['projectUid'] as string | undefined;
+      const foundationUid = req.query['foundation_uid'] as string | undefined;
+
+      // Extract user email from auth context (impersonation-aware, already lowercased)
+      const userEmail = getEffectiveEmail(req);
+      if (!userEmail) {
+        const validationError = ServiceValidationError.forField('email', 'User email not found in authentication context', {
+          operation: 'get_user_latest_past_meetings',
+          service: 'user_controller',
+          path: req.path,
+        });
+
+        next(validationError);
+        return;
+      }
+
+      const pastMeetings = await this.userService.getUserLatestPastMeetings(req, userEmail, projectUid, foundationUid);
+
+      logger.success(req, 'get_user_latest_past_meetings', startTime, {
+        count: pastMeetings.length,
+        project_uid: projectUid,
+        foundation_uid: foundationUid,
       });
 
       // Private, revalidate-every-time — see getUserMeetings for full rationale.

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -46,6 +46,25 @@ export class UserController {
         return;
       }
 
+      // projectUid and projectSlug must be supplied together (project/foundation lens) or
+      // omitted together (Me lens). Surveys scope on projectSlug while meetings/votes scope on
+      // projectUid — a half-supplied call would silently produce inconsistent aggregation across
+      // the three sources. Reject early so the contract stays explicit.
+      if (!!projectUid !== !!projectSlug) {
+        next(
+          ServiceValidationError.forField(
+            projectUid ? 'projectSlug' : 'projectUid',
+            'projectUid and projectSlug must be supplied together or omitted together',
+            {
+              operation: 'get_pending_actions',
+              service: 'user_controller',
+              path: req.path,
+            }
+          )
+        );
+        return;
+      }
+
       // Optional `?limit=` clamps the response size so mobile / summary cards can request a
       // smaller payload. Absent = unbounded; when present it must be a positive integer. Any
       // present-but-non-string value (array from `?limit=1&limit=2`, object from `?limit[foo]=1`)

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -4,6 +4,7 @@
 import { NextFunction, Request, Response } from 'express';
 
 import { ServiceValidationError } from '../errors';
+import { getStringQueryParam } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { UserService } from '../services/user.service';
 import { getEffectiveEmail } from '../utils/auth-helper';
@@ -22,9 +23,11 @@ export class UserController {
     // user-scoped across the user's FGA grants instead of project-scoped.
     // TODO: `persona` is accepted for telemetry only — the aggregator no longer consumes it.
     // Drop from the query contract once all frontend callers stop sending it.
-    const persona = req.query['persona'] as string | undefined;
-    const projectUid = req.query['projectUid'] as string | undefined;
-    const projectSlug = req.query['projectSlug'] as string | undefined;
+    // `getStringQueryParam` drops non-string values (arrays from `?k=a&k=b`, objects from
+    // `?k[x]=y`) that Express would otherwise leak through a bare `as string | undefined` cast.
+    const persona = getStringQueryParam(req, 'persona');
+    const projectUid = getStringQueryParam(req, 'projectUid');
+    const projectSlug = getStringQueryParam(req, 'projectSlug');
 
     const startTime = logger.startOperation(req, 'get_pending_actions', {
       ...(persona !== undefined && { persona }),
@@ -116,15 +119,15 @@ export class UserController {
    * @query foundation_uid - Optional foundation UID to filter meetings (OR across child projects)
    */
   public async getUserMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const projectUid = getStringQueryParam(req, 'projectUid');
+    const foundationUid = getStringQueryParam(req, 'foundation_uid');
+
     const startTime = logger.startOperation(req, 'get_user_meetings', {
-      project_uid: req.query['projectUid'],
-      foundation_uid: req.query['foundation_uid'],
+      project_uid: projectUid,
+      foundation_uid: foundationUid,
     });
 
     try {
-      const projectUid = req.query['projectUid'] as string | undefined;
-      const foundationUid = req.query['foundation_uid'] as string | undefined;
-
       // No email extraction needed — the service uses req.bearerToken (via filter_grants=direct
       // server-side FGA lookup). Auth middleware has already ensured the user is authenticated.
       const meetings = await this.userService.getUserMeetings(req, projectUid, foundationUid);
@@ -154,15 +157,15 @@ export class UserController {
    * @query foundation_uid - Optional foundation UID to filter meetings (OR across child projects)
    */
   public async getUserPastMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const projectUid = getStringQueryParam(req, 'projectUid');
+    const foundationUid = getStringQueryParam(req, 'foundation_uid');
+
     const startTime = logger.startOperation(req, 'get_user_past_meetings', {
-      project_uid: req.query['projectUid'],
-      foundation_uid: req.query['foundation_uid'],
+      project_uid: projectUid,
+      foundation_uid: foundationUid,
     });
 
     try {
-      const projectUid = req.query['projectUid'] as string | undefined;
-      const foundationUid = req.query['foundation_uid'] as string | undefined;
-
       // Extract user email from auth context (impersonation-aware, already lowercased)
       const userEmail = getEffectiveEmail(req);
       if (!userEmail) {
@@ -195,22 +198,26 @@ export class UserController {
 
   /**
    * GET /api/user/latest-past-meetings - Get up to 5 most-recent past meetings for the authenticated user
-   * Returns an array of up to 5 past meetings the user has direct FGA access to with
-   * `scheduled_end_time` in the past. Uses query service sort=name_desc + page_size=5 instead of
-   * paginating the full history.
+   * Returns an array of up to 5 past meetings the user has direct FGA access to with an
+   * `effective end` (scheduled_end_time, or start + duration when end is absent) in the past.
+   * Uses `sort=name_desc` and over-fetches via `page_size=LATEST_PAST_MEETINGS_FETCH_SIZE`
+   * (10 today) instead of paginating the full history; the service drops ongoing meetings from
+   * the top of the sort and slices down to LATEST_PAST_MEETINGS_RETURN_LIMIT (5). The response
+   * may therefore be fewer than 5 rows if many concurrently-ongoing meetings sit at the head
+   * of the sort for this user.
    * @query projectUid - Optional project UID to filter meetings
    * @query foundation_uid - Optional foundation UID to filter meetings (OR across child projects)
    */
   public async getUserLatestPastMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const projectUid = getStringQueryParam(req, 'projectUid');
+    const foundationUid = getStringQueryParam(req, 'foundation_uid');
+
     const startTime = logger.startOperation(req, 'get_user_latest_past_meetings', {
-      project_uid: req.query['projectUid'],
-      foundation_uid: req.query['foundation_uid'],
+      project_uid: projectUid,
+      foundation_uid: foundationUid,
     });
 
     try {
-      const projectUid = req.query['projectUid'] as string | undefined;
-      const foundationUid = req.query['foundation_uid'] as string | undefined;
-
       // No email extraction needed — the service uses req.bearerToken (via filter_grants=direct
       // server-side FGA lookup). Auth middleware has already ensured the user is authenticated.
       const pastMeetings = await this.userService.getUserLatestPastMeetings(req, projectUid, foundationUid);

--- a/apps/lfx-one/src/server/controllers/user.controller.ts
+++ b/apps/lfx-one/src/server/controllers/user.controller.ts
@@ -20,6 +20,8 @@ export class UserController {
   public async getPendingActions(req: Request, res: Response, next: NextFunction): Promise<void> {
     // projectUid/projectSlug/persona are optional. When omitted, the aggregator runs
     // user-scoped across the user's FGA grants instead of project-scoped.
+    // TODO: `persona` is accepted for telemetry only — the aggregator no longer consumes it.
+    // Drop from the query contract once all frontend callers stop sending it.
     const persona = req.query['persona'] as string | undefined;
     const projectUid = req.query['projectUid'] as string | undefined;
     const projectSlug = req.query['projectSlug'] as string | undefined;
@@ -190,20 +192,9 @@ export class UserController {
       const projectUid = req.query['projectUid'] as string | undefined;
       const foundationUid = req.query['foundation_uid'] as string | undefined;
 
-      // Extract user email from auth context (impersonation-aware, already lowercased)
-      const userEmail = getEffectiveEmail(req);
-      if (!userEmail) {
-        const validationError = ServiceValidationError.forField('email', 'User email not found in authentication context', {
-          operation: 'get_user_latest_past_meetings',
-          service: 'user_controller',
-          path: req.path,
-        });
-
-        next(validationError);
-        return;
-      }
-
-      const pastMeetings = await this.userService.getUserLatestPastMeetings(req, userEmail, projectUid, foundationUid);
+      // No email extraction needed — the service uses req.bearerToken (via filter_grants=direct
+      // server-side FGA lookup). Auth middleware has already ensured the user is authenticated.
+      const pastMeetings = await this.userService.getUserLatestPastMeetings(req, projectUid, foundationUid);
 
       logger.success(req, 'get_user_latest_past_meetings', startTime, {
         count: pastMeetings.length,

--- a/apps/lfx-one/src/server/routes/user.route.ts
+++ b/apps/lfx-one/src/server/routes/user.route.ts
@@ -17,6 +17,9 @@ router.get('/meetings', (req, res, next) => userController.getUserMeetings(req, 
 // GET /api/user/past-meetings - Get past meetings for the authenticated user
 router.get('/past-meetings', (req, res, next) => userController.getUserPastMeetings(req, res, next));
 
+// GET /api/user/latest-past-meetings - Get up to 5 most-recent past meetings (truly past, fast-path)
+router.get('/latest-past-meetings', (req, res, next) => userController.getUserLatestPastMeetings(req, res, next));
+
 // GET /api/user/salesforce-id - Proxy test for the API Gateway token
 router.get('/salesforce-id', (req, res, next) => userController.getSalesforceId(req, res, next));
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -967,13 +967,14 @@ export class ProjectService {
   }
 
   /**
-   * Get pending survey actions for a user
-   * Queries for non-responded surveys and transforms them into PendingActionItem format
+   * Get pending survey actions for a user.
+   * Queries for non-responded surveys and transforms them into PendingActionItem format.
+   * When `projectSlug` is omitted, returns surveys across all of the user's projects (Me-lens).
    * @param email - User's email from OIDC authentication
-   * @param projectSlug - Project slug to filter surveys
+   * @param projectSlug - Optional project slug; omit for unscoped (all-projects) results
    * @returns Array of pending action items with survey links
    */
-  public async getPendingActionSurveys(email: string, projectSlug: string): Promise<PendingActionItem[]> {
+  public async getPendingActionSurveys(email: string, projectSlug?: string): Promise<PendingActionItem[]> {
     // The COMMITTEE_CATEGORY='Board' filter was dropped — a pending survey is a pending
     // action regardless of which committee runs it. If the table grows to include noisy
     // categories in the future, reintroduce a committee-scoped filter here rather than a
@@ -982,6 +983,14 @@ export class ProjectService {
     // — the Snowflake column stores emails lowercased and an un-normalized input silently
     // misses rows when the caller passed a mixed-case address.
     const normalizedEmail = email.trim().toLowerCase();
+
+    const conditions = ['EMAIL = ?', 'SURVEY_CUTOFF_DATE > CURRENT_DATE()', "RESPONSE_TYPE = 'non_response'"];
+    const binds: string[] = [normalizedEmail];
+    if (projectSlug) {
+      conditions.push('PROJECT_SLUG = ?');
+      binds.push(projectSlug);
+    }
+
     const query = `
       SELECT
         SURVEY_TITLE,
@@ -989,14 +998,11 @@ export class ProjectService {
         PROJECT_NAME,
         SURVEY_LINK
       FROM ANALYTICS.PLATINUM_LFX_ONE.MEMBER_DASHBOARD_PENDING_ACTION_SURVEYS
-      WHERE EMAIL = ?
-        AND PROJECT_SLUG = ?
-        AND SURVEY_CUTOFF_DATE > CURRENT_DATE()
-        AND RESPONSE_TYPE = 'non_response'
+      WHERE ${conditions.join(' AND ')}
       ORDER BY SURVEY_CUTOFF_DATE ASC
     `;
 
-    const result = await this.snowflakeService.execute<PendingSurveyRow>(query, [normalizedEmail, projectSlug]);
+    const result = await this.snowflakeService.execute<PendingSurveyRow>(query, binds);
 
     // Transform database rows to PendingActionItem format
     return result.rows.map((row) => {
@@ -1016,7 +1022,7 @@ export class ProjectService {
       });
 
       return {
-        type: 'Submit Feedback',
+        type: 'Survey',
         badge: row.PROJECT_NAME,
         text: `${row.SURVEY_TITLE} is due ${formattedDate}`,
         icon: 'fa-regular fa-clipboard-list',

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NATS_CONFIG, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
+import { NATS_CONFIG, PENDING_ACTION_SURVEYS_ROW_LIMIT, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
 import { NatsSubjects } from '@lfx-one/shared/enums';
 import {
   BoardMeetingInviteeRow,
@@ -991,6 +991,10 @@ export class ProjectService {
       binds.push(projectSlug);
     }
 
+    // LIMIT bounds the micro-partition scan on the Me-lens unscoped path (no PROJECT_SLUG
+    // predicate), where Snowflake would otherwise filter only by EMAIL. Paired with the
+    // ORDER BY, the result set is the N most-urgent pending surveys — the dashboard surfaces
+    // far fewer than this cap, and the scoped path is naturally small too.
     const query = `
       SELECT
         SURVEY_TITLE,
@@ -1000,6 +1004,7 @@ export class ProjectService {
       FROM ANALYTICS.PLATINUM_LFX_ONE.MEMBER_DASHBOARD_PENDING_ACTION_SURVEYS
       WHERE ${conditions.join(' AND ')}
       ORDER BY SURVEY_CUTOFF_DATE ASC
+      LIMIT ${PENDING_ACTION_SURVEYS_ROW_LIMIT}
     `;
 
     const result = await this.snowflakeService.execute<PendingSurveyRow>(query, binds);

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -820,6 +820,12 @@ export class UserService {
    * request more than 5 so that when the first rows are ongoing (scheduled end still in the
    * future), we can drop them and still return up to 5 truly-past meetings in one request.
    * Skips the participant/attendance scan since the card does not surface `user_attended`.
+   *
+   * Cross-service dependency: the `sort_name = start_time` contract is owned by the
+   * `lfx-v2-meeting-service` indexer. If that field is ever repurposed (e.g. to alphabetical
+   * meeting name), this endpoint would silently return lexicographically-ordered results
+   * instead of the most-recent-first. Pin the contract via the indexer doc in that repo:
+   * https://github.com/linuxfoundation/lfx-v2-meeting-service/blob/main/docs/indexer-contract.md
    */
   public async getUserLatestPastMeetings(req: Request, projectUid?: string, foundationUid?: string): Promise<PastMeeting[]> {
     logger.debug(req, 'get_user_latest_past_meetings', 'Fetching user latest past meetings via filter_grants=direct + sort=name_desc', {

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1,7 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { LATEST_PAST_MEETINGS_FETCH_SIZE, LATEST_PAST_MEETINGS_RETURN_LIMIT, NATS_CONFIG, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
+import {
+  LATEST_PAST_MEETINGS_FETCH_SIZE,
+  LATEST_PAST_MEETINGS_RETURN_LIMIT,
+  NATS_CONFIG,
+  QUERY_SERVICE_FILTERS_OR_BATCH_SIZE,
+  ROOT_PROJECT_SLUG,
+} from '@lfx-one/shared/constants';
 import { NatsSubjects, PollStatus } from '@lfx-one/shared/enums';
 import {
   ActiveWeeksStreakResponse,
@@ -1207,22 +1213,40 @@ export class UserService {
 
     // No `filter_grants` on the `vote` query — users have no direct FGA grant on the parent vote
     // doc; access is implied by their `vote_response` rows fetched above.
-    const votes = await fetchAllQueryResources<Vote>(
-      req,
-      (pageToken) =>
-        this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-          type: 'vote',
-          filters_or: pendingVoteUids.map((uid) => `vote_uid:${uid}`),
-          ...(pageToken && { page_token: pageToken }),
-        }),
-      { failOnPartial: true }
-    ).catch((error) => {
-      logger.warning(req, 'fetch_pending_votes', 'Failed to fetch vote details, returning empty list', {
-        vote_uid_count: pendingVoteUids.length,
-        err: error,
+    //
+    // Chunk `filters_or` at QUERY_SERVICE_FILTERS_OR_BATCH_SIZE to stay under query-service /
+    // OpenSearch URL-length limits when the user has a large number of pending invitations.
+    // Matches the repo pattern in `committee.service.ts getCommitteesByIds`.
+    const voteBatches: string[][] = [];
+    for (let i = 0; i < pendingVoteUids.length; i += QUERY_SERVICE_FILTERS_OR_BATCH_SIZE) {
+      voteBatches.push(pendingVoteUids.slice(i, i + QUERY_SERVICE_FILTERS_OR_BATCH_SIZE));
+    }
+
+    // Batches are non-overlapping slices of `pendingVoteUids`, so any given vote row can match
+    // at most one batch — no dedupe step needed after the flatten.
+    const votes = await Promise.all(
+      voteBatches.map((batch) =>
+        fetchAllQueryResources<Vote>(
+          req,
+          (pageToken) =>
+            this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+              type: 'vote',
+              filters_or: batch.map((uid) => `vote_uid:${uid}`),
+              ...(pageToken && { page_token: pageToken }),
+            }),
+          { failOnPartial: true }
+        )
+      )
+    )
+      .then((batchResults) => batchResults.flat())
+      .catch((error) => {
+        logger.warning(req, 'fetch_pending_votes', 'Failed to fetch vote details, returning empty list', {
+          vote_uid_count: pendingVoteUids.length,
+          batch_count: voteBatches.length,
+          err: error,
+        });
+        return [] as Vote[];
       });
-      return [] as Vote[];
-    });
 
     const now = Date.now();
     return votes.filter((v) => v.status === PollStatus.ACTIVE && !!v.end_time && new Date(v.end_time).getTime() > now);

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NATS_CONFIG, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
+import { LATEST_PAST_MEETINGS_FETCH_SIZE, LATEST_PAST_MEETINGS_RETURN_LIMIT, NATS_CONFIG, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
 import { NatsSubjects, PollStatus } from '@lfx-one/shared/enums';
 import {
   ActiveWeeksStreakResponse,
@@ -488,7 +488,12 @@ export class UserService {
    * @param req - Express request object
    * @param projectUid - Optional project UID to filter meetings by
    * @param foundationUid - Optional foundation UID to filter meetings by (OR across child projects)
-   * @param options - When `basic: true`, skips RSVP enrichment, project-name enrichment, and access decoration.
+   * @param options - When `basic: true`, skips RSVP enrichment, project-name enrichment, and
+   *   `addAccessToResources` — intended for internal callers that do not surface those fields
+   *   (today: the pending-actions aggregator). Do not use from route handlers that return the
+   *   meeting payload to the frontend, since the `invited: true` decoration in this mode is
+   *   derived from the FGA tuple's existence (`filter_grants=direct`) and is NOT an
+   *   authorization check — it is a data shape marker, not an access decision.
    * @returns Array of Meeting objects the user has some direct FGA grant on
    */
   public async getUserMeetings(req: Request, projectUid?: string, foundationUid?: string, options?: { basic?: boolean }): Promise<Meeting[]> {
@@ -623,12 +628,17 @@ export class UserService {
     });
 
     if (options?.basic) {
+      // `invited: true` reflects that every row has a direct host/participant FGA tuple
+      // (pre-filtered by `filter_grants=direct`) — it is a data-shape marker, not an access
+      // decision. Callers must not treat it as authorization metadata.
       return sortedMeetings.map((m) => ({ ...m, invited: true }));
     }
 
     const enriched = await this.meetingService.getMeetingProjectName(req, sortedMeetings);
 
-    // Every result has a direct host or participant FGA tuple, so the user is invited by definition.
+    // `invited: true` — every row has a direct host/participant FGA tuple by virtue of
+    // `filter_grants=direct`, so the user is invited by definition. Data-shape marker, not an
+    // access decision (the subsequent `addAccessToResources` is the actual access layer).
     const invited = enriched.map((m) => ({ ...m, invited: true }));
 
     return this.accessCheckService.addAccessToResources(req, invited, 'v1_meeting', 'organizer');
@@ -834,18 +844,14 @@ export class UserService {
 
     const projectFilterParams = this.buildProjectScopeFilters(projectUid, foundationProjectUids);
 
-    // Over-fetch so the post-filter step (drop ongoing meetings whose scheduled end is still
-    // in the future) can still yield up to 5 truly-past rows when the top of the sort happens
-    // to include a few in-progress meetings. 10 is a small, bounded buffer.
-    const FETCH_SIZE = 10;
-    const RETURN_LIMIT = 5;
-
+    // See module-level LATEST_PAST_MEETINGS_FETCH_SIZE / RETURN_LIMIT JSDoc for why we
+    // over-fetch here.
     const response = await this.microserviceProxy
       .proxyRequest<QueryServiceResponse<PastMeeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
         type: 'v1_past_meeting',
         filter_grants: 'direct',
         sort: 'name_desc',
-        page_size: FETCH_SIZE,
+        page_size: LATEST_PAST_MEETINGS_FETCH_SIZE,
         ...projectFilterParams,
       })
       .catch((error) => {
@@ -881,7 +887,7 @@ export class UserService {
         const effectiveEnd = this.computeEffectivePastMeetingEnd(meeting);
         return effectiveEnd !== null && effectiveEnd < now;
       })
-      .slice(0, RETURN_LIMIT);
+      .slice(0, LATEST_PAST_MEETINGS_RETURN_LIMIT);
 
     if (filtered.length === 0) {
       return [];

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -799,12 +799,13 @@ export class UserService {
   /**
    * Returns up to 5 most-recent past meetings the user has an FGA grant on.
    * Filters out meetings whose scheduled end has not yet passed. Issues a single query-service
-   * call with `sort=name_desc` + `page_size=5` — the meeting-service indexer populates
-   * `sort_name` with the RFC3339 UTC `start_time`, so the top rows are the most recent. Skips
-   * the participant/attendance scan since the card does not surface `user_attended`. `email`
-   * is accepted for signature parity with `getUserPastMeetings`.
+   * call with `sort=name_desc` + a small over-fetch — the meeting-service indexer populates
+   * `sort_name` with the RFC3339 UTC `start_time`, so the top rows are the most recent. We
+   * request more than 5 so that when the first rows are ongoing (scheduled end still in the
+   * future), we can drop them and still return up to 5 truly-past meetings in one request.
+   * Skips the participant/attendance scan since the card does not surface `user_attended`.
    */
-  public async getUserLatestPastMeetings(req: Request, email: string, projectUid?: string, foundationUid?: string): Promise<PastMeeting[]> {
+  public async getUserLatestPastMeetings(req: Request, projectUid?: string, foundationUid?: string): Promise<PastMeeting[]> {
     logger.debug(req, 'get_user_latest_past_meetings', 'Fetching user latest past meetings via filter_grants=direct + sort=name_desc', {
       has_project_filter: !!projectUid,
       has_foundation_filter: !!foundationUid,
@@ -833,12 +834,18 @@ export class UserService {
 
     const projectFilterParams = this.buildProjectScopeFilters(projectUid, foundationProjectUids);
 
+    // Over-fetch so the post-filter step (drop ongoing meetings whose scheduled end is still
+    // in the future) can still yield up to 5 truly-past rows when the top of the sort happens
+    // to include a few in-progress meetings. 10 is a small, bounded buffer.
+    const FETCH_SIZE = 10;
+    const RETURN_LIMIT = 5;
+
     const response = await this.microserviceProxy
       .proxyRequest<QueryServiceResponse<PastMeeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
         type: 'v1_past_meeting',
         filter_grants: 'direct',
         sort: 'name_desc',
-        page_size: 5,
+        page_size: FETCH_SIZE,
         ...projectFilterParams,
       })
       .catch((error) => {
@@ -869,10 +876,12 @@ export class UserService {
     }));
 
     const now = Date.now();
-    const filtered = normalized.filter((meeting) => {
-      const effectiveEnd = this.computeEffectivePastMeetingEnd(meeting);
-      return effectiveEnd !== null && effectiveEnd < now;
-    });
+    const filtered = normalized
+      .filter((meeting) => {
+        const effectiveEnd = this.computeEffectivePastMeetingEnd(meeting);
+        return effectiveEnd !== null && effectiveEnd < now;
+      })
+      .slice(0, RETURN_LIMIT);
 
     if (filtered.length === 0) {
       return [];
@@ -1074,6 +1083,12 @@ export class UserService {
     projectSlug: string | undefined,
     projectUid: string | undefined
   ): Promise<PendingActionItem[]> {
+    // INFO-level breadcrumb for the unscoped Me-lens path — reads log at DEBUG by default, so
+    // without this the unscoped aggregation path has no prod footprint for capacity planning.
+    if (!projectUid && !projectSlug) {
+      logger.info(req, 'get_user_pending_actions', 'Running unscoped (Me-lens) aggregation', { me_lens: true });
+    }
+
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
 
@@ -1471,7 +1486,9 @@ export class UserService {
     }
     const start = meeting.scheduled_start_time || meeting.start_time;
     const duration = parseToInt(meeting.duration);
-    if (start && duration) {
+    // Explicit nullish / NaN check so a parsed duration of 0 is not treated as "unknown end"
+    // (a zero-minute meeting has effectiveEnd === start, which is still a usable cutoff).
+    if (start && duration !== undefined && duration !== null && !Number.isNaN(duration)) {
       const startMs = new Date(start).getTime();
       if (!Number.isNaN(startMs)) return startMs + duration * 60 * 1000;
     }

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -454,15 +454,25 @@ export class UserService {
    * Get all pending actions for the authenticated user across every persona. A pending action
    * is a pending action regardless of which dashboard the user is viewing — the board-only
    * scoping in the earlier implementation was an MVP artifact, not a principled design choice.
+   *
+   * When `projectUid` and `projectSlug` are omitted, the aggregator runs unscoped across all of
+   * the user's FGA grants (Me-lens). When provided, results are scoped to that project
+   * (project-lens / foundation-lens dashboards).
    * @param req - Express request object
-   * @param projectUid - Project UID for filtering
+   * @param projectUid - Optional project UID; omit for unscoped (all-grants) aggregation
    * @param email - User email
-   * @param projectSlug - Project slug for survey filtering
+   * @param projectSlug - Optional project slug; omit for unscoped survey aggregation
    * @param limit - Optional cap on the response size (aggregator still runs in full;
    *   this just shrinks the payload for callers that only need a top-N view)
    * @returns Array of pending action items
    */
-  public async getPendingActions(req: Request, projectUid: string, email: string, projectSlug: string, limit?: number): Promise<PendingActionItem[]> {
+  public async getPendingActions(
+    req: Request,
+    projectUid: string | undefined,
+    email: string,
+    projectSlug: string | undefined,
+    limit?: number
+  ): Promise<PendingActionItem[]> {
     const actions = await this.getUserPendingActions(req, email, projectSlug, projectUid);
     return limit && limit > 0 && actions.length > limit ? actions.slice(0, limit) : actions;
   }
@@ -478,9 +488,10 @@ export class UserService {
    * @param req - Express request object
    * @param projectUid - Optional project UID to filter meetings by
    * @param foundationUid - Optional foundation UID to filter meetings by (OR across child projects)
+   * @param options - When `basic: true`, skips RSVP enrichment, project-name enrichment, and access decoration.
    * @returns Array of Meeting objects the user has some direct FGA grant on
    */
-  public async getUserMeetings(req: Request, projectUid?: string, foundationUid?: string): Promise<Meeting[]> {
+  public async getUserMeetings(req: Request, projectUid?: string, foundationUid?: string, options?: { basic?: boolean }): Promise<Meeting[]> {
     // .catch — a foundation lookup failure degrades to an empty scope (caught by the empty-set
     // guard below), preventing a NATS/upstream blip from 500'ing the Me lens.
     const foundationProjectUids = foundationUid
@@ -536,50 +547,69 @@ export class UserService {
     // Wrapped in try/catch so an RSVP-lookup failure degrades gracefully: meetings still return,
     // `my_rsvp` stays undefined per row, the dashboard doesn't 500, and the Pending RSVP filter
     // chip just shows the unfiltered list.
-    const rawUsername = await getUsernameFromAuth(req);
-    const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
-    const email = getEffectiveEmail(req) ?? '';
+    if (!options?.basic) {
+      const rawUsername = await getUsernameFromAuth(req);
+      const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
+      const email = getEffectiveEmail(req) ?? '';
 
-    if ((email || username) && meetings.length > 0) {
-      try {
-        const [userRsvps, activeRegistrantIds] = await Promise.all([
-          this.fetchAllUserRsvps(req, email, username),
-          this.fetchUserActiveRegistrantIds(req, email, username),
-        ]);
+      if ((email || username) && meetings.length > 0) {
+        try {
+          const [userRsvps, activeRegistrantIds] = await Promise.all([
+            this.fetchAllUserRsvps(req, email, username),
+            this.fetchUserActiveRegistrantIds(req, email, username),
+          ]);
 
-        // Strongest-response-wins (accepted/declined beats maybe beats nothing) — same logic as
-        // `transformMissingRsvpsToActions`. Drop RSVPs whose `registrant_id` isn't in the active
-        // set; otherwise stale RSVPs from removed registrations would falsely mark meetings as
-        // "responded".
-        const rsvpByMeeting = new Map<string, MeetingRsvp>();
-        for (const rsvp of userRsvps) {
-          if (!rsvp.meeting_id) continue;
-          if (!rsvp.registrant_id || !activeRegistrantIds.has(rsvp.registrant_id)) continue;
-          const existing = rsvpByMeeting.get(rsvp.meeting_id);
-          if (!existing || (existing.response_type === 'maybe' && rsvp.response_type !== 'maybe')) {
-            rsvpByMeeting.set(rsvp.meeting_id, rsvp);
+          // Strongest-response-wins (accepted/declined beats maybe beats nothing) — same logic as
+          // `transformMissingRsvpsToActions`. Drop RSVPs whose `registrant_id` isn't in the active
+          // set; otherwise stale RSVPs from removed registrations would falsely mark meetings as
+          // "responded".
+          const rsvpByMeeting = new Map<string, MeetingRsvp>();
+          for (const rsvp of userRsvps) {
+            if (!rsvp.meeting_id) continue;
+            if (!rsvp.registrant_id || !activeRegistrantIds.has(rsvp.registrant_id)) continue;
+            const existing = rsvpByMeeting.get(rsvp.meeting_id);
+            if (!existing || (existing.response_type === 'maybe' && rsvp.response_type !== 'maybe')) {
+              rsvpByMeeting.set(rsvp.meeting_id, rsvp);
+            }
           }
-        }
 
-        for (const meeting of meetings) {
-          if (meeting.id) {
-            meeting.my_rsvp = rsvpByMeeting.get(meeting.id) ?? null;
+          for (const meeting of meetings) {
+            if (meeting.id) {
+              meeting.my_rsvp = rsvpByMeeting.get(meeting.id) ?? null;
+            }
           }
+        } catch (error) {
+          logger.warning(req, 'get_user_meetings', 'RSVP enrichment failed, continuing without my_rsvp', {
+            err: error,
+          });
         }
-      } catch (error) {
-        logger.warning(req, 'get_user_meetings', 'RSVP enrichment failed, continuing without my_rsvp', {
-          err: error,
-        });
       }
     }
 
     // Drop past meetings; recurring meetings survive if any occurrence is still active.
-    const upcomingMeetings = meetings.filter((meeting) => {
-      if (meeting.occurrences && meeting.occurrences.length > 0) {
-        return meeting.occurrences.some((occurrence) => occurrence.status !== 'cancel' && !hasMeetingEnded(meeting, occurrence));
-      }
-      return !hasMeetingEnded(meeting);
-    });
+    // Basic mode powers pending-actions aggregation, where a completed meeting can't yield an
+    // actionable RSVP/agenda nag — so the 40-minute grace `hasMeetingEnded` allows doesn't apply.
+    const upcomingMeetings = options?.basic
+      ? meetings.filter((meeting) => {
+          const now = Date.now();
+          if (meeting.occurrences && meeting.occurrences.length > 0) {
+            return meeting.occurrences.some((occ) => {
+              if (occ.status === 'cancel') return false;
+              const startMs = new Date(occ.start_time).getTime();
+              const durationMinutes = parseToInt(occ.duration) ?? parseToInt(meeting.duration) ?? 0;
+              return now < startMs + durationMinutes * 60 * 1000;
+            });
+          }
+          const startMs = new Date(meeting.start_time).getTime();
+          const durationMinutes = parseToInt(meeting.duration) ?? 0;
+          return now < startMs + durationMinutes * 60 * 1000;
+        })
+      : meetings.filter((meeting) => {
+          if (meeting.occurrences && meeting.occurrences.length > 0) {
+            return meeting.occurrences.some((occurrence) => occurrence.status !== 'cancel' && !hasMeetingEnded(meeting, occurrence));
+          }
+          return !hasMeetingEnded(meeting);
+        });
 
     // Sort by the next active occurrence so recurring meetings — whose meeting.start_time is the
     // series start (often in the past) — are ordered by when the user will actually attend next.
@@ -591,6 +621,10 @@ export class UserService {
       const timeB = occurrenceB ? new Date(occurrenceB.start_time).getTime() : new Date(b.start_time).getTime();
       return timeA - timeB;
     });
+
+    if (options?.basic) {
+      return sortedMeetings.map((m) => ({ ...m, invited: true }));
+    }
 
     const enriched = await this.meetingService.getMeetingProjectName(req, sortedMeetings);
 
@@ -682,6 +716,7 @@ export class UserService {
           this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
             type: 'v1_past_meeting',
             filter_grants: 'direct',
+            sort: 'name_desc',
             page_size: 500,
             ...projectFilterParams,
             ...(pageToken && { page_token: pageToken }),
@@ -717,12 +752,25 @@ export class UserService {
       id: m.meeting_and_occurrence_id,
     }));
 
+    const now = Date.now();
+    const pastOnly = normalizedMeetings.filter((meeting) => {
+      const effectiveEnd = this.computeEffectivePastMeetingEnd(meeting);
+      return effectiveEnd !== null && effectiveEnd < now;
+    });
+
+    if (normalizedMeetings.length - pastOnly.length > 0) {
+      logger.debug(req, 'get_user_past_meetings', 'Filtered out ongoing meetings', {
+        filtered_out: normalizedMeetings.length - pastOnly.length,
+        remaining: pastOnly.length,
+      });
+    }
+
     logger.debug(req, 'get_user_past_meetings', 'Fetched past meetings from query service', {
-      count: normalizedMeetings.length,
+      count: pastOnly.length,
       participant_matches: participants.length,
     });
 
-    if (normalizedMeetings.length === 0) {
+    if (pastOnly.length === 0) {
       return [];
     }
 
@@ -738,16 +786,99 @@ export class UserService {
         const prior = userAttendedByOccurrenceId.get(p.meeting_and_occurrence_id) ?? false;
         userAttendedByOccurrenceId.set(p.meeting_and_occurrence_id, prior || !!p.is_attended);
       }
-      for (const meeting of normalizedMeetings) {
+      for (const meeting of pastOnly) {
         meeting.user_attended = userAttendedByOccurrenceId.get(meeting.id) ?? false;
       }
     }
 
-    // Sort by scheduled_start_time descending (most recent first)
-    normalizedMeetings.sort((a, b) => new Date(b.scheduled_start_time ?? b.start_time).getTime() - new Date(a.scheduled_start_time ?? a.start_time).getTime());
+    const enriched = await this.meetingService.getMeetingProjectName(req, pastOnly);
 
-    const enriched = await this.meetingService.getMeetingProjectName(req, normalizedMeetings);
+    return this.accessCheckService.addAccessToResources(req, enriched, 'v1_past_meeting', 'organizer');
+  }
 
+  /**
+   * Returns up to 5 most-recent past meetings the user has an FGA grant on.
+   * Filters out meetings whose scheduled end has not yet passed. Issues a single query-service
+   * call with `sort=name_desc` + `page_size=5` — the meeting-service indexer populates
+   * `sort_name` with the RFC3339 UTC `start_time`, so the top rows are the most recent. Skips
+   * the participant/attendance scan since the card does not surface `user_attended`. `email`
+   * is accepted for signature parity with `getUserPastMeetings`.
+   */
+  public async getUserLatestPastMeetings(req: Request, email: string, projectUid?: string, foundationUid?: string): Promise<PastMeeting[]> {
+    logger.debug(req, 'get_user_latest_past_meetings', 'Fetching user latest past meetings via filter_grants=direct + sort=name_desc', {
+      has_project_filter: !!projectUid,
+      has_foundation_filter: !!foundationUid,
+    });
+
+    // .catch — a foundation lookup failure degrades to an empty scope (caught by the empty-set
+    // guard below), preventing a NATS/upstream blip from 500'ing the Me lens.
+    const foundationProjectUids = foundationUid
+      ? await this.projectService
+          .getFoundationProjectUids(req, foundationUid)
+          .then((uids) => new Set(uids))
+          .catch((error) => {
+            logger.warning(req, 'get_user_latest_past_meetings', 'Foundation project lookup failed, treating as empty scope', { err: error });
+            return new Set<string>();
+          })
+      : undefined;
+
+    // Foundation filter requested but resolved to zero child projects: short-circuit before the
+    // helper collapses to unfiltered (global) scope.
+    if (foundationUid && foundationProjectUids !== undefined && foundationProjectUids.size === 0) {
+      logger.debug(req, 'get_user_latest_past_meetings', 'Foundation scope resolved to empty set, returning empty list', {
+        foundation_uid: foundationUid,
+      });
+      return [];
+    }
+
+    const projectFilterParams = this.buildProjectScopeFilters(projectUid, foundationProjectUids);
+
+    const response = await this.microserviceProxy
+      .proxyRequest<QueryServiceResponse<PastMeeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'v1_past_meeting',
+        filter_grants: 'direct',
+        sort: 'name_desc',
+        page_size: 5,
+        ...projectFilterParams,
+      })
+      .catch((error) => {
+        logger.warning(req, 'get_user_latest_past_meetings', 'Past meeting query failed, returning empty list', {
+          err: error,
+        });
+        return null;
+      });
+
+    if (!response || !response.resources || response.resources.length === 0) {
+      return [];
+    }
+
+    const rows = response.resources.map((r) => r.data);
+
+    const indexable = rows.filter((m): m is PastMeeting & { meeting_and_occurrence_id: string } => !!m.meeting_and_occurrence_id);
+    const droppedCount = rows.length - indexable.length;
+    if (droppedCount > 0) {
+      logger.warning(req, 'get_user_latest_past_meetings', 'Dropped past meeting rows missing meeting_and_occurrence_id', {
+        dropped: droppedCount,
+        total: rows.length,
+      });
+    }
+
+    const normalized = indexable.map((m) => ({
+      ...m,
+      id: m.meeting_and_occurrence_id,
+    }));
+
+    const now = Date.now();
+    const filtered = normalized.filter((meeting) => {
+      const effectiveEnd = this.computeEffectivePastMeetingEnd(meeting);
+      return effectiveEnd !== null && effectiveEnd < now;
+    });
+
+    if (filtered.length === 0) {
+      return [];
+    }
+
+    const enriched = await this.meetingService.getMeetingProjectName(req, filtered);
     return this.accessCheckService.addAccessToResources(req, enriched, 'v1_past_meeting', 'organizer');
   }
 
@@ -925,16 +1056,24 @@ export class UserService {
   }
 
   /**
-   * Aggregate pending actions for the current user within a project scope. Sources run in parallel
+   * Aggregate pending actions for the current user. Sources run in parallel
    * with per-source `.catch(() => [])` so one flaky source can't wipe the list:
    *   - Non-responded surveys (Snowflake)
    *   - Upcoming meetings within the next two weeks (Review Agenda action)
    *   - Active votes the user hasn't cast (Cast Vote action)
    *   - Missing RSVPs for meetings in the 2-week window (Set RSVP action)
-   * No meeting-type filter — a working-group meeting next week is as much a pending action as
-   * a board meeting.
+   *
+   * When `projectSlug` / `projectUid` are omitted, every source runs user-scoped across all of
+   * the user's FGA grants (Me-lens single unscoped request). When provided, every source is
+   * filtered to that project (project/foundation-lens). No meeting-type filter — a working-group
+   * meeting next week is as much a pending action as a board meeting.
    */
-  private async getUserPendingActions(req: Request, email: string, projectSlug: string, projectUid: string): Promise<PendingActionItem[]> {
+  private async getUserPendingActions(
+    req: Request,
+    email: string,
+    projectSlug: string | undefined,
+    projectUid: string | undefined
+  ): Promise<PendingActionItem[]> {
     const rawUsername = await getUsernameFromAuth(req);
     const username = rawUsername ? stripAuthPrefix(rawUsername) : null;
 
@@ -945,12 +1084,12 @@ export class UserService {
         return [];
       }),
 
-      this.getUserMeetings(req, projectUid).catch((error) => {
+      this.getUserMeetings(req, projectUid, undefined, { basic: true }).catch((error) => {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch user meetings for pending actions', { err: error });
         return [] as Meeting[];
       }),
 
-      this.fetchPendingVotes(req, email, username, projectUid).catch((error) => {
+      this.fetchPendingVotes(req, projectUid).catch((error) => {
         logger.warning(req, 'get_user_pending_actions', 'Failed to fetch pending votes', { err: error });
         return [] as Vote[];
       }),
@@ -994,21 +1133,22 @@ export class UserService {
    * `individual_vote` type was fabricated in the shared interface and the query returned zero
    * rows in practice.
    *
-   * ITX creates a `vote_response` record per invitee on poll initiation and stamps
-   * `vote_status='submitted'` once the user actually casts. "Pending" is therefore:
-   *   - `vote_status !== 'submitted'`  (not cast yet)
-   *   - `!voter_removed`               (active invitation)
-   *   - scoped to the current project
-   * Then fetch the Vote details and keep only those still `active` with an `end_time` in the
-   * future.
+   * Source rows come from `filter_grants=direct` on `vote_response` — the voting service writes
+   * a direct `owner = user:{username}` FGA tuple per invitee, so the query service pre-filters
+   * OpenSearch to exactly this user's rows. When `projectUid` is provided it is pushed
+   * server-side to drop out-of-scope rows before pagination; when omitted, the unscoped Me-lens
+   * call already gets exactly the user's vote_response rows across all their projects via
+   * `filter_grants=direct`. The remaining `vote_status !== 'submitted'` and `!voter_removed`
+   * checks stay client-side. Caveat: the FGA tuple is only emitted when the invitee has a
+   * non-empty `Username`, so users invited by email but without an Auth0 username won't appear
+   * here. We accept this trade-off — meetings already work the same way and FGA is the source
+   * of truth for invitations.
+   *
+   * Parent `vote` rows are fetched in a single batched query-service call (`type=vote` + `filters_or`
+   * on each pending `vote_uid`) instead of per-vote REST. The indexed `vote` doc carries `name`,
+   * `end_time`, and `status` — everything the `transformVotesToActions` consumer needs.
    */
-  private async fetchPendingVotes(req: Request, email: string, username: string | null, projectUid: string): Promise<Vote[]> {
-    const normalizedEmail = email ? email.trim().toLowerCase() : '';
-    const orClauses: string[] = [];
-    if (normalizedEmail) orClauses.push(`user_email:${normalizedEmail}`);
-    if (username) orClauses.push(`username:${username}`);
-    if (orClauses.length === 0) return [];
-
+  private async fetchPendingVotes(req: Request, projectUid?: string): Promise<Vote[]> {
     interface VoteResponseRow {
       vote_uid?: string;
       vote_id?: string;
@@ -1025,7 +1165,8 @@ export class UserService {
       (pageToken) =>
         this.microserviceProxy.proxyRequest<QueryServiceResponse<VoteResponseRow>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
           type: 'vote_response',
-          filters_or: orClauses,
+          filter_grants: 'direct',
+          ...(projectUid && { filters: [`project_uid:${projectUid}`] }),
           ...(pageToken && { page_token: pageToken }),
         }),
       { failOnPartial: true }
@@ -1036,27 +1177,34 @@ export class UserService {
     const pendingVoteUids = Array.from(
       new Set(
         responses
-          .filter((r) => r.vote_status !== 'submitted' && !r.voter_removed && r.project_uid === projectUid)
+          .filter((r) => r.vote_status !== 'submitted' && !r.voter_removed)
           .map((r) => r.vote_uid ?? r.poll_id)
           .filter((uid): uid is string => !!uid)
       )
     );
     if (pendingVoteUids.length === 0) return [];
 
-    const now = Date.now();
-    const votes = await Promise.all(
-      pendingVoteUids.map((uid) =>
-        this.microserviceProxy.proxyRequest<Vote>(req, 'LFX_V2_SERVICE', `/votes/${uid}`, 'GET').catch((error) => {
-          logger.warning(req, 'fetch_pending_votes', 'Failed to fetch vote details, skipping', {
-            vote_uid: uid,
-            err: error,
-          });
-          return null;
-        })
-      )
-    );
+    // No `filter_grants` on the `vote` query — users have no direct FGA grant on the parent vote
+    // doc; access is implied by their `vote_response` rows fetched above.
+    const votes = await fetchAllQueryResources<Vote>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'vote',
+          filters_or: pendingVoteUids.map((uid) => `vote_uid:${uid}`),
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      { failOnPartial: true }
+    ).catch((error) => {
+      logger.warning(req, 'fetch_pending_votes', 'Failed to fetch vote details, returning empty list', {
+        vote_uid_count: pendingVoteUids.length,
+        err: error,
+      });
+      return [] as Vote[];
+    });
 
-    return votes.filter((v): v is Vote => v !== null && v.status === PollStatus.ACTIVE && !!v.end_time && new Date(v.end_time).getTime() > now);
+    const now = Date.now();
+    return votes.filter((v) => v.status === PollStatus.ACTIVE && !!v.end_time && new Date(v.end_time).getTime() > now);
   }
 
   /**
@@ -1185,7 +1333,7 @@ export class UserService {
         day: 'numeric',
       });
       return {
-        type: 'Cast Vote',
+        type: 'Vote',
         badge,
         text: `Cast your vote on ${vote.name}`,
         icon: 'fa-regular fa-check-to-slot',
@@ -1223,7 +1371,7 @@ export class UserService {
     const buttonLink = queryString ? `/meetings/${meeting.id}?${queryString}` : `/meetings/${meeting.id}`;
 
     return {
-      type: 'Set RSVP',
+      type: 'RSVP',
       badge,
       text: `RSVP to ${meeting.title}`,
       icon: 'fa-regular fa-calendar-check',
@@ -1245,20 +1393,21 @@ export class UserService {
 
     for (const meeting of meetings) {
       if (meeting.occurrences && meeting.occurrences.length > 0) {
-        // Filter active occurrences (not cancelled)
-        const activeOccurrences = meeting.occurrences.filter((occ) => occ.status !== 'cancel');
+        // Recurring meetings emit at most one Agenda action — the earliest in-window occurrence.
+        // Otherwise a weekly series fills the 5-row card with duplicates of the same agenda.
+        const nextInWindow = meeting.occurrences
+          .filter((occ) => occ.status !== 'cancel')
+          .map((occurrence) => {
+            const startTime = new Date(occurrence.start_time);
+            const durationMinutes = parseToInt(occurrence.duration) ?? parseToInt(meeting.duration) ?? 0;
+            const meetingEndWithBuffer = new Date(startTime.getTime() + (durationMinutes + this.bufferMinutes) * 60 * 1000);
+            return { occurrence, startTime, meetingEndWithBuffer };
+          })
+          .filter(({ startTime, meetingEndWithBuffer }) => now < meetingEndWithBuffer && startTime <= twoWeeksFromNow)
+          .sort((a, b) => a.startTime.getTime() - b.startTime.getTime())[0];
 
-        for (const occurrence of activeOccurrences) {
-          const startTime = new Date(occurrence.start_time);
-          // Parse duration handling both string and number types (v1 meetings return strings)
-          const durationMinutes = parseToInt(occurrence.duration) ?? parseToInt(meeting.duration) ?? 0;
-          // Calculate meeting end time + buffer
-          const meetingEndWithBuffer = new Date(startTime.getTime() + (durationMinutes + this.bufferMinutes) * 60 * 1000);
-
-          // Only include if meeting hasn't ended (with buffer) and is within 2 weeks
-          if (now < meetingEndWithBuffer && startTime <= twoWeeksFromNow) {
-            actions.push(this.createMeetingAction(meeting, occurrence));
-          }
+        if (nextInWindow) {
+          actions.push(this.createMeetingAction(meeting, nextInWindow.occurrence));
         }
       } else {
         const startTime = new Date(meeting.start_time);
@@ -1304,7 +1453,7 @@ export class UserService {
     const buttonLink = queryString ? `/meetings/${meeting.id}?${queryString}` : `/meetings/${meeting.id}`;
 
     return {
-      type: 'Review Agenda',
+      type: 'Agenda',
       badge: dateStr,
       text: `Review ${title} Agenda and Materials`,
       icon: 'fa-light fa-calendar-check',
@@ -1313,6 +1462,20 @@ export class UserService {
       buttonLink,
       date: formattedDate,
     };
+  }
+
+  private computeEffectivePastMeetingEnd(meeting: PastMeeting): number | null {
+    if (meeting.scheduled_end_time) {
+      const scheduledEnd = new Date(meeting.scheduled_end_time).getTime();
+      if (!Number.isNaN(scheduledEnd)) return scheduledEnd;
+    }
+    const start = meeting.scheduled_start_time || meeting.start_time;
+    const duration = parseToInt(meeting.duration);
+    if (start && duration) {
+      const startMs = new Date(start).getTime();
+      if (!Number.isNaN(startMs)) return startMs + duration * 60 * 1000;
+    }
+    return null;
   }
 
   /**

--- a/packages/shared/src/constants/api.constants.ts
+++ b/packages/shared/src/constants/api.constants.ts
@@ -15,6 +15,14 @@ export const DEFAULT_QUERY_PARAMS: Record<string, string> = {
 };
 
 /**
+ * Maximum number of `filters_or` clauses per query-service request.
+ * @description URL-length guard for batched lookups on `/query/resources`. When the caller has
+ * more than this many IDs/values to OR together, split into chunks of this size to keep each
+ * request URL under OpenSearch/query-service limits.
+ */
+export const QUERY_SERVICE_FILTERS_OR_BATCH_SIZE = 100;
+
+/**
  * NATS configuration constants
  * @description Configuration for NATS messaging system used for inter-service communication
  * @readonly

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -516,11 +516,12 @@ export { MEETING_TEMPLATES } from './meeting-templates';
  * Over-fetch size for the "latest past meetings" fast-path (Me-lens dashboard card).
  * @description The `v1_past_meeting` index includes meetings as soon as they START (not when
  * they END), so rows at the top of `sort=name_desc` may be in-progress. The aggregator
- * over-fetches this many rows, drops ongoing meetings via `scheduled_end_time < now`, then
- * slices down to `LATEST_PAST_MEETINGS_RETURN_LIMIT`. The buffer (FETCH - RETURN) bounds the
- * number of concurrently-ongoing meetings we tolerate near the head of the sort — if more
- * than that many are ongoing for a single user, we return fewer than the limit rather than
- * paginating full history.
+ * over-fetches this many rows, drops ongoing meetings by filtering on each meeting's
+ * effective end time (`scheduled_end_time` when present, otherwise start time + duration),
+ * then slices down to `LATEST_PAST_MEETINGS_RETURN_LIMIT`. The buffer (FETCH - RETURN) bounds
+ * the number of concurrently-ongoing meetings we tolerate near the head of the sort — if
+ * more than that many are ongoing for a single user, we return fewer than the limit rather
+ * than paginating full history.
  */
 export const LATEST_PAST_MEETINGS_FETCH_SIZE = 10;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -507,3 +507,25 @@ export const MEETING_DURATION_OPTIONS = [
  * @description Re-exported from meeting-templates/index.ts for convenient access
  */
 export { MEETING_TEMPLATES } from './meeting-templates';
+
+// ============================================================================
+// Latest Past Meetings Fast-Path
+// ============================================================================
+
+/**
+ * Over-fetch size for the "latest past meetings" fast-path (Me-lens dashboard card).
+ * @description The `v1_past_meeting` index includes meetings as soon as they START (not when
+ * they END), so rows at the top of `sort=name_desc` may be in-progress. The aggregator
+ * over-fetches this many rows, drops ongoing meetings via `scheduled_end_time < now`, then
+ * slices down to `LATEST_PAST_MEETINGS_RETURN_LIMIT`. The buffer (FETCH - RETURN) bounds the
+ * number of concurrently-ongoing meetings we tolerate near the head of the sort — if more
+ * than that many are ongoing for a single user, we return fewer than the limit rather than
+ * paginating full history.
+ */
+export const LATEST_PAST_MEETINGS_FETCH_SIZE = 10;
+
+/**
+ * Maximum rows returned by the "latest past meetings" fast-path after the ongoing-meeting
+ * filter. Five is the row count surfaced by the dashboard Last Meeting / past-meetings card.
+ */
+export const LATEST_PAST_MEETINGS_RETURN_LIMIT = 5;

--- a/packages/shared/src/constants/snowflake.constant.ts
+++ b/packages/shared/src/constants/snowflake.constant.ts
@@ -60,3 +60,14 @@ export const SNOWFLAKE_CONFIG = {
    */
   MAX_RETRIES: 3,
 } as const;
+
+/**
+ * Row cap for the pending-surveys query in `getPendingActionSurveys`.
+ * @description When the Me-lens path calls this without a `PROJECT_SLUG` predicate, Snowflake
+ * would otherwise filter only by `EMAIL`, widening the micro-partition scan for users enrolled
+ * in many projects. Pairing the existing `ORDER BY SURVEY_CUTOFF_DATE ASC` with this cap keeps
+ * the 50 most-urgent pending surveys — far more than the dashboard surfaces today (≤10 rows)
+ * — while bounding compute on the unscoped path. The same cap applies to the scoped path; a
+ * single user is extremely unlikely to have >50 open surveys within a single project.
+ */
+export const PENDING_ACTION_SURVEYS_ROW_LIMIT = 50;


### PR DESCRIPTION
## Summary

Performance pass on pending actions + user meetings dashboards. The Me lens and the multi-persona dashboard now aggregate via FGA-direct grants in a single request instead of fanning out per foundation, and per-vote REST is replaced with a single batched query-service call.

### Backend

- **Pending actions aggregator is now scope-optional** (`projectUid`/`projectSlug`/`persona` all optional). Omitted → runs unscoped across the user's FGA grants (Me lens). Provided → scoped to project/foundation lens.
- **`fetchPendingVotes` rewritten**: drops the client-side `user_email` / `username` OR-clause and uses `filter_grants=direct` on `vote_response` (the voting service emits a direct FGA tuple per invitee, so OpenSearch pre-filters to this user's rows). Parent `vote` docs are fetched in a single batched query-service call (`type=vote` + `filters_or` on pending `vote_uid`s) instead of N per-vote REST calls. Caveat: the FGA tuple is only emitted when the invitee has a non-empty username — same trade-off meetings already accept, and FGA is the source of truth for invitations.
- **`getUserMeetings` grows a `basic: true` option** — skips RSVP enrichment, project-name enrichment, and access decoration when called from the pending-actions aggregator (the aggregator doesn't need any of that).
- **New `/api/user/latest-past-meetings` fast-path** — uses the meeting-service indexer's `sort_name` = RFC3339 `start_time` with `sort=name_desc` + `page_size=5` to return the 5 most-recent past meetings without paginating full history. Filters out meetings whose scheduled end hasn't actually passed yet.
- **Past meeting filter drops ongoing meetings**, and **agenda actions for recurring meetings** now emit at most one entry per series (the earliest in-window occurrence) instead of filling the 5-row card with duplicate agendas of the same weekly series.
- **Survey action queries are scope-optional** (`projectSlug` optional on Snowflake query).

### Frontend

- Multi-persona dashboard collapses from N foundation-scoped `forkJoin` fan-outs to one unscoped `projectService.getPendingActions()` call.
- User dashboard similarly drops the project-context subscription.
- `my-meetings` uses the new `/latest-past-meetings` fast-path and replaces client-side past-meeting sorting with server-authoritative ordering. "Next Meeting" picks imminent (≤10 min out) or in-progress meetings over strict chronological first, with a "+N overlapping" hint when multiple meetings collide with the displayed one.
- `meetings-dashboard` drops its client-side past-meeting sort — the meeting-service indexer sorts on `start_time` now.
- Pending-action tag labels shortened: `Cast Vote → Vote`, `Set RSVP → RSVP`, `Submit Feedback → Survey`; pending-actions row widens the label column to fit.
- `meeting-join` suppresses `root` as a parent in the project breadcrumb.
- Dashboard meeting-card clipboard copy uses `window.location.origin + href` so the copied URL is shareable.

## External references

- Depends on FGA tuples emitted by [lfx-v2-voting-service](https://github.com/linuxfoundation/lfx-v2-voting-service) for `vote_response` resources — those are already in place.
- Relies on `sort_name` being populated from `start_time` in the [lfx-v2-meeting-service](https://github.com/linuxfoundation/lfx-v2-meeting-service) indexer (already shipped).