### PR TITLE
fix(profile): polish identity, password, and username ux

### DIFF
--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -59,7 +59,7 @@
                 @if (username && username !== 'N/A') {
                   <div class="flex items-center gap-2" data-testid="profile-username">
                     <i class="fa-light fa-user w-4 text-center text-slate-400"></i>
-                    <span class="truncate">{{ username }}</span>
+                    <span class="truncate">&#64;{{ username }}</span>
                   </div>
                 }
                 @if (emailInfo()) {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -55,10 +55,11 @@
 
               <!-- Column 2: Username & Email -->
               <div class="flex flex-col gap-2 text-xs text-slate-500">
-                @if (displayUsername() && displayUsername() !== 'N/A') {
+                @let username = displayUsername();
+                @if (username && username !== 'N/A') {
                   <div class="flex items-center gap-2" data-testid="profile-username">
                     <i class="fa-light fa-user w-4 text-center text-slate-400"></i>
-                    <span class="truncate">{{ displayUsername() }}</span>
+                    <span class="truncate">{{ username }}</span>
                   </div>
                 }
                 @if (emailInfo()) {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -56,7 +56,7 @@
               <!-- Column 2: Username & Email -->
               <div class="flex flex-col gap-2 text-xs text-slate-500">
                 @let username = displayUsername();
-                @if (username && username !== 'N/A') {
+                @if (username) {
                   <div class="flex items-center gap-2" data-testid="profile-username">
                     <i class="fa-light fa-user w-4 text-center text-slate-400"></i>
                     <span class="truncate">&#64;{{ username }}</span>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -55,10 +55,10 @@
 
               <!-- Column 2: Username & Email -->
               <div class="flex flex-col gap-2 text-xs text-slate-500">
-                @if (profileData()?.username) {
+                @if (displayUsername() && displayUsername() !== 'N/A') {
                   <div class="flex items-center gap-2" data-testid="profile-username">
                     <i class="fa-light fa-user w-4 text-center text-slate-400"></i>
-                    <span class="truncate">&#64;{{ profileData()?.username }}</span>
+                    <span class="truncate">{{ displayUsername() }}</span>
                   </div>
                 }
                 @if (emailInfo()) {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -14,6 +14,7 @@ import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { BehaviorSubject, catchError, combineLatest, filter, map, of, startWith, switchMap, take } from 'rxjs';
 
+import { stripAuthPrefix } from '@app/shared/pipes/strip-auth-prefix.pipe';
 import { ProfileEditDialogComponent } from '../../modules/profile/components/profile-edit-dialog/profile-edit-dialog.component';
 
 /**
@@ -23,6 +24,10 @@ import { ProfileEditDialogComponent } from '../../modules/profile/components/pro
  * - Tab navigation (horizontal on desktop, dropdown on mobile)
  * - Router outlet for child components
  */
+// Error codes that originate from the Flow C profile-auth (/passwordless/callback) flow.
+// Child routes (e.g. identities) handle their own error codes — do not swallow them here.
+const PROFILE_AUTH_ERROR_CODES = new Set(['profile_auth_not_configured', 'profile_auth_failed', 'token_exchange_failed', 'login_session_invalid', 'user_mismatch']);
+
 @Component({
   selector: 'lfx-profile-layout',
   imports: [RouterOutlet, RouterLink, RouterLinkActive, ReactiveFormsModule, SelectComponent],
@@ -70,16 +75,20 @@ export class ProfileLayoutComponent {
   public readonly loading = signal<boolean>(true);
 
   // Computed signals
+  public readonly displayUsername = computed(() => stripAuthPrefix(this.profileData()?.username));
+
   public readonly displayName = computed(() => {
     const data = this.profileData();
     if (!data) return '';
-    return `${data.firstName || ''} ${data.lastName || ''}`.trim() || data.username || 'User';
+    const cleanUsername = stripAuthPrefix(data.username);
+    return `${data.firstName || ''} ${data.lastName || ''}`.trim() || (cleanUsername !== 'N/A' ? cleanUsername : 'User');
   });
 
   public readonly initials = computed(() => {
     const data = this.profileData();
     if (!data) return 'U';
-    return data.firstName?.charAt(0).toUpperCase() || data.username?.charAt(0).toUpperCase() || 'U';
+    const cleanUsername = stripAuthPrefix(data.username);
+    return data.firstName?.charAt(0).toUpperCase() || (cleanUsername !== 'N/A' ? cleanUsername.charAt(0).toUpperCase() : 'U') || 'U';
   });
 
   public readonly jobTitle = computed(() => this.profileData()?.jobTitle || '');
@@ -133,7 +142,7 @@ export class ProfileLayoutComponent {
         this.router.navigate([], { relativeTo: this.route, queryParams: {}, replaceUrl: true });
       }
 
-      if (params['error']) {
+      if (PROFILE_AUTH_ERROR_CODES.has(params['error'])) {
         this.messageService.add({
           severity: 'error',
           summary: 'Authorization Error',

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -14,8 +14,18 @@ import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { BehaviorSubject, catchError, combineLatest, filter, map, of, startWith, switchMap, take } from 'rxjs';
 
-import { stripAuthPrefix } from '@app/shared/pipes/strip-auth-prefix.pipe';
+import { stripAuthPrefix } from '@app/shared/utils/strip-auth-prefix.util';
 import { ProfileEditDialogComponent } from '../../modules/profile/components/profile-edit-dialog/profile-edit-dialog.component';
+
+// Error codes that originate from the Flow C profile-auth (/passwordless/callback) flow.
+// Child routes (e.g. identities) handle their own error codes — do not swallow them here.
+const PROFILE_AUTH_ERROR_CODES = new Set([
+  'profile_auth_not_configured',
+  'profile_auth_failed',
+  'token_exchange_failed',
+  'login_session_invalid',
+  'user_mismatch',
+]);
 
 /**
  * ProfileLayoutComponent serves as the shell for all profile pages.
@@ -24,10 +34,6 @@ import { ProfileEditDialogComponent } from '../../modules/profile/components/pro
  * - Tab navigation (horizontal on desktop, dropdown on mobile)
  * - Router outlet for child components
  */
-// Error codes that originate from the Flow C profile-auth (/passwordless/callback) flow.
-// Child routes (e.g. identities) handle their own error codes — do not swallow them here.
-const PROFILE_AUTH_ERROR_CODES = new Set(['profile_auth_not_configured', 'profile_auth_failed', 'token_exchange_failed', 'login_session_invalid', 'user_mismatch']);
-
 @Component({
   selector: 'lfx-profile-layout',
   imports: [RouterOutlet, RouterLink, RouterLinkActive, ReactiveFormsModule, SelectComponent],
@@ -88,7 +94,7 @@ export class ProfileLayoutComponent {
     const data = this.profileData();
     if (!data) return 'U';
     const cleanUsername = stripAuthPrefix(data.username);
-    return data.firstName?.charAt(0).toUpperCase() || (cleanUsername !== 'N/A' ? cleanUsername.charAt(0).toUpperCase() : 'U') || 'U';
+    return data.firstName?.charAt(0).toUpperCase() || (cleanUsername !== 'N/A' ? cleanUsername.charAt(0).toUpperCase() : 'U');
   });
 
   public readonly jobTitle = computed(() => this.profileData()?.jobTitle || '');

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -14,7 +14,7 @@ import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { BehaviorSubject, catchError, combineLatest, filter, map, of, startWith, switchMap, take } from 'rxjs';
 
-import { stripAuthPrefix } from '@app/shared/utils/strip-auth-prefix.util';
+import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
 import { ProfileEditDialogComponent } from '../../modules/profile/components/profile-edit-dialog/profile-edit-dialog.component';
 
 // Error codes that originate from the Flow C profile-auth (/passwordless/callback) flow.
@@ -81,20 +81,20 @@ export class ProfileLayoutComponent {
   public readonly loading = signal<boolean>(true);
 
   // Computed signals
-  public readonly displayUsername = computed(() => stripAuthPrefix(this.profileData()?.username));
+  public readonly displayUsername = computed(() => stripAuthPrefixOrNull(this.profileData()?.username));
 
   public readonly displayName = computed(() => {
     const data = this.profileData();
     if (!data) return '';
-    const cleanUsername = stripAuthPrefix(data.username);
-    return `${data.firstName || ''} ${data.lastName || ''}`.trim() || (cleanUsername !== 'N/A' ? cleanUsername : 'User');
+    const cleanUsername = stripAuthPrefixOrNull(data.username);
+    return `${data.firstName || ''} ${data.lastName || ''}`.trim() || cleanUsername || 'User';
   });
 
   public readonly initials = computed(() => {
     const data = this.profileData();
     if (!data) return 'U';
-    const cleanUsername = stripAuthPrefix(data.username);
-    return data.firstName?.charAt(0).toUpperCase() || (cleanUsername !== 'N/A' ? cleanUsername.charAt(0).toUpperCase() : 'U');
+    const cleanUsername = stripAuthPrefixOrNull(data.username);
+    return data.firstName?.charAt(0).toUpperCase() || cleanUsername?.charAt(0).toUpperCase() || 'U';
   });
 
   public readonly jobTitle = computed(() => this.profileData()?.jobTitle || '');

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
@@ -11,7 +11,7 @@ import { SelectComponent } from '@components/select/select.component';
 import { COUNTRIES, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared';
 import { CombinedProfile, ProfileUpdateRequest, UserEmail, UserMetadata } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
-import { stripAuthPrefix } from '@app/shared/pipes/strip-auth-prefix.pipe';
+import { stripAuthPrefix } from '@app/shared/utils/strip-auth-prefix.util';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -222,7 +222,7 @@ export class ProfileEditDialogComponent {
     this.profileForm.patchValue({
       given_name: profile.user.first_name || '',
       family_name: profile.user.last_name || '',
-      username: stripAuthPrefix(profile.user.username),
+      username: profile.user.username ? stripAuthPrefix(profile.user.username) : '',
       country: countryValue,
       state_province: profile.profile?.state_province || '',
       city: profile.profile?.city || '',

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
@@ -11,8 +11,8 @@ import { SelectComponent } from '@components/select/select.component';
 import { COUNTRIES, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared';
 import { CombinedProfile, ProfileUpdateRequest, UserEmail, UserMetadata } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
-import { stripAuthPrefix } from '@app/shared/utils/strip-auth-prefix.util';
 import { UserService } from '@services/user.service';
+import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { finalize } from 'rxjs';
@@ -222,7 +222,7 @@ export class ProfileEditDialogComponent {
     this.profileForm.patchValue({
       given_name: profile.user.first_name || '',
       family_name: profile.user.last_name || '',
-      username: profile.user.username ? stripAuthPrefix(profile.user.username) : '',
+      username: stripAuthPrefixOrNull(profile.user.username) ?? '',
       country: countryValue,
       state_province: profile.profile?.state_province || '',
       city: profile.profile?.city || '',

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
@@ -11,6 +11,7 @@ import { SelectComponent } from '@components/select/select.component';
 import { COUNTRIES, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared';
 import { CombinedProfile, ProfileUpdateRequest, UserEmail, UserMetadata } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
+import { stripAuthPrefix } from '@app/shared/pipes/strip-auth-prefix.pipe';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -221,7 +222,7 @@ export class ProfileEditDialogComponent {
     this.profileForm.patchValue({
       given_name: profile.user.first_name || '',
       family_name: profile.user.last_name || '',
-      username: profile.user.username || '',
+      username: stripAuthPrefix(profile.user.username),
       country: countryValue,
       state_province: profile.profile?.state_province || '',
       city: profile.profile?.city || '',

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.html
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.html
@@ -2,6 +2,29 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex w-full flex-col gap-8 pb-12" data-testid="profile-identities">
+  <!-- Auth service unavailable banner -->
+  @if (identitiesLoadError()) {
+    <lfx-message
+      severity="error"
+      title="Identity service unavailable"
+      text="Identity verification status cannot be loaded right now. Please try again in a few minutes."
+      data-testid="identities-service-error-banner" />
+  }
+
+  <!-- Already linked to another LFID banner -->
+  @if (conflictBanner()) {
+    <lfx-message severity="warn" [closable]="true" (onClose)="dismissConflictBanner()" data-testid="identities-conflict-banner">
+      <ng-template #content>
+        <p class="text-sm">
+          This identity is already linked to another LFX account. A single identity can only be linked to one account. If you believe this is an error,
+          <a href="https://jira.linuxfoundation.org/plugins/servlet/desk/portal/4" target="_blank" rel="noopener noreferrer" class="font-medium underline">
+            contact support </a
+          >.
+        </p>
+      </ng-template>
+    </lfx-message>
+  }
+
   <!-- Left Column: Identities -->
   <div class="flex flex-col gap-5">
     <!-- Header with Add Button -->

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -1,13 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { isPlatformBrowser } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
-import { ChangeDetectionStrategy, Component, computed, inject, OnInit, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, OnInit, PLATFORM_ID, Signal, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { MenuComponent } from '@components/menu/menu.component';
+import { MessageComponent } from '@components/message/message.component';
 import {
   AddAccountDialogData,
   ConnectedIdentityFull,
@@ -19,7 +21,7 @@ import {
 import { UserService } from '@services/user.service';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
-import { map, startWith, Subject, switchMap, take } from 'rxjs';
+import { catchError, map, of, startWith, Subject, switchMap, take } from 'rxjs';
 
 import { AddAccountDialogComponent } from '../components/add-account-dialog/add-account-dialog.component';
 import { RemoveIdentityDialogComponent } from '../components/remove-identity-dialog/remove-identity-dialog.component';
@@ -32,7 +34,7 @@ interface IdentitiesState {
 
 @Component({
   selector: 'lfx-profile-identities',
-  imports: [CardComponent, ButtonComponent, MenuComponent],
+  imports: [CardComponent, ButtonComponent, MenuComponent, MessageComponent],
   providers: [DialogService],
   templateUrl: './profile-identities.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -42,6 +44,19 @@ export class ProfileIdentitiesComponent implements OnInit {
   private readonly dialogService = inject(DialogService);
   private readonly messageService = inject(MessageService);
   private readonly route = inject(ActivatedRoute);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  public readonly identitiesLoadError = signal(false);
+  // Manual dismiss overrides the query-param-derived banner.
+  private readonly conflictDismissed = signal(false);
+  private readonly queryParams = toSignal(this.route.queryParams, { initialValue: this.route.snapshot.queryParams });
+  public readonly conflictBanner: Signal<{ linkedTo: string | null } | null> = computed(() => {
+    if (this.conflictDismissed()) return null;
+    const params = this.queryParams();
+    if (params?.['error'] !== 'already_linked') return null;
+    const linkedTo = params['linkedTo'] ? decodeURIComponent(params['linkedTo']) : null;
+    return { linkedTo };
+  });
 
   public readonly identities: Signal<ConnectedIdentityFull[]> = computed(() =>
     this.identitiesState()
@@ -49,7 +64,9 @@ export class ProfileIdentitiesComponent implements OnInit {
       .map((enriched) => this.mapToConnectedIdentity(enriched))
   );
   public readonly loading: Signal<boolean> = computed(() => !this.identitiesState().loaded);
-  public readonly isEmpty: Signal<boolean> = computed(() => this.identitiesState().loaded && this.identitiesState().identities.length === 0);
+  public readonly isEmpty: Signal<boolean> = computed(
+    () => !this.identitiesLoadError() && this.identitiesState().loaded && this.identitiesState().identities.length === 0
+  );
 
   public readonly unverifiedIdentities: Signal<ConnectedIdentityFull[]> = computed(() => this.identities().filter((i) => i.state === 'unverified'));
   public readonly verifiedIdentities: Signal<ConnectedIdentityFull[]> = computed(() => this.identities().filter((i) => i.state === 'verified'));
@@ -65,19 +82,36 @@ export class ProfileIdentitiesComponent implements OnInit {
     if (params['success'] === 'identity_linked') {
       this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Identity linked successfully.' });
       this.refreshTrigger$.next();
+      this.clearQueryParams();
+    } else if (params['error'] === 'already_linked') {
+      // Banner renders via the conflictBanner computed signal (derived from queryParams).
+      // Clean up URL via history API so the banner signal isn't wiped by a router navigation.
+      this.clearQueryParams();
     } else if (params['error']) {
       const errorMap: Record<string, string> = {
         social_auth_failed: 'Social authentication failed. Please try again.',
         invalid_state: 'Security validation failed. Please try again.',
         link_failed: 'Failed to link identity. Please try again.',
-        already_linked: 'This account is already linked to another LFX profile.',
         social_verification_failed: 'Identity verification failed. Please try again.',
         invalid_provider: 'Invalid identity provider specified.',
         no_management_token: 'Authorization expired. Please try again.',
         no_identity_token: 'No identity token received. Please try again.',
       };
       this.messageService.add({ severity: 'error', summary: 'Error', detail: errorMap[params['error']] || 'An error occurred. Please try again.' });
+      this.clearQueryParams();
     }
+  }
+
+  public dismissConflictBanner(): void {
+    this.conflictDismissed.set(true);
+    this.clearQueryParams();
+  }
+
+  private clearQueryParams(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    // Use history API instead of router.navigate to avoid triggering route re-evaluation
+    // that could destroy component state or re-run lifecycle hooks.
+    window.history.replaceState({}, '', window.location.pathname);
   }
 
   public onVerify(identity: ConnectedIdentityFull): void {
@@ -188,7 +222,18 @@ export class ProfileIdentitiesComponent implements OnInit {
     return toSignal(
       this.refreshTrigger$.pipe(
         startWith(undefined),
-        switchMap(() => this.userService.getIdentities()),
+        switchMap(() =>
+          this.userService.getIdentities().pipe(
+            catchError((err: HttpErrorResponse) => {
+              if (err.status === 503) {
+                this.identitiesLoadError.set(true);
+              } else {
+                this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load identities.' });
+              }
+              return of([] as EnrichedIdentity[]);
+            })
+          )
+        ),
         map((identities): IdentitiesState => ({ identities, loaded: true }))
       ),
       { initialValue: { identities: [] as EnrichedIdentity[], loaded: false } }

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -50,12 +50,9 @@ export class ProfileIdentitiesComponent implements OnInit {
   // Manual dismiss overrides the query-param-derived banner.
   private readonly conflictDismissed = signal(false);
   private readonly queryParams = toSignal(this.route.queryParams, { initialValue: this.route.snapshot.queryParams });
-  public readonly conflictBanner: Signal<{ linkedTo: string | null } | null> = computed(() => {
-    if (this.conflictDismissed()) return null;
-    const params = this.queryParams();
-    if (params?.['error'] !== 'already_linked') return null;
-    const linkedTo = params['linkedTo'] ? decodeURIComponent(params['linkedTo']) : null;
-    return { linkedTo };
+  public readonly conflictBanner: Signal<boolean> = computed(() => {
+    if (this.conflictDismissed()) return false;
+    return this.queryParams()?.['error'] === 'already_linked';
   });
 
   public readonly identities: Signal<ConnectedIdentityFull[]> = computed(() =>
@@ -105,13 +102,6 @@ export class ProfileIdentitiesComponent implements OnInit {
   public dismissConflictBanner(): void {
     this.conflictDismissed.set(true);
     this.clearQueryParams();
-  }
-
-  private clearQueryParams(): void {
-    if (!isPlatformBrowser(this.platformId)) return;
-    // Use history API instead of router.navigate to avoid triggering route re-evaluation
-    // that could destroy component state or re-run lifecycle hooks.
-    window.history.replaceState({}, '', window.location.pathname);
   }
 
   public onVerify(identity: ConnectedIdentityFull): void {
@@ -165,6 +155,13 @@ export class ProfileIdentitiesComponent implements OnInit {
         this.refreshTrigger$.next();
       }
     });
+  }
+
+  private clearQueryParams(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    // Use history API instead of router.navigate to avoid triggering route re-evaluation
+    // that could destroy component state or re-run lifecycle hooks.
+    window.history.replaceState({}, '', window.location.pathname);
   }
 
   private openRemoveDialog(identity: ConnectedIdentityFull): void {

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -47,13 +47,14 @@ export class ProfileIdentitiesComponent implements OnInit {
   private readonly platformId = inject(PLATFORM_ID);
 
   public readonly identitiesLoadError = signal(false);
-  // Manual dismiss overrides the query-param-derived banner.
   private readonly conflictDismissed = signal(false);
-  private readonly queryParams = toSignal(this.route.queryParams, { initialValue: this.route.snapshot.queryParams });
-  public readonly conflictBanner: Signal<boolean> = computed(() => {
-    if (this.conflictDismissed()) return false;
-    return this.queryParams()?.['error'] === 'already_linked';
-  });
+  // Captured once from the URL snapshot in ngOnInit. Using a plain signal instead of
+  // toSignal(queryParams) avoids a subtle invariant: clearQueryParams() uses
+  // history.replaceState (not router.navigate), which does not emit on the Router's
+  // queryParams observable. If that ever changes to router.navigate, this approach
+  // stays correct while a queryParams-derived computed would silently break.
+  private readonly conflictDetected = signal(false);
+  public readonly conflictBanner: Signal<boolean> = computed(() => this.conflictDetected() && !this.conflictDismissed());
 
   public readonly identities: Signal<ConnectedIdentityFull[]> = computed(() =>
     this.identitiesState()
@@ -81,8 +82,7 @@ export class ProfileIdentitiesComponent implements OnInit {
       this.refreshTrigger$.next();
       this.clearQueryParams();
     } else if (params['error'] === 'already_linked') {
-      // Banner renders via the conflictBanner computed signal (derived from queryParams).
-      // Clean up URL via history API so the banner signal isn't wiped by a router navigation.
+      this.conflictDetected.set(true);
       this.clearQueryParams();
     } else if (params['error']) {
       const errorMap: Record<string, string> = {
@@ -161,7 +161,7 @@ export class ProfileIdentitiesComponent implements OnInit {
     if (!isPlatformBrowser(this.platformId)) return;
     // Use history API instead of router.navigate to avoid triggering route re-evaluation
     // that could destroy component state or re-run lifecycle hooks.
-    window.history.replaceState({}, '', window.location.pathname);
+    window.history.replaceState(window.history.state, '', window.location.pathname);
   }
 
   private openRemoveDialog(identity: ConnectedIdentityFull): void {
@@ -222,12 +222,10 @@ export class ProfileIdentitiesComponent implements OnInit {
         switchMap(() => {
           this.identitiesLoadError.set(false);
           return this.userService.getIdentities().pipe(
-            catchError((err: HttpErrorResponse) => {
-              if (err.status === 503) {
-                this.identitiesLoadError.set(true);
-              } else {
-                this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load identities.' });
-              }
+            catchError(() => {
+              // Any load failure hides the list entirely — a missing Auth0 overlay
+              // would mis-label every CDP identity as "unverified".
+              this.identitiesLoadError.set(true);
               return of([] as EnrichedIdentity[]);
             })
           );

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -219,8 +219,9 @@ export class ProfileIdentitiesComponent implements OnInit {
     return toSignal(
       this.refreshTrigger$.pipe(
         startWith(undefined),
-        switchMap(() =>
-          this.userService.getIdentities().pipe(
+        switchMap(() => {
+          this.identitiesLoadError.set(false);
+          return this.userService.getIdentities().pipe(
             catchError((err: HttpErrorResponse) => {
               if (err.status === 503) {
                 this.identitiesLoadError.set(true);
@@ -229,8 +230,8 @@ export class ProfileIdentitiesComponent implements OnInit {
               }
               return of([] as EnrichedIdentity[]);
             })
-          )
-        ),
+          );
+        }),
         map((identities): IdentitiesState => ({ identities, loaded: true }))
       ),
       { initialValue: { identities: [] as EnrichedIdentity[], loaded: false } }

--- a/apps/lfx-one/src/app/modules/profile/password/profile-password.component.html
+++ b/apps/lfx-one/src/app/modules/profile/password/profile-password.component.html
@@ -1,6 +1,7 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<p-toast></p-toast>
 <div class="w-full" data-testid="profile-password">
   <!-- Password Security Info Banner -->
   <lfx-message severity="info" icon="fa-light fa-shield-check" styleClass="mb-6" title="Secure Your Account">

--- a/apps/lfx-one/src/app/shared/pipes/strip-auth-prefix.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/strip-auth-prefix.pipe.ts
@@ -1,0 +1,21 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+const LEGACY_USERNAME_MAX_LENGTH = 60;
+
+export function stripAuthPrefix(value: string | null | undefined): string {
+  if (!value) return 'N/A';
+  const stripped = value.startsWith('auth0|') ? value.slice(6) : value;
+  return stripped.length > LEGACY_USERNAME_MAX_LENGTH ? 'N/A' : stripped;
+}
+
+@Pipe({
+  name: 'stripAuthPrefix',
+})
+export class StripAuthPrefixPipe implements PipeTransform {
+  public transform(value: string | null | undefined): string {
+    return stripAuthPrefix(value);
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -263,12 +263,7 @@ export class UserService {
    * Get user's enriched identities (CDP cross-referenced with Auth0)
    */
   public getIdentities(): Observable<EnrichedIdentity[]> {
-    return this.http.get<EnrichedIdentity[]>('/api/profile/identities').pipe(
-      catchError(() => {
-        this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load identities.' });
-        return of([] as EnrichedIdentity[]);
-      })
-    );
+    return this.http.get<EnrichedIdentity[]>('/api/profile/identities');
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/utils/strip-auth-prefix.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/strip-auth-prefix.util.ts
@@ -6,5 +6,6 @@ const LEGACY_USERNAME_MAX_LENGTH = 60;
 export function stripAuthPrefix(value: string | null | undefined): string {
   if (!value) return 'N/A';
   const stripped = value.startsWith('auth0|') ? value.slice(6) : value;
+  if (!stripped.trim()) return 'N/A';
   return stripped.length > LEGACY_USERNAME_MAX_LENGTH ? 'N/A' : stripped;
 }

--- a/apps/lfx-one/src/app/shared/utils/strip-auth-prefix.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/strip-auth-prefix.util.ts
@@ -1,21 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Pipe, PipeTransform } from '@angular/core';
-
 const LEGACY_USERNAME_MAX_LENGTH = 60;
 
 export function stripAuthPrefix(value: string | null | undefined): string {
   if (!value) return 'N/A';
   const stripped = value.startsWith('auth0|') ? value.slice(6) : value;
   return stripped.length > LEGACY_USERNAME_MAX_LENGTH ? 'N/A' : stripped;
-}
-
-@Pipe({
-  name: 'stripAuthPrefix',
-})
-export class StripAuthPrefixPipe implements PipeTransform {
-  public transform(value: string | null | undefined): string {
-    return stripAuthPrefix(value);
-  }
 }

--- a/apps/lfx-one/src/app/shared/utils/strip-auth-prefix.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/strip-auth-prefix.util.ts
@@ -3,9 +3,13 @@
 
 const LEGACY_USERNAME_MAX_LENGTH = 60;
 
-export function stripAuthPrefix(value: string | null | undefined): string {
-  if (!value) return 'N/A';
+export function stripAuthPrefixOrNull(value: string | null | undefined): string | null {
+  if (!value) return null;
   const stripped = value.startsWith('auth0|') ? value.slice(6) : value;
-  if (!stripped.trim()) return 'N/A';
-  return stripped.length > LEGACY_USERNAME_MAX_LENGTH ? 'N/A' : stripped;
+  if (!stripped.trim()) return null;
+  return stripped.length > LEGACY_USERNAME_MAX_LENGTH ? null : stripped;
+}
+
+export function stripAuthPrefix(value: string | null | undefined): string {
+  return stripAuthPrefixOrNull(value) ?? 'N/A';
 }

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -31,6 +31,36 @@ import { UserService } from '../services/user.service';
 import { getUsernameFromAuth } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
 
+// Maps auth-service error strings to user-facing responses. First match wins; if
+// none match, the password-change path falls back to a generic 502.
+const PASSWORD_ERROR_RULES: readonly {
+  pattern: RegExp;
+  status: number;
+  code: string;
+  message: string;
+  useUpstreamMessage?: boolean;
+}[] = [
+  {
+    pattern: /wrong password|invalid password|incorrect password/,
+    status: 400,
+    code: 'INVALID_CURRENT_PASSWORD',
+    message: 'Your current password is incorrect.',
+  },
+  {
+    pattern: /password is too weak|password policy|does not meet/,
+    status: 400,
+    code: 'PASSWORD_POLICY_VIOLATION',
+    message: 'Your new password does not meet the password policy requirements.',
+    useUpstreamMessage: true,
+  },
+  {
+    pattern: /too many|rate limit|blocked/,
+    status: 429,
+    code: 'TOO_MANY_ATTEMPTS',
+    message: 'Too many password change attempts. Please wait a few minutes and try again.',
+  },
+];
+
 /**
  * Controller for handling profile HTTP requests
  */
@@ -573,45 +603,14 @@ export class ProfileController {
       const result = await this.emailVerificationService.changePassword(req, mgmtToken, current_password, new_password);
 
       if (!result.success) {
-        const msg = result.message || result.error || '';
-        const isWrongPassword =
-          msg.toLowerCase().includes('wrong password') || msg.toLowerCase().includes('invalid password') || msg.toLowerCase().includes('incorrect password');
-        const isPolicyViolation =
-          msg.toLowerCase().includes('password is too weak') || msg.toLowerCase().includes('password policy') || msg.toLowerCase().includes('does not meet');
-        const isRateLimit = msg.toLowerCase().includes('too many') || msg.toLowerCase().includes('rate limit') || msg.toLowerCase().includes('blocked');
-
-        if (isWrongPassword) {
-          return next(
-            new MicroserviceError('Your current password is incorrect.', 400, 'INVALID_CURRENT_PASSWORD', {
-              operation: 'change_password',
-              service: 'profile_controller',
-              path: req.path,
-            })
-          );
-        }
-
-        if (isPolicyViolation) {
-          return next(
-            new MicroserviceError(result.message || 'Your new password does not meet the password policy requirements.', 400, 'PASSWORD_POLICY_VIOLATION', {
-              operation: 'change_password',
-              service: 'profile_controller',
-              path: req.path,
-            })
-          );
-        }
-
-        if (isRateLimit) {
-          return next(
-            new MicroserviceError('Too many password change attempts. Please wait a few minutes and try again.', 429, 'TOO_MANY_ATTEMPTS', {
-              operation: 'change_password',
-              service: 'profile_controller',
-              path: req.path,
-            })
-          );
-        }
+        const msg = (result.message || result.error || '').toLowerCase();
+        const match = PASSWORD_ERROR_RULES.find((rule) => rule.pattern.test(msg));
+        const { status, code, message } = match
+          ? { status: match.status, code: match.code, message: match.useUpstreamMessage ? result.message || match.message : match.message }
+          : { status: 502, code: 'AUTH_SERVICE_ERROR', message: result.message || 'Failed to change password' };
 
         return next(
-          new MicroserviceError(result.message || 'Failed to change password', 502, 'AUTH_SERVICE_ERROR', {
+          new MicroserviceError(message, status, code, {
             operation: 'change_password',
             service: 'profile_controller',
             path: req.path,
@@ -1409,13 +1408,8 @@ export class ProfileController {
           social_sub: socialSub,
           is_already_linked: isAlreadyLinked,
         });
-        if (isAlreadyLinked) {
-          const linkedTo = encodeURIComponent(linkResponse.message?.match(/account:\s*(\S+)/)?.[1] || '');
-          const linkedToParam = linkedTo ? `&linkedTo=${linkedTo}` : '';
-          res.redirect(`${returnTo}?error=already_linked${linkedToParam}`);
-        } else {
-          res.redirect(`${returnTo}?error=link_failed`);
-        }
+        // Do not include the owning LFID — leaking it would enable account enumeration.
+        res.redirect(`${returnTo}?error=${isAlreadyLinked ? 'already_linked' : 'link_failed'}`);
         return;
       }
 

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -573,6 +573,43 @@ export class ProfileController {
       const result = await this.emailVerificationService.changePassword(req, mgmtToken, current_password, new_password);
 
       if (!result.success) {
+        const msg = result.message || result.error || '';
+        const isWrongPassword =
+          msg.toLowerCase().includes('wrong password') || msg.toLowerCase().includes('invalid password') || msg.toLowerCase().includes('incorrect password');
+        const isPolicyViolation =
+          msg.toLowerCase().includes('password is too weak') || msg.toLowerCase().includes('password policy') || msg.toLowerCase().includes('does not meet');
+        const isRateLimit = msg.toLowerCase().includes('too many') || msg.toLowerCase().includes('rate limit') || msg.toLowerCase().includes('blocked');
+
+        if (isWrongPassword) {
+          return next(
+            new MicroserviceError('Your current password is incorrect.', 400, 'INVALID_CURRENT_PASSWORD', {
+              operation: 'change_password',
+              service: 'profile_controller',
+              path: req.path,
+            })
+          );
+        }
+
+        if (isPolicyViolation) {
+          return next(
+            new MicroserviceError(result.message || 'Your new password does not meet the password policy requirements.', 400, 'PASSWORD_POLICY_VIOLATION', {
+              operation: 'change_password',
+              service: 'profile_controller',
+              path: req.path,
+            })
+          );
+        }
+
+        if (isRateLimit) {
+          return next(
+            new MicroserviceError('Too many password change attempts. Please wait a few minutes and try again.', 429, 'TOO_MANY_ATTEMPTS', {
+              operation: 'change_password',
+              service: 'profile_controller',
+              path: req.path,
+            })
+          );
+        }
+
         return next(
           new MicroserviceError(result.message || 'Failed to change password', 502, 'AUTH_SERVICE_ERROR', {
             operation: 'change_password',
@@ -618,14 +655,7 @@ export class ProfileController {
       // Fetch CDP identities and auth-service identities in parallel
       const [cdpIdentities, auth0Identities] = await Promise.all([
         this.cdpService.getIdentitiesForUser(req, lfid),
-        auth0Sub
-          ? this.auth0Service.getUserIdentities(req, auth0Sub).catch((err: unknown) => {
-              logger.warning(req, 'get_identities', 'Auth0 identity fetch failed, continuing without cross-reference', {
-                err,
-              });
-              return [] as Auth0Identity[];
-            })
-          : Promise.resolve([]),
+        auth0Sub ? this.auth0Service.getUserIdentities(req, auth0Sub) : Promise.resolve([]),
       ]);
 
       logger.debug(req, 'get_identities', 'Raw identity data before reconciliation', {
@@ -1379,8 +1409,13 @@ export class ProfileController {
           social_sub: socialSub,
           is_already_linked: isAlreadyLinked,
         });
-        const errorParam = isAlreadyLinked ? 'already_linked' : 'link_failed';
-        res.redirect(`${returnTo}?error=${errorParam}`);
+        if (isAlreadyLinked) {
+          const linkedTo = encodeURIComponent(linkResponse.message?.match(/account:\s*(\S+)/)?.[1] || '');
+          const linkedToParam = linkedTo ? `&linkedTo=${linkedTo}` : '';
+          res.redirect(`${returnTo}?error=already_linked${linkedToParam}`);
+        } else {
+          res.redirect(`${returnTo}?error=link_failed`);
+        }
         return;
       }
 

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -54,7 +54,7 @@ const PASSWORD_ERROR_RULES: readonly {
     useUpstreamMessage: true,
   },
   {
-    pattern: /too many|rate limit|blocked/,
+    pattern: /\btoo many (attempts|requests)\b|\brate.?limit\b|\baccount (is )?blocked\b/,
     status: 429,
     code: 'TOO_MANY_ATTEMPTS',
     message: 'Too many password change attempts. Please wait a few minutes and try again.',

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -346,7 +346,7 @@ export class ProfileController {
 
       const [freshEmails, identities] = await Promise.all([
         this.emailVerificationService.getUserEmails(req, userSub),
-        this.emailVerificationService.listIdentities(req, userSub),
+        this.emailVerificationService.listIdentitiesSafe(req, userSub),
       ]);
 
       const primaryEmail = freshEmails?.primary_email || sessionEmail;
@@ -603,11 +603,22 @@ export class ProfileController {
       const result = await this.emailVerificationService.changePassword(req, mgmtToken, current_password, new_password);
 
       if (!result.success) {
-        const msg = (result.message || result.error || '').toLowerCase();
-        const match = PASSWORD_ERROR_RULES.find((rule) => rule.pattern.test(msg));
+        const upstreamText = [result.error, result.message].filter(Boolean).join(' ').toLowerCase();
+        const match = PASSWORD_ERROR_RULES.find((rule) => rule.pattern.test(upstreamText));
         const { status, code, message } = match
-          ? { status: match.status, code: match.code, message: match.useUpstreamMessage ? result.message || match.message : match.message }
+          ? {
+              status: match.status,
+              code: match.code,
+              message: match.useUpstreamMessage ? result.message || result.error || match.message : match.message,
+            }
           : { status: 502, code: 'AUTH_SERVICE_ERROR', message: result.message || 'Failed to change password' };
+
+        if (!match) {
+          logger.warning(req, 'change_password', 'Unclassified password change failure — upstream message format may have changed', {
+            upstream_message: result.message,
+            upstream_error: result.error,
+          });
+        }
 
         return next(
           new MicroserviceError(message, status, code, {

--- a/apps/lfx-one/src/server/services/email-verification.service.ts
+++ b/apps/lfx-one/src/server/services/email-verification.service.ts
@@ -521,6 +521,19 @@ export class EmailVerificationService {
    * @param userIdentifier - User's subject ID (e.g. auth0|123456789), username, or email — sent as raw string to auth-service which resolves it without JWT audience validation (same convention as getUserEmails)
    * @returns Array of Auth0 linked identities
    */
+  /**
+   * Non-throwing variant for callers that can degrade gracefully (e.g. email backfill).
+   * Returns an empty array on failure. Use listIdentities() when identity data is critical.
+   */
+  public async listIdentitiesSafe(req: Request, userIdentifier: string): Promise<Auth0Identity[]> {
+    try {
+      return await this.listIdentities(req, userIdentifier);
+    } catch (error) {
+      logger.warning(req, 'list_identities_safe', 'Identity list unavailable — continuing without it', { err: error });
+      return [];
+    }
+  }
+
   public async listIdentities(req: Request, userIdentifier: string): Promise<Auth0Identity[]> {
     const codec = this.natsService.getCodec();
 

--- a/apps/lfx-one/src/server/services/email-verification.service.ts
+++ b/apps/lfx-one/src/server/services/email-verification.service.ts
@@ -526,17 +526,14 @@ export class EmailVerificationService {
 
     logger.debug(req, 'list_identities', 'Listing user identities via NATS');
 
+    let parsed: ListIdentitiesNatsResponse;
     try {
-      const payload = JSON.stringify({
-        user: { auth_token: userIdentifier },
-      });
-
+      const payload = JSON.stringify({ user: { auth_token: userIdentifier } });
       const response = await this.natsService.request(NatsSubjects.USER_IDENTITY_LIST, codec.encode(payload), {
         timeout: NATS_CONFIG.REQUEST_TIMEOUT,
       });
-
       const responseText = codec.decode(response.data);
-      const parsed: ListIdentitiesNatsResponse = JSON.parse(responseText);
+      parsed = JSON.parse(responseText);
 
       logger.debug(req, 'list_identities', 'Raw NATS USER_IDENTITY_LIST response', {
         raw_response: responseText,
@@ -544,34 +541,27 @@ export class EmailVerificationService {
         parsed_data: parsed.data,
         parsed_error: parsed.error,
       });
-
-      if (!parsed.success || !parsed.data) {
-        logger.warning(req, 'list_identities', 'NATS identity list returned unsuccessful', {
-          error: parsed.error,
-          message: parsed.message,
-        });
-        throw new MicroserviceError('Auth service temporarily unavailable', 503, 'AUTH_SERVICE_UNAVAILABLE', {
-          operation: 'list_identities',
-          service: 'email_verification_service',
-        });
-      }
-
-      logger.debug(req, 'list_identities', 'Fetched identities via NATS', {
-        identity_count: parsed.data.length,
-      });
-
-      return parsed.data;
     } catch (error) {
-      if (error instanceof MicroserviceError) {
-        throw error;
-      }
-      logger.warning(req, 'list_identities', 'Failed to list identities via NATS', {
-        err: error,
-      });
-      throw new MicroserviceError('Auth service temporarily unavailable', 503, 'AUTH_SERVICE_UNAVAILABLE', {
-        operation: 'list_identities',
-        service: 'email_verification_service',
-      });
+      logger.warning(req, 'list_identities', 'Failed to list identities via NATS', { err: error });
+      throw this.authServiceUnavailable();
     }
+
+    if (!parsed.success || !parsed.data) {
+      logger.warning(req, 'list_identities', 'NATS identity list returned unsuccessful', {
+        error: parsed.error,
+        message: parsed.message,
+      });
+      throw this.authServiceUnavailable();
+    }
+
+    logger.debug(req, 'list_identities', 'Fetched identities via NATS', { identity_count: parsed.data.length });
+    return parsed.data;
+  }
+
+  private authServiceUnavailable(): MicroserviceError {
+    return new MicroserviceError('Auth service temporarily unavailable', 503, 'AUTH_SERVICE_UNAVAILABLE', {
+      operation: 'list_identities',
+      service: 'email_verification_service',
+    });
   }
 }

--- a/apps/lfx-one/src/server/services/email-verification.service.ts
+++ b/apps/lfx-one/src/server/services/email-verification.service.ts
@@ -516,12 +516,6 @@ export class EmailVerificationService {
   }
 
   /**
-   * List linked identities for a user via NATS
-   * @param req - Express request object for logging
-   * @param userIdentifier - User's subject ID (e.g. auth0|123456789), username, or email — sent as raw string to auth-service which resolves it without JWT audience validation (same convention as getUserEmails)
-   * @returns Array of Auth0 linked identities
-   */
-  /**
    * Non-throwing variant for callers that can degrade gracefully (e.g. email backfill).
    * Returns an empty array on failure. Use listIdentities() when identity data is critical.
    */
@@ -534,6 +528,13 @@ export class EmailVerificationService {
     }
   }
 
+  /**
+   * List linked identities for a user via NATS.
+   * @param req - Express request object for logging
+   * @param userIdentifier - User's subject ID (e.g. auth0|123456789), username, or email — sent as raw string to auth-service which resolves it without JWT audience validation (same convention as getUserEmails)
+   * @returns Array of Auth0 linked identities
+   * @throws {MicroserviceError} 503 when the auth service is unavailable
+   */
   public async listIdentities(req: Request, userIdentifier: string): Promise<Auth0Identity[]> {
     const codec = this.natsService.getCodec();
 
@@ -556,7 +557,7 @@ export class EmailVerificationService {
       });
     } catch (error) {
       logger.warning(req, 'list_identities', 'Failed to list identities via NATS', { err: error });
-      throw this.authServiceUnavailable();
+      throw this.authServiceUnavailable('list_identities');
     }
 
     if (!parsed.success || !parsed.data) {
@@ -564,16 +565,16 @@ export class EmailVerificationService {
         error: parsed.error,
         message: parsed.message,
       });
-      throw this.authServiceUnavailable();
+      throw this.authServiceUnavailable('list_identities');
     }
 
     logger.debug(req, 'list_identities', 'Fetched identities via NATS', { identity_count: parsed.data.length });
     return parsed.data;
   }
 
-  private authServiceUnavailable(): MicroserviceError {
+  private authServiceUnavailable(operation: string): MicroserviceError {
     return new MicroserviceError('Auth service temporarily unavailable', 503, 'AUTH_SERVICE_UNAVAILABLE', {
-      operation: 'list_identities',
+      operation,
       service: 'email_verification_service',
     });
   }

--- a/apps/lfx-one/src/server/services/email-verification.service.ts
+++ b/apps/lfx-one/src/server/services/email-verification.service.ts
@@ -15,6 +15,7 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
+import { MicroserviceError } from '../errors';
 import { logger } from './logger.service';
 import { NatsService } from './nats.service';
 
@@ -549,7 +550,10 @@ export class EmailVerificationService {
           error: parsed.error,
           message: parsed.message,
         });
-        return [];
+        throw new MicroserviceError('Auth service temporarily unavailable', 503, 'AUTH_SERVICE_UNAVAILABLE', {
+          operation: 'list_identities',
+          service: 'email_verification_service',
+        });
       }
 
       logger.debug(req, 'list_identities', 'Fetched identities via NATS', {
@@ -558,10 +562,16 @@ export class EmailVerificationService {
 
       return parsed.data;
     } catch (error) {
-      logger.warning(req, 'list_identities', 'Failed to list identities via NATS, returning empty array', {
+      if (error instanceof MicroserviceError) {
+        throw error;
+      }
+      logger.warning(req, 'list_identities', 'Failed to list identities via NATS', {
         err: error,
       });
-      return [];
+      throw new MicroserviceError('Auth service temporarily unavailable', 503, 'AUTH_SERVICE_UNAVAILABLE', {
+        operation: 'list_identities',
+        service: 'email_verification_service',
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary

Four related polish fixes in the Profile module that surface real state to users instead of silently degrading:

- **Username display** — Strip `auth0|` prefix from the profile card and Edit Profile dialog. Legacy hash-style usernames (>60 chars after stripping) fall back to `"N/A"` via a new shared `stripAuthPrefix` pipe.
- **Identity service outages** — Propagate auth-service failures as HTTP `503` (`MicroserviceError`) instead of returning an empty identity list. The Identities tab renders an honest "Identity service unavailable" banner instead of falsely marking every CDP identity as unverified when auth0 is down.
- **Already-linked identity** — Show a persistent, dismissible banner when a user attempts to link an identity already attached to another LFX account. Copy is intentionally generic (no LFID disclosure / enumeration risk). Uses `history.replaceState` to clean the URL without destroying banner state.
- **Password change feedback** — Add `<p-toast>` to the Password tab template so the existing `MessageService` calls render. Backend now differentiates auth-service failures: `400` for invalid current password / policy violation, `429` for rate limiting, `502` for true service errors.

Fixes LFXV2-1575.

## Test plan

- [ ] Log in as an `auth0|`-prefixed user — profile card + Edit Profile dialog show the cleaned username.
- [ ] Stub a username >60 chars — both surfaces render `"N/A"`.
- [ ] Stop the auth-service (or force `listIdentities` to throw) — `/api/profile/identities` returns 503 and the Identities tab shows the "Identity service unavailable" error banner. No false "unverified" labels.
- [ ] Visit `/profile/identities?error=already_linked` directly — amber banner renders with generic copy and a working "contact support" link (`.../desk/portal/4`). URL cleans itself. Dismiss hides the banner without triggering a re-render.
- [ ] Real conflict flow: LFID_X owns a GitHub identity, LFID_Y attempts to link the same identity — banner renders. Confirm **no** LFID appears in the banner copy or URL.
- [ ] Password tab — correct current password → success toast; wrong current password → "Your current password is incorrect."; weak new password → policy message; auth-service down → generic service-unavailable toast (502).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>