### PR TITLE
style(dashboards): polish UI consistency across My Dashboard and lens pages

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/board-member/board-member-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/board-member/board-member-dashboard.component.html
@@ -2,15 +2,15 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="dashboard-container">
-  <!-- Foundation Project -->
+  <!-- Page Header -->
   @if (selectedFoundation()) {
-    <div class="mb-6 flex justify-between items-center gap-4" data-testid="foundation-project">
-      <h1>{{ selectedFoundation()?.name }} Overview</h1>
+    <div class="mb-6" data-testid="foundation-project">
+      <h1 class="font-display font-light text-2xl">{{ selectedFoundation()?.name }} Overview</h1>
     </div>
   }
 
   <!-- Dashboard Sections -->
-  <div class="flex flex-col gap-6" data-testid="dashboard-sections-grid">
+  <div class="flex flex-col gap-10" data-testid="dashboard-sections-grid">
     <!-- Foundation Health - Full Width -->
     @defer (on idle) {
       <lfx-foundation-health />

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
@@ -2,24 +2,12 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <section data-testid="foundation-health-section">
-  <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
-    <div class="flex flex-col gap-3">
-      <div class="flex gap-3 flex-wrap">
-        <h2 class="mb-0">{{ title() }}</h2>
-        <!-- Data Copilot Button -->
-        <lfx-data-copilot [includeOrganizationId]="false" [includeOrganizationName]="false"></lfx-data-copilot>
-      </div>
-
-      <div class="flex flex-wrap items-center gap-2">
-        <!-- Filter Pills -->
-        <lfx-filter-pills
-          [options]="filterOptions"
-          [selectedFilter]="selectedFilter()"
-          (filterChange)="handleFilterChange($event)"
-          data-testid="foundation-health-filters"></lfx-filter-pills>
-      </div>
-    </div>
-
+  <!-- Title row -->
+  <div class="flex items-center gap-3 mb-3">
+    <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">{{ title() }}</h2>
+    <div class="flex-1 border-t border-gray-200 self-center"></div>
+    <!-- Data Copilot Button -->
+    <lfx-data-copilot [includeOrganizationId]="false" [includeOrganizationName]="false"></lfx-data-copilot>
     <!-- Carousel Controls -->
     <div class="flex items-center gap-2">
       <button
@@ -39,6 +27,14 @@
         <i class="fa-light fa-chevron-right"></i>
       </button>
     </div>
+  </div>
+  <!-- Filter Pills row -->
+  <div class="flex flex-wrap items-center gap-2 mb-4">
+    <lfx-filter-pills
+      [options]="filterOptions"
+      [selectedFilter]="selectedFilter()"
+      (filterChange)="handleFilterChange($event)"
+      data-testid="foundation-health-filters"></lfx-filter-pills>
   </div>
 
   @if (!hasFoundationSelected()) {

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
@@ -16,7 +16,7 @@
         class="h-8 w-8 p-0 flex items-center justify-center rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
         data-testid="foundation-health-carousel-prev"
         aria-label="Scroll left">
-        <i class="fa-light fa-chevron-left"></i>
+        <i class="fa-light fa-chevron-left" aria-hidden="true"></i>
       </button>
       <button
         type="button"
@@ -24,7 +24,7 @@
         class="h-8 w-8 p-0 flex items-center justify-center rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
         data-testid="foundation-health-carousel-next"
         aria-label="Scroll right">
-        <i class="fa-light fa-chevron-right"></i>
+        <i class="fa-light fa-chevron-right" aria-hidden="true"></i>
       </button>
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-projects/my-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-projects/my-projects.component.html
@@ -2,11 +2,12 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div data-testid="dashboard-my-projects-section">
-  <div class="flex items-center justify-between mb-4">
-    <h2>
+  <div class="flex items-center gap-3 mb-4">
+    <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
       <i class="fa-light fa-laptop-code text-lg"></i>
       My Projects
     </h2>
+    <div class="flex-1 border-t border-gray-200 self-center"></div>
   </div>
 
   <div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-projects/my-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-projects/my-projects.component.html
@@ -4,7 +4,7 @@
 <div data-testid="dashboard-my-projects-section">
   <div class="flex items-center gap-3 mb-4">
     <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
-      <i class="fa-light fa-laptop-code text-lg"></i>
+      <i class="fa-light fa-laptop-code text-lg" aria-hidden="true"></i>
       My Projects
     </h2>
     <div class="flex-1 border-t border-gray-200 self-center"></div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/organization-involvement/organization-involvement.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/organization-involvement/organization-involvement.component.html
@@ -16,7 +16,7 @@
         class="h-8 w-8 p-0 flex items-center justify-center rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
         data-testid="dashboard-involvement-scroll-left"
         aria-label="Scroll left">
-        <i class="fa-light fa-chevron-left"></i>
+        <i class="fa-light fa-chevron-left" aria-hidden="true"></i>
       </button>
       <button
         type="button"
@@ -24,7 +24,7 @@
         class="h-8 w-8 p-0 flex items-center justify-center rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
         data-testid="dashboard-involvement-scroll-right"
         aria-label="Scroll right">
-        <i class="fa-light fa-chevron-right"></i>
+        <i class="fa-light fa-chevron-right" aria-hidden="true"></i>
       </button>
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/organization-involvement/organization-involvement.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/organization-involvement/organization-involvement.component.html
@@ -2,20 +2,12 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <section data-testid="dashboard-organization-involvement-section">
-  <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
-    <div class="flex flex-col gap-3">
-      <div class="flex justify-between gap-3 flex-wrap">
-        <h2 class="mb-0">{{ accountName() }}'s Involvement</h2>
-        <!-- Data Copilot Button -->
-        <lfx-data-copilot></lfx-data-copilot>
-      </div>
-
-      <div class="flex flex-wrap items-center gap-2">
-        <!-- Filter Pills -->
-        <lfx-filter-pills [options]="filterOptions" [selectedFilter]="selectedFilter()" (filterChange)="handleFilterChange($event)"></lfx-filter-pills>
-      </div>
-    </div>
-
+  <!-- Title row -->
+  <div class="flex items-center gap-3 mb-3">
+    <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">{{ accountName() }}'s Involvement</h2>
+    <div class="flex-1 border-t border-gray-200 self-center"></div>
+    <!-- Data Copilot Button -->
+    <lfx-data-copilot></lfx-data-copilot>
     <!-- Carousel Controls -->
     <div class="flex items-center gap-2">
       <button
@@ -35,6 +27,10 @@
         <i class="fa-light fa-chevron-right"></i>
       </button>
     </div>
+  </div>
+  <!-- Filter Pills row -->
+  <div class="flex flex-wrap items-center gap-2 mb-4">
+    <lfx-filter-pills [options]="filterOptions" [selectedFilter]="selectedFilter()" (filterChange)="handleFilterChange($event)"></lfx-filter-pills>
   </div>
 
   @if (!hasFoundationSelected()) {

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -18,19 +18,18 @@
       data-testid="dashboard-pending-actions-list">
       @for (item of visibleActions(); track item.buttonLink ?? item.type + '-' + item.text) {
         <div
-          class="flex items-center justify-between gap-4 px-4 py-3 bg-gradient-to-r from-white to-[rgba(255,251,235,0.8)]"
+          class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0 px-4 py-3 bg-gradient-to-r from-white to-[rgba(255,251,235,0.8)]"
           [attr.data-testid]="'dashboard-pending-actions-item-' + item.type">
-          <!-- Label + text -->
-          <div class="flex items-center gap-3 min-w-0 flex-1">
-            <div class="w-32 shrink-0">
-              <lfx-tag [value]="item.type" [severity]="item.severity" [icon]="item.icon" styleClass="whitespace-nowrap" />
-            </div>
-            <p class="text-sm font-medium text-gray-900 truncate" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
-              {{ item.text }}
-            </p>
+          <!-- Label — 20% on sm+ -->
+          <div class="shrink-0 sm:w-1/5">
+            <lfx-tag [value]="item.type" [severity]="item.severity" [icon]="item.icon" styleClass="whitespace-nowrap" />
           </div>
-          <!-- Action button -->
-          <div class="shrink-0">
+          <!-- Description — 60% on sm+ -->
+          <p class="text-sm font-medium text-gray-900 sm:w-3/5 sm:min-w-0 sm:truncate sm:px-4" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
+            {{ item.text }}
+          </p>
+          <!-- Action button — 20% on sm+, right-aligned -->
+          <div class="self-start sm:self-auto sm:w-1/5 sm:flex sm:justify-end">
             @if (item.buttonLink) {
               <lfx-button
                 size="small"

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -17,7 +17,7 @@
         class="h-8 w-8 p-0 flex items-center justify-center rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
         data-testid="ed-evolution-carousel-prev"
         aria-label="Scroll left">
-        <i class="fa-light fa-chevron-left"></i>
+        <i class="fa-light fa-chevron-left" aria-hidden="true"></i>
       </button>
       <button
         type="button"
@@ -25,7 +25,7 @@
         class="h-8 w-8 p-0 flex items-center justify-center rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
         data-testid="ed-evolution-carousel-next"
         aria-label="Scroll right">
-        <i class="fa-light fa-chevron-right"></i>
+        <i class="fa-light fa-chevron-right" aria-hidden="true"></i>
       </button>
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -2,36 +2,37 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <section data-testid="ed-evolution-section">
-  <div class="flex flex-wrap gap-3 items-end justify-between mb-4">
-    <div class="flex flex-col gap-1">
-      <h2 class="mb-0"><i class="fa-light fa-chart-line-up mr-2" aria-hidden="true"></i>Marketing Metrics</h2>
-      <p class="text-sm text-gray-500 mb-0">North Star KPIs · Brand · Influence</p>
-      <!-- Filter Pills -->
-      <lfx-filter-pills [options]="filterOptions" [selectedFilter]="selectedFilter()" (filterChange)="setFilter($event)" data-testid="ed-evolution-filters" />
-    </div>
-
+  <!-- Title row -->
+  <div class="flex items-center gap-3 mb-3">
+    <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
+      <i class="fa-light fa-chart-line-up text-lg" aria-hidden="true"></i>
+      Marketing Metrics
+    </h2>
+    <div class="flex-1 border-t border-gray-200 self-center"></div>
     <!-- Carousel Controls -->
     <div class="flex items-center gap-2">
-      <lfx-button
-        icon="fa-light fa-chevron-left"
-        [outlined]="true"
-        severity="secondary"
-        size="small"
-        ariaLabel="Scroll left"
-        (onClick)="scrollShadowDirective()?.scrollLeft()"
-        data-testid="ed-evolution-carousel-prev" />
-      <span class="text-xs text-gray-500 tabular-nums" data-testid="ed-evolution-carousel-count"
-        >{{ totalCardCount() }} {{ totalCardCount() === 1 ? 'card' : 'cards' }}</span
-      >
-      <lfx-button
-        icon="fa-light fa-chevron-right"
-        [outlined]="true"
-        severity="secondary"
-        size="small"
-        ariaLabel="Scroll right"
-        (onClick)="scrollShadowDirective()?.scrollRight()"
-        data-testid="ed-evolution-carousel-next" />
+      <button
+        type="button"
+        (click)="scrollShadowDirective()?.scrollLeft()"
+        class="h-8 w-8 p-0 flex items-center justify-center rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+        data-testid="ed-evolution-carousel-prev"
+        aria-label="Scroll left">
+        <i class="fa-light fa-chevron-left"></i>
+      </button>
+      <button
+        type="button"
+        (click)="scrollShadowDirective()?.scrollRight()"
+        class="h-8 w-8 p-0 flex items-center justify-center rounded border border-gray-300 bg-white text-gray-600 hover:bg-gray-100 hover:border-gray-400 transition-colors"
+        data-testid="ed-evolution-carousel-next"
+        aria-label="Scroll right">
+        <i class="fa-light fa-chevron-right"></i>
+      </button>
     </div>
+  </div>
+  <!-- Subtitle + Filter Pills row -->
+  <div class="flex flex-col gap-1 mb-4">
+    <p class="text-sm text-gray-500 mb-0">North Star KPIs · Brand · Influence</p>
+    <lfx-filter-pills [options]="filterOptions" [selectedFilter]="selectedFilter()" (filterChange)="setFilter($event)" data-testid="ed-evolution-filters" />
   </div>
 
   <!-- Reusable card template used by both North Star and non-North-Star loops -->
@@ -194,11 +195,6 @@
       aria-hidden="true"></div>
   </div>
 
-  <!-- Data source hint -->
-  <div class="flex items-center gap-1 mt-2 text-xs text-gray-400">
-    <i class="fa-light fa-circle-info"></i>
-    <span>Hover over any card for more details</span>
-  </div>
 </section>
 
 <!-- Drill-Down Drawers -->

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -4,7 +4,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { ButtonComponent } from '@components/button/button.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { MetricCardComponent } from '@components/metric-card/metric-card.component';
@@ -180,7 +179,6 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     NgTemplateOutlet,
-    ButtonComponent,
     ChartComponent,
     FilterPillsComponent,
     MetricCardComponent,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.html
@@ -2,15 +2,15 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="ed-dashboard-container">
-  <!-- Foundation Project -->
+  <!-- Page Header -->
   @if (selectedFoundation()) {
-    <div class="mb-6 flex justify-between items-center gap-4" data-testid="ed-dashboard-foundation-project">
-      <h1>{{ selectedFoundation()?.name }} Overview</h1>
+    <div class="mb-6" data-testid="ed-dashboard-foundation-project">
+      <h1 class="font-display font-light text-2xl">{{ selectedFoundation()?.name }} Overview</h1>
     </div>
   }
 
   <!-- Dashboard Sections -->
-  <div class="flex flex-col gap-6" data-testid="ed-dashboard-sections-grid">
+  <div class="flex flex-col gap-10" data-testid="ed-dashboard-sections-grid">
     <!-- Foundation Health -->
     @defer (on idle) {
       <lfx-foundation-health />

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -9,7 +9,7 @@
   </div>
 
   <!-- Dashboard Sections -->
-  <div class="flex flex-col gap-6" data-testid="multi-persona-dashboard-sections">
+  <div class="flex flex-col gap-10" data-testid="multi-persona-dashboard-sections">
     <!-- My Meetings -->
     @defer (on idle) {
       <lfx-my-meetings />
@@ -60,18 +60,19 @@
     <!-- My Foundations and Projects Section -->
     <section data-testid="multi-persona-projects-section">
       <!-- Section Header -->
-      <div class="mb-4 flex items-center h-8">
-        <h2 class="flex items-center gap-2">
+      <div class="flex items-center gap-3 mb-4">
+        <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
           <i class="fa-light fa-layer-group text-lg"></i>
           <span>{{ sectionTitle() }}</span>
         </h2>
+        <div class="flex-1 border-t border-gray-200 self-center"></div>
       </div>
 
       <!-- Summary Stat Cards -->
       <div class="mb-4" data-testid="multi-persona-summary-stats">
         <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
           <div
-            class="grid w-full grid-cols-2 divide-y sm:divide-y-0 sm:divide-x divide-gray-200"
+            class="grid w-full grid-cols-1 divide-y sm:divide-y-0 sm:divide-x divide-gray-200"
             [class.sm:grid-cols-4]="hasFoundations() && hasProjects()"
             [class.sm:grid-cols-3]="hasFoundations() !== hasProjects()"
             [class.sm:grid-cols-2]="!hasFoundations() && !hasProjects()">
@@ -134,13 +135,18 @@
       </div>
 
       <!-- Projects Table -->
-      <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="multi-persona-table">
+      <lfx-card styleClass="[&_.p-card-body]:!px-5" data-testid="multi-persona-table">
         <lfx-table
           [value]="projectRows()"
-          [paginator]="false"
+          [paginator]="projectRows().length > 10"
+          [rows]="10"
+          [rowsPerPageOptions]="rppOptions()"
+          [showFirstLastIcon]="false"
+          [showCurrentPageReport]="true"
+          currentPageReportTemplate="Showing {first} to {last} of {totalRecords}"
           selectionMode="single"
           (onRowSelect)="openRow($event.data)"
-          styleClass="[&_.p-datatable-tbody>tr]:cursor-pointer">
+          styleClass="[&_.p-datatable-tbody>tr]:cursor-pointer [&_.p-datatable-tbody_td]:!py-4">
           <ng-template #header>
             <tr>
               <th>Name</th>
@@ -148,9 +154,6 @@
                 <th>Type</th>
               }
               <th>Your Role</th>
-              @if (hasFoundations()) {
-                <th>Health</th>
-              }
               <th>Voting</th>
             </tr>
           </ng-template>
@@ -198,29 +201,6 @@
               <td>
                 <span class="role-badge" [attr.data-role]="row.role">{{ row.role }}</span>
               </td>
-              <!-- Health -->
-              @if (hasFoundations()) {
-                <td>
-                  @if (row.healthStatus) {
-                    <div class="flex items-center gap-2">
-                      <span
-                        class="health-dot"
-                        [class.health-dot--on-track]="row.healthStatus === 'on-track'"
-                        [class.health-dot--watch]="row.healthStatus === 'watch'"
-                        [class.health-dot--needs-attention]="row.healthStatus === 'needs-attention'"></span>
-                      <span
-                        class="text-sm"
-                        [class.text-emerald-700]="row.healthStatus === 'on-track'"
-                        [class.text-amber-700]="row.healthStatus === 'watch'"
-                        [class.text-red-700]="row.healthStatus === 'needs-attention'"
-                        >{{ row.healthDetail }}</span
-                      >
-                    </div>
-                  } @else {
-                    <span class="text-sm text-gray-400">&mdash;</span>
-                  }
-                </td>
-              }
               <!-- Voting -->
               <td>
                 @if (row.votingStatus) {
@@ -238,7 +218,7 @@
           </ng-template>
           <ng-template #emptymessage>
             <tr>
-              <td [attr.colspan]="3 + (showTypeColumn() ? 1 : 0) + (hasFoundations() ? 1 : 0)" class="py-8 text-center text-sm text-gray-400">
+              <td [attr.colspan]="3 + (showTypeColumn() ? 1 : 0)" class="py-8 text-center text-sm text-gray-400">
                 No foundations or projects found.
               </td>
             </tr>

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -62,7 +62,7 @@
       <!-- Section Header -->
       <div class="flex items-center gap-3 mb-4">
         <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
-          <i class="fa-light fa-layer-group text-lg"></i>
+          <i class="fa-light fa-layer-group text-lg" aria-hidden="true"></i>
           <span>{{ sectionTitle() }}</span>
         </h2>
         <div class="flex-1 border-t border-gray-200 self-center"></div>

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -77,6 +77,7 @@ export class MultiPersonaDashboardComponent {
   protected readonly subtitleText: Signal<string> = this.initSubtitleText();
   protected readonly analyticsSummary: Signal<MultiFoundationSummaryResponse | null> = this.initAnalyticsSummary();
   protected readonly projectRows: Signal<PersonaProjectRow[]> = this.initProjectRows();
+  protected readonly rppOptions = computed<number[] | undefined>(() => (this.projectRows().length > 10 ? [10, 25, 50] : undefined));
   // Independent loading signals so each pill renders as its source lands (no combineLatest gate).
   protected readonly openSurveysLoading = signal(true);
   protected readonly meetingsPillLoading = signal(true);
@@ -128,6 +129,11 @@ export class MultiPersonaDashboardComponent {
   private initSubtitleText(): Signal<string> {
     return computed(() => {
       const personas = this.personaService.allPersonas();
+
+      if (personas.length > 1) {
+        return 'This is a collection of your activities across all roles, foundations, and projects.';
+      }
+
       const roleLabels = personas.map((p) => {
         switch (p) {
           case 'executive-director':

--- a/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/project-dashboard/project-dashboard.component.html
@@ -10,7 +10,7 @@
   }
 
   <!-- Dashboard Sections -->
-  <div class="flex flex-col gap-6" data-testid="project-dashboard-sections-grid">
+  <div class="flex flex-col gap-10" data-testid="project-dashboard-sections-grid">
     <!-- Recent Progress - Full Width -->
     @defer (on idle) {
       <lfx-recent-progress />


### PR DESCRIPTION
## What
Visual polish and consistency pass across the My Dashboard and Foundation/Project lens Dashboard pages.

## How

**Layout & spacing**
- Section gap increased to `gap-10` on all dashboard lenses (project, board-member, ED, multi-persona)
- Summary stat cards in multi-persona dashboard stack to single column on mobile (`grid-cols-1` base)

**My Foundations and Projects table**
- Added client-side pagination (10/25/50 rows); paginator hidden when ≤10 results
- Card padding `!px-5` and cell padding `!py-4` for better breathing room
- Removed Health column

**Pending Actions**
- 20/60/20 column split (type / description / button) on desktop
- Fully vertical stack on mobile

**Section headers**
- Unified all section titles to: icon + `text-base font-medium text-gray-900` + inline divider
- Applies to: My Foundations/Projects, My Projects, Foundation Health, Organization Involvement, Marketing Metrics

**Other**
- Multi-role subtitle replaced with cleaner generic text
- Foundation/ED dashboard page header font specs fixed (`font-display font-light text-2xl`)
- "Hover over any card for more details" label removed from marketing overview
- Marketing overview carousel controls replaced with native `<button>` elements matching other sections

## Related
N/A

## Checklist
- [ ] Tests added/updated
- [ ] License headers on new files
- [ ] Docs updated if needed

Generated with [Claude Code](https://claude.ai/code)