### PR TITLE
fix(me-lens): resolve project_uid from entity on edit

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -192,7 +192,7 @@ export class CommitteeManageComponent {
       },
       display_name: this.form.value.display_name || this.form.value.name,
       website: this.form.value.website || null,
-      project_uid: this.project()?.uid || null,
+      project_uid: this.committee()?.project_uid || this.project()?.uid || null,
     };
 
     const committeeData = this.cleanFormData(formValue);
@@ -285,7 +285,7 @@ export class CommitteeManageComponent {
       },
       display_name: this.form.value.display_name || this.form.value.name,
       website: this.form.value.website || null,
-      project_uid: this.project()?.uid || null,
+      project_uid: this.committee()?.project_uid || this.project()?.uid || null,
     };
 
     const committeeData = this.cleanFormData(formValue);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -477,7 +477,7 @@ export class MeetingManageComponent {
     }
 
     return {
-      project_uid: this.projectContextService.activeContextUid(),
+      project_uid: this.meeting()?.project_uid || this.projectContextService.activeContextUid(),
       title: formValue.title,
       description: formValue.description || '',
       start_time: startDateTime,

--- a/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/vote-manage/vote-manage.component.ts
@@ -130,8 +130,8 @@ export class VoteManageComponent {
       return;
     }
 
-    const project = this.project();
-    if (!project?.uid) {
+    const projectUid = this.vote()?.project_uid || this.project()?.uid;
+    if (!projectUid) {
       this.messageService.add({
         severity: 'error',
         summary: 'Error',
@@ -145,7 +145,7 @@ export class VoteManageComponent {
     const formValue = this.form().getRawValue() as VoteFormValue;
 
     if (this.isEditMode() && this.voteId()) {
-      const updateRequest = buildUpdateVoteRequest(formValue, project.uid);
+      const updateRequest = buildUpdateVoteRequest(formValue, projectUid);
       this.voteService.updateVote(this.voteId()!, updateRequest).subscribe({
         next: () => {
           this.messageService.add({
@@ -166,7 +166,7 @@ export class VoteManageComponent {
         },
       });
     } else {
-      const createRequest = buildCreateVoteRequest(formValue, project.uid);
+      const createRequest = buildCreateVoteRequest(formValue, projectUid);
       this.voteService.createVote(createRequest).subscribe({
         next: () => {
           this.messageService.add({
@@ -247,8 +247,8 @@ export class VoteManageComponent {
   }
 
   private submitVote(): void {
-    const project = this.project();
-    if (!project?.uid) {
+    const projectUid = this.vote()?.project_uid || this.project()?.uid;
+    if (!projectUid) {
       this.messageService.add({
         severity: 'error',
         summary: 'Error',
@@ -262,7 +262,7 @@ export class VoteManageComponent {
     const formValue = this.form().getRawValue() as VoteFormValue;
 
     if (this.isEditMode() && this.voteId()) {
-      const updateRequest = buildUpdateVoteRequest(formValue, project.uid);
+      const updateRequest = buildUpdateVoteRequest(formValue, projectUid);
       // Update the vote first, then enable it to open immediately
       this.voteService.updateVote(this.voteId()!, updateRequest).subscribe({
         next: () => {
@@ -297,7 +297,7 @@ export class VoteManageComponent {
         },
       });
     } else {
-      const createRequest = buildCreateVoteRequest(formValue, project.uid);
+      const createRequest = buildCreateVoteRequest(formValue, projectUid);
       // Create the vote first, then enable it to open immediately
       this.voteService.createVote(createRequest).subscribe({
         next: (createdVote) => {


### PR DESCRIPTION
## Summary

- In the Me lens, `ProjectContextService.activeContextUid()` is empty — there is no single active project. Meeting, committee, and vote edit forms previously pulled `project_uid` exclusively from the context, so edits initiated from the Me lens were shipping an empty `project_uid` upstream. Meetings require it on update (full PUT replace), so the record was effectively broken.
- Source `project_uid` from the loaded entity first (`entity.project_uid`, already present on every GET response) and fall back to the project context for create flows and the Project lens.
- Mailing lists are unaffected — the update payload does not include `project_uid`; upstream derives it from the parent GroupsIO service.

## Changes

- `meeting-manage.component.ts` — `prepareMeetingData()` resolves `project_uid` from `meeting()` first.
- `committee-manage.component.ts` — both `onSubmit` and `onSubmitAll` resolve `project_uid` from `committee()` first.
- `vote-manage.component.ts` — `onSaveAsDraft` and `submitVote` resolve a local `projectUid` from `vote()` first and pass it into `buildUpdateVoteRequest` / `buildCreateVoteRequest`.