### PR TITLE
feat(certification): add unified certification view

### DIFF
--- a/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.html
@@ -1,0 +1,97 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<lfx-card data-testid="unified-cert-card">
+  <div class="p-4 flex items-start gap-5">
+    <!-- Col 1: Logo -->
+    <div
+      class="flex-shrink-0 w-14 h-14 flex items-center justify-center overflow-hidden rounded-xl bg-gray-50 border border-gray-100"
+      data-testid="unified-cert-card-image-container">
+      @if (hasImage()) {
+        <img
+          [src]="cert().imageUrl"
+          [alt]="cert().name"
+          class="w-14 h-14 object-cover scale-[1.16] origin-[center_60%]"
+          data-testid="unified-cert-card-image" />
+      } @else {
+        <i class="fa-light fa-award text-2xl text-gray-400" aria-hidden="true" data-testid="unified-cert-card-icon-fallback"></i>
+      }
+    </div>
+
+    <!-- Col 2: Main content -->
+    <div class="flex-1 min-w-0 flex flex-col gap-3">
+      <!-- Top row: name | actions -->
+      <div class="flex items-start justify-between gap-4">
+        <div class="flex flex-col gap-0.5 min-w-0">
+          <h3 class="text-sm font-semibold text-gray-900 leading-snug" data-testid="unified-cert-card-name">{{ cert().name }}</h3>
+          <p class="text-sm text-gray-500" data-testid="unified-cert-card-issued-by">{{ cert().issuedBy }}</p>
+        </div>
+
+        <!-- Action buttons -->
+        <div class="flex-shrink-0 flex items-center gap-2" data-testid="unified-cert-card-actions">
+          @if (stateBadge()) {
+            <span
+              class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
+              [class]="stateBadge()!.classes"
+              data-testid="unified-cert-card-state-badge">
+              {{ stateBadge()!.label }}
+            </span>
+          }
+          @if (secondaryAction()) {
+            <lfx-button
+              severity="secondary"
+              size="small"
+              styleClass="whitespace-nowrap"
+              [label]="secondaryAction()!.label"
+              [icon]="secondaryAction()!.icon ?? ''"
+              [href]="secondaryAction()!.href"
+              target="_blank"
+              rel="noopener noreferrer"
+              [outlined]="true"
+              data-testid="unified-cert-card-secondary-btn" />
+          }
+          @if (primaryAction()) {
+            <lfx-button
+              [severity]="primaryAction()!.severity ?? 'primary'"
+              size="small"
+              styleClass="whitespace-nowrap"
+              [label]="primaryAction()!.label"
+              [icon]="primaryAction()!.icon ?? ''"
+              [href]="primaryAction()!.href"
+              target="_blank"
+              rel="noopener noreferrer"
+              [outlined]="true"
+              data-testid="unified-cert-card-primary-btn" />
+          }
+        </div>
+      </div>
+
+      <!-- Description -->
+      <p class="text-sm text-gray-600 line-clamp-2" [title]="cert().description" data-testid="unified-cert-card-description">
+        {{ cert().description }}
+      </p>
+
+      <!-- Meta row -->
+      @if (metaFields().length > 0) {
+        <div class="border-t border-gray-100 pt-3" data-testid="unified-cert-card-meta-row">
+          <div class="flex flex-wrap gap-x-8 gap-y-1.5 text-xs" data-testid="unified-cert-card-meta">
+            @for (field of metaFields(); track field.label) {
+              <div class="flex flex-col gap-0.5">
+                <span class="text-gray-400">{{ field.label }}</span>
+                @if (field.label === 'Date Earned' || (field.label === 'Valid Until' && field.value !== 'No Expiry')) {
+                  <span class="font-medium" [class]="field.classes ?? 'text-gray-700'" data-testid="unified-cert-card-meta-value">
+                    {{ field.value | date: 'MMM d, y' }}
+                  </span>
+                } @else {
+                  <span class="font-medium" [class]="field.classes ?? 'text-gray-500 font-mono'" data-testid="unified-cert-card-meta-value">
+                    {{ field.value }}
+                  </span>
+                }
+              </div>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+</lfx-card>

--- a/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.html
@@ -2,33 +2,46 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <lfx-card data-testid="unified-cert-card">
-  <div class="p-5 flex items-start gap-5">
-    <!-- Col 1: Logo -->
-    <div
-      class="flex-shrink-0 w-14 h-14 flex items-center justify-center overflow-hidden rounded-xl bg-gray-50 border border-gray-100"
-      data-testid="unified-cert-card-image-container">
-      @if (hasImage()) {
-        <img
-          [src]="cert().imageUrl"
-          [alt]="cert().name"
-          class="w-14 h-14 object-cover scale-[1.16] origin-[center_60%]"
-          data-testid="unified-cert-card-image" />
-      } @else {
-        <i class="fa-light fa-award text-2xl text-gray-400" aria-hidden="true" data-testid="unified-cert-card-icon-fallback"></i>
+  <div class="p-5 flex flex-col gap-3 md:flex-row md:items-start md:gap-5">
+    <!-- Top row on mobile: logo + badge | Desktop: logo only (col 1) -->
+    <div class="flex items-start justify-between gap-3 md:block md:flex-shrink-0">
+      <!-- Logo -->
+      <div
+        class="flex-shrink-0 w-14 h-14 flex items-center justify-center overflow-hidden rounded-xl bg-gray-50 border border-gray-100"
+        data-testid="unified-cert-card-image-container">
+        @if (hasImage()) {
+          <img
+            [src]="cert().imageUrl"
+            [alt]="cert().name"
+            class="w-14 h-14 object-cover scale-[1.16] origin-[center_60%]"
+            data-testid="unified-cert-card-image" />
+        } @else {
+          <i class="fa-light fa-award text-2xl text-gray-400" aria-hidden="true" data-testid="unified-cert-card-icon-fallback"></i>
+        }
+      </div>
+
+      <!-- Mobile-only badge (shown next to logo) -->
+      @if (stateBadge()) {
+        <span
+          class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium md:hidden"
+          [class]="stateBadge()!.classes"
+          data-testid="unified-cert-card-state-badge-mobile">
+          {{ stateBadge()!.label }}
+        </span>
       }
     </div>
 
     <!-- Col 2: Main content -->
     <div class="flex-1 min-w-0 flex flex-col gap-3">
-      <!-- Top row: name | actions -->
+      <!-- Top row: name | actions (desktop) / name only (mobile) -->
       <div class="flex items-start justify-between gap-4">
         <div class="flex flex-col gap-1 min-w-0">
           <h3 class="text-sm font-semibold text-gray-900 leading-snug" data-testid="unified-cert-card-name">{{ cert().name }}</h3>
           <p class="text-sm text-gray-500" data-testid="unified-cert-card-issued-by">{{ cert().issuedBy }}</p>
         </div>
 
-        <!-- Action buttons -->
-        <div class="flex-shrink-0 flex items-center gap-2" data-testid="unified-cert-card-actions">
+        <!-- Desktop-only action buttons + badge -->
+        <div class="flex-shrink-0 hidden md:flex items-center gap-2" data-testid="unified-cert-card-actions">
           @if (stateBadge()) {
             <span
               class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium"
@@ -90,6 +103,38 @@
               </div>
             }
           </div>
+        </div>
+      }
+
+      <!-- Mobile-only action buttons row -->
+      @if (primaryAction() || secondaryAction()) {
+        <div class="flex md:hidden items-center gap-2 pt-1" data-testid="unified-cert-card-actions-mobile">
+          @if (secondaryAction()) {
+            <lfx-button
+              severity="secondary"
+              size="small"
+              styleClass="whitespace-nowrap"
+              [label]="secondaryAction()!.label"
+              [icon]="secondaryAction()!.icon ?? ''"
+              [href]="secondaryAction()!.href"
+              target="_blank"
+              rel="noopener noreferrer"
+              [outlined]="true"
+              data-testid="unified-cert-card-secondary-btn-mobile" />
+          }
+          @if (primaryAction()) {
+            <lfx-button
+              [severity]="primaryAction()!.severity ?? 'primary'"
+              size="small"
+              styleClass="whitespace-nowrap"
+              [label]="primaryAction()!.label"
+              [icon]="primaryAction()!.icon ?? ''"
+              [href]="primaryAction()!.href"
+              target="_blank"
+              rel="noopener noreferrer"
+              [outlined]="true"
+              data-testid="unified-cert-card-primary-btn-mobile" />
+          }
         </div>
       }
     </div>

--- a/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <lfx-card data-testid="unified-cert-card">
-  <div class="p-4 flex items-start gap-5">
+  <div class="p-5 flex items-start gap-5">
     <!-- Col 1: Logo -->
     <div
       class="flex-shrink-0 w-14 h-14 flex items-center justify-center overflow-hidden rounded-xl bg-gray-50 border border-gray-100"
@@ -22,7 +22,7 @@
     <div class="flex-1 min-w-0 flex flex-col gap-3">
       <!-- Top row: name | actions -->
       <div class="flex items-start justify-between gap-4">
-        <div class="flex flex-col gap-0.5 min-w-0">
+        <div class="flex flex-col gap-1 min-w-0">
           <h3 class="text-sm font-semibold text-gray-900 leading-snug" data-testid="unified-cert-card-name">{{ cert().name }}</h3>
           <p class="text-sm text-gray-500" data-testid="unified-cert-card-issued-by">{{ cert().issuedBy }}</p>
         </div>

--- a/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.scss
+++ b/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.ts
@@ -57,11 +57,10 @@ export class UnifiedCertCardComponent {
       if (cert.expiryDate) {
         const expired = new Date(cert.expiryDate) < new Date();
         const expiringSoon = !expired && new Date(cert.expiryDate).getTime() - Date.now() <= NINETY_DAYS_MS;
-        fields.push({
-          label: 'Valid Until',
-          value: cert.expiryDate,
-          classes: expired ? 'text-red-600 font-medium' : expiringSoon ? 'text-amber-600 font-medium' : 'text-gray-700',
-        });
+        let expiryClasses = 'text-gray-700';
+        if (expired) expiryClasses = 'text-red-600 font-medium';
+        else if (expiringSoon) expiryClasses = 'text-amber-600 font-medium';
+        fields.push({ label: 'Valid Until', value: cert.expiryDate, classes: expiryClasses });
       } else if (cert.certId) {
         fields.push({ label: 'Valid Until', value: 'No Expiry', classes: 'text-gray-700' });
       }
@@ -74,7 +73,7 @@ export class UnifiedCertCardComponent {
     });
   }
 
-  private initPrimaryAction(): Signal<{ label: string; href: string; icon?: string } | null> {
+  private initPrimaryAction(): Signal<{ label: string; href: string; icon?: string; severity?: ButtonSeverity } | null> {
     return computed(() => {
       const cert = this.cert();
       const renewUrl = cert.isActiveEnrollment ? this.continueLearningUrl() : this.enrollAgainUrl();

--- a/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.ts
@@ -95,7 +95,7 @@ export class UnifiedCertCardComponent {
   private initSecondaryAction(): Signal<{ label: string; href: string; icon?: string } | null> {
     return computed(() => {
       const cert = this.cert();
-      if (cert.state === 'cert-expired' && cert.downloadUrl) {
+      if ((cert.state === 'cert-expired' || cert.state === 'expiring-soon') && cert.downloadUrl) {
         return { label: 'Download', href: cert.downloadUrl, icon: 'fa-light fa-arrow-down-to-line' };
       }
       return null;

--- a/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.ts
@@ -1,0 +1,119 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Generated with [Claude Code](https://claude.ai/code)
+
+import { DatePipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, input, Signal } from '@angular/core';
+import { ButtonSeverity, UnifiedCertification, UnifiedCertState } from '@lfx-one/shared/interfaces';
+import { COURSE_URL_PREFIX, CONTINUE_LEARNING_URL, ENROLL_AGAIN_URL, ENROLL_AGAIN_URL_PREFIX } from '@lfx-one/shared/constants';
+
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+
+@Component({
+  selector: 'lfx-unified-cert-card',
+  imports: [ButtonComponent, CardComponent, DatePipe],
+  templateUrl: './unified-cert-card.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class UnifiedCertCardComponent {
+  // ─── Inputs ────────────────────────────────────────────────────────────────
+  public readonly cert = input.required<UnifiedCertification>();
+
+  // ─── Computed Signals ──────────────────────────────────────────────────────
+  protected readonly hasImage = computed(() => !!this.cert().imageUrl);
+  protected readonly stateBadge: Signal<{ label: string; classes: string } | null> = this.initStateBadge();
+  protected readonly metaFields: Signal<{ label: string; value: string; classes?: string }[]> = this.initMetaFields();
+  protected readonly primaryAction: Signal<{ label: string; href: string; icon?: string; severity?: ButtonSeverity } | null> = this.initPrimaryAction();
+  protected readonly secondaryAction: Signal<{ label: string; href: string; icon?: string } | null> = this.initSecondaryAction();
+  protected readonly continueLearningUrl: Signal<string> = this.initContinueLearningUrl();
+  protected readonly enrollAgainUrl: Signal<string> = this.initEnrollAgainUrl();
+
+  // ─── Private Initializers ──────────────────────────────────────────────────
+  private initStateBadge(): Signal<{ label: string; classes: string } | null> {
+    return computed(() => {
+      const state = this.cert().state;
+      const badges: Partial<Record<UnifiedCertState, { label: string; classes: string }>> = {
+        'expiring-soon': { label: 'Expiring Soon', classes: 'bg-amber-50 border border-amber-200 text-amber-700' },
+        'enrolled-cert-expired': { label: 'Cert Expired', classes: 'bg-red-50 border border-red-200 text-red-700' },
+        'cert-expired': { label: 'Expired', classes: 'bg-red-50 border border-red-200 text-red-700' },
+      };
+      return badges[state] ?? null;
+    });
+  }
+
+  private initMetaFields(): Signal<{ label: string; value: string; classes?: string }[]> {
+    return computed(() => {
+      const cert = this.cert();
+      const fields: { label: string; value: string; classes?: string }[] = [];
+
+      if (cert.issuedDate) {
+        fields.push({ label: 'Date Earned', value: cert.issuedDate });
+      }
+
+      if (cert.expiryDate) {
+        const expired = new Date(cert.expiryDate) < new Date();
+        const expiringSoon = !expired && new Date(cert.expiryDate).getTime() - Date.now() <= NINETY_DAYS_MS;
+        fields.push({
+          label: 'Valid Until',
+          value: cert.expiryDate,
+          classes: expired ? 'text-red-600 font-medium' : expiringSoon ? 'text-amber-600 font-medium' : 'text-gray-700',
+        });
+      } else if (cert.certId) {
+        fields.push({ label: 'Valid Until', value: 'No Expiry', classes: 'text-gray-700' });
+      }
+
+      if (cert.certificateId) {
+        fields.push({ label: 'Certificate ID', value: cert.certificateId });
+      }
+
+      return fields;
+    });
+  }
+
+  private initPrimaryAction(): Signal<{ label: string; href: string; icon?: string } | null> {
+    return computed(() => {
+      const cert = this.cert();
+      const renewUrl = cert.isActiveEnrollment ? this.continueLearningUrl() : this.enrollAgainUrl();
+      switch (cert.state) {
+        case 'certified-active':
+        case 'cert-only':
+          return cert.downloadUrl ? { label: 'Download', href: cert.downloadUrl, icon: 'fa-light fa-arrow-down-to-line', severity: 'secondary' } : null;
+        case 'expiring-soon':
+        case 'enrolled-cert-expired':
+          return { label: 'Renew Now', href: renewUrl };
+        case 'cert-expired':
+          return { label: 'Renew Now', href: renewUrl };
+        default:
+          return null;
+      }
+    });
+  }
+
+  private initSecondaryAction(): Signal<{ label: string; href: string; icon?: string } | null> {
+    return computed(() => {
+      const cert = this.cert();
+      if (cert.state === 'cert-expired' && cert.downloadUrl) {
+        return { label: 'Download', href: cert.downloadUrl, icon: 'fa-light fa-arrow-down-to-line' };
+      }
+      return null;
+    });
+  }
+
+  private initContinueLearningUrl(): Signal<string> {
+    return computed(() => {
+      const slug = this.cert().courseSlug;
+      return slug ? `${COURSE_URL_PREFIX}${slug}` : CONTINUE_LEARNING_URL;
+    });
+  }
+
+  private initEnrollAgainUrl(): Signal<string> {
+    return computed(() => {
+      const slug = this.cert().courseSlug;
+      return slug ? `${ENROLL_AGAIN_URL_PREFIX}${slug}` : ENROLL_AGAIN_URL;
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/components/unified-cert-card/unified-cert-card.component.ts
@@ -11,7 +11,11 @@ import { COURSE_URL_PREFIX, CONTINUE_LEARNING_URL, ENROLL_AGAIN_URL, ENROLL_AGAI
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 
-const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
+const EXPIRY_CLASS_BY_STATE: Partial<Record<UnifiedCertState, string>> = {
+  'expiring-soon': 'text-amber-600 font-medium',
+  'enrolled-cert-expired': 'text-red-600 font-medium',
+  'cert-expired': 'text-red-600 font-medium',
+};
 
 @Component({
   selector: 'lfx-unified-cert-card',
@@ -55,11 +59,7 @@ export class UnifiedCertCardComponent {
       }
 
       if (cert.expiryDate) {
-        const expired = new Date(cert.expiryDate) < new Date();
-        const expiringSoon = !expired && new Date(cert.expiryDate).getTime() - Date.now() <= NINETY_DAYS_MS;
-        let expiryClasses = 'text-gray-700';
-        if (expired) expiryClasses = 'text-red-600 font-medium';
-        else if (expiringSoon) expiryClasses = 'text-amber-600 font-medium';
+        const expiryClasses = EXPIRY_CLASS_BY_STATE[cert.state] ?? 'text-gray-700';
         fields.push({ label: 'Valid Until', value: cert.expiryDate, classes: expiryClasses });
       } else if (cert.certId) {
         fields.push({ label: 'Valid Until', value: 'No Expiry', classes: 'text-gray-700' });

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.html
@@ -66,7 +66,7 @@
 
       <!-- ── TAB: Certifications ──────────────────────────────────────────── -->
       @if (activeTab() === 'certifications') {
-        @if (certifications() === undefined) {
+        @if (unifiedCerts() === undefined) {
           <!-- Loading state -->
           <div class="flex flex-col gap-4" data-testid="certs-loading">
             @for (i of [1, 2, 3]; track i) {
@@ -82,9 +82,9 @@
               </lfx-card>
             }
           </div>
-        } @else if (certifications()!.length === 0) {
+        } @else if (myCerts().length === 0) {
           <div class="flex flex-col items-center justify-center py-20 text-center gap-4" data-testid="certs-empty-state">
-            <i class="fa-light fa-certificate text-6xl text-gray-300"></i>
+            <i class="fa-light fa-certificate text-6xl text-gray-300" aria-hidden="true"></i>
             <div class="flex flex-col gap-2 max-w-md">
               <h2 class="text-lg font-semibold text-gray-700">No certifications yet</h2>
               <p class="text-gray-500 text-sm">
@@ -101,12 +101,9 @@
               data-testid="certs-empty-cta" />
           </div>
         } @else {
-          <p class="text-sm text-gray-400 mb-4" data-testid="certs-count">
-            {{ certifications()!.length }} {{ certifications()!.length === 1 ? 'certification' : 'certifications' }}
-          </p>
-          <div class="flex flex-col gap-4" data-testid="certs-list">
-            @for (cert of certifications()!; track cert.id) {
-              <lfx-certification-card [cert]="cert" data-testid="cert-list-item" />
+          <div class="flex flex-col gap-4" data-testid="certs-content">
+            @for (cert of myCerts(); track cert.courseId) {
+              <lfx-unified-cert-card [cert]="cert" data-testid="cert-item" />
             }
           </div>
         }

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.ts
@@ -5,8 +5,8 @@
 
 import { ChangeDetectionStrategy, Component, computed, inject, signal, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { Certification, FilterPillOption, TrainingEnrollment } from '@lfx-one/shared/interfaces';
-import { CERTIFICATION_PRODUCT_TYPE, TRAINING_PRODUCT_TYPE } from '@lfx-one/shared/constants';
+import { Certification, FilterPillOption, TrainingEnrollment, UnifiedCertification } from '@lfx-one/shared/interfaces';
+import { TRAINING_PRODUCT_TYPE } from '@lfx-one/shared/constants';
 
 import { SkeletonModule } from 'primeng/skeleton';
 
@@ -14,9 +14,9 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { TrainingService } from '@shared/services/training.service';
-import { CertificationCardComponent } from '../components/certification-card/certification-card.component';
 import { RewardsComponent } from '../components/rewards/rewards.component';
 import { TrainingCardComponent } from '../components/training-card/training-card.component';
+import { UnifiedCertCardComponent } from '../components/unified-cert-card/unified-cert-card.component';
 
 const PAGE_SUBTITLE = 'Track your Linux Foundation learning journey — active certifications, enrolled courses, rewards, and resources all in one place.';
 
@@ -46,7 +46,7 @@ const USEFUL_LINKS = [
 
 @Component({
   selector: 'lfx-trainings-dashboard',
-  imports: [ButtonComponent, CardComponent, CertificationCardComponent, FilterPillsComponent, RewardsComponent, SkeletonModule, TrainingCardComponent],
+  imports: [ButtonComponent, CardComponent, FilterPillsComponent, RewardsComponent, SkeletonModule, TrainingCardComponent, UnifiedCertCardComponent],
   templateUrl: './trainings-dashboard.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -62,18 +62,21 @@ export class TrainingsDashboardComponent {
   // ─── Writable Signals ──────────────────────────────────────────────────────
   protected readonly activeTab = signal<string>('certifications');
 
-  // ─── Computed Signals ──────────────────────────────────────────────────────
-  protected readonly certifications: Signal<Certification[] | undefined> = this.initCertifications();
+  // ─── Data Signals ──────────────────────────────────────────────────────────
+  protected readonly unifiedCerts: Signal<UnifiedCertification[] | undefined> = this.initUnifiedCerts();
   protected readonly enrollments: Signal<TrainingEnrollment[] | undefined> = this.initEnrollments();
   protected readonly completedTrainings: Signal<Certification[] | undefined> = this.initCompletedTrainings();
 
   // ─── Stat Card Signals ─────────────────────────────────────────────────────
   protected readonly trainingsStatsLoading = computed(
-    () => this.certifications() === undefined || this.enrollments() === undefined || this.completedTrainings() === undefined
+    () => this.unifiedCerts() === undefined || this.enrollments() === undefined || this.completedTrainings() === undefined
   );
   protected readonly enrolledCount = computed(() => this.enrollments()?.length ?? 0);
   protected readonly completedCount = computed(() => this.completedTrainings()?.length ?? 0);
-  protected readonly certificatesCount = computed(() => this.certifications()?.length ?? 0);
+  protected readonly certificatesCount = computed(() => this.unifiedCerts()?.filter((c) => c.certId !== null).length ?? 0);
+
+  // ─── Certification Section Signals ────────────────────────────────────────
+  protected readonly myCerts = computed(() => this.unifiedCerts()?.filter((c) => c.certId !== null) ?? []);
 
   // ─── Protected Methods ─────────────────────────────────────────────────────
   protected onTabChange(tabId: string): void {
@@ -81,8 +84,8 @@ export class TrainingsDashboardComponent {
   }
 
   // ─── Private Initializers ──────────────────────────────────────────────────
-  private initCertifications(): Signal<Certification[] | undefined> {
-    return toSignal(this.trainingService.getCertifications(CERTIFICATION_PRODUCT_TYPE));
+  private initUnifiedCerts(): Signal<UnifiedCertification[] | undefined> {
+    return toSignal(this.trainingService.getUnifiedCertifications());
   }
 
   private initEnrollments(): Signal<TrainingEnrollment[] | undefined> {

--- a/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/trainings/trainings-dashboard/trainings-dashboard.component.ts
@@ -73,10 +73,10 @@ export class TrainingsDashboardComponent {
   );
   protected readonly enrolledCount = computed(() => this.enrollments()?.length ?? 0);
   protected readonly completedCount = computed(() => this.completedTrainings()?.length ?? 0);
-  protected readonly certificatesCount = computed(() => this.unifiedCerts()?.filter((c) => c.certId !== null).length ?? 0);
 
   // ─── Certification Section Signals ────────────────────────────────────────
   protected readonly myCerts = computed(() => this.unifiedCerts()?.filter((c) => c.certId !== null) ?? []);
+  protected readonly certificatesCount = computed(() => this.myCerts().length);
 
   // ─── Protected Methods ─────────────────────────────────────────────────────
   protected onTabChange(tabId: string): void {

--- a/apps/lfx-one/src/app/shared/components/button/button.component.scss
+++ b/apps/lfx-one/src/app/shared/components/button/button.component.scss
@@ -35,6 +35,14 @@
     }
   }
 
+  .p-button.p-button-outlined.p-button-secondary {
+    @apply bg-white border border-gray-300 text-gray-900;
+
+    &:not(:disabled):hover {
+      @apply bg-gray-50 border-gray-400;
+    }
+  }
+
   /* Small button sizing for cards */
   .p-button:not([class*='text-sm']).p-button-sm {
     @apply text-xs tracking-wide px-2.5 py-1.5 gap-2;

--- a/apps/lfx-one/src/app/shared/services/training.service.ts
+++ b/apps/lfx-one/src/app/shared/services/training.service.ts
@@ -5,7 +5,7 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { Certification, TrainingEnrollment } from '@lfx-one/shared/interfaces';
+import { Certification, TrainingEnrollment, UnifiedCertification } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of } from 'rxjs';
 
 @Injectable({
@@ -24,5 +24,9 @@ export class TrainingService {
 
   public getEnrollments(): Observable<TrainingEnrollment[]> {
     return this.http.get<TrainingEnrollment[]>('/api/training/enrollments').pipe(catchError(() => of([])));
+  }
+
+  public getUnifiedCertifications(): Observable<UnifiedCertification[]> {
+    return this.http.get<UnifiedCertification[]>('/api/training/certifications/unified').pipe(catchError(() => of([])));
   }
 }

--- a/apps/lfx-one/src/server/controllers/training.controller.ts
+++ b/apps/lfx-one/src/server/controllers/training.controller.ts
@@ -45,6 +45,35 @@ export class TrainingController {
   }
 
   /**
+   * GET /api/training/certifications/unified
+   * Get unified certification view (joined enrollments + certificates) for the authenticated user
+   */
+  public async getUnifiedCertifications(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_unified_certifications');
+
+    try {
+      const rawUsername = await getUsernameFromAuth(req);
+
+      if (!rawUsername) {
+        throw new AuthenticationError('User authentication required', {
+          operation: 'get_unified_certifications',
+        });
+      }
+
+      const username = stripAuthPrefix(rawUsername);
+      const certifications = await this.trainingService.getUnifiedCertifications(req, username);
+
+      logger.success(req, 'get_unified_certifications', startTime, {
+        result_count: certifications.length,
+      });
+
+      res.json(certifications);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /api/training/enrollments
    * Get ongoing training enrollments for the authenticated user
    */

--- a/apps/lfx-one/src/server/routes/training.route.ts
+++ b/apps/lfx-one/src/server/routes/training.route.ts
@@ -11,6 +11,7 @@ const router = Router();
 const trainingController = new TrainingController();
 
 router.get('/certifications', (req, res, next) => trainingController.getCertifications(req, res, next));
+router.get('/certifications/unified', (req, res, next) => trainingController.getUnifiedCertifications(req, res, next));
 router.get('/enrollments', (req, res, next) => trainingController.getEnrollments(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/training.service.ts
+++ b/apps/lfx-one/src/server/services/training.service.ts
@@ -48,7 +48,7 @@ const UNIFIED_CERTIFICATIONS_QUERY = `
     SELECT *,
       ROW_NUMBER() OVER (
         PARTITION BY COURSE_ID
-        ORDER BY IS_ACTIVE_ENROLLMENT DESC NULLS LAST, ENROLLMENT_ID
+        ORDER BY IS_ACTIVE_ENROLLMENT DESC NULLS LAST, ENROLLMENT_TS DESC NULLS LAST, ENROLLMENT_ID DESC
       ) AS rn
     FROM ANALYTICS.PLATINUM_LFX_ONE.USER_COURSE_ENROLLMENTS
     WHERE USER_NAME = ? AND PRODUCT_TYPE = ?
@@ -84,6 +84,7 @@ const UNIFIED_CERTIFICATIONS_QUERY = `
     c.DOWNLOAD_URL
   FROM e
   FULL OUTER JOIN c ON e.COURSE_ID = c.COURSE_ID
+  WHERE COALESCE(e.COURSE_ID, c.COURSE_ID) IS NOT NULL
   ORDER BY
     CASE
       WHEN c._KEY IS NOT NULL AND (c.EXPIRATION_DATE IS NULL OR c.EXPIRATION_DATE >= CURRENT_DATE())
@@ -233,7 +234,7 @@ export class TrainingService {
 
   private mapRowToUnifiedCert(row: UnifiedCertRow): UnifiedCertification {
     return {
-      courseId: row.COURSE_ID,
+      courseId: row.COURSE_ID ?? '',
       name: row.COURSE_NAME,
       description: row.COURSE_GROUP_DESCRIPTION ?? '',
       imageUrl: row.LOGO_URL ?? '',
@@ -254,19 +255,19 @@ export class TrainingService {
 
   private deriveUnifiedCertState(row: UnifiedCertRow): UnifiedCertState {
     const hasCert = row.CERT_KEY !== null;
-    const hasActivEnrollment = row.IS_ACTIVE_ENROLLMENT === true;
+    const hasActiveEnrollment = row.IS_ACTIVE_ENROLLMENT === true;
     const now = new Date();
     const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
 
     const certExpired = hasCert && row.EXPIRATION_DATE !== null && new Date(row.EXPIRATION_DATE) < now;
     const certExpiringSoon = hasCert && row.EXPIRATION_DATE !== null && !certExpired && new Date(row.EXPIRATION_DATE).getTime() - now.getTime() <= ninetyDaysMs;
 
-    if (hasCert && certExpired && hasActivEnrollment) return 'enrolled-cert-expired';
+    if (hasCert && certExpired && hasActiveEnrollment) return 'enrolled-cert-expired';
     if (hasCert && certExpired) return 'cert-expired';
     if (hasCert && certExpiringSoon) return 'expiring-soon';
     if (hasCert && !row.ENROLLMENT_ID) return 'cert-only';
     if (hasCert) return 'certified-active';
-    if (hasActivEnrollment) return 'in-progress';
+    if (hasActiveEnrollment) return 'in-progress';
     return 'cert-expired'; // expired enrollment, no cert
   }
 

--- a/apps/lfx-one/src/server/services/training.service.ts
+++ b/apps/lfx-one/src/server/services/training.service.ts
@@ -102,11 +102,11 @@ const UNIFIED_CERTIFICATIONS_QUERY = `
 
 const UNIFIED_CERT_STATE_ORDER: Record<UnifiedCertState, number> = {
   'certified-active': 1,
+  'cert-only': 1,
   'expiring-soon': 2,
   'enrolled-cert-expired': 3,
   'cert-expired': 4,
   'in-progress': 5,
-  'cert-only': 6,
 };
 
 export class TrainingService {

--- a/apps/lfx-one/src/server/services/training.service.ts
+++ b/apps/lfx-one/src/server/services/training.service.ts
@@ -3,8 +3,17 @@
 
 // Generated with [Claude Code](https://claude.ai/code)
 
-import { CertificateRow, Certification, CertificationStatus, EnrollmentRow, TrainingEnrollment } from '@lfx-one/shared/interfaces';
-import { TRAINING_PRODUCT_TYPE } from '@lfx-one/shared/constants';
+import {
+  CertificateRow,
+  Certification,
+  CertificationStatus,
+  EnrollmentRow,
+  TrainingEnrollment,
+  UnifiedCertification,
+  UnifiedCertRow,
+  UnifiedCertState,
+} from '@lfx-one/shared/interfaces';
+import { CERTIFICATION_PRODUCT_TYPE, TRAINING_PRODUCT_TYPE } from '@lfx-one/shared/constants';
 import { Request } from 'express';
 
 import { logger } from './logger.service';
@@ -32,6 +41,60 @@ const ENROLLMENTS_QUERY = `
   FROM ANALYTICS.PLATINUM_LFX_ONE.USER_COURSE_ENROLLMENTS
   WHERE USER_NAME = ? AND PRODUCT_TYPE = ?
   ORDER BY ENROLLMENT_TS DESC
+`;
+
+const UNIFIED_CERTIFICATIONS_QUERY = `
+  WITH best_enrollment AS (
+    SELECT *,
+      ROW_NUMBER() OVER (
+        PARTITION BY COURSE_ID
+        ORDER BY IS_ACTIVE_ENROLLMENT DESC NULLS LAST, ENROLLMENT_ID
+      ) AS rn
+    FROM ANALYTICS.PLATINUM_LFX_ONE.USER_COURSE_ENROLLMENTS
+    WHERE USER_NAME = ? AND PRODUCT_TYPE = ?
+  ),
+  best_cert AS (
+    SELECT *,
+      ROW_NUMBER() OVER (
+        PARTITION BY COURSE_ID
+        ORDER BY EXPIRATION_DATE DESC NULLS FIRST
+      ) AS rn
+    FROM ANALYTICS.PLATINUM_LFX_ONE.USER_CERTIFICATES
+    WHERE USER_NAME = ?
+      AND PRODUCT_TYPE = ?
+  ),
+  e AS (SELECT * FROM best_enrollment WHERE rn = 1),
+  c AS (SELECT * FROM best_cert WHERE rn = 1)
+
+  SELECT
+    COALESCE(e.COURSE_ID, c.COURSE_ID)                    AS COURSE_ID,
+    COALESCE(e.COURSE_NAME, c.COURSE_NAME)                AS COURSE_NAME,
+    COALESCE(e.COURSE_GROUP_DESCRIPTION, c.COURSE_GROUP_DESCRIPTION) AS COURSE_GROUP_DESCRIPTION,
+    COALESCE(e.LOGO_URL, c.LOGO_URL)                      AS LOGO_URL,
+    COALESCE(e.PROJECT_NAME, c.PROJECT_NAME)              AS PROJECT_NAME,
+    COALESCE(e.LEVEL, c.LEVEL)                            AS LEVEL,
+    e.ENROLLMENT_ID,
+    e.STATUS                                              AS ENROLLMENT_STATUS,
+    e.IS_ACTIVE_ENROLLMENT,
+    e.COURSE_SLUG,
+    c._KEY                                                AS CERT_KEY,
+    c.IDENTIFIER                                          AS CERT_IDENTIFIER,
+    c.ISSUED_TS,
+    c.EXPIRATION_DATE,
+    c.DOWNLOAD_URL
+  FROM e
+  FULL OUTER JOIN c ON e.COURSE_ID = c.COURSE_ID
+  ORDER BY
+    CASE
+      WHEN c._KEY IS NOT NULL AND (c.EXPIRATION_DATE IS NULL OR c.EXPIRATION_DATE >= CURRENT_DATE())
+           AND NOT (c.EXPIRATION_DATE IS NOT NULL AND DATEDIFF('day', CURRENT_DATE(), c.EXPIRATION_DATE) <= 90) THEN 1
+      WHEN c.EXPIRATION_DATE IS NOT NULL AND c.EXPIRATION_DATE >= CURRENT_DATE()
+           AND DATEDIFF('day', CURRENT_DATE(), c.EXPIRATION_DATE) <= 90 THEN 2
+      WHEN c.EXPIRATION_DATE IS NOT NULL AND c.EXPIRATION_DATE < CURRENT_DATE() AND e.IS_ACTIVE_ENROLLMENT = TRUE THEN 3
+      WHEN c.EXPIRATION_DATE IS NOT NULL AND c.EXPIRATION_DATE < CURRENT_DATE() THEN 4
+      ELSE 5
+    END,
+    COALESCE(e.COURSE_NAME, c.COURSE_NAME) ASC
 `;
 
 export class TrainingService {
@@ -91,6 +154,33 @@ export class TrainingService {
     return this.enrichWithTiLogos(req, enrollments, courseIds);
   }
 
+  public async getUnifiedCertifications(req: Request, username: string): Promise<UnifiedCertification[]> {
+    logger.debug(req, 'get_unified_certifications', 'Fetching unified certifications from Snowflake', { username });
+
+    let result: { rows: UnifiedCertRow[] };
+
+    try {
+      result = await this.snowflakeService.execute<UnifiedCertRow>(UNIFIED_CERTIFICATIONS_QUERY, [
+        username,
+        CERTIFICATION_PRODUCT_TYPE,
+        username,
+        CERTIFICATION_PRODUCT_TYPE,
+      ]);
+    } catch (error) {
+      logger.warning(req, 'get_unified_certifications', 'Snowflake query failed, returning empty', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+
+    logger.debug(req, 'get_unified_certifications', 'Fetched unified certifications', { count: result.rows.length });
+
+    const items = result.rows.map((row) => this.mapRowToUnifiedCert(row));
+    const courseIds = result.rows.map((row) => row.COURSE_ID);
+
+    return this.enrichWithTiLogos(req, items, courseIds);
+  }
+
   // ─── Private Enrichment Methods ────────────────────────────────────────────
 
   /**
@@ -139,6 +229,45 @@ export class TrainingService {
       level: row.LEVEL ?? '',
       courseSlug: row.COURSE_SLUG ?? null,
     };
+  }
+
+  private mapRowToUnifiedCert(row: UnifiedCertRow): UnifiedCertification {
+    return {
+      courseId: row.COURSE_ID,
+      name: row.COURSE_NAME,
+      description: row.COURSE_GROUP_DESCRIPTION ?? '',
+      imageUrl: row.LOGO_URL ?? '',
+      issuedBy: row.PROJECT_NAME ?? '',
+      level: row.LEVEL ?? '',
+      state: this.deriveUnifiedCertState(row),
+      enrollmentId: row.ENROLLMENT_ID ?? null,
+      enrollmentStatus: row.ENROLLMENT_STATUS ?? null,
+      isActiveEnrollment: row.IS_ACTIVE_ENROLLMENT ?? null,
+      courseSlug: row.COURSE_SLUG ?? null,
+      certId: row.CERT_KEY ?? null,
+      certificateId: row.CERT_IDENTIFIER ?? null,
+      issuedDate: row.ISSUED_TS ?? null,
+      expiryDate: row.EXPIRATION_DATE ?? null,
+      downloadUrl: row.DOWNLOAD_URL ?? null,
+    };
+  }
+
+  private deriveUnifiedCertState(row: UnifiedCertRow): UnifiedCertState {
+    const hasCert = row.CERT_KEY !== null;
+    const hasActivEnrollment = row.IS_ACTIVE_ENROLLMENT === true;
+    const now = new Date();
+    const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+
+    const certExpired = hasCert && row.EXPIRATION_DATE !== null && new Date(row.EXPIRATION_DATE) < now;
+    const certExpiringSoon = hasCert && row.EXPIRATION_DATE !== null && !certExpired && new Date(row.EXPIRATION_DATE).getTime() - now.getTime() <= ninetyDaysMs;
+
+    if (hasCert && certExpired && hasActivEnrollment) return 'enrolled-cert-expired';
+    if (hasCert && certExpired) return 'cert-expired';
+    if (hasCert && certExpiringSoon) return 'expiring-soon';
+    if (hasCert && !row.ENROLLMENT_ID) return 'cert-only';
+    if (hasCert) return 'certified-active';
+    if (hasActivEnrollment) return 'in-progress';
+    return 'cert-expired'; // expired enrollment, no cert
   }
 
   private deriveStatus(expirationDate: string | null): CertificationStatus {

--- a/apps/lfx-one/src/server/services/training.service.ts
+++ b/apps/lfx-one/src/server/services/training.service.ts
@@ -45,7 +45,9 @@ const ENROLLMENTS_QUERY = `
 
 const UNIFIED_CERTIFICATIONS_QUERY = `
   WITH best_enrollment AS (
-    SELECT *,
+    SELECT
+      COURSE_ID, COURSE_NAME, COURSE_GROUP_DESCRIPTION, LOGO_URL, PROJECT_NAME, LEVEL,
+      ENROLLMENT_ID, STATUS, IS_ACTIVE_ENROLLMENT, COURSE_SLUG,
       ROW_NUMBER() OVER (
         PARTITION BY COURSE_ID
         ORDER BY IS_ACTIVE_ENROLLMENT DESC NULLS LAST, ENROLLMENT_TS DESC NULLS LAST, ENROLLMENT_ID DESC
@@ -54,7 +56,9 @@ const UNIFIED_CERTIFICATIONS_QUERY = `
     WHERE USER_NAME = ? AND PRODUCT_TYPE = ?
   ),
   best_cert AS (
-    SELECT *,
+    SELECT
+      COURSE_ID, COURSE_NAME, COURSE_GROUP_DESCRIPTION, LOGO_URL, PROJECT_NAME, LEVEL,
+      _KEY, IDENTIFIER, ISSUED_TS, EXPIRATION_DATE, DOWNLOAD_URL,
       ROW_NUMBER() OVER (
         PARTITION BY COURSE_ID
         ORDER BY EXPIRATION_DATE DESC NULLS FIRST, ISSUED_TS DESC NULLS LAST, _KEY DESC
@@ -85,18 +89,16 @@ const UNIFIED_CERTIFICATIONS_QUERY = `
   FROM e
   FULL OUTER JOIN c ON e.COURSE_ID = c.COURSE_ID
   WHERE COALESCE(e.COURSE_ID, c.COURSE_ID) IS NOT NULL
-  ORDER BY
-    CASE
-      WHEN c._KEY IS NOT NULL AND (c.EXPIRATION_DATE IS NULL OR c.EXPIRATION_DATE >= CURRENT_DATE())
-           AND NOT (c.EXPIRATION_DATE IS NOT NULL AND DATEDIFF('day', CURRENT_DATE(), c.EXPIRATION_DATE) <= 90) THEN 1
-      WHEN c.EXPIRATION_DATE IS NOT NULL AND c.EXPIRATION_DATE >= CURRENT_DATE()
-           AND DATEDIFF('day', CURRENT_DATE(), c.EXPIRATION_DATE) <= 90 THEN 2
-      WHEN c.EXPIRATION_DATE IS NOT NULL AND c.EXPIRATION_DATE < CURRENT_DATE() AND e.IS_ACTIVE_ENROLLMENT = TRUE THEN 3
-      WHEN c.EXPIRATION_DATE IS NOT NULL AND c.EXPIRATION_DATE < CURRENT_DATE() THEN 4
-      ELSE 5
-    END,
-    COALESCE(e.COURSE_NAME, c.COURSE_NAME) ASC
 `;
+
+const UNIFIED_CERT_STATE_ORDER: Record<UnifiedCertState, number> = {
+  'certified-active': 1,
+  'expiring-soon': 2,
+  'enrolled-cert-expired': 3,
+  'cert-expired': 4,
+  'in-progress': 5,
+  'cert-only': 6,
+};
 
 export class TrainingService {
   private readonly snowflakeService: SnowflakeService;
@@ -177,7 +179,8 @@ export class TrainingService {
     logger.debug(req, 'get_unified_certifications', 'Fetched unified certifications', { count: result.rows.length });
 
     const items = result.rows.map((row) => this.mapRowToUnifiedCert(row));
-    const courseIds = result.rows.map((row) => row.COURSE_ID);
+    items.sort((a, b) => UNIFIED_CERT_STATE_ORDER[a.state] - UNIFIED_CERT_STATE_ORDER[b.state] || a.name.localeCompare(b.name));
+    const courseIds = items.map((item) => item.courseId || null);
 
     return this.enrichWithTiLogos(req, items, courseIds);
   }

--- a/apps/lfx-one/src/server/services/training.service.ts
+++ b/apps/lfx-one/src/server/services/training.service.ts
@@ -57,7 +57,7 @@ const UNIFIED_CERTIFICATIONS_QUERY = `
     SELECT *,
       ROW_NUMBER() OVER (
         PARTITION BY COURSE_ID
-        ORDER BY EXPIRATION_DATE DESC NULLS FIRST
+        ORDER BY EXPIRATION_DATE DESC NULLS FIRST, ISSUED_TS DESC NULLS LAST, _KEY DESC
       ) AS rn
     FROM ANALYTICS.PLATINUM_LFX_ONE.USER_CERTIFICATES
     WHERE USER_NAME = ?
@@ -256,11 +256,20 @@ export class TrainingService {
   private deriveUnifiedCertState(row: UnifiedCertRow): UnifiedCertState {
     const hasCert = row.CERT_KEY !== null;
     const hasActiveEnrollment = row.IS_ACTIVE_ENROLLMENT === true;
-    const now = new Date();
-    const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
 
-    const certExpired = hasCert && row.EXPIRATION_DATE !== null && new Date(row.EXPIRATION_DATE) < now;
-    const certExpiringSoon = hasCert && row.EXPIRATION_DATE !== null && !certExpired && new Date(row.EXPIRATION_DATE).getTime() - now.getTime() <= ninetyDaysMs;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const todayPlus90 = new Date(today);
+    todayPlus90.setDate(todayPlus90.getDate() + 90);
+
+    let expiryDateOnly: Date | null = null;
+    if (row.EXPIRATION_DATE !== null) {
+      expiryDateOnly = new Date(row.EXPIRATION_DATE);
+      expiryDateOnly.setHours(0, 0, 0, 0);
+    }
+
+    const certExpired = hasCert && expiryDateOnly !== null && expiryDateOnly < today;
+    const certExpiringSoon = hasCert && expiryDateOnly !== null && !certExpired && expiryDateOnly <= todayPlus90;
 
     if (hasCert && certExpired && hasActiveEnrollment) return 'enrolled-cert-expired';
     if (hasCert && certExpired) return 'cert-expired';

--- a/packages/shared/src/constants/training.constants.ts
+++ b/packages/shared/src/constants/training.constants.ts
@@ -7,3 +7,5 @@ export type ProductType = typeof TRAINING_PRODUCT_TYPE | typeof CERTIFICATION_PR
 
 export const CONTINUE_LEARNING_URL = 'https://trainingportal.linuxfoundation.org/learn/dashboard';
 export const COURSE_URL_PREFIX = 'https://trainingportal.linuxfoundation.org/learn/course/';
+export const ENROLL_AGAIN_URL = 'https://trainingportal.linuxfoundation.org/courses';
+export const ENROLL_AGAIN_URL_PREFIX = 'https://trainingportal.linuxfoundation.org/courses/';

--- a/packages/shared/src/interfaces/training.interface.ts
+++ b/packages/shared/src/interfaces/training.interface.ts
@@ -7,6 +7,83 @@
 export type CertificationStatus = 'active' | 'expired';
 
 /**
+ * Unified certification state derived from joining USER_COURSE_ENROLLMENTS and USER_CERTIFICATES on COURSE_ID.
+ * Represents where a user is in the certification lifecycle for a given course.
+ */
+export type UnifiedCertState =
+  | 'certified-active' // Has a valid certificate, not expiring soon
+  | 'expiring-soon' // Has a valid certificate expiring within 90 days
+  | 'in-progress' // Active enrollment, no certificate yet
+  | 'enrolled-cert-expired' // Active enrollment but certificate has expired — needs renewal
+  | 'cert-expired' // No active enrollment and certificate has expired
+  | 'cert-only'; // Has certificate, no enrollment record
+
+/**
+ * Unified view of a certification, merging enrollment and certificate data by COURSE_ID.
+ */
+export interface UnifiedCertification {
+  /** COURSE_ID — the join key */
+  courseId: string;
+  /** Course name (from whichever source has it) */
+  name: string;
+  /** Course description */
+  description: string;
+  /** Logo image URL */
+  imageUrl: string;
+  /** Issuing project name */
+  issuedBy: string;
+  /** Difficulty level */
+  level: string;
+  /** Derived lifecycle state */
+  state: UnifiedCertState;
+
+  // ── Enrollment fields (null if no enrollment record) ──────────────────────
+  /** ENROLLMENT_ID; null if no enrollment */
+  enrollmentId: string | null;
+  /** Enrollment status from Snowflake */
+  enrollmentStatus: 'started' | 'completed' | 'not-started' | 'not-completed' | null;
+  /** Whether the enrollment is currently active */
+  isActiveEnrollment: boolean | null;
+  /** URL slug for the exam prep course */
+  courseSlug: string | null;
+
+  // ── Certificate fields (null if no certificate record) ────────────────────
+  /** Certificate record identifier */
+  certId: string | null;
+  /** Certificate identifier (human-readable ID for verification) */
+  certificateId: string | null;
+  /** ISO date string for when the certificate was issued; null if no cert */
+  issuedDate: string | null;
+  /** ISO date string for certificate expiry; null means perpetual or no cert */
+  expiryDate: string | null;
+  /** URL to download the certificate; null if unavailable */
+  downloadUrl: string | null;
+}
+
+/**
+ * Snowflake row shape for the unified certification join query
+ */
+export interface UnifiedCertRow {
+  COURSE_ID: string;
+  COURSE_NAME: string;
+  COURSE_GROUP_DESCRIPTION: string | null;
+  LOGO_URL: string | null;
+  PROJECT_NAME: string | null;
+  LEVEL: string | null;
+  // Enrollment columns
+  ENROLLMENT_ID: string | null;
+  ENROLLMENT_STATUS: 'started' | 'completed' | 'not-started' | 'not-completed' | null;
+  IS_ACTIVE_ENROLLMENT: boolean | null;
+  COURSE_SLUG: string | null;
+  // Certificate columns
+  CERT_KEY: string | null;
+  CERT_IDENTIFIER: string | null;
+  ISSUED_TS: string | null;
+  EXPIRATION_DATE: string | null;
+  DOWNLOAD_URL: string | null;
+}
+
+/**
  * A Linux Foundation certification earned by the user
  */
 export interface Certification {

--- a/packages/shared/src/interfaces/training.interface.ts
+++ b/packages/shared/src/interfaces/training.interface.ts
@@ -64,7 +64,7 @@ export interface UnifiedCertification {
  * Snowflake row shape for the unified certification join query
  */
 export interface UnifiedCertRow {
-  COURSE_ID: string;
+  COURSE_ID: string | null;
   COURSE_NAME: string;
   COURSE_GROUP_DESCRIPTION: string | null;
   LOGO_URL: string | null;


### PR DESCRIPTION
## Summary

- Introduces a unified certifications tab joining certificate and enrollment data per course via a Snowflake CTE + FULL OUTER JOIN on `COURSE_ID`
- Replaces separate cert/enrollment sections with a single `UnifiedCertCardComponent` per certification, showing state badges, meta fields, and context-aware action buttons
- Sorts certs: valid first, expiring soon second, expired last
- Fixes outlined secondary button color in shared `ButtonComponent` (was rendering blue instead of gray)

## Actual Implementation

<img width="1439" height="1755" alt="Screenshot 2026-04-23 at 7 03 26 PM" src="https://github.com/user-attachments/assets/697045e2-c90e-414f-90bf-9355c8d9a2d7" />
<img width="795" height="448" alt="Screenshot 2026-04-23 at 7 08 46 PM" src="https://github.com/user-attachments/assets/6d324c6d-7856-4919-9dc0-6debff7cbf09" />

## State logic

| State | Condition | Badge | Button |
|---|---|---|---|
| `certified-active` | Has cert, valid, enrolled | — | Download |
| `cert-only` | Has cert, valid, no enrollment | — | Download |
| `expiring-soon` | Expires within 90 days | Expiring Soon | Renew Now |
| `enrolled-cert-expired` | Expired cert + active enrollment | Cert Expired | Renew Now |
| `cert-expired` | Expired cert, no active enrollment | Expired | Renew Now |

Renew Now links to `/learn/course/` if actively enrolled, `/courses/` otherwise.

## Test plan

- [ ] Certifications tab shows one card per course (no duplicates for multi-cert courses)
- [ ] Valid certs appear first, expiring soon second, expired last
- [ ] Download button is gray (secondary), not blue
- [ ] Renew Now button appears for expiring and expired certs
- [ ] State badges show correctly for each state
- [ ] Empty state shown when user has no certificates

🤖 Generated with [Claude Code](https://claude.com/claude-code)