### PR TITLE
build(ui): fail on template diagnostics and silence cjs warnings

### DIFF
--- a/apps/lfx-one/angular.json
+++ b/apps/lfx-one/angular.json
@@ -54,13 +54,15 @@
             },
             "allowedCommonJsDependencies": [
               "@linuxfoundation/lfx-ui-core",
+              "@openfeature/web-sdk",
               "combined-stream",
               "mime-types",
               "asynckit",
               "hasown",
               "es-set-tostringtag",
               "safe-buffer",
-              "lodash.isempty"
+              "lodash.isempty",
+              "quill-delta"
             ],
             "externalDependencies": ["snowflake-sdk", "@opentelemetry/api", "@opentelemetry/semantic-conventions", "pdfkit"]
           },

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -740,7 +740,7 @@
                 <h1>Meeting Participants</h1>
                 <span class="text-base text-gray-500">{{ attendedCount() }} attended / {{ invitedCount() }} invited</span>
               </div>
-            } @else if (meeting().committees?.length) {
+            } @else if (meeting().committees.length) {
               <div class="flex flex-col">
                 <h1>Meeting Members</h1>
                 <span class="text-base text-gray-500">{{ totalInvitees() }} members</span>

--- a/apps/lfx-one/tsconfig.json
+++ b/apps/lfx-one/tsconfig.json
@@ -36,6 +36,9 @@
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
-    "strictTemplates": true
+    "strictTemplates": true,
+    "extendedDiagnostics": {
+      "defaultCategory": "error"
+    }
   }
 }


### PR DESCRIPTION
## Summary

Promote Angular extended diagnostics (NG8xxx family) to **errors** so template issues fail the build instead of being silently emitted as warnings. Also silence the two remaining third-party CommonJS bundler warnings so a clean build signals a clean codebase.

## Why

The recent PR #569 introduced a redundant optional chain (`meeting().committees?.length`) that triggered `NG8107` at build time — but the build still passed because extended diagnostics default to `warning`. This kind of issue should fail CI. Promoting the category to `error` catches the same class of real template bugs automatically:

- `NG8107` `optionalChainNotNullable` — our exact case
- `invalidBananaInBox` — `[(foo)]` where target isn't two-way
- `interpolatedSignalNotInvoked` — signal used without `()` in a template
- `uninvokedFunctionInEventBinding`
- `nullishCoalescingNotNullable`
- `missingControlFlowDirective`
- …and the rest of the Angular template diagnostic family

## Changes

- `apps/lfx-one/tsconfig.json` — add `extendedDiagnostics.defaultCategory: "error"` under `angularCompilerOptions`. Requires `strictTemplates`, which is already enabled.
- `apps/lfx-one/angular.json` — allowlist `@openfeature/web-sdk` and `quill-delta` in `allowedCommonJsDependencies` so the two remaining third-party CJS bundler warnings stop firing. Bundle size is unaffected; only the diagnostic is suppressed.
- `apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html` — drop the redundant `?.` on `meeting().committees.length` (the field is typed as non-optional `MeetingCommittee[]`).

## Tradeoff

Per Angular docs, minor Angular upgrades can add new diagnostic checks. If a new check trips on legitimate code, it can be demoted individually in the same config:

```json
"extendedDiagnostics": {
  "defaultCategory": "error",
  "checks": { "someNewCheck": "warning" }
}
```

## Verification

- `yarn build` — clean, zero warnings.
- Temporarily reverted the `committees.length` fix → build failed with `NG8107: ERROR` and exit code 1, confirming the gate works.