### PR TITLE
fix(profile): align t-shirt size options with v1 Salesforce picklist

### DIFF
--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -7,7 +7,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { NonNullableFormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, NavigationEnd, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { SelectComponent } from '@components/select/select.component';
-import { PROFILE_TABS, TSHIRT_SIZES } from '@lfx-one/shared/constants';
+import { normalizeTShirtSize, PROFILE_TABS, TSHIRT_SIZES } from '@lfx-one/shared/constants';
 import { CombinedProfile, ProfileHeaderData, ProfileTab, ProfileUpdateRequest, UserMetadata } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
@@ -304,7 +304,7 @@ export class ProfileLayoutComponent {
       address: profile.profile?.address || '',
       postalCode: profile.profile?.postal_code || '',
       phoneNumber: profile.profile?.phone_number || '',
-      tshirtSize: profile.profile?.t_shirt_size || '',
+      tshirtSize: normalizeTShirtSize(profile.profile?.t_shirt_size),
       avatarUrl: profile.profile?.picture || '',
     };
   }

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-dialog/profile-edit-dialog.component.ts
@@ -8,7 +8,7 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
-import { COUNTRIES, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared';
+import { COUNTRIES, normalizeTShirtSize, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared';
 import { CombinedProfile, ProfileUpdateRequest, UserEmail, UserMetadata } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { UserService } from '@services/user.service';
@@ -228,7 +228,7 @@ export class ProfileEditDialogComponent {
       address: profile.profile?.address || '',
       postal_code: profile.profile?.postal_code || '',
       phone_number: profile.profile?.phone_number || '',
-      t_shirt_size: profile.profile?.t_shirt_size || '',
+      t_shirt_size: normalizeTShirtSize(profile.profile?.t_shirt_size),
       job_title: profile.profile?.job_title || '',
       organization: profile.profile?.organization || '',
     });

--- a/apps/lfx-one/src/app/modules/profile/manage-profile/profile-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/manage-profile/profile-manage.component.ts
@@ -9,7 +9,7 @@ import { CardComponent } from '@components/card/card.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { MessageComponent } from '@components/message/message.component';
 import { SelectComponent } from '@components/select/select.component';
-import { COUNTRIES, markFormControlsAsTouched, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared';
+import { COUNTRIES, markFormControlsAsTouched, normalizeTShirtSize, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared';
 import { CombinedProfile, ProfileUpdateRequest, UserMetadata } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -229,7 +229,7 @@ export class ProfileManageComponent implements OnInit {
       address: profile.profile?.address || '',
       postal_code: profile.profile?.postal_code || '',
       phone_number: profile.profile?.phone_number || '',
-      t_shirt_size: profile.profile?.t_shirt_size || '',
+      t_shirt_size: normalizeTShirtSize(profile.profile?.t_shirt_size),
     });
 
     // Set the initial country signal value

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -48,6 +48,9 @@ import { NatsService } from './nats.service';
 import { ProjectService } from './project.service';
 import { SnowflakeService } from './snowflake.service';
 
+const VALID_TSHIRT_SIZES: ReadonlySet<string> = new Set(TSHIRT_SIZES.map((s) => s.value));
+const VALID_TSHIRT_SIZES_LABEL = TSHIRT_SIZES.map((s) => s.value).join(', ');
+
 /**
  * Service for handling user-related operations and user analytics
  */
@@ -177,11 +180,8 @@ export class UserService {
    */
   public validateUserMetadata(metadata: UserMetadata): boolean {
     // Validate t-shirt size if provided
-    if (metadata?.t_shirt_size) {
-      const validSizes = TSHIRT_SIZES.map((s) => s.value);
-      if (!validSizes.includes(metadata.t_shirt_size as (typeof TSHIRT_SIZES)[number]['value'])) {
-        throw new Error(`Invalid t-shirt size. Must be one of: ${validSizes.join(', ')}`);
-      }
+    if (metadata?.t_shirt_size && !VALID_TSHIRT_SIZES.has(metadata.t_shirt_size)) {
+      throw new Error(`Invalid t-shirt size. Must be one of: ${VALID_TSHIRT_SIZES_LABEL}`);
     }
 
     // Validate phone number format if provided

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -7,6 +7,7 @@ import {
   NATS_CONFIG,
   QUERY_SERVICE_FILTERS_OR_BATCH_SIZE,
   ROOT_PROJECT_SLUG,
+  TSHIRT_SIZES,
 } from '@lfx-one/shared/constants';
 import { NatsSubjects, PollStatus } from '@lfx-one/shared/enums';
 import {
@@ -177,8 +178,8 @@ export class UserService {
   public validateUserMetadata(metadata: UserMetadata): boolean {
     // Validate t-shirt size if provided
     if (metadata?.t_shirt_size) {
-      const validSizes = ['XS', 'S', 'M', 'L', 'XL', 'XXL', 'XXXL'];
-      if (!validSizes.includes(metadata.t_shirt_size.toUpperCase())) {
+      const validSizes = TSHIRT_SIZES.map((s) => s.value);
+      if (!validSizes.includes(metadata.t_shirt_size as (typeof TSHIRT_SIZES)[number]['value'])) {
         throw new Error(`Invalid t-shirt size. Must be one of: ${validSizes.join(', ')}`);
       }
     }

--- a/packages/shared/src/constants/tshirt-sizes.constants.ts
+++ b/packages/shared/src/constants/tshirt-sizes.constants.ts
@@ -2,19 +2,36 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * T-shirt size options for profile forms and swag distribution
+ * T-shirt size options for profile forms and swag distribution.
+ * Values mirror the v1 Salesforce picklist so v2→v1 sync round-trips cleanly.
  */
 export const TSHIRT_SIZES = [
-  { label: 'Extra Small', value: 'XS' },
-  { label: 'Small', value: 'S' },
-  { label: 'Medium', value: 'M' },
-  { label: 'Large', value: 'L' },
-  { label: 'Extra Large', value: 'XL' },
-  { label: 'XXL', value: 'XXL' },
-  { label: 'XXXL', value: 'XXXL' },
+  { label: 'Fitted-Cut Small', value: 'Fitted-Cut Small' },
+  { label: 'Fitted-Cut Medium', value: 'Fitted-Cut Medium' },
+  { label: 'Fitted-Cut Large', value: 'Fitted-Cut Large' },
+  { label: 'Fitted-Cut XL', value: 'Fitted-Cut XL' },
+  { label: 'Fitted-Cut 2XL', value: 'Fitted-Cut 2XL' },
+  { label: 'Straight-Cut Small', value: 'Straight-Cut Small' },
+  { label: 'Straight-Cut Medium', value: 'Straight-Cut Medium' },
+  { label: 'Straight-Cut Large', value: 'Straight-Cut Large' },
+  { label: 'Straight-Cut XL', value: 'Straight-Cut XL' },
+  { label: 'Straight-Cut 2XL', value: 'Straight-Cut 2XL' },
+  { label: 'Straight-Cut 3XL', value: 'Straight-Cut 3XL' },
 ] as const;
 
 /**
  * Type for T-shirt size values
  */
 export type TShirtSize = (typeof TSHIRT_SIZES)[number]['value'];
+
+/**
+ * Coerce a stored t-shirt size into one of the current valid options.
+ * Returns '' for nullish, empty, or unrecognised values — used to drop
+ * legacy values when loading a stored profile, so the form never re-submits
+ * a size that would fail validation.
+ */
+export function normalizeTShirtSize(value: string | null | undefined): TShirtSize | '' {
+  if (!value) return '';
+  const match = TSHIRT_SIZES.find((s) => s.value === value);
+  return match ? match.value : '';
+}


### PR DESCRIPTION
## Summary

- Replace the v2-only `XS/S/M/L/XL/XXL/XXXL` t-shirt size enum with the 11 Fitted-Cut / Straight-Cut values from the v1 Salesforce picklist (`value === label`), so v2→v1 sync can round-trip without `user-service` rejecting `tshirt_size__c` as an invalid picklist value.
- Point `validateUserMetadata()` at the shared `TSHIRT_SIZES` constant instead of a hardcoded array, and drop `.toUpperCase()` (the new values are case-sensitive mixed-case). One source of truth now — the server can't drift from the picklist.
- Add `normalizeTShirtSize()` and use it when populating the two profile forms and the header, so legacy stored values (e.g. `"M"`, `"XL"`) fall back to `''` on load instead of being silently re-submitted and rejected by the validator on every save.

## Why

Any user whose `user_metadata.t_shirt_size` in Auth0 was set while v2 had the short-code enum (or before we had one at all) couldn't save their profile — editing any field returned `Validation failed for user_metadata / Invalid t-shirt size`. Separately, the v2 values never matched what v1's `user-service` accepts, so the picklist write was failing downstream of sync.

## Behaviour after merge

- **New users** see the 11 Fitted-Cut / Straight-Cut options and save cleanly.
- **Existing users with legacy values** get an empty dropdown on next visit; unrelated fields save cleanly because the invalid value is no longer sent. They pick a current option when convenient.
- **v2→v1 sync** writes a v1-compatible string to `tshirt_size__c`, so the downstream 422 during testing should stop.

## Test plan

- [ ] Log in as a user with no `t_shirt_size` stored → edit another field (e.g. phone number) → save succeeds.
- [ ] Log in as a user with a legacy `t_shirt_size` (e.g. `"M"`) in Auth0 → dropdown shows empty, saving an unrelated field succeeds.
- [ ] Pick any of the 11 new sizes → save → re-open profile → dropdown shows the selected value and header label renders the same value.
- [ ] Submit a deliberately bogus `t_shirt_size` via API → backend returns validation error listing the 11 valid values (no `.toUpperCase()` leaking case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)