### PR TITLE
fix(events): show context-aware empty state in event selection

### DIFF
--- a/apps/lfx-one/e2e/event-selection-robust.spec.ts
+++ b/apps/lfx-one/e2e/event-selection-robust.spec.ts
@@ -1,0 +1,166 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, test } from '@playwright/test';
+
+const EMPTY_EVENTS_RESPONSE = {
+  data: [],
+  total: 0,
+  pageSize: 10,
+  offset: 0,
+};
+
+const EMPTY_COUNTRIES_RESPONSE = { data: [] };
+
+/**
+ * Intercept both /api/events calls (main + probe) to return controlled empty responses,
+ * then navigate to the My Events dashboard and open the visa-letter application dialog.
+ */
+async function openVisaDialogWithEmptyEvents(page: Parameters<typeof test>[1]['page']) {
+  await page.route('**/api/events**', (route) => {
+    const url = route.request().url();
+    if (
+      url.includes('/countries') ||
+      url.includes('/visa-requests') ||
+      url.includes('/travel-fund-requests') ||
+      url.includes('/organizations') ||
+      url.includes('/all')
+    ) {
+      return route.continue();
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_EVENTS_RESPONSE) });
+  });
+
+  await page.route('**/api/events/countries', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) })
+  );
+
+  await page.goto('/me/events', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+
+  // Switch to the visa-letters tab
+  await page.getByTestId('filter-pill-visa-letters').click();
+
+  // Open the application dialog
+  await page.getByTestId('events-new-request-button').click();
+
+  // Wait for the event-selection grid to be visible inside the dialog
+  await expect(page.getByTestId('event-selection-grid')).toBeVisible({ timeout: 10000 });
+}
+
+test.describe('Event Selection — Robust Structural Tests', () => {
+  test.describe('Container structure', () => {
+    test('event-selection root container exists with correct testid', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      await expect(page.getByTestId('event-selection')).toBeAttached();
+    });
+
+    test('filter bar renders all three filter controls', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      const filters = page.getByTestId('event-selection-filters');
+      await expect(filters).toBeAttached();
+      await expect(page.getByTestId('event-selection-search')).toBeAttached();
+      await expect(page.getByTestId('event-selection-time-filter')).toBeAttached();
+      await expect(page.getByTestId('event-selection-location-filter')).toBeAttached();
+    });
+
+    test('events grid container is always rendered', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      await expect(page.getByTestId('event-selection-grid')).toBeAttached();
+    });
+  });
+
+  test.describe('Empty state structure (no registered events)', () => {
+    test('empty state container has correct testid', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      await expect(page.getByTestId('event-selection-empty-state')).toBeAttached();
+    });
+
+    test('empty state has title element', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      const title = page.getByTestId('event-selection-empty-title');
+      await expect(title).toBeAttached();
+      await expect(title).not.toBeEmpty();
+    });
+
+    test('empty state has description element', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      const desc = page.getByTestId('event-selection-empty-description');
+      await expect(desc).toBeAttached();
+      await expect(desc).not.toBeEmpty();
+    });
+
+    test('empty state has icon element', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      await expect(page.getByTestId('event-selection-empty-icon')).toBeAttached();
+    });
+
+    test('empty state title is a <p> tag', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      const title = page.getByTestId('event-selection-empty-title');
+      await expect(title).toHaveCount(1);
+      const tag = await title.evaluate((el) => el.tagName.toLowerCase());
+      expect(tag).toBe('p');
+    });
+
+    test('empty state description is a <p> tag', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      const desc = page.getByTestId('event-selection-empty-description');
+      await expect(desc).toHaveCount(1);
+      const tag = await desc.evaluate((el) => el.tagName.toLowerCase());
+      expect(tag).toBe('p');
+    });
+
+    test('visa dialog shows "No registered events" title when user has zero registered events', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      const title = page.getByTestId('event-selection-empty-title');
+      await expect(title).toHaveText('No registered events');
+    });
+
+    test('visa dialog empty description mentions visa letter', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      const desc = page.getByTestId('event-selection-empty-description');
+      await expect(desc).toContainText('visa letter');
+    });
+
+    test('grid is not rendered when empty', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      await expect(page.getByTestId('event-selection-grid').locator('[data-testid^="event-selection-card-"]')).toHaveCount(0);
+    });
+
+    test('load-more button is not rendered when empty', async ({ page }) => {
+      await openVisaDialogWithEmptyEvents(page);
+      await expect(page.getByTestId('event-selection-load-more')).not.toBeAttached();
+    });
+  });
+
+  test.describe('Empty state — travel funding variant', () => {
+    test('travel funding dialog shows "No registered events" title', async ({ page }) => {
+      await page.route('**/api/events**', (route) => {
+        const url = route.request().url();
+        if (
+          url.includes('/countries') ||
+          url.includes('/visa-requests') ||
+          url.includes('/travel-fund-requests') ||
+          url.includes('/organizations') ||
+          url.includes('/all')
+        ) {
+          return route.continue();
+        }
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_EVENTS_RESPONSE) });
+      });
+      await page.route('**/api/events/countries', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) })
+      );
+
+      await page.goto('/me/events', { waitUntil: 'domcontentloaded' });
+      await expect(page).not.toHaveURL(/auth0\.com/);
+      await page.getByTestId('filter-pill-travel-funding').click();
+      await page.getByTestId('events-new-request-button').click();
+      await expect(page.getByTestId('event-selection-grid')).toBeVisible({ timeout: 10000 });
+
+      await expect(page.getByTestId('event-selection-empty-title')).toHaveText('No registered events');
+      await expect(page.getByTestId('event-selection-empty-description')).toContainText('travel funding');
+    });
+  });
+});

--- a/apps/lfx-one/e2e/event-selection-robust.spec.ts
+++ b/apps/lfx-one/e2e/event-selection-robust.spec.ts
@@ -19,21 +19,17 @@ const EMPTY_COUNTRIES_RESPONSE = { data: [] };
 async function openVisaDialogWithEmptyEvents(page: Parameters<typeof test>[1]['page']) {
   await page.route('**/api/events**', (route) => {
     const url = route.request().url();
-    if (
-      url.includes('/countries') ||
-      url.includes('/visa-requests') ||
-      url.includes('/travel-fund-requests') ||
-      url.includes('/organizations') ||
-      url.includes('/all')
-    ) {
+    // Countries must be fulfilled here — a separate route for **/api/events/countries
+    // would never be reached because this broader handler matches first and route.continue()
+    // short-circuits before the more-specific handler runs.
+    if (url.includes('/countries')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) });
+    }
+    if (url.includes('/visa-requests') || url.includes('/travel-fund-requests') || url.includes('/organizations') || url.includes('/all')) {
       return route.continue();
     }
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_EVENTS_RESPONSE) });
   });
-
-  await page.route('**/api/events/countries', (route) =>
-    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) })
-  );
 
   await page.goto('/me/events', { waitUntil: 'domcontentloaded' });
   await expect(page).not.toHaveURL(/auth0\.com/);
@@ -138,20 +134,14 @@ test.describe('Event Selection — Robust Structural Tests', () => {
     test('travel funding dialog shows "No registered events" title', async ({ page }) => {
       await page.route('**/api/events**', (route) => {
         const url = route.request().url();
-        if (
-          url.includes('/countries') ||
-          url.includes('/visa-requests') ||
-          url.includes('/travel-fund-requests') ||
-          url.includes('/organizations') ||
-          url.includes('/all')
-        ) {
+        if (url.includes('/countries')) {
+          return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) });
+        }
+        if (url.includes('/visa-requests') || url.includes('/travel-fund-requests') || url.includes('/organizations') || url.includes('/all')) {
           return route.continue();
         }
         return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_EVENTS_RESPONSE) });
       });
-      await page.route('**/api/events/countries', (route) =>
-        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) })
-      );
 
       await page.goto('/me/events', { waitUntil: 'domcontentloaded' });
       await expect(page).not.toHaveURL(/auth0\.com/);

--- a/apps/lfx-one/e2e/event-selection-robust.spec.ts
+++ b/apps/lfx-one/e2e/event-selection-robust.spec.ts
@@ -22,7 +22,7 @@ async function mockEventRoutes(page: Page, { probeTotal = 0, mainStatus = 200 }:
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) });
     }
     if (url.includes('/visa-requests') || url.includes('/travel-fund-requests') || url.includes('/organizations') || url.includes('/all')) {
-      return route.continue();
+      return route.fulfill({ status: mainStatus !== 200 ? mainStatus : 200, contentType: 'application/json', body: JSON.stringify({ data: [] }) });
     }
 
     // Distinguish the pageSize=1 probe from the main paginated query via URL params.

--- a/apps/lfx-one/e2e/event-selection-robust.spec.ts
+++ b/apps/lfx-one/e2e/event-selection-robust.spec.ts
@@ -1,156 +1,190 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 
-const EMPTY_EVENTS_RESPONSE = {
-  data: [],
-  total: 0,
-  pageSize: 10,
-  offset: 0,
-};
-
+const EMPTY_EVENTS_RESPONSE = { data: [], total: 0, pageSize: 10, offset: 0 };
 const EMPTY_COUNTRIES_RESPONSE = { data: [] };
 
 /**
- * Intercept both /api/events calls (main + probe) to return controlled empty responses,
- * then navigate to the My Events dashboard and open the visa-letter application dialog.
+ * Register a route handler that mocks all /api/events* calls deterministically.
+ *
+ * @param probeTotal  Total returned by the pageSize=1 registered-events probe (default 0 = no
+ *                    registered events). Set >0 to simulate a user who is registered.
+ * @param mainStatus  HTTP status for the primary events query (default 200 = success with empty
+ *                    list). Set to 500 to trigger the error empty-state branch.
  */
-async function openVisaDialogWithEmptyEvents(page: Parameters<typeof test>[1]['page']) {
+async function mockEventRoutes(page: Page, { probeTotal = 0, mainStatus = 200 }: { probeTotal?: number; mainStatus?: number } = {}) {
   await page.route('**/api/events**', (route) => {
     const url = route.request().url();
-    // Countries must be fulfilled here — a separate route for **/api/events/countries
-    // would never be reached because this broader handler matches first and route.continue()
-    // short-circuits before the more-specific handler runs.
+
     if (url.includes('/countries')) {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) });
     }
     if (url.includes('/visa-requests') || url.includes('/travel-fund-requests') || url.includes('/organizations') || url.includes('/all')) {
       return route.continue();
     }
+
+    // Distinguish the pageSize=1 probe from the main paginated query via URL params.
+    const parsedUrl = new URL(url);
+    const isProbe = parsedUrl.searchParams.get('pageSize') === '1';
+
+    if (isProbe) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [], total: probeTotal, pageSize: 1, offset: 0 }),
+      });
+    }
+
+    if (mainStatus !== 200) {
+      return route.fulfill({ status: mainStatus, contentType: 'application/json', body: JSON.stringify({ error: 'Server error' }) });
+    }
+
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_EVENTS_RESPONSE) });
   });
+}
 
+/**
+ * Navigate to /me/events, switch to the given tab, open the application dialog, and wait
+ * for the event-selection grid to be visible.
+ */
+async function openDialogWithEmptyEvents(
+  page: Page,
+  tab: 'visa-letters' | 'travel-funding' = 'visa-letters',
+  routeOptions: { probeTotal?: number; mainStatus?: number } = {}
+) {
+  await mockEventRoutes(page, routeOptions);
   await page.goto('/me/events', { waitUntil: 'domcontentloaded' });
   await expect(page).not.toHaveURL(/auth0\.com/);
-
-  // Switch to the visa-letters tab
-  await page.getByTestId('filter-pill-visa-letters').click();
-
-  // Open the application dialog
+  await page.getByTestId(`filter-pill-${tab}`).click();
   await page.getByTestId('events-new-request-button').click();
-
-  // Wait for the event-selection grid to be visible inside the dialog
   await expect(page.getByTestId('event-selection-grid')).toBeVisible({ timeout: 10000 });
 }
 
 test.describe('Event Selection — Robust Structural Tests', () => {
   test.describe('Container structure', () => {
     test('event-selection root container exists with correct testid', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
+      await openDialogWithEmptyEvents(page);
       await expect(page.getByTestId('event-selection')).toBeAttached();
     });
 
     test('filter bar renders all three filter controls', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
-      const filters = page.getByTestId('event-selection-filters');
-      await expect(filters).toBeAttached();
+      await openDialogWithEmptyEvents(page);
+      await expect(page.getByTestId('event-selection-filters')).toBeAttached();
       await expect(page.getByTestId('event-selection-search')).toBeAttached();
       await expect(page.getByTestId('event-selection-time-filter')).toBeAttached();
       await expect(page.getByTestId('event-selection-location-filter')).toBeAttached();
     });
 
     test('events grid container is always rendered', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
+      await openDialogWithEmptyEvents(page);
       await expect(page.getByTestId('event-selection-grid')).toBeAttached();
     });
   });
 
-  test.describe('Empty state structure (no registered events)', () => {
+  test.describe('Empty state — no registered events (probe returns 0)', () => {
     test('empty state container has correct testid', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
+      await openDialogWithEmptyEvents(page);
       await expect(page.getByTestId('event-selection-empty-state')).toBeAttached();
     });
 
-    test('empty state has title element', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
+    test('empty state title is a non-empty <p> tag', async ({ page }) => {
+      await openDialogWithEmptyEvents(page);
       const title = page.getByTestId('event-selection-empty-title');
-      await expect(title).toBeAttached();
+      await expect(title).toHaveCount(1);
       await expect(title).not.toBeEmpty();
+      expect(await title.evaluate((el) => el.tagName.toLowerCase())).toBe('p');
     });
 
-    test('empty state has description element', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
+    test('empty state description is a non-empty <p> tag', async ({ page }) => {
+      await openDialogWithEmptyEvents(page);
       const desc = page.getByTestId('event-selection-empty-description');
-      await expect(desc).toBeAttached();
+      await expect(desc).toHaveCount(1);
       await expect(desc).not.toBeEmpty();
+      expect(await desc.evaluate((el) => el.tagName.toLowerCase())).toBe('p');
     });
 
-    test('empty state has icon element', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
+    test('empty state icon element is present', async ({ page }) => {
+      await openDialogWithEmptyEvents(page);
       await expect(page.getByTestId('event-selection-empty-icon')).toBeAttached();
     });
 
-    test('empty state title is a <p> tag', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
-      const title = page.getByTestId('event-selection-empty-title');
-      await expect(title).toHaveCount(1);
-      const tag = await title.evaluate((el) => el.tagName.toLowerCase());
-      expect(tag).toBe('p');
+    test('visa dialog shows "No registered events" title', async ({ page }) => {
+      await openDialogWithEmptyEvents(page);
+      await expect(page.getByTestId('event-selection-empty-title')).toHaveText('No registered events');
     });
 
-    test('empty state description is a <p> tag', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
-      const desc = page.getByTestId('event-selection-empty-description');
-      await expect(desc).toHaveCount(1);
-      const tag = await desc.evaluate((el) => el.tagName.toLowerCase());
-      expect(tag).toBe('p');
+    test('visa dialog description mentions visa letter', async ({ page }) => {
+      await openDialogWithEmptyEvents(page);
+      await expect(page.getByTestId('event-selection-empty-description')).toContainText('visa letter');
     });
 
-    test('visa dialog shows "No registered events" title when user has zero registered events', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
-      const title = page.getByTestId('event-selection-empty-title');
-      await expect(title).toHaveText('No registered events');
+    test('travel-funding dialog shows "No registered events" title', async ({ page }) => {
+      await openDialogWithEmptyEvents(page, 'travel-funding');
+      await expect(page.getByTestId('event-selection-empty-title')).toHaveText('No registered events');
     });
 
-    test('visa dialog empty description mentions visa letter', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
-      const desc = page.getByTestId('event-selection-empty-description');
-      await expect(desc).toContainText('visa letter');
+    test('travel-funding dialog description mentions travel funding', async ({ page }) => {
+      await openDialogWithEmptyEvents(page, 'travel-funding');
+      await expect(page.getByTestId('event-selection-empty-description')).toContainText('travel funding');
     });
 
-    test('grid is not rendered when empty', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
+    test('event grid cards are not rendered when empty', async ({ page }) => {
+      await openDialogWithEmptyEvents(page);
       await expect(page.getByTestId('event-selection-grid').locator('[data-testid^="event-selection-card-"]')).toHaveCount(0);
     });
 
     test('load-more button is not rendered when empty', async ({ page }) => {
-      await openVisaDialogWithEmptyEvents(page);
+      await openDialogWithEmptyEvents(page);
       await expect(page.getByTestId('event-selection-load-more')).not.toBeAttached();
     });
   });
 
-  test.describe('Empty state — travel funding variant', () => {
-    test('travel funding dialog shows "No registered events" title', async ({ page }) => {
-      await page.route('**/api/events**', (route) => {
-        const url = route.request().url();
-        if (url.includes('/countries')) {
-          return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_COUNTRIES_RESPONSE) });
-        }
-        if (url.includes('/visa-requests') || url.includes('/travel-fund-requests') || url.includes('/organizations') || url.includes('/all')) {
-          return route.continue();
-        }
-        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(EMPTY_EVENTS_RESPONSE) });
-      });
+  test.describe('Empty state — initial load error', () => {
+    test('shows "Unable to load events" title when API returns 500', async ({ page }) => {
+      await openDialogWithEmptyEvents(page, 'visa-letters', { mainStatus: 500 });
+      await expect(page.getByTestId('event-selection-empty-title')).toHaveText('Unable to load events');
+    });
 
-      await page.goto('/me/events', { waitUntil: 'domcontentloaded' });
-      await expect(page).not.toHaveURL(/auth0\.com/);
-      await page.getByTestId('filter-pill-travel-funding').click();
-      await page.getByTestId('events-new-request-button').click();
-      await expect(page.getByTestId('event-selection-grid')).toBeVisible({ timeout: 10000 });
+    test('error description prompts the user to try again', async ({ page }) => {
+      await openDialogWithEmptyEvents(page, 'visa-letters', { mainStatus: 500 });
+      await expect(page.getByTestId('event-selection-empty-description')).toContainText('try again');
+    });
+  });
 
-      await expect(page.getByTestId('event-selection-empty-title')).toHaveText('No registered events');
-      await expect(page.getByTestId('event-selection-empty-description')).toContainText('travel funding');
+  test.describe('Empty state — request type not available (has registered events, no matching events)', () => {
+    test('visa dialog shows "Visa letters not available" when registered events exist but none match', async ({ page }) => {
+      // probeTotal > 0 means user has registered events, but the main query (filtered by
+      // isVisaRequestAccepted=true) returns empty — so no events support visa letters.
+      await openDialogWithEmptyEvents(page, 'visa-letters', { probeTotal: 3 });
+      await expect(page.getByTestId('event-selection-empty-title')).toHaveText('Visa letters not available');
+    });
+
+    test('travel-funding dialog shows "Travel funding not available" when registered events exist but none match', async ({ page }) => {
+      await openDialogWithEmptyEvents(page, 'travel-funding', { probeTotal: 3 });
+      await expect(page.getByTestId('event-selection-empty-title')).toHaveText('Travel funding not available');
+    });
+  });
+
+  test.describe('Empty state — active filters hiding results', () => {
+    test('shows "No events match your filters" when search narrows results to zero', async ({ page }) => {
+      // probeTotal > 0: user has registered events. Main query returns empty with any filters.
+      // Typing in the search box activates hasActiveFilters(), triggering the filter branch.
+      await openDialogWithEmptyEvents(page, 'visa-letters', { probeTotal: 3 });
+
+      await page.getByTestId('event-selection-search').locator('input').fill('xyznonexistent');
+      // Wait for the 500ms debounce to fire and the component to re-evaluate
+      await page.waitForTimeout(600);
+
+      await expect(page.getByTestId('event-selection-empty-title')).toHaveText('No events match your filters');
+    });
+
+    test('"No events match your filters" description prompts to clear filters', async ({ page }) => {
+      await openDialogWithEmptyEvents(page, 'visa-letters', { probeTotal: 3 });
+      await page.getByTestId('event-selection-search').locator('input').fill('xyznonexistent');
+      await page.waitForTimeout(600);
+      await expect(page.getByTestId('event-selection-empty-description')).toContainText('filters');
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.html
@@ -23,15 +23,15 @@
 
   <!-- Events grid -->
   <div class="events-scroll-area overflow-y-auto" data-testid="event-selection-grid">
-    @if (loading()) {
+    @if (initialLoading()) {
       <div class="flex items-center justify-center py-16">
         <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
       </div>
     } @else if (allEvents().length === 0) {
-      <div class="flex flex-col items-center justify-center gap-2 py-16 text-center">
+      <div class="flex flex-col items-center justify-center gap-2 py-16 text-center" data-testid="event-selection-empty-state">
         <i class="fa-light fa-calendar-xmark text-3xl text-gray-300"></i>
-        <p class="text-sm text-gray-500">No registered events found</p>
-        <p class="text-xs text-gray-400">Register for an event to continue</p>
+        <p class="text-sm text-gray-500" data-testid="event-selection-empty-title">{{ emptyState().title }}</p>
+        <p class="text-xs text-gray-400" data-testid="event-selection-empty-description">{{ emptyState().description }}</p>
       </div>
     } @else {
       <div class="grid grid-cols-3 gap-3">

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.html
@@ -23,17 +23,11 @@
 
   <!-- Events grid -->
   <div class="events-scroll-area overflow-y-auto" data-testid="event-selection-grid">
-    @if (initialLoading()) {
+    @if (loading()) {
       <div class="flex items-center justify-center py-16">
         <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
       </div>
-    } @else if (allEvents().length === 0) {
-      <div class="flex flex-col items-center justify-center gap-2 py-16 text-center" data-testid="event-selection-empty-state">
-        <i class="fa-light fa-calendar-xmark text-3xl text-gray-300"></i>
-        <p class="text-sm text-gray-500" data-testid="event-selection-empty-title">{{ emptyState().title }}</p>
-        <p class="text-xs text-gray-400" data-testid="event-selection-empty-description">{{ emptyState().description }}</p>
-      </div>
-    } @else {
+    } @else if (allEvents().length > 0) {
       <div class="grid grid-cols-3 gap-3">
         @for (event of allEvents(); track event.id) {
           <div
@@ -84,6 +78,17 @@
             (onClick)="onLoadMore()" />
         </div>
       }
+    } @else if (registeredEventsLoading() && !eventsLoadError()) {
+      <!-- Wait for the registration probe before rendering the empty state to avoid a premature message. -->
+      <div class="flex items-center justify-center py-16">
+        <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+      </div>
+    } @else {
+      <div class="flex flex-col items-center justify-center gap-2 py-16 text-center" data-testid="event-selection-empty-state">
+        <i [class]="emptyState().icon" data-testid="event-selection-empty-icon"></i>
+        <p class="text-sm text-gray-500" data-testid="event-selection-empty-title">{{ emptyState().title }}</p>
+        <p class="text-xs text-gray-400" data-testid="event-selection-empty-description">{{ emptyState().description }}</p>
+      </div>
     }
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
@@ -10,7 +10,7 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { EMPTY_MY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
 import { MyEvent, RequestType, TimeFilterValue } from '@lfx-one/shared/interfaces';
-import { catchError, combineLatest, debounceTime, EMPTY, finalize, of, scan, skip, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, EMPTY, finalize, map, of, scan, skip, switchMap, tap } from 'rxjs';
 import { EVENT_SELECTION_PAGE_SIZE } from '@lfx-one/shared/constants/events.constants';
 @Component({
   selector: 'lfx-event-selection',
@@ -42,6 +42,7 @@ export class EventSelectionComponent {
   // Events & pagination
   protected readonly loading = signal(true);
   protected readonly loadingMore = signal(false);
+  protected readonly registeredEventsLoading = signal(true);
   private currentOffset = signal(0);
 
   // Location filter options loaded once
@@ -75,6 +76,35 @@ export class EventSelectionComponent {
   // Combine initial events with any "load more" results
   protected readonly allEvents = computed(() => this.initialEventsResponse().data);
   protected readonly hasMore = computed(() => this.allEvents().length < this.initialEventsResponse().total);
+
+  // Detects whether the user has any registered upcoming events at all (ignoring request-type and other filters).
+  // Used to differentiate the empty state between "no registered events" and "feature not available on registered events".
+  private readonly registeredEventsTotal = this.initializeRegisteredEventsTotal();
+
+  // Treat unresolved (0 with loading=true) as "has events" to avoid flashing the wrong message; the spinner covers the load.
+  private readonly hasNoRegisteredUpcomingEvents = computed(() => !this.registeredEventsLoading() && this.registeredEventsTotal() === 0);
+
+  protected readonly emptyState = computed(() => {
+    const isVisa = this.requestType() === 'visa';
+    if (this.hasNoRegisteredUpcomingEvents()) {
+      return {
+        title: 'No registered events',
+        description: isVisa
+          ? 'You must be registered for an upcoming event to apply for a visa letter.'
+          : 'You must be registered for an upcoming event to apply for travel funding.',
+      };
+    }
+
+    return {
+      title: isVisa ? 'Visa letters not available' : 'Travel funding not available',
+      description: isVisa
+        ? 'None of your registered events currently offer visa letter requests. Check back later or contact the event organizer for more information.'
+        : 'None of your registered events currently offer travel funding. Check back later or contact the event organizer for more information.',
+    };
+  });
+
+  // Wait for both the initial events query and the registered-events lookup before deciding which empty state to render.
+  protected readonly initialLoading = computed(() => this.loading() || this.registeredEventsLoading());
 
   public constructor() {
     // Reset additional events when filters change (skip initial emission)
@@ -154,5 +184,16 @@ export class EventSelectionComponent {
     return toSignal(this.eventsService.getUpcomingCountries().pipe(catchError(() => of({ data: [] }))), {
       initialValue: { data: [] as string[] },
     });
+  }
+
+  private initializeRegisteredEventsTotal() {
+    return toSignal(
+      this.eventsService.getMyEvents({ isPast: false, registeredOnly: true, pageSize: 1 }).pipe(
+        map((res) => res.total ?? 0),
+        catchError(() => of(0)),
+        finalize(() => this.registeredEventsLoading.set(false))
+      ),
+      { initialValue: 0 }
+    );
   }
 }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
@@ -43,6 +43,7 @@ export class EventSelectionComponent {
   protected readonly loading = signal(true);
   protected readonly loadingMore = signal(false);
   protected readonly registeredEventsLoading = signal(true);
+  protected readonly eventsLoadError = signal(false);
   private currentOffset = signal(0);
 
   // Location filter options loaded once
@@ -79,15 +80,34 @@ export class EventSelectionComponent {
 
   // Detects whether the user has any registered upcoming events at all (ignoring request-type and other filters).
   // Used to differentiate the empty state between "no registered events" and "feature not available on registered events".
+  // null means the probe failed (network error) — treated as unknown, not zero.
   private readonly registeredEventsTotal = this.initializeRegisteredEventsTotal();
 
-  // Treat unresolved (0 with loading=true) as "has events" to avoid flashing the wrong message; the spinner covers the load.
+  // Only true when the probe resolved successfully with a confirmed zero total.
   private readonly hasNoRegisteredUpcomingEvents = computed(() => !this.registeredEventsLoading() && this.registeredEventsTotal() === 0);
+
+  // True when the user has applied search, location, or time filters that may be hiding results.
+  private readonly hasActiveFilters = computed(() => {
+    const f = this.activeFilters();
+    return !!(f.searchQuery || f.country || f.startDateFrom);
+  });
 
   protected readonly emptyState = computed(() => {
     const isVisa = this.requestType() === 'visa';
+
+    // 1. Initial load failed — show a neutral error rather than a misleading "not available" message.
+    if (this.eventsLoadError()) {
+      return {
+        icon: 'fa-light fa-triangle-exclamation text-3xl text-amber-400',
+        title: 'Unable to load events',
+        description: 'Something went wrong while loading your events. Please try again.',
+      };
+    }
+
+    // 2. No registered upcoming events at all — must register first.
     if (this.hasNoRegisteredUpcomingEvents()) {
       return {
+        icon: 'fa-light fa-calendar-xmark text-3xl text-gray-300',
         title: 'No registered events',
         description: isVisa
           ? 'You must be registered for an upcoming event to apply for a visa letter.'
@@ -95,7 +115,18 @@ export class EventSelectionComponent {
       };
     }
 
+    // 3. Active filters are hiding results — suggest clearing them.
+    if (this.hasActiveFilters()) {
+      return {
+        icon: 'fa-light fa-filter-slash text-3xl text-gray-300',
+        title: 'No events match your filters',
+        description: 'Try adjusting or clearing your search and filters.',
+      };
+    }
+
+    // 4. User has registered events but none support this request type.
     return {
+      icon: 'fa-light fa-calendar-xmark text-3xl text-gray-300',
       title: isVisa ? 'Visa letters not available' : 'Travel funding not available',
       description: isVisa
         ? 'None of your registered events currently offer visa letter requests. Check back later or contact the event organizer for more information.'
@@ -103,15 +134,13 @@ export class EventSelectionComponent {
     };
   });
 
-  // Wait for both the initial events query and the registered-events lookup before deciding which empty state to render.
-  protected readonly initialLoading = computed(() => this.loading() || this.registeredEventsLoading());
-
   public constructor() {
     // Reset additional events when filters change (skip initial emission)
     toObservable(this.activeFilters)
       .pipe(skip(1), takeUntilDestroyed())
       .subscribe(() => {
         this.currentOffset.set(0);
+        this.eventsLoadError.set(false);
       });
   }
 
@@ -155,7 +184,7 @@ export class EventSelectionComponent {
           this.eventsService.getMyEvents({ isPast: false, pageSize: EVENT_SELECTION_PAGE_SIZE, offset, registeredOnly: true, ...filters }).pipe(
             catchError(() => {
               if (offset === 0) {
-                // Initial load failed - show empty state
+                this.eventsLoadError.set(true);
                 return of(EMPTY_MY_EVENTS_RESPONSE);
               }
               // Load more failed - revert offset so retry fetches the same page
@@ -190,10 +219,10 @@ export class EventSelectionComponent {
     return toSignal(
       this.eventsService.getMyEvents({ isPast: false, registeredOnly: true, pageSize: 1 }).pipe(
         map((res) => res.total ?? 0),
-        catchError(() => of(0)),
+        catchError(() => of(null)),
         finalize(() => this.registeredEventsLoading.set(false))
       ),
-      { initialValue: 0 }
+      { initialValue: null as number | null }
     );
   }
 }

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
@@ -78,9 +78,7 @@ export class EventSelectionComponent {
   protected readonly allEvents = computed(() => this.initialEventsResponse().data);
   protected readonly hasMore = computed(() => this.allEvents().length < this.initialEventsResponse().total);
 
-  // Detects whether the user has any registered upcoming events at all (ignoring request-type and other filters).
-  // Used to differentiate the empty state between "no registered events" and "feature not available on registered events".
-  // null means the probe failed (network error) — treated as unknown, not zero.
+  // null = probe skipped (results were present) or probe failed; both treated as unknown, not zero.
   private readonly registeredEventsTotal = this.initializeRegisteredEventsTotal();
 
   // Only true when the probe resolved successfully with a confirmed zero total.
@@ -216,8 +214,7 @@ export class EventSelectionComponent {
   }
 
   private initializeRegisteredEventsTotal() {
-    // Defer the probe until the main query finishes. If results are already visible the empty
-    // state is never rendered, so the probe adds no value and is skipped entirely.
+    // Probe fires only when the main query settles with zero results; skipped otherwise.
     return toSignal(
       toObservable(this.loading).pipe(
         filter((loading) => !loading),

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/components/event-selection/event-selection.component.ts
@@ -10,7 +10,7 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { EMPTY_MY_EVENTS_RESPONSE } from '@lfx-one/shared/constants';
 import { MyEvent, RequestType, TimeFilterValue } from '@lfx-one/shared/interfaces';
-import { catchError, combineLatest, debounceTime, EMPTY, finalize, map, of, scan, skip, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, EMPTY, filter, finalize, map, of, scan, skip, switchMap, take, tap } from 'rxjs';
 import { EVENT_SELECTION_PAGE_SIZE } from '@lfx-one/shared/constants/events.constants';
 @Component({
   selector: 'lfx-event-selection',
@@ -216,11 +216,23 @@ export class EventSelectionComponent {
   }
 
   private initializeRegisteredEventsTotal() {
+    // Defer the probe until the main query finishes. If results are already visible the empty
+    // state is never rendered, so the probe adds no value and is skipped entirely.
     return toSignal(
-      this.eventsService.getMyEvents({ isPast: false, registeredOnly: true, pageSize: 1 }).pipe(
-        map((res) => res.total ?? 0),
-        catchError(() => of(null)),
-        finalize(() => this.registeredEventsLoading.set(false))
+      toObservable(this.loading).pipe(
+        filter((loading) => !loading),
+        take(1),
+        switchMap(() => {
+          if (this.allEvents().length > 0 || this.eventsLoadError()) {
+            this.registeredEventsLoading.set(false);
+            return of(null as number | null);
+          }
+          return this.eventsService.getMyEvents({ isPast: false, registeredOnly: true, pageSize: 1 }).pipe(
+            map((res) => res.total ?? 0),
+            catchError(() => of(null as number | null)),
+            finalize(() => this.registeredEventsLoading.set(false))
+          );
+        })
       ),
       { initialValue: null as number | null }
     );


### PR DESCRIPTION
## Summary

- Adds a secondary API call to detect whether the user has any registered
  upcoming events at all, independent of request type or filters
- Replaces the generic \"No registered events found\" empty state with four
  context-aware states:
  - **Unable to load events** — shown when the initial API call fails (network/server error)
  - **No registered events** — shown when the user has no upcoming registered events at all (must register first)
  - **No events match your filters** — shown when the user has registered events but active search, location, or time filters are hiding all results
  - **Visa letters not available** / **Travel funding not available** — shown when the user has registered events but none offer the selected request type
- Gates the empty state on `loading()` and `registeredEventsLoading()` independently so populated results render as soon as the main query resolves, without waiting for the probe
- Adds `event-selection-robust.spec.ts` with Playwright structural tests covering the new empty-state branches

## Review resolution (post-merge follow-up commits)

All feedback from Copilot and CodeRabbit has been addressed:

| Concern | Resolution |
|---|---|
| Probe failure (`catchError(() => of(0))`) collapsed network error to "no registered events" | Changed to `of(null)`; `null === 0` is `false` so unknown probe state is treated as unknown, not zero |
| Initial load errors surfaced as "feature not available" | Added `eventsLoadError` signal; `emptyState()` checks it first and shows a neutral error message |
| Populated results blocked until probe resolved | Main `@if/else` branches on `loading()` only; `registeredEventsLoading()` gates only the secondary spinner inside the empty branch |
| Probe fired unconditionally on every dialog open | Probe is now lazy: deferred via `toObservable(loading).pipe(filter(!loading), take(1))`; skipped entirely when results are present or an error occurred |
| `Page` type annotation used `Parameters<typeof test>[1]` | Replaced with direct `import { Page } from '@playwright/test'` |
| Travel-funding tests duplicated route-setup logic | Extracted `mockEventRoutes()` and `openDialogWithEmptyEvents(page, tab, routeOptions)` shared helpers |
| Only "no registered events" branch was tested | Added test describes for all four empty-state branches, including error and filter scenarios |
| Route handler called `route.continue()` for secondary paths | Replaced with `route.fulfill()` so all `/api/events*` traffic is fully mocked |