### PR TITLE
feat(committees): restore add link and new folder actions

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -434,7 +434,7 @@
           <lfx-committee-surveys [committee]="committee()!" [canEdit]="canEdit()" />
         }
         @case ('documents') {
-          <lfx-committee-documents [committee]="committee()!" />
+          <lfx-committee-documents [committee]="committee()!" [canEdit]="canEdit()" />
         }
         @case ('settings') {
           <lfx-committee-settings-tab [committee]="committee()!" [canEdit]="canEdit()" (committeeUpdated)="refreshCommittee()" />

--- a/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.html
@@ -1,45 +1,67 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<lfx-card data-testid="committee-documents-card">
-  <!-- Filters -->
-  <div class="pb-3 mb-3 border-b border-gray-100">
-    <div class="flex flex-wrap items-center gap-2">
-      <!-- Search -->
-      <div class="flex-1 min-w-48">
-        <lfx-input-text
-          [form]="filterForm"
-          control="search"
-          placeholder="Search documents..."
-          icon="fa-light fa-search"
-          styleClass="w-full"
-          size="small"
-          data-testid="committee-documents-search-input">
-        </lfx-input-text>
-      </div>
+<div class="flex flex-col gap-4 pt-2" data-testid="committee-documents-tab">
+  @if (canEdit()) {
+    <div class="flex items-center justify-end gap-2">
+      <lfx-button
+        label="New Folder"
+        icon="fa-light fa-folder-plus"
+        size="small"
+        severity="secondary"
+        [outlined]="true"
+        (onClick)="openNewFolderDialog()"
+        data-testid="committee-documents-new-folder-button"></lfx-button>
+      <lfx-button
+        label="Add Link"
+        icon="fa-light fa-link"
+        severity="info"
+        size="small"
+        (onClick)="openAddLinkDialog()"
+        data-testid="committee-documents-add-link-button"></lfx-button>
+    </div>
+  }
 
-      <!-- Source filter -->
-      <div class="w-36 shrink-0 overflow-hidden">
-        <lfx-select
-          [form]="filterForm"
-          control="source"
-          size="small"
-          [options]="sourceOptions"
-          placeholder="All Sources"
-          [showClear]="true"
-          styleClass="w-full"
-          data-testid="committee-documents-source-filter">
-        </lfx-select>
+  <lfx-card data-testid="committee-documents-card">
+    <!-- Filters -->
+    <div class="pb-3 mb-3 border-b border-gray-100">
+      <div class="flex flex-wrap items-center gap-2">
+        <!-- Search -->
+        <div class="flex-1 min-w-48">
+          <lfx-input-text
+            [form]="filterForm"
+            control="search"
+            placeholder="Search documents..."
+            icon="fa-light fa-search"
+            styleClass="w-full"
+            size="small"
+            data-testid="committee-documents-search-input">
+          </lfx-input-text>
+        </div>
+
+        <!-- Source filter -->
+        <div class="w-36 shrink-0 overflow-hidden">
+          <lfx-select
+            [form]="filterForm"
+            control="source"
+            size="small"
+            [options]="sourceOptions"
+            placeholder="All Sources"
+            [showClear]="true"
+            styleClass="w-full"
+            data-testid="committee-documents-source-filter">
+          </lfx-select>
+        </div>
       </div>
     </div>
-  </div>
 
-  <!-- Table -->
-  <lfx-documents-table
-    [documents]="filteredDocuments()"
-    [loading]="loading()"
-    [showFoundation]="false"
-    testIdPrefix="committee-documents"
-    emptyMessage="No documents found for this group">
-  </lfx-documents-table>
-</lfx-card>
+    <!-- Table -->
+    <lfx-documents-table
+      [documents]="filteredDocuments()"
+      [loading]="loading()"
+      [showFoundation]="false"
+      testIdPrefix="committee-documents"
+      emptyMessage="No documents found for this group">
+    </lfx-documents-table>
+  </lfx-card>
+</div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
@@ -4,27 +4,38 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { DocumentsTableComponent } from '@components/documents-table/documents-table.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
-import { DocumentsTableComponent } from '@components/documents-table/documents-table.component';
 import { MEETING_GROUP_SOURCES } from '@lfx-one/shared/constants';
-import { Committee, MyDocumentItem, MyDocumentSource } from '@lfx-one/shared/interfaces';
+import { Committee, CommitteeDocument, MyDocumentItem, MyDocumentSource } from '@lfx-one/shared/interfaces';
+import { CommitteeService } from '@services/committee.service';
 import { DocumentService } from '@services/document.service';
-import { catchError, debounceTime, distinctUntilChanged, finalize, map, of, startWith, switchMap } from 'rxjs';
+import { MessageService } from 'primeng/api';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, filter, finalize, map, of, startWith, switchMap, take } from 'rxjs';
+
+import { DocumentFormComponent } from '../document-form/document-form.component';
 
 @Component({
   selector: 'lfx-committee-documents',
-  imports: [CardComponent, InputTextComponent, SelectComponent, DocumentsTableComponent, ReactiveFormsModule],
+  imports: [ButtonComponent, CardComponent, InputTextComponent, SelectComponent, DocumentsTableComponent, ReactiveFormsModule],
+  providers: [DialogService, MessageService],
   templateUrl: './committee-documents.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CommitteeDocumentsComponent {
   // === Services ===
   private readonly documentService = inject(DocumentService);
+  private readonly committeeService = inject(CommitteeService);
+  private readonly dialogService = inject(DialogService);
+  private readonly messageService = inject(MessageService);
 
   // === Inputs ===
   public readonly committee = input.required<Committee>();
+  public readonly canEdit = input<boolean>(false);
 
   // === Forms ===
   protected readonly filterForm = new FormGroup({
@@ -34,6 +45,7 @@ export class CommitteeDocumentsComponent {
 
   // === Writable Signals ===
   protected readonly loading = signal<boolean>(true);
+  protected readonly refreshTrigger = signal<number>(0);
 
   // === Static Options ===
   protected readonly sourceOptions: { label: string; value: MyDocumentSource | null }[] = [
@@ -48,6 +60,52 @@ export class CommitteeDocumentsComponent {
   protected readonly sourceFilter: Signal<MyDocumentSource | null> = this.initSourceFilter();
   protected readonly documents: Signal<MyDocumentItem[]> = this.initDocuments();
   protected readonly filteredDocuments: Signal<MyDocumentItem[]> = this.initFilteredDocuments();
+  protected readonly committeeDocuments: Signal<CommitteeDocument[]> = this.initCommitteeDocuments();
+  protected readonly folderOptions: Signal<{ label: string; value: string }[]> = this.initFolderOptions();
+
+  // === Public Methods ===
+  public openAddLinkDialog(): void {
+    const dialogRef: DynamicDialogRef | null = this.dialogService.open(DocumentFormComponent, {
+      header: 'Add Link',
+      width: '560px',
+      modal: true,
+      closable: true,
+      data: {
+        mode: 'link',
+        committeeId: this.committee().uid,
+        folders: this.folderOptions(),
+      },
+    });
+
+    dialogRef?.onClose.pipe(take(1)).subscribe({
+      next: (result: boolean | undefined) => {
+        if (result) {
+          this.refreshTrigger.update((v) => v + 1);
+        }
+      },
+    });
+  }
+
+  public openNewFolderDialog(): void {
+    const dialogRef: DynamicDialogRef | null = this.dialogService.open(DocumentFormComponent, {
+      header: 'New Folder',
+      width: '560px',
+      modal: true,
+      closable: true,
+      data: {
+        mode: 'folder',
+        committeeId: this.committee().uid,
+      },
+    });
+
+    dialogRef?.onClose.pipe(take(1)).subscribe({
+      next: (result: boolean | undefined) => {
+        if (result) {
+          this.refreshTrigger.update((v) => v + 1);
+        }
+      },
+    });
+  }
 
   // === Private Initializers ===
   private initSearchQuery(): Signal<string> {
@@ -68,8 +126,8 @@ export class CommitteeDocumentsComponent {
 
   private initDocuments(): Signal<MyDocumentItem[]> {
     return toSignal(
-      toObservable(this.committee).pipe(
-        switchMap((committee) => {
+      combineLatest([toObservable(this.committee), toObservable(this.refreshTrigger)]).pipe(
+        switchMap(([committee]) => {
           this.loading.set(true);
           return this.documentService.getMyDocuments(committee.project_uid, committee.uid).pipe(
             catchError(() => of([] as MyDocumentItem[])),
@@ -96,5 +154,23 @@ export class CommitteeDocumentsComponent {
         return true;
       });
     });
+  }
+
+  private initCommitteeDocuments(): Signal<CommitteeDocument[]> {
+    return toSignal(
+      combineLatest([toObservable(this.committee), toObservable(this.refreshTrigger)]).pipe(
+        filter(([committee]) => !!committee?.uid),
+        switchMap(([committee]) => this.committeeService.getCommitteeDocuments(committee.uid))
+      ),
+      { initialValue: [] as CommitteeDocument[] }
+    );
+  }
+
+  private initFolderOptions(): Signal<{ label: string; value: string }[]> {
+    return computed(() =>
+      this.committeeDocuments()
+        .filter((doc) => doc.type === 'folder')
+        .map((folder) => ({ label: folder.name, value: folder.uid }))
+    );
   }
 }

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.html
@@ -3,7 +3,7 @@
 
 <lfx-table
   [value]="documents()"
-  [paginator]="true"
+  [paginator]="hasDocuments()"
   [rows]="10"
   [rowsPerPageOptions]="[10, 25, 50]"
   [loading]="loading()"

--- a/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
+++ b/apps/lfx-one/src/app/shared/components/documents-table/documents-table.component.ts
@@ -29,6 +29,7 @@ export class DocumentsTableComponent {
   public readonly emptyMessage = input<string>('No documents found');
 
   protected readonly colSpan = computed(() => (this.showFoundation() ? 6 : 5));
+  protected readonly hasDocuments = computed(() => this.documents().length > 0);
 
   protected openDocument(doc: MyDocumentItem): void {
     if (!doc.url) return;


### PR DESCRIPTION
## Summary

- Restores the **Add Link** and **New Folder** actions on the committee documents tab, gated by `committee.writer` via `canEdit`. The buttons were inadvertently dropped in #479 when the tab was refactored to the aggregated documents view; the dialog (`DocumentFormComponent`), service methods (`CommitteeService.createCommitteeDocument`), and backend route all survived the refactor and are reused as-is.
- After a successful create, a `refreshTrigger` signal re-drives both the aggregated documents fetch and the raw `getCommitteeDocuments` fetch (the latter powers the folder picker in the Add Link dialog).
- Styling matches sibling committee tabs (surveys / votes / meetings): primary **Add Link** is `severity="info"`, secondary **New Folder** is `severity="secondary" [outlined]="true"`, right-aligned action row, no in-tab title/subtitle (parent header already provides context).
- Bonus: the shared `DocumentsTableComponent` now hides its paginator when the list is empty — `[paginator]="hasDocuments()"`. Benefits both the committee tab and the My Documents page.

## Context

The create buttons existed before commit [`9f2f699e`](https://github.com/linuxfoundation/lfx-v2-ui/commit/9f2f699e) ("replace committee documents tab with aggregated documents view", merged in #479). That refactor switched the data source to the unified `DocumentService.getMyDocuments(project_uid, committee_uid)` pipeline but the header row containing the action buttons was removed along with the old per-source merging logic. This PR re-wires creation on top of the new aggregated view without reverting the refactor.

## Out of scope

Per-row **delete** is not included. Restoring delete requires extending the shared `DocumentsTableComponent` (used by My Documents) with a per-row deletable predicate plus the committee-document `type` discriminator, and re-adding the folder cascade-delete logic. Worth a follow-up PR when prioritized.