### PR TITLE
fix(meetings): handle registrants drawer closing and show invited count

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -720,8 +720,8 @@
     </div>
 
     <!-- Meeting Registrants Drawer (rendered outside the card so PrimeNG's overlay/mask isn't
-         re-parented under p-card's body, which causes the drawer to close itself when the
-         opening click bubbles back through the card's content tree). -->
+         re-parented under lfx-card's content tree, which causes the drawer to close itself
+         when the opening click bubbles back through that subtree). -->
     <p-drawer
       [(visible)]="showRegistrants"
       [position]="drawerPosition()"
@@ -738,7 +738,7 @@
             @if (isPastMeeting()) {
               <div class="flex flex-col">
                 <h1>Meeting Participants</h1>
-                <span class="text-base text-gray-500">{{ attendedCount() }} attended / {{ pastMeetingInvitedCount() }} invited</span>
+                <span class="text-base text-gray-500">{{ attendedCount() }} attended / {{ invitedCount() }} invited</span>
               </div>
             } @else if (meeting().committees?.length) {
               <div class="flex flex-col">

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -486,54 +486,6 @@
             }
           </div>
 
-          <!-- Meeting Registrants Drawer (shown for organizers and invited users) -->
-
-          <p-drawer
-            [(visible)]="showRegistrants"
-            [position]="drawerPosition()"
-            styleClass="xl:w-1/4 lg:w-1/3 md:w-5/12 sm:w-1/2 w-full"
-            [modal]="true"
-            [showCloseIcon]="false"
-            data-testid="meeting-registrants-drawer">
-            <ng-template #header>
-              <div class="flex items-center justify-between w-full">
-                <div class="flex items-center gap-3">
-                  <div class="bg-blue-600 text-white rounded-full w-12 h-12 flex items-center justify-center">
-                    <i class="fa-light fa-user-group text-white text-2xl"></i>
-                  </div>
-                  @if (isPastMeeting()) {
-                    <div class="flex flex-col">
-                      <h1>Meeting Participants</h1>
-                      <span class="text-base text-gray-500">{{ participantCount() }} participants</span>
-                    </div>
-                  } @else if (meeting().committees && meeting().committees.length > 0) {
-                    <div class="flex flex-col">
-                      <h1>Meeting Members</h1>
-                      <span class="text-base text-gray-500">{{ totalInvitees() }} members</span>
-                    </div>
-                  } @else {
-                    <div class="flex flex-col">
-                      <h1>Meeting Guests</h1>
-                      <span class="text-base text-gray-500">{{ totalInvitees() }} guests</span>
-                    </div>
-                  }
-                </div>
-                <button type="button" class="text-gray-400 hover:text-gray-600 p-2 cursor-pointer" (click)="onDrawerHide()" aria-label="Close panel">
-                  <i class="fa-light fa-xmark text-xl"></i>
-                </button>
-              </div>
-            </ng-template>
-            <lfx-meeting-registrants-display
-              [meeting]="meeting()"
-              [pastMeeting]="isPastMeeting()"
-              [showAddRegistrant]="!!meeting().organizer && !isPastMeeting()"
-              [myMeetingRegistrants]="true"
-              [initialRegistrants]="registrants()"
-              [initialRegistrantsLoading]="registrantsLoading()"
-              [visible]="showRegistrants()"
-              (refreshRequested)="onRegistrantsRefreshRequested($event)">
-            </lfx-meeting-registrants-display>
-          </p-drawer>
           @if (!(isPastMeeting() && !pastMeetingFullAccess())) {
             <!-- Divider -->
             <hr class="border-gray-200 my-4" />
@@ -766,6 +718,56 @@
         </lfx-card>
       </div>
     </div>
+
+    <!-- Meeting Registrants Drawer (rendered outside the card so PrimeNG's overlay/mask isn't
+         re-parented under p-card's body, which causes the drawer to close itself when the
+         opening click bubbles back through the card's content tree). -->
+    <p-drawer
+      [(visible)]="showRegistrants"
+      [position]="drawerPosition()"
+      styleClass="xl:w-1/4 lg:w-1/3 md:w-5/12 sm:w-1/2 w-full"
+      [modal]="true"
+      [showCloseIcon]="false"
+      data-testid="meeting-registrants-drawer">
+      <ng-template #header>
+        <div class="flex items-center justify-between w-full">
+          <div class="flex items-center gap-3">
+            <div class="bg-blue-600 text-white rounded-full w-12 h-12 flex items-center justify-center">
+              <i class="fa-light fa-user-group text-white text-2xl"></i>
+            </div>
+            @if (isPastMeeting()) {
+              <div class="flex flex-col">
+                <h1>Meeting Participants</h1>
+                <span class="text-base text-gray-500">{{ attendedCount() }} attended / {{ pastMeetingInvitedCount() }} invited</span>
+              </div>
+            } @else if (meeting().committees && meeting().committees.length > 0) {
+              <div class="flex flex-col">
+                <h1>Meeting Members</h1>
+                <span class="text-base text-gray-500">{{ totalInvitees() }} members</span>
+              </div>
+            } @else {
+              <div class="flex flex-col">
+                <h1>Meeting Guests</h1>
+                <span class="text-base text-gray-500">{{ totalInvitees() }} guests</span>
+              </div>
+            }
+          </div>
+          <button type="button" class="text-gray-400 hover:text-gray-600 p-2 cursor-pointer" (click)="onDrawerHide()" aria-label="Close panel">
+            <i class="fa-light fa-xmark text-xl"></i>
+          </button>
+        </div>
+      </ng-template>
+      <lfx-meeting-registrants-display
+        [meeting]="meeting()"
+        [pastMeeting]="isPastMeeting()"
+        [showAddRegistrant]="!!meeting().organizer && !isPastMeeting()"
+        [myMeetingRegistrants]="true"
+        [initialRegistrants]="registrants()"
+        [initialRegistrantsLoading]="registrantsLoading()"
+        [visible]="showRegistrants()"
+        (refreshRequested)="onRegistrantsRefreshRequested($event)">
+      </lfx-meeting-registrants-display>
+    </p-drawer>
 
     <!-- Meeting Materials Drawer -->
     @if (meeting().organizer && !isPastMeeting()) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -740,7 +740,7 @@
                 <h1>Meeting Participants</h1>
                 <span class="text-base text-gray-500">{{ attendedCount() }} attended / {{ pastMeetingInvitedCount() }} invited</span>
               </div>
-            } @else if (meeting().committees && meeting().committees.length > 0) {
+            } @else if (meeting().committees?.length) {
               <div class="flex flex-col">
                 <h1>Meeting Members</h1>
                 <span class="text-base text-gray-500">{{ totalInvitees() }} members</span>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -216,7 +216,7 @@ export class MeetingJoinComponent implements OnInit {
   protected participantCount = computed(() => this.pastMeetingParticipants().length);
   protected attendedCount = computed(() => this.pastMeetingParticipants().filter((p) => p.is_attended).length);
   protected absentCount = computed(() => this.participantCount() - this.attendedCount());
-  protected pastMeetingInvitedCount = computed(() => this.pastMeetingParticipants().filter((p) => p.is_invited).length);
+  protected invitedCount = computed(() => this.pastMeetingParticipants().filter((p) => p.is_invited).length);
   protected attendancePercentage = computed(() => {
     const total = this.participantCount();
     const attended = this.attendedCount();

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -215,6 +215,7 @@ export class MeetingJoinComponent implements OnInit {
   protected participantCount = computed(() => this.pastMeetingParticipants().length);
   protected attendedCount = computed(() => this.pastMeetingParticipants().filter((p) => p.is_attended).length);
   protected absentCount = computed(() => this.participantCount() - this.attendedCount());
+  protected pastMeetingInvitedCount = computed(() => this.pastMeetingParticipants().filter((p) => p.is_invited).length);
   protected attendancePercentage = computed(() => {
     const total = this.participantCount();
     const attended = this.attendedCount();


### PR DESCRIPTION
# Summary

This pull request refactors the placement and logic of the Meeting Registrants Drawer in the `meeting-join` component. The main goal is to render the drawer outside the meeting card to prevent overlay issues and to improve the display of participant counts for past meetings. The changes also introduce a new computed property for the number of invited participants in past meetings.

**UI Refactor and Bug Fixes:**

* Moved the `<p-drawer>` for meeting registrants outside the main meeting card in `meeting-join.component.html` to prevent PrimeNG's overlay/mask from being incorrectly re-parented, which previously caused the drawer to close unintentionally. [[1]](diffhunk://#diff-d562f941fd79a04e5588ac49e82090af5ea411cd9d17f02e75450fef91fbfedbL489-L536) [[2]](diffhunk://#diff-d562f941fd79a04e5588ac49e82090af5ea411cd9d17f02e75450fef91fbfedbR722-R771)

**Display and Logic Improvements:**

* Updated the drawer's header for past meetings to show both the number of attendees and the number of invited participants (`{{ attendedCount() }} attended / {{ pastMeetingInvitedCount() }} invited`) for better clarity.
* Added a new computed property `pastMeetingInvitedCount` in `meeting-join.component.ts` to support the improved display logic in the drawer header.