### PR TITLE
fix(votes): normalize vote_uid to uid from query service response

### DIFF
--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CreateVoteRequest, QueryServiceCountResponse, QueryServiceResponse, UpdateVoteRequest, Vote, VoteResultsResponse } from '@lfx-one/shared/interfaces';
+import { CreateVoteRequest, IndexedVote, QueryServiceCountResponse, QueryServiceResponse, UpdateVoteRequest, Vote, VoteResultsResponse } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';
@@ -41,16 +41,14 @@ export class VoteService {
       type: 'vote',
     };
 
-    const rawVotes = await fetchAllQueryResources<Vote & { vote_uid?: string }>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote & { vote_uid?: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+    const rawVotes = await fetchAllQueryResources<IndexedVote>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<IndexedVote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
         ...params,
         ...(pageToken && { page_token: pageToken }),
       })
     );
 
-    // The voting service indexes votes with `vote_uid` (not `uid`). Normalize so
-    // downstream code can rely on the standard Vote.uid field.
-    const votes = rawVotes.map((v) => ({ ...v, uid: v.uid || v.vote_uid || '' })) as Vote[];
+    const votes = rawVotes.map((v) => this.normalizeIndexedVote(req, v));
 
     logger.debug(req, 'get_votes', 'Completed vote fetch', {
       final_count: votes.length,
@@ -122,13 +120,12 @@ export class VoteService {
       req,
       operation: 'create_vote',
       pollFn: async () => {
-        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote & { vote_uid?: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<IndexedVote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
           type: 'vote',
           tags: voteUid,
         });
         if (resources.length > 0) {
-          const raw = resources[0].data;
-          fetchedVote = { ...raw, uid: raw.uid || raw.vote_uid || '' } as Vote;
+          fetchedVote = this.normalizeIndexedVote(req, resources[0].data);
           return true;
         }
         return false;
@@ -198,13 +195,12 @@ export class VoteService {
       req,
       operation: 'enable_vote',
       pollFn: async () => {
-        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote & { vote_uid?: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<IndexedVote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
           type: 'vote',
           tags: voteUid,
         });
         if (resources.length > 0 && resources[0].data.status === 'active') {
-          const raw = resources[0].data;
-          fetchedVote = { ...raw, uid: raw.uid || raw.vote_uid || '' } as Vote;
+          fetchedVote = this.normalizeIndexedVote(req, resources[0].data);
           return true;
         }
         return false;
@@ -322,5 +318,24 @@ export class VoteService {
       });
 
     return this.projectService.enrichWithProjectData(req, sorted);
+  }
+
+  // ============================================
+  // Private Helpers
+  // ============================================
+
+  /**
+   * Normalizes a vote from the query service indexer shape (vote_uid) to the
+   * canonical REST shape (uid). The voting service indexes votes with `vote_uid`
+   * while the REST API returns `uid` — these are the same value, different field names.
+   */
+  private normalizeIndexedVote(req: Request, raw: IndexedVote): Vote {
+    const uid = raw.uid || raw.vote_uid;
+    if (!uid) {
+      logger.warning(req, 'normalize_indexed_vote', 'Indexed vote missing uid and vote_uid', {
+        name: raw.name,
+      });
+    }
+    return { ...raw, uid: uid ?? '' } as Vote;
   }
 }

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -8,7 +8,6 @@ import { ResourceNotFoundError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
-import { generateM2MToken } from '../utils/m2m-token.util';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { ProjectService } from './project.service';
@@ -42,12 +41,16 @@ export class VoteService {
       type: 'vote',
     };
 
-    const votes = await fetchAllQueryResources<Vote>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+    const rawVotes = await fetchAllQueryResources<Vote & { vote_uid?: string }>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote & { vote_uid?: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
         ...params,
         ...(pageToken && { page_token: pageToken }),
       })
     );
+
+    // The voting service indexes votes with `vote_uid` (not `uid`). Normalize so
+    // downstream code can rely on the standard Vote.uid field.
+    const votes = rawVotes.map((v) => ({ ...v, uid: v.uid || v.vote_uid || '' })) as Vote[];
 
     logger.debug(req, 'get_votes', 'Completed vote fetch', {
       final_count: votes.length,
@@ -119,12 +122,13 @@ export class VoteService {
       req,
       operation: 'create_vote',
       pollFn: async () => {
-        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote & { vote_uid?: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
           type: 'vote',
           tags: voteUid,
         });
         if (resources.length > 0) {
-          fetchedVote = resources[0].data;
+          const raw = resources[0].data;
+          fetchedVote = { ...raw, uid: raw.uid || raw.vote_uid || '' } as Vote;
           return true;
         }
         return false;
@@ -194,12 +198,13 @@ export class VoteService {
       req,
       operation: 'enable_vote',
       pollFn: async () => {
-        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Vote & { vote_uid?: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
           type: 'vote',
           tags: voteUid,
         });
         if (resources.length > 0 && resources[0].data.status === 'active') {
-          fetchedVote = resources[0].data;
+          const raw = resources[0].data;
+          fetchedVote = { ...raw, uid: raw.uid || raw.vote_uid || '' } as Vote;
           return true;
         }
         return false;
@@ -222,26 +227,11 @@ export class VoteService {
 
   /**
    * Fetches aggregated vote results for a given vote.
-   *
-   * The upstream `/votes/:uid/results` endpoint requires the `results_viewer` FGA relation on the
-   * vote, which is only granted to voters (participants). Project admins and committee managers
-   * have `viewer` but not `results_viewer`, so their user bearer token would be rejected with 403.
-   * We use an M2M token here — the route is already authenticated and the user's access to the
-   * vote itself was already verified by the query-service when the vote list was fetched.
    */
   public async getVoteResults(req: Request, voteUid: string): Promise<VoteResultsResponse> {
     logger.debug(req, 'get_vote_results', 'Fetching vote results', { vote_uid: voteUid });
 
-    const m2mToken = await generateM2MToken(req);
-    const results = await this.microserviceProxy.proxyRequest<VoteResultsResponse>(
-      req,
-      'LFX_V2_SERVICE',
-      `/votes/${voteUid}/results`,
-      'GET',
-      undefined,
-      undefined,
-      { Authorization: `Bearer ${m2mToken}` }
-    );
+    const results = await this.microserviceProxy.proxyRequest<VoteResultsResponse>(req, 'LFX_V2_SERVICE', `/votes/${voteUid}/results`, 'GET');
 
     logger.debug(req, 'get_vote_results', 'Completed vote results fetch', {
       vote_uid: voteUid,

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -336,6 +336,8 @@ export class VoteService {
         name: raw.name,
       });
     }
-    return { ...raw, uid: uid ?? '' } as Vote;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { vote_uid: _discard, ...rest } = raw;
+    return { ...rest, uid: uid ?? '' };
   }
 }

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -8,6 +8,7 @@ import { ResourceNotFoundError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
+import { generateM2MToken } from '../utils/m2m-token.util';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { ProjectService } from './project.service';
@@ -220,12 +221,27 @@ export class VoteService {
   }
 
   /**
-   * Fetches aggregated vote results for a given vote
+   * Fetches aggregated vote results for a given vote.
+   *
+   * The upstream `/votes/:uid/results` endpoint requires the `results_viewer` FGA relation on the
+   * vote, which is only granted to voters (participants). Project admins and committee managers
+   * have `viewer` but not `results_viewer`, so their user bearer token would be rejected with 403.
+   * We use an M2M token here — the route is already authenticated and the user's access to the
+   * vote itself was already verified by the query-service when the vote list was fetched.
    */
   public async getVoteResults(req: Request, voteUid: string): Promise<VoteResultsResponse> {
     logger.debug(req, 'get_vote_results', 'Fetching vote results', { vote_uid: voteUid });
 
-    const results = await this.microserviceProxy.proxyRequest<VoteResultsResponse>(req, 'LFX_V2_SERVICE', `/votes/${voteUid}/results`, 'GET');
+    const m2mToken = await generateM2MToken(req);
+    const results = await this.microserviceProxy.proxyRequest<VoteResultsResponse>(
+      req,
+      'LFX_V2_SERVICE',
+      `/votes/${voteUid}/results`,
+      'GET',
+      undefined,
+      undefined,
+      { Authorization: `Bearer ${m2mToken}` }
+    );
 
     logger.debug(req, 'get_vote_results', 'Completed vote results fetch', {
       vote_uid: voteUid,

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -220,8 +220,7 @@ export interface Vote {
 /**
  * Vote resource shape as returned by the query service indexer.
  * Uses `vote_uid` (v2 primary key) — NOT `uid`.
- * Normalize to canonical `Vote` via VoteService.normalizeIndexedVote().
- * @see lfx-v2-voting-service/docs/indexer-contract.md
+ * Normalize to canonical `Vote` shape before passing to downstream consumers.
  */
 export interface IndexedVote extends Omit<Vote, 'uid'> {
   vote_uid: string;

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -218,6 +218,17 @@ export interface Vote {
 }
 
 /**
+ * Vote resource shape as returned by the query service indexer.
+ * Uses `vote_uid` (v2 primary key) — NOT `uid`.
+ * Normalize to canonical `Vote` via VoteService.normalizeIndexedVote().
+ * @see lfx-v2-voting-service/docs/indexer-contract.md
+ */
+export interface IndexedVote extends Omit<Vote, 'uid'> {
+  vote_uid: string;
+  uid?: string;
+}
+
+/**
  * Individual Vote entity from query service
  * @description Represents a user's participation record from lfx.index.individual_vote
  */


### PR DESCRIPTION
## Summary

The voting service indexes votes with the field name `vote_uid` (Go json tag on `VoteData.VoteUID`), not `uid`. When votes are fetched from the query service (project lens, committee/group tab), `resource.data` contains `vote_uid` but not `uid` — so `vote.uid` is `undefined` at runtime.

Clicking "Results" emits `undefined` to the drawer's `initVote()`, which short-circuits with `if (!id) return of(null)`. The `@if (vote(); as voteData)` guard then renders nothing, leaving the drawer empty.

The Me lens was unaffected because `getMyVotes` fetches individual votes via `GET /votes/:uid` directly from the voting service API, which returns properly shaped `{ uid: "..." }` objects.

## Changes

- **`vote.service.ts`**: Normalize `vote_uid → uid` in all three places that read votes from the query service: `getVotes`, `createVote` post-create polling, and `enableVote` post-enable polling.

## Test plan

- [ ] Navigate to a project's Votes tab — click "Results" on any ended vote — drawer opens with vote name and results
- [ ] Navigate to a committee/group's Votes tab — click "Results" on any ended vote — drawer opens correctly
- [ ] Me lens "My Votes" still works (no regression)
- [ ] Creating a new vote returns a vote with a valid `uid`
- [ ] Enabling a vote returns a vote with a valid `uid`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)