### PR TITLE
fix(dashboards): link cast-vote action to /votes and dedupe per-vote

### DIFF
--- a/apps/lfx-one/src/app/shared/services/hidden-actions.service.ts
+++ b/apps/lfx-one/src/app/shared/services/hidden-actions.service.ts
@@ -54,17 +54,16 @@ export class HiddenActionsService {
 
   /**
    * Generate a unique identifier for an action.
-   * Uses buttonLink URL if available, otherwise combines type, badge, and text.
-   * Including text ensures uniqueness when multiple actions have the same type and badge.
+   * Always combines type, badge, and text — and appends buttonLink when present — so siblings
+   * that share a destination URL (e.g., multiple pending votes linking to /votes) still get
+   * distinct cookies. Using buttonLink alone would cause dismissing one to hide all siblings.
    *
    * @param item The pending action item
    * @returns A unique string identifier
    */
   private getActionIdentifier(item: PendingActionItem): string {
-    if (item.buttonLink) {
-      return item.buttonLink;
-    }
-    return `${item.type}-${item.badge}-${item.text}`;
+    const base = `${item.type}-${item.badge}-${item.text}`;
+    return item.buttonLink ? `${base}|${item.buttonLink}` : base;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1371,8 +1371,9 @@ export class UserService {
   }
 
   /**
-   * Build a "Cast Vote" pending action per active vote. Links to the votes drawer on the
-   * My Activity page where casting actually happens — there's no standalone vote-detail route.
+   * Build a "Cast Vote" pending action per active vote. Links to the My Votes page (me-lens of
+   * /votes) — there's no standalone vote-detail route, so the user lands on the list and picks
+   * the vote to cast.
    */
   private transformVotesToActions(votes: Vote[]): PendingActionItem[] {
     return votes.map((vote) => {
@@ -1390,7 +1391,7 @@ export class UserService {
         icon: 'fa-regular fa-check-to-slot',
         severity: 'warn',
         buttonText: 'Cast Vote',
-        buttonLink: '/my-activity',
+        buttonLink: '/votes',
         date: `Closes ${formattedEnd}`,
       };
     });


### PR DESCRIPTION
## Summary
- The Cast Vote pending action was pointing to `/my-activity`, which is being retired — switched it to `/votes` (the me-lens My Votes page).
- `HiddenActionsService.getActionIdentifier` used `buttonLink` alone as the cookie key, so every vote sharing the same destination URL collapsed into one cookie. Dismissing one Cast Vote hid all of them. Identifier now always combines `type-badge-text` and appends `buttonLink`, guaranteeing distinct dismissal cookies per item even when siblings share a URL.

## Notes
- Existing `lfx_hidden_*` cookies produced by the old scheme will reappear once after rollout because the hash input changed. Self-heals inside the 24h cookie TTL.
- Surveys and meetings were already correct — surveys use unique external `SURVEY_LINK` URLs, meetings embed the meeting ID in the path. Only the vote action had the hardcoded `/my-activity` link causing both problems.