### PR TITLE
feat(committees): redesign group detail page header and overview tab

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -158,7 +158,9 @@ export class CommitteeDashboardComponent {
   }
 
   public onCommitteeClick(committee: Committee): void {
-    this.router.navigate(['/groups', committee.uid]);
+    this.router.navigate(['/groups', committee.uid], {
+      state: { backLabel: this.isMeLens() ? 'My Groups' : 'Groups' },
+    });
   }
 
   public onFoundationFilterChange(value: string | null): void {

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -37,336 +37,337 @@
         <div class="px-6 pt-5 pb-4 flex flex-col gap-4">
           <!-- Back link -->
           <button
+            type="button"
             class="flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 transition-colors w-fit"
             (click)="goBack()"
             data-testid="committee-view-back-link">
             <i class="fa-light fa-angle-left text-xs"></i>
             {{ backLabel() }}
           </button>
-        <div class="flex items-center gap-3">
-          <h1 class="font-display font-light text-[20px]" data-testid="committee-view-name">{{ committee()?.name }}</h1>
-          @if (!committee()?.public) {
-            <i class="fa-light fa-lock w-4 h-4 text-gray-400"></i>
-          }
-          <!-- Join / Request to Join / Contact Admin / Leave actions -->
-          <div class="ml-auto flex items-center gap-2">
-            @if (isVisitor()) {
-              @if (committee()?.join_mode === 'open') {
-                <lfx-button
-                  label="Join Group"
-                  icon="fa-light fa-user-plus"
-                  severity="info"
-                  size="small"
-                  [loading]="joiningOrLeaving()"
-                  (onClick)="handleJoinRequest()"
-                  data-testid="committee-view-join-btn" />
-              } @else if (committee()?.join_mode === 'application') {
-                <lfx-button
-                  label="Request to Join"
-                  icon="fa-light fa-paper-plane"
-                  severity="secondary"
-                  [outlined]="true"
-                  size="small"
-                  [loading]="joiningOrLeaving()"
-                  (onClick)="handleJoinRequest()"
-                  data-testid="committee-view-request-to-join-btn" />
-              } @else if (committee()?.join_mode === 'invite_only') {
-                <lfx-button
-                  label="Request Access"
-                  icon="fa-light fa-paper-plane"
-                  severity="secondary"
-                  [outlined]="true"
-                  size="small"
-                  [loading]="joiningOrLeaving()"
-                  (onClick)="handleJoinRequest()"
-                  data-testid="committee-view-request-access-btn" />
-              } @else {
-                <lfx-button
-                  label="Contact Admin"
-                  icon="fa-light fa-envelope"
-                  severity="secondary"
-                  [outlined]="true"
-                  size="small"
-                  (onClick)="handleJoinRequest()"
-                  data-testid="committee-view-contact-admin-btn" />
-              }
-            } @else if (isMemberOrAdmin() && !canEdit()) {
-              <lfx-button
-                label="Leave Group"
-                icon="fa-light fa-arrow-right-from-bracket"
-                severity="secondary"
-                [outlined]="true"
-                size="small"
-                [loading]="joiningOrLeaving()"
-                (onClick)="handleLeaveRequest()"
-                data-testid="committee-view-leave-btn" />
+          <div class="flex items-center gap-3">
+            <h1 class="font-display font-light text-[20px]" data-testid="committee-view-name">{{ committee()?.name }}</h1>
+            @if (!committee()?.public) {
+              <i class="fa-light fa-lock w-4 h-4 text-gray-400"></i>
             }
-          </div>
-        </div>
-        <!-- Description + Channels card side by side -->
-        <div class="flex flex-col lg:flex-row justify-between items-start gap-6">
-          <!-- Left column -->
-          <div class="flex flex-col gap-3 flex-1 min-w-0">
-            @if (committee()?.description || canEdit()) {
-              <div class="flex items-start gap-2 max-w-2xl" data-testid="committee-view-description">
-                @if (committee()?.description) {
-                  <p class="text-gray-500 flex-1 text-sm">{{ committee()?.description }}</p>
-                } @else if (canEdit()) {
-                  <span class="text-gray-400 text-sm italic flex-1">No description yet.</span>
-                }
-                @if (canEdit()) {
+            <!-- Join / Request to Join / Contact Admin / Leave actions -->
+            <div class="ml-auto flex items-center gap-2">
+              @if (isVisitor()) {
+                @if (committee()?.join_mode === 'open') {
                   <lfx-button
-                    icon="fa-light fa-pen-to-square"
-                    [text]="true"
-                    [rounded]="true"
+                    label="Join Group"
+                    icon="fa-light fa-user-plus"
+                    severity="info"
                     size="small"
+                    [loading]="joiningOrLeaving()"
+                    (onClick)="handleJoinRequest()"
+                    data-testid="committee-view-join-btn" />
+                } @else if (committee()?.join_mode === 'application') {
+                  <lfx-button
+                    label="Request to Join"
+                    icon="fa-light fa-paper-plane"
                     severity="secondary"
-                    tooltip="Edit description"
-                    (onClick)="openEditDescription()"></lfx-button>
+                    [outlined]="true"
+                    size="small"
+                    [loading]="joiningOrLeaving()"
+                    (onClick)="handleJoinRequest()"
+                    data-testid="committee-view-request-to-join-btn" />
+                } @else if (committee()?.join_mode === 'invite_only') {
+                  <lfx-button
+                    label="Request Access"
+                    icon="fa-light fa-paper-plane"
+                    severity="secondary"
+                    [outlined]="true"
+                    size="small"
+                    [loading]="joiningOrLeaving()"
+                    (onClick)="handleJoinRequest()"
+                    data-testid="committee-view-request-access-btn" />
+                } @else {
+                  <lfx-button
+                    label="Contact Admin"
+                    icon="fa-light fa-envelope"
+                    severity="secondary"
+                    [outlined]="true"
+                    size="small"
+                    (onClick)="handleJoinRequest()"
+                    data-testid="committee-view-contact-admin-btn" />
                 }
-              </div>
-            }
-            <div class="flex items-center gap-3 flex-wrap">
-              @if (committee()?.category) {
-                <lfx-tag [value]="committee()!.category" [severity]="categorySeverity()"></lfx-tag>
-              }
-              @if (committee()?.enable_voting) {
-                <lfx-tag value="Voting Enabled" severity="success"></lfx-tag>
-              }
-              @if (committee()?.join_mode) {
-                <lfx-tag [value]="committee()!.join_mode! | joinModeLabel" severity="secondary"></lfx-tag>
+              } @else if (isMemberOrAdmin() && !canEdit()) {
+                <lfx-button
+                  label="Leave Group"
+                  icon="fa-light fa-arrow-right-from-bracket"
+                  severity="secondary"
+                  [outlined]="true"
+                  size="small"
+                  [loading]="joiningOrLeaving()"
+                  (onClick)="handleLeaveRequest()"
+                  data-testid="committee-view-leave-btn" />
               }
             </div>
-            <div class="flex items-center gap-4 flex-wrap">
-              @if (committee()?.project_name || committee()?.foundation_name) {
-                <div class="flex items-center gap-1.5">
-                  <span class="text-xs font-medium text-gray-500">Parent Project:</span>
-                  <span class="text-xs text-gray-700">{{ committee()?.project_name || committee()?.foundation_name }}</span>
+          </div>
+          <!-- Description + Channels card side by side -->
+          <div class="flex flex-col lg:flex-row justify-between items-start gap-6">
+            <!-- Left column -->
+            <div class="flex flex-col gap-3 flex-1 min-w-0">
+              @if (committee()?.description || canEdit()) {
+                <div class="flex items-start gap-2 max-w-2xl" data-testid="committee-view-description">
+                  @if (committee()?.description) {
+                    <p class="text-gray-500 flex-1 text-sm">{{ committee()?.description }}</p>
+                  } @else if (canEdit()) {
+                    <span class="text-gray-400 text-sm italic flex-1">No description yet.</span>
+                  }
+                  @if (canEdit()) {
+                    <lfx-button
+                      icon="fa-light fa-pen-to-square"
+                      [text]="true"
+                      [rounded]="true"
+                      size="small"
+                      severity="secondary"
+                      tooltip="Edit description"
+                      (onClick)="openEditDescription()"></lfx-button>
+                  }
                 </div>
               }
-              @if (parentGroup(); as parent) {
-                <button
-                  class="flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors cursor-pointer"
-                  (click)="navigateToParentGroup()"
-                  data-testid="committee-view-parent-group-link">
-                  <i class="fa-light fa-sitemap text-[11px]"></i>
-                  <span>Parent Group:</span>
-                  <span>{{ parent.name }}</span>
-                  <i class="fa-light fa-chevron-right text-[10px]"></i>
-                </button>
-              }
-              @if (subGroupsLoading()) {
-                <p-skeleton width="120px" height="16px" borderRadius="4px" />
-              } @else if (subGroups().length === 1) {
-                <!-- Single sub-group: inline link, no dropdown -->
-                <button
-                  class="flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors cursor-pointer"
-                  (click)="navigateToSubGroup(subGroups()[0])"
-                  data-testid="committee-view-sub-group-link">
-                  <i class="fa-light fa-sitemap text-[11px]"></i>
-                  <span>Sub-Group:</span>
-                  <span>{{ subGroups()[0].name }}</span>
-                  <i class="fa-light fa-chevron-right text-[10px]"></i>
-                </button>
-              } @else if (subGroups().length > 1) {
-                <!-- Multiple sub-groups: dropdown popover -->
-                <div class="relative">
+              <div class="flex items-center gap-3 flex-wrap">
+                @if (committee()?.category) {
+                  <lfx-tag [value]="committee()!.category" [severity]="categorySeverity()"></lfx-tag>
+                }
+                @if (committee()?.enable_voting) {
+                  <lfx-tag value="Voting Enabled" severity="success"></lfx-tag>
+                }
+                @if (committee()?.join_mode) {
+                  <lfx-tag [value]="committee()!.join_mode! | joinModeLabel" severity="secondary"></lfx-tag>
+                }
+              </div>
+              <div class="flex items-center gap-4 flex-wrap">
+                @if (committee()?.project_name || committee()?.foundation_name) {
+                  <div class="flex items-center gap-1.5">
+                    <span class="text-xs font-medium text-gray-500">Parent Project:</span>
+                    <span class="text-xs text-gray-700">{{ committee()?.project_name || committee()?.foundation_name }}</span>
+                  </div>
+                }
+                @if (parentGroup(); as parent) {
                   <button
                     class="flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors cursor-pointer"
-                    (click)="subGroupsPopover.toggle($event)"
-                    data-testid="committee-view-sub-groups-trigger">
+                    (click)="navigateToParentGroup()"
+                    data-testid="committee-view-parent-group-link">
                     <i class="fa-light fa-sitemap text-[11px]"></i>
-                    <span>Sub-Groups</span>
-                    <lfx-tag [value]="'' + subGroups().length" [rounded]="true" severity="info" styleClass="!text-[10px] !px-1.5 !py-0" />
-                    <i class="fa-light fa-chevron-down text-[10px]"></i>
+                    <span>Parent Group:</span>
+                    <span>{{ parent.name }}</span>
+                    <i class="fa-light fa-chevron-right text-[10px]"></i>
                   </button>
-                  <p-popover #subGroupsPopover [style]="{ width: '360px' }" data-testid="committee-view-sub-groups-popover">
-                    <div class="flex flex-col">
-                      <div class="text-[11px] font-semibold text-gray-400 uppercase tracking-wide px-3 pt-2 pb-1.5">Sub-Groups</div>
-                      @for (sg of subGroups(); track sg.uid) {
-                        <button
-                          class="flex items-center gap-3 px-3 py-2.5 hover:bg-gray-50 transition-colors cursor-pointer w-full text-left"
-                          (click)="navigateToSubGroup(sg); subGroupsPopover.hide()"
-                          data-testid="committee-view-sub-group-item">
-                          <div
-                            class="w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold shrink-0"
-                            [ngClass]="sg.category | categoryAvatarColor">
-                            {{ sg.name | initials }}
-                          </div>
-                          <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-                            <span class="text-sm font-medium text-gray-900 truncate">{{ sg.name }}</span>
-                            <span class="text-sm text-gray-500">{{ sg.category }} &middot; {{ sg.total_members }} members</span>
-                          </div>
-                          <i class="fa-light fa-chevron-right text-xs text-gray-400 shrink-0"></i>
-                        </button>
-                      }
-                    </div>
-                  </p-popover>
-                </div>
-              }
-            </div>
-            <div class="flex items-center gap-1">
-              <span class="text-xs text-gray-400">Created {{ committee()?.created_at | date: 'MMM d, y' }}</span>
-              @if (committee()?.updated_at) {
-                <span class="text-xs text-gray-400">&middot; Updated {{ committee()?.updated_at | date: 'MMM d, y' }}</span>
-              }
-            </div>
-          </div>
-          <!-- Right: Channels card -->
-          @if (hasChannels()) {
-            <div
-              class="relative bg-gray-50 border border-gray-200 rounded-lg text-[12.5px] text-gray-600 w-full lg:max-w-[380px] flex-shrink-0 self-start"
-              data-testid="committee-view-channels-card"
-              [attr.inert]="isVisitor() || null">
-              <!-- Associated Mailing Lists -->
-              @if (associatedMailingLists().length > 0) {
-                @let firstMl = associatedMailingLists()[0];
-                @let extraCount = extraMailingListCount();
-                <!-- First mailing list row -->
-                <div class="relative flex items-center gap-2.5 px-3.5 py-2.5 border-b border-gray-200" data-testid="committee-view-mailing-list-row">
-                  <div class="w-[30px] h-[30px] rounded-md bg-blue-50 flex items-center justify-center flex-shrink-0">
-                    <i class="fa-light fa-envelope text-blue-600 text-xs" aria-hidden="true"></i>
-                  </div>
-                  <div class="flex-1 min-w-0">
-                    <div class="flex items-center gap-1.5 flex-wrap">
-                      <a
-                        [href]="'mailto:' + (firstMl | mailingListEmail)"
-                        class="text-[12.5px] font-semibold text-gray-900 hover:text-blue-600 transition-colors no-underline"
-                        [title]="firstMl.group_name"
-                        >{{ firstMl.group_name }}</a
-                      >
-                      @if (firstMl.public) {
-                        <lfx-tag value="Public" severity="success" styleClass="!text-[10px]" />
-                      } @else {
-                        <lfx-tag value="Private" severity="danger" styleClass="!text-[10px]" />
-                      }
-                    </div>
-                    <div class="text-[11px] text-gray-400 mt-0.5 flex items-center min-w-0">
-                      <a
-                        [href]="'mailto:' + (firstMl | mailingListEmail)"
-                        class="text-gray-400 hover:text-blue-600 transition-colors no-underline truncate min-w-0"
-                        [title]="firstMl | mailingListEmail"
-                        >{{ firstMl | mailingListEmail }}</a
-                      >
-                      <span class="shrink-0 ml-1">&middot; {{ firstMl.subscriber_count }} subscribers</span>
-                    </div>
-                  </div>
-                  @if (extraCount > 0) {
-                    <lfx-button
-                      [label]="(mlExpanded() ? '−' : '+') + extraCount"
-                      [text]="true"
-                      size="small"
-                      severity="success"
-                      styleClass="!text-[11px] !font-medium !rounded-full !px-2 !py-0.5 !bg-green-50 hover:!bg-green-100 !text-green-700"
-                      (onClick)="$event.stopPropagation(); mlExpanded.set(!mlExpanded())"
-                      [attr.aria-expanded]="mlExpanded()"
-                      [ariaLabel]="mlExpanded() ? 'Collapse additional mailing lists' : 'Show ' + extraCount + ' more mailing lists'"
-                      data-testid="committee-view-ml-expand-btn"></lfx-button>
-                  }
-                  <!-- Expanded mailing list dropdown (overlay) -->
-                  @if (mlExpanded() && extraCount > 0) {
-                    <div
-                      class="absolute top-full right-0 left-0 z-20 bg-white border border-gray-200 rounded-b-lg shadow-lg"
-                      (click)="$event.stopPropagation()">
-                      @for (ml of extraMailingLists(); track ml.uid) {
-                        <div class="flex items-center gap-2.5 px-3.5 py-2.5" [class.border-b]="!$last" [class.border-gray-200]="!$last">
-                          <div class="w-[30px] h-[30px] rounded-md bg-blue-50 flex items-center justify-center flex-shrink-0">
-                            <i class="fa-light fa-envelope text-blue-600 text-xs" aria-hidden="true"></i>
-                          </div>
-                          <div class="flex-1 min-w-0">
-                            <div class="flex items-center gap-1.5 flex-wrap">
-                              <a
-                                [href]="'mailto:' + (ml | mailingListEmail)"
-                                class="text-[12.5px] font-semibold text-gray-900 hover:text-blue-600 transition-colors no-underline"
-                                [title]="ml.group_name"
-                                >{{ ml.group_name }}</a
-                              >
-                              @if (ml.public) {
-                                <lfx-tag value="Public" severity="success" styleClass="!text-[10px]" />
-                              } @else {
-                                <lfx-tag value="Private" severity="danger" styleClass="!text-[10px]" />
-                              }
-                            </div>
-                            <div class="text-[11px] text-gray-400 mt-0.5 flex items-center min-w-0">
-                              <a
-                                [href]="'mailto:' + (ml | mailingListEmail)"
-                                class="text-gray-400 hover:text-blue-600 transition-colors no-underline truncate min-w-0"
-                                [title]="ml | mailingListEmail"
-                                >{{ ml | mailingListEmail }}</a
-                              >
-                              <span class="shrink-0 ml-1">&middot; {{ ml.subscriber_count }} subscribers</span>
-                            </div>
-                          </div>
-                        </div>
-                      }
-                    </div>
-                  }
-                </div>
-              }
-
-              <!-- Chat Channel + Website rows -->
-              <div class="flex flex-col divide-y divide-gray-200">
-                @if (committee()?.chat_channel; as chatChannel) {
-                  <div class="flex items-center gap-2.5 px-3.5 py-2.5" data-testid="committee-view-chat-channel-row">
-                    <div class="w-[30px] h-[30px] rounded-md bg-gray-100 flex items-center justify-center flex-shrink-0">
-                      <i [class]="chatPlatformIcon()" class="text-gray-600 text-xs" aria-hidden="true"></i>
-                    </div>
-                    <div class="flex-1 min-w-0">
-                      <div class="text-[11px] font-medium text-gray-500">{{ chatPlatformLabel() }}</div>
-                      @if (chatChannel.startsWith('http://') || chatChannel.startsWith('https://')) {
-                        <a
-                          [href]="chatChannel"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          class="text-[11px] text-blue-600 hover:text-blue-800 hover:underline no-underline truncate block"
-                          [title]="chatChannel"
-                          >{{ chatChannel }}</a
-                        >
-                      } @else {
-                        <span class="text-[11px] text-gray-600 truncate block" [title]="chatChannel">{{ chatChannel }}</span>
-                      }
-                    </div>
-                  </div>
                 }
-                @if (committee()?.website; as website) {
-                  <div class="flex items-center gap-2.5 px-3.5 py-2.5" data-testid="committee-view-website-row">
-                    <div class="w-[30px] h-[30px] rounded-md bg-gray-100 flex items-center justify-center flex-shrink-0">
-                      <i [class]="repoPlatformIcon()" class="text-gray-600 text-xs" aria-hidden="true"></i>
-                    </div>
-                    <div class="flex-1 min-w-0">
-                      <div class="text-[11px] font-medium text-gray-500">{{ repoPlatformLabel() }}</div>
-                      @if (website | safeUrl; as safeUrl) {
-                        <a
-                          [href]="safeUrl"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          class="text-[11px] text-blue-600 hover:text-blue-800 hover:underline no-underline truncate block"
-                          [title]="website"
-                          >{{ website }}</a
-                        >
-                      } @else {
-                        <span class="text-[11px] text-gray-600 truncate block" [title]="website">{{ website }}</span>
-                      }
-                    </div>
+                @if (subGroupsLoading()) {
+                  <p-skeleton width="120px" height="16px" borderRadius="4px" />
+                } @else if (subGroups().length === 1) {
+                  <!-- Single sub-group: inline link, no dropdown -->
+                  <button
+                    class="flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors cursor-pointer"
+                    (click)="navigateToSubGroup(subGroups()[0])"
+                    data-testid="committee-view-sub-group-link">
+                    <i class="fa-light fa-sitemap text-[11px]"></i>
+                    <span>Sub-Group:</span>
+                    <span>{{ subGroups()[0].name }}</span>
+                    <i class="fa-light fa-chevron-right text-[10px]"></i>
+                  </button>
+                } @else if (subGroups().length > 1) {
+                  <!-- Multiple sub-groups: dropdown popover -->
+                  <div class="relative">
+                    <button
+                      class="flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors cursor-pointer"
+                      (click)="subGroupsPopover.toggle($event)"
+                      data-testid="committee-view-sub-groups-trigger">
+                      <i class="fa-light fa-sitemap text-[11px]"></i>
+                      <span>Sub-Groups</span>
+                      <lfx-tag [value]="'' + subGroups().length" [rounded]="true" severity="info" styleClass="!text-[10px] !px-1.5 !py-0" />
+                      <i class="fa-light fa-chevron-down text-[10px]"></i>
+                    </button>
+                    <p-popover #subGroupsPopover [style]="{ width: '360px' }" data-testid="committee-view-sub-groups-popover">
+                      <div class="flex flex-col">
+                        <div class="text-[11px] font-semibold text-gray-400 uppercase tracking-wide px-3 pt-2 pb-1.5">Sub-Groups</div>
+                        @for (sg of subGroups(); track sg.uid) {
+                          <button
+                            class="flex items-center gap-3 px-3 py-2.5 hover:bg-gray-50 transition-colors cursor-pointer w-full text-left"
+                            (click)="navigateToSubGroup(sg); subGroupsPopover.hide()"
+                            data-testid="committee-view-sub-group-item">
+                            <div
+                              class="w-10 h-10 rounded-full flex items-center justify-center text-sm font-semibold shrink-0"
+                              [ngClass]="sg.category | categoryAvatarColor">
+                              {{ sg.name | initials }}
+                            </div>
+                            <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+                              <span class="text-sm font-medium text-gray-900 truncate">{{ sg.name }}</span>
+                              <span class="text-sm text-gray-500">{{ sg.category }} &middot; {{ sg.total_members }} members</span>
+                            </div>
+                            <i class="fa-light fa-chevron-right text-xs text-gray-400 shrink-0"></i>
+                          </button>
+                        }
+                      </div>
+                    </p-popover>
                   </div>
-                }
-                @if (associatedMailingLists().length === 0 && !committee()?.chat_channel && !committee()?.website) {
-                  <div class="px-3.5 py-2.5 text-gray-400">No channels configured</div>
                 }
               </div>
-
-              <!-- Visitor blur mask -->
-              @if (isVisitor()) {
-                <div class="absolute inset-0 bg-gray-50/60 backdrop-blur-sm rounded-lg z-[5] flex items-center justify-center">
-                  <div class="text-center">
-                    <i class="fa-light fa-lock text-gray-400 mb-1"></i>
-                    <div class="text-[11px] font-medium text-gray-500">Join to view channels</div>
-                  </div>
-                </div>
-              }
+              <div class="flex items-center gap-1">
+                <span class="text-xs text-gray-400">Created {{ committee()?.created_at | date: 'MMM d, y' }}</span>
+                @if (committee()?.updated_at) {
+                  <span class="text-xs text-gray-400">&middot; Updated {{ committee()?.updated_at | date: 'MMM d, y' }}</span>
+                }
+              </div>
             </div>
-          }
-        </div>
+            <!-- Right: Channels card -->
+            @if (hasChannels()) {
+              <div
+                class="relative bg-gray-50 border border-gray-200 rounded-lg text-[12.5px] text-gray-600 w-full lg:max-w-[380px] flex-shrink-0 self-start"
+                data-testid="committee-view-channels-card"
+                [attr.inert]="isVisitor() || null">
+                <!-- Associated Mailing Lists -->
+                @if (associatedMailingLists().length > 0) {
+                  @let firstMl = associatedMailingLists()[0];
+                  @let extraCount = extraMailingListCount();
+                  <!-- First mailing list row -->
+                  <div class="relative flex items-center gap-2.5 px-3.5 py-2.5 border-b border-gray-200" data-testid="committee-view-mailing-list-row">
+                    <div class="w-[30px] h-[30px] rounded-md bg-blue-50 flex items-center justify-center flex-shrink-0">
+                      <i class="fa-light fa-envelope text-blue-600 text-xs" aria-hidden="true"></i>
+                    </div>
+                    <div class="flex-1 min-w-0">
+                      <div class="flex items-center gap-1.5 flex-wrap">
+                        <a
+                          [href]="'mailto:' + (firstMl | mailingListEmail)"
+                          class="text-[12.5px] font-semibold text-gray-900 hover:text-blue-600 transition-colors no-underline"
+                          [title]="firstMl.group_name"
+                          >{{ firstMl.group_name }}</a
+                        >
+                        @if (firstMl.public) {
+                          <lfx-tag value="Public" severity="success" styleClass="!text-[10px]" />
+                        } @else {
+                          <lfx-tag value="Private" severity="danger" styleClass="!text-[10px]" />
+                        }
+                      </div>
+                      <div class="text-[11px] text-gray-400 mt-0.5 flex items-center min-w-0">
+                        <a
+                          [href]="'mailto:' + (firstMl | mailingListEmail)"
+                          class="text-gray-400 hover:text-blue-600 transition-colors no-underline truncate min-w-0"
+                          [title]="firstMl | mailingListEmail"
+                          >{{ firstMl | mailingListEmail }}</a
+                        >
+                        <span class="shrink-0 ml-1">&middot; {{ firstMl.subscriber_count }} subscribers</span>
+                      </div>
+                    </div>
+                    @if (extraCount > 0) {
+                      <lfx-button
+                        [label]="(mlExpanded() ? '−' : '+') + extraCount"
+                        [text]="true"
+                        size="small"
+                        severity="success"
+                        styleClass="!text-[11px] !font-medium !rounded-full !px-2 !py-0.5 !bg-green-50 hover:!bg-green-100 !text-green-700"
+                        (onClick)="$event.stopPropagation(); mlExpanded.set(!mlExpanded())"
+                        [attr.aria-expanded]="mlExpanded()"
+                        [ariaLabel]="mlExpanded() ? 'Collapse additional mailing lists' : 'Show ' + extraCount + ' more mailing lists'"
+                        data-testid="committee-view-ml-expand-btn"></lfx-button>
+                    }
+                    <!-- Expanded mailing list dropdown (overlay) -->
+                    @if (mlExpanded() && extraCount > 0) {
+                      <div
+                        class="absolute top-full right-0 left-0 z-20 bg-white border border-gray-200 rounded-b-lg shadow-lg"
+                        (click)="$event.stopPropagation()">
+                        @for (ml of extraMailingLists(); track ml.uid) {
+                          <div class="flex items-center gap-2.5 px-3.5 py-2.5" [class.border-b]="!$last" [class.border-gray-200]="!$last">
+                            <div class="w-[30px] h-[30px] rounded-md bg-blue-50 flex items-center justify-center flex-shrink-0">
+                              <i class="fa-light fa-envelope text-blue-600 text-xs" aria-hidden="true"></i>
+                            </div>
+                            <div class="flex-1 min-w-0">
+                              <div class="flex items-center gap-1.5 flex-wrap">
+                                <a
+                                  [href]="'mailto:' + (ml | mailingListEmail)"
+                                  class="text-[12.5px] font-semibold text-gray-900 hover:text-blue-600 transition-colors no-underline"
+                                  [title]="ml.group_name"
+                                  >{{ ml.group_name }}</a
+                                >
+                                @if (ml.public) {
+                                  <lfx-tag value="Public" severity="success" styleClass="!text-[10px]" />
+                                } @else {
+                                  <lfx-tag value="Private" severity="danger" styleClass="!text-[10px]" />
+                                }
+                              </div>
+                              <div class="text-[11px] text-gray-400 mt-0.5 flex items-center min-w-0">
+                                <a
+                                  [href]="'mailto:' + (ml | mailingListEmail)"
+                                  class="text-gray-400 hover:text-blue-600 transition-colors no-underline truncate min-w-0"
+                                  [title]="ml | mailingListEmail"
+                                  >{{ ml | mailingListEmail }}</a
+                                >
+                                <span class="shrink-0 ml-1">&middot; {{ ml.subscriber_count }} subscribers</span>
+                              </div>
+                            </div>
+                          </div>
+                        }
+                      </div>
+                    }
+                  </div>
+                }
+
+                <!-- Chat Channel + Website rows -->
+                <div class="flex flex-col divide-y divide-gray-200">
+                  @if (committee()?.chat_channel; as chatChannel) {
+                    <div class="flex items-center gap-2.5 px-3.5 py-2.5" data-testid="committee-view-chat-channel-row">
+                      <div class="w-[30px] h-[30px] rounded-md bg-gray-100 flex items-center justify-center flex-shrink-0">
+                        <i [class]="chatPlatformIcon()" class="text-gray-600 text-xs" aria-hidden="true"></i>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <div class="text-[11px] font-medium text-gray-500">{{ chatPlatformLabel() }}</div>
+                        @if (chatChannel.startsWith('http://') || chatChannel.startsWith('https://')) {
+                          <a
+                            [href]="chatChannel"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="text-[11px] text-blue-600 hover:text-blue-800 hover:underline no-underline truncate block"
+                            [title]="chatChannel"
+                            >{{ chatChannel }}</a
+                          >
+                        } @else {
+                          <span class="text-[11px] text-gray-600 truncate block" [title]="chatChannel">{{ chatChannel }}</span>
+                        }
+                      </div>
+                    </div>
+                  }
+                  @if (committee()?.website; as website) {
+                    <div class="flex items-center gap-2.5 px-3.5 py-2.5" data-testid="committee-view-website-row">
+                      <div class="w-[30px] h-[30px] rounded-md bg-gray-100 flex items-center justify-center flex-shrink-0">
+                        <i [class]="repoPlatformIcon()" class="text-gray-600 text-xs" aria-hidden="true"></i>
+                      </div>
+                      <div class="flex-1 min-w-0">
+                        <div class="text-[11px] font-medium text-gray-500">{{ repoPlatformLabel() }}</div>
+                        @if (website | safeUrl; as safeUrl) {
+                          <a
+                            [href]="safeUrl"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="text-[11px] text-blue-600 hover:text-blue-800 hover:underline no-underline truncate block"
+                            [title]="website"
+                            >{{ website }}</a
+                          >
+                        } @else {
+                          <span class="text-[11px] text-gray-600 truncate block" [title]="website">{{ website }}</span>
+                        }
+                      </div>
+                    </div>
+                  }
+                  @if (associatedMailingLists().length === 0 && !committee()?.chat_channel && !committee()?.website) {
+                    <div class="px-3.5 py-2.5 text-gray-400">No channels configured</div>
+                  }
+                </div>
+
+                <!-- Visitor blur mask -->
+                @if (isVisitor()) {
+                  <div class="absolute inset-0 bg-gray-50/60 backdrop-blur-sm rounded-lg z-[5] flex items-center justify-center">
+                    <div class="text-center">
+                      <i class="fa-light fa-lock text-gray-400 mb-1"></i>
+                      <div class="text-[11px] font-medium text-gray-500">Join to view channels</div>
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+          </div>
         </div>
 
         <!-- Tabs strip -->

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -33,10 +33,18 @@
     <!-- Committee Dashboard Content -->
     <div class="flex flex-col gap-6">
       <!-- Header Section -->
-      <div class="flex flex-col gap-3" data-testid="committee-view-header">
-        <lfx-breadcrumb [model]="breadcrumbItems()" data-testid="committee-view-breadcrumb"></lfx-breadcrumb>
+      <lfx-card styleClass="[&_.p-card-body]:!p-0" data-testid="committee-view-header">
+        <div class="px-6 pt-5 pb-4 flex flex-col gap-4">
+          <!-- Back link -->
+          <button
+            class="flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 transition-colors w-fit"
+            (click)="goBack()"
+            data-testid="committee-view-back-link">
+            <i class="fa-light fa-angle-left text-xs"></i>
+            {{ backLabel() }}
+          </button>
         <div class="flex items-center gap-3">
-          <h1 data-testid="committee-view-name">{{ committee()?.name }}</h1>
+          <h1 class="font-display font-light text-[20px]" data-testid="committee-view-name">{{ committee()?.name }}</h1>
           @if (!committee()?.public) {
             <i class="fa-light fa-lock w-4 h-4 text-gray-400"></i>
           }
@@ -93,18 +101,6 @@
                 (onClick)="handleLeaveRequest()"
                 data-testid="committee-view-leave-btn" />
             }
-            @if (canEdit() || canReview()) {
-              <lfx-button
-                icon="fa-light fa-gear"
-                [text]="true"
-                [rounded]="true"
-                size="small"
-                [severity]="showSettings() ? 'primary' : 'secondary'"
-                [tooltip]="showSettings() ? 'Hide settings tab' : 'Show settings tab'"
-                [ariaLabel]="showSettings() ? 'Hide settings tab' : 'Show settings tab'"
-                (onClick)="toggleSettings()"
-                data-testid="committee-view-settings-toggle" />
-            }
           </div>
         </div>
         <!-- Description + Channels card side by side -->
@@ -114,14 +110,7 @@
             @if (committee()?.description || canEdit()) {
               <div class="flex items-start gap-2 max-w-2xl" data-testid="committee-view-description">
                 @if (committee()?.description) {
-                  <p class="text-gray-500 line-clamp-2 flex-1">{{ committee()?.description }}</p>
-                  <lfx-button
-                    label="more"
-                    [text]="true"
-                    size="small"
-                    severity="info"
-                    styleClass="!text-xs !p-0 whitespace-nowrap"
-                    (onClick)="openDescriptionView()"></lfx-button>
+                  <p class="text-gray-500 flex-1 text-sm">{{ committee()?.description }}</p>
                 } @else if (canEdit()) {
                   <span class="text-gray-400 text-sm italic flex-1">No description yet.</span>
                 }
@@ -378,29 +367,27 @@
             </div>
           }
         </div>
-      </div>
+        </div>
 
-      <!-- Tabs -->
-      <div class="flex gap-1 border-b" data-testid="committee-view-tabs">
-        @for (tab of visibleTabs(); track tab.key) {
-          <button
-            (click)="activeTab.set(tab.key)"
-            class="px-4 py-2 text-sm font-medium transition-colors"
-            [ngClass]="{
-              'border-b-2 border-blue-600 text-blue-600': activeTab() === tab.key,
-              'text-gray-500': activeTab() !== tab.key,
-            }">
-            <i class="fa-light {{ tab.icon }} mr-2"></i>{{ tab.label }}
-            @if (tab.badge && tab.badge() !== null) {
-              <lfx-tag
-                [value]="'' + tab.badge()"
-                [rounded]="true"
-                [severity]="activeTab() === tab.key ? 'info' : 'secondary'"
-                styleClass="ml-1 !text-[10px] !px-1.5 !py-0.5" />
-            }
-          </button>
-        }
-      </div>
+        <!-- Tabs strip -->
+        <div class="border-t border-gray-200 px-6 py-4 flex gap-2 flex-wrap" data-testid="committee-view-tabs">
+          @for (tab of visibleTabs(); track tab.key) {
+            <button
+              (click)="activeTab.set(tab.key)"
+              class="flex items-center px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
+              [ngClass]="activeTab() === tab.key ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'">
+              <i class="fa-light {{ tab.icon }} mr-1.5"></i>{{ tab.label }}
+              @if (tab.badge && tab.badge() !== null) {
+                <lfx-tag
+                  [value]="'' + tab.badge()"
+                  [rounded]="true"
+                  [severity]="activeTab() === tab.key ? 'contrast' : 'secondary'"
+                  styleClass="ml-1.5 !text-[10px] !px-1.5 !py-0.5" />
+              }
+            </button>
+          }
+        </div>
+      </lfx-card>
 
       <!-- Tab Panels -->
       @switch (activeTab()) {

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -147,6 +147,7 @@
                 }
                 @if (parentGroup(); as parent) {
                   <button
+                    type="button"
                     class="flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors cursor-pointer"
                     (click)="navigateToParentGroup()"
                     data-testid="committee-view-parent-group-link">
@@ -161,6 +162,7 @@
                 } @else if (subGroups().length === 1) {
                   <!-- Single sub-group: inline link, no dropdown -->
                   <button
+                    type="button"
                     class="flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors cursor-pointer"
                     (click)="navigateToSubGroup(subGroups()[0])"
                     data-testid="committee-view-sub-group-link">
@@ -173,6 +175,7 @@
                   <!-- Multiple sub-groups: dropdown popover -->
                   <div class="relative">
                     <button
+                      type="button"
                       class="flex items-center gap-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors cursor-pointer"
                       (click)="subGroupsPopover.toggle($event)"
                       data-testid="committee-view-sub-groups-trigger">
@@ -186,6 +189,7 @@
                         <div class="text-[11px] font-semibold text-gray-400 uppercase tracking-wide px-3 pt-2 pb-1.5">Sub-Groups</div>
                         @for (sg of subGroups(); track sg.uid) {
                           <button
+                            type="button"
                             class="flex items-center gap-3 px-3 py-2.5 hover:bg-gray-50 transition-colors cursor-pointer w-full text-left"
                             (click)="navigateToSubGroup(sg); subGroupsPopover.hide()"
                             data-testid="committee-view-sub-group-item">
@@ -374,6 +378,7 @@
         <div class="border-t border-gray-200 px-6 py-4 flex gap-2 flex-wrap" data-testid="committee-view-tabs">
           @for (tab of visibleTabs(); track tab.key) {
             <button
+              type="button"
               (click)="activeTab.set(tab.key)"
               class="flex items-center px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
               [ngClass]="activeTab() === tab.key ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'">

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -42,7 +42,7 @@
             (click)="goBack()"
             data-testid="committee-view-back-link">
             <i class="fa-light fa-angle-left text-xs"></i>
-            {{ backLabel() }}
+            {{ backLabel() ?? 'Groups' }}
           </button>
           <div class="flex items-center gap-3">
             <h1 class="font-display font-light text-[20px]" data-testid="committee-view-name">{{ committee()?.name }}</h1>
@@ -122,6 +122,7 @@
                       [rounded]="true"
                       size="small"
                       severity="secondary"
+                      [ariaLabel]="committee()?.description ? 'Edit description' : 'Add description'"
                       tooltip="Edit description"
                       (onClick)="openEditDescription()"></lfx-button>
                   }
@@ -221,8 +222,8 @@
             @if (hasChannels()) {
               <div
                 class="relative bg-gray-50 border border-gray-200 rounded-lg text-[12.5px] text-gray-600 w-full lg:max-w-[380px] flex-shrink-0 self-start"
-                data-testid="committee-view-channels-card"
-                [attr.inert]="isVisitor() || null">
+                data-testid="committee-view-channels-card">
+                <div [attr.inert]="isVisitor() || null">
                 <!-- Associated Mailing Lists -->
                 @if (associatedMailingLists().length > 0) {
                   @let firstMl = associatedMailingLists()[0];
@@ -360,7 +361,8 @@
                   }
                 </div>
 
-                <!-- Visitor blur mask -->
+                </div>
+                <!-- Visitor blur mask (sibling of inert subtree so it's reachable by assistive tech) -->
                 @if (isVisitor()) {
                   <div class="absolute inset-0 bg-gray-50/60 backdrop-blur-sm rounded-lg z-[5] flex items-center justify-center">
                     <div class="text-center">

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -87,7 +87,7 @@ export class CommitteeViewComponent {
   private readonly dialogService = inject(DialogService);
   private readonly userService = inject(UserService);
 
-  private readonly navBackLabel: string = this.router.getCurrentNavigation()?.extras?.state?.['backLabel'] ?? null;
+  private readonly navBackLabel: string | null = this.router.getCurrentNavigation()?.extras?.state?.['backLabel'] ?? null;
 
   public meetingsTimeFilter = signal<'upcoming' | 'past'>('upcoming');
 
@@ -192,9 +192,7 @@ export class CommitteeViewComponent {
   ];
 
   public visibleTabs = computed(() =>
-    this.tabConfig
-      .filter((tab) => tab.visible())
-      .map((tab) => ({ ...tab, label: typeof tab.label === 'function' ? tab.label() : tab.label })),
+    this.tabConfig.filter((tab) => tab.visible()).map((tab) => ({ ...tab, label: typeof tab.label === 'function' ? tab.label() : tab.label }))
   );
 
   // -- Tab state --

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, linkedSignal, signal, Signal, WritableSignal } from '@angular/core';
+import { Component, computed, inject, linkedSignal, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { DatePipe, NgClass } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
@@ -9,8 +9,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { PopoverModule } from 'primeng/popover';
 import { SkeletonModule } from 'primeng/skeleton';
-import { BreadcrumbComponent } from '@components/breadcrumb/breadcrumb.component';
 import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { RouteLoadingComponent } from '@components/loading/route-loading.component';
 import {
@@ -33,7 +33,7 @@ import { InitialsPipe } from '@pipes/initials.pipe';
 import { JoinModeLabelPipe } from '@pipes/join-mode-label.pipe';
 import { SafeUrlPipe } from '@pipes/safe-url.pipe';
 import { DescriptionDialogComponent } from '../components/description-dialog/description-dialog.component';
-import { MenuItem, MessageService } from 'primeng/api';
+import { MessageService } from 'primeng/api';
 import { catchError, combineLatest, EMPTY, filter, finalize, map, of, switchMap, take } from 'rxjs';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { JoinApplicationDialogResult } from '@lfx-one/shared/interfaces';
@@ -51,8 +51,8 @@ import { CommitteeVotesComponent } from '../components/committee-votes/committee
 @Component({
   selector: 'lfx-committee-view',
   imports: [
-    BreadcrumbComponent,
     ButtonComponent,
+    CardComponent,
     TagComponent,
     RouteLoadingComponent,
     DatePipe,
@@ -87,6 +87,8 @@ export class CommitteeViewComponent {
   private readonly dialogService = inject(DialogService);
   private readonly userService = inject(UserService);
 
+  private readonly navBackLabel: string = this.router.getCurrentNavigation()?.extras?.state?.['backLabel'] ?? null;
+
   public meetingsTimeFilter = signal<'upcoming' | 'past'>('upcoming');
 
   private readonly committeeId: Signal<string | null> = this.initCommitteeId();
@@ -102,7 +104,6 @@ export class CommitteeViewComponent {
   public membersLoading = signal<boolean>(true);
   public myRoleLoading: Signal<boolean> = computed(() => this.membersLoading());
   public joiningOrLeaving = signal(false);
-  public showSettings = this.initShowSettings();
 
   // -- Computed / toSignal --
   public committee: Signal<Committee | null> = this.initializeCommittee();
@@ -124,7 +125,7 @@ export class CommitteeViewComponent {
     return getCommitteeCategorySeverity(category || '');
   });
 
-  public breadcrumbItems: Signal<MenuItem[]> = computed(() => [{ label: 'Groups', routerLink: ['/groups'] }, { label: this.committee()?.name || '' }]);
+  public backLabel: Signal<string> = computed(() => this.navBackLabel ?? (this.myRole() !== null ? 'My Groups' : 'Groups'));
 
   public canEdit: Signal<boolean> = computed(() => !!this.committee()?.writer);
 
@@ -176,19 +177,25 @@ export class CommitteeViewComponent {
     { key: 'overview', label: 'Overview', icon: 'fa-gauge', visible: () => true },
     {
       key: 'members',
-      label: 'Members',
+      label: () => {
+        const count = this.committee()?.total_members;
+        return count != null ? `Members (${count})` : 'Members';
+      },
       icon: 'fa-users',
       visible: () => this.isMemberOrAdmin() && this.isMembersTabVisible(),
-      badge: () => this.committee()?.total_members ?? null,
     },
     { key: 'votes', label: 'Votes', icon: 'fa-check-to-slot', visible: () => this.isMemberOrAdmin() && this.isVotesTabVisible() },
     { key: 'meetings', label: 'Meetings', icon: 'fa-calendar', visible: () => this.isMemberOrAdmin() },
     { key: 'surveys', label: 'Surveys', icon: 'fa-chart-simple', visible: () => this.isMemberOrAdmin() },
     { key: 'documents', label: 'Documents', icon: 'fa-folder-open', visible: () => this.isMemberOrAdmin() },
-    { key: 'settings', label: 'Settings', icon: 'fa-gear', visible: () => (this.canEdit() || this.canReview()) && this.showSettings() },
+    { key: 'settings', label: 'Settings', icon: 'fa-gear', visible: () => this.canEdit() || this.canReview() },
   ];
 
-  public visibleTabs: Signal<TabConfigEntry[]> = computed(() => this.tabConfig.filter((tab) => tab.visible()));
+  public visibleTabs = computed(() =>
+    this.tabConfig
+      .filter((tab) => tab.visible())
+      .map((tab) => ({ ...tab, label: typeof tab.label === 'function' ? tab.label() : tab.label })),
+  );
 
   // -- Tab state --
   public activeTab = linkedSignal<{ id: string | null; visible: TabConfigEntry[] }, CommitteeTab>({
@@ -212,10 +219,6 @@ export class CommitteeViewComponent {
 
   public refreshCommittee(): void {
     this.refresh.update((v) => v + 1);
-  }
-
-  public toggleSettings(): void {
-    this.showSettings.update((v) => !v);
   }
 
   public refreshMembers(): void {
@@ -417,13 +420,6 @@ export class CommitteeViewComponent {
       ),
       { requireSync: true }
     );
-  }
-
-  private initShowSettings(): WritableSignal<boolean> {
-    return linkedSignal<{ id: string | null; tab: CommitteeTab | null }, boolean>({
-      source: () => ({ id: this.committeeId(), tab: this.initialTab() }),
-      computation: ({ tab }) => tab === 'settings',
-    });
   }
 
   private initAutoSelectInitialTab(): void {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -81,7 +81,7 @@
               <p-skeleton width="100%" height="1.75rem" />
               <p-skeleton width="100%" height="1.75rem" />
             </div>
-          } @else if (chairs().length > 0) {
+          } @else if (chairs().length) {
             <div class="flex flex-col gap-1.5">
               @for (chair of chairs(); track chair.uid) {
                 <div class="flex items-center gap-2">
@@ -186,7 +186,7 @@
                 <i class="fa-light fa-list-check text-gray-400"></i>
                 My Pending Actions
               </h2>
-              @if (pendingActionItems().length > 0) {
+              @if (pendingActionItems().length) {
                 <lfx-button
                   label="View All"
                   [text]="true"
@@ -206,7 +206,7 @@
                   </div>
                 }
               </div>
-            } @else if (pendingActionItems().length > 0) {
+            } @else if (pendingActionItems().length) {
               <div
                 class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200"
                 data-testid="committee-overview-pending-actions-list">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -5,7 +5,6 @@
   <!-- Two-column layout: Stats+Chairs | Meetings+Actions -->
   @if (!myRoleLoading()) {
     <div class="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-6 items-start" data-testid="committee-overview-stats">
-
       <!-- LEFT: Stats list + Chairs -->
       <lfx-card styleClass="[&_.p-card-body]:!p-0">
         <!-- Stats rows -->
@@ -90,7 +89,7 @@
                   <div
                     class="w-7 h-7 rounded-full flex items-center justify-center text-white text-[10px] font-semibold flex-shrink-0"
                     [style.background-color]="chair.role?.name === 'Chair' ? '#6366f1' : '#f59e0b'">
-                    {{ (chair.first_name[0] || '') + (chair.last_name[0] || '') }}
+                    {{ (chair.first_name?.[0] || '') + (chair.last_name?.[0] || '') }}
                   </div>
                   <div class="min-w-0">
                     <p class="text-[13px] font-medium text-gray-900 truncate">{{ chair.first_name }} {{ chair.last_name }}</p>
@@ -118,7 +117,13 @@
                 <i class="fa-light fa-calendar text-gray-400"></i>
                 Next Meeting
               </h2>
-              <lfx-button label="View All" [text]="true" size="small" severity="info" styleClass="!text-xs" (onClick)="navigateToTab('meetings:upcoming')"></lfx-button>
+              <lfx-button
+                label="View All"
+                [text]="true"
+                size="small"
+                severity="info"
+                styleClass="!text-xs"
+                (onClick)="navigateToTab('meetings:upcoming')"></lfx-button>
             </div>
             @if (upcomingMeetingsLoading()) {
               <lfx-card>
@@ -147,7 +152,13 @@
                 <i class="fa-light fa-clock-rotate-left text-gray-400"></i>
                 Past Meeting
               </h2>
-              <lfx-button label="View All" [text]="true" size="small" severity="info" styleClass="!text-xs" (onClick)="navigateToTab('meetings:past')"></lfx-button>
+              <lfx-button
+                label="View All"
+                [text]="true"
+                size="small"
+                severity="info"
+                styleClass="!text-xs"
+                (onClick)="navigateToTab('meetings:past')"></lfx-button>
             </div>
             @if (pastMeetingsLoading()) {
               <lfx-card>
@@ -228,7 +239,9 @@
           </div>
         } @else if (canJoin()) {
           <!-- Visitor CTA -->
-          <div class="rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-100 p-6 text-center" data-testid="committee-overview-visitor-cta">
+          <div
+            class="rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-100 p-6 text-center"
+            data-testid="committee-overview-visitor-cta">
             <div class="flex flex-col gap-3 items-center">
               <i [class]="joinCtaIcon() + ' text-2xl text-blue-500'"></i>
               <h3 class="text-base font-semibold text-gray-900">{{ joinCtaTitle() }}</h3>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -210,10 +210,10 @@
               <div
                 class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200"
                 data-testid="committee-overview-pending-actions-list">
-                @for (item of pendingActionItems(); track item.type + item.text) {
+                @for (item of pendingActionItems(); track item.type + item.text; let idx = $index) {
                   <div
                     class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0 px-4 py-3 bg-gradient-to-r from-white to-[rgba(255,251,235,0.8)]"
-                    [attr.data-testid]="'committee-overview-pending-action-' + item.type">
+                    [attr.data-testid]="'committee-overview-pending-action-' + item.type + '-' + idx">
                     <div class="shrink-0 sm:w-1/5">
                       <lfx-tag [value]="item.type" [severity]="item.severity" [icon]="item.icon" styleClass="whitespace-nowrap" />
                     </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -2,310 +2,243 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-6 pt-2">
-  <!-- Role Banner -->
+  <!-- Two-column layout: Stats+Chairs | Meetings+Actions -->
   @if (!myRoleLoading()) {
-    @switch (bannerType()) {
-      @case ('visitor') {
-        @if (canJoin()) {
-          <lfx-message
-            severity="info"
-            icon="fa-light fa-right-to-bracket"
-            [text]="joinBannerText()"
-            data-testid="committee-overview-visitor-banner"></lfx-message>
-        }
-      }
-      @case ('member') {
-        <lfx-message
-          severity="success"
-          icon="fa-light fa-circle-check"
-          text="You are a member of this {{ categoryLabel() }}."
-          data-testid="committee-overview-member-banner"></lfx-message>
-      }
-      @case ('chair') {
-        <lfx-message
-          severity="info"
-          icon="fa-light fa-user-crown"
-          text="You are a {{ myRole() }} of this {{ categoryLabel() }}."
-          data-testid="committee-overview-chair-banner"></lfx-message>
-      }
-    }
-  }
+    <div class="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-6 items-start" data-testid="committee-overview-stats">
 
-  <!-- Stats Strip: 5 stat cards + Chairs card inline -->
-  <div class="grid grid-cols-2 md:grid-cols-[repeat(5,1fr)_1.5fr] gap-4 items-stretch" data-testid="committee-overview-stats">
-    <!-- Members -->
-    <lfx-card styleClass="h-full [&_.p-card-body]:h-full [&_.p-card-content]:h-full">
-      <div class="flex flex-col items-center justify-center gap-1 h-full">
-        @if (membersLoading()) {
-          <p class="text-2xl font-bold text-gray-400">&mdash;</p>
-        } @else {
-          <p class="text-2xl font-bold text-gray-900">{{ members().length }}</p>
-        }
-        <p class="text-sm text-gray-500">Members</p>
-      </div>
-    </lfx-card>
-
-    <!-- Organizations -->
-    <lfx-card styleClass="h-full [&_.p-card-body]:h-full [&_.p-card-content]:h-full">
-      <div class="flex flex-col items-center justify-center gap-1 h-full">
-        @if (membersLoading()) {
-          <p class="text-2xl font-bold text-gray-400">&mdash;</p>
-        } @else {
-          <p class="text-2xl font-bold text-gray-900">{{ orgCount() }}</p>
-        }
-        <p class="text-sm text-gray-500">Organizations</p>
-      </div>
-    </lfx-card>
-
-    <!-- Meetings YTD -->
-    <lfx-card styleClass="h-full [&_.p-card-body]:h-full [&_.p-card-content]:h-full">
-      <div class="flex flex-col items-center justify-center gap-1 h-full">
-        @if (meetingsLoading()) {
-          <p class="text-2xl font-bold text-gray-400">&mdash;</p>
-        } @else {
-          <p class="text-2xl font-bold text-gray-900">{{ meetingsCount() }}</p>
-        }
-        <p class="text-sm text-gray-500">Meetings</p>
-      </div>
-    </lfx-card>
-
-    <!-- Active Votes -->
-    <lfx-card styleClass="h-full [&_.p-card-body]:h-full [&_.p-card-content]:h-full">
-      <div class="flex flex-col items-center justify-center gap-1 h-full">
-        @if (votesLoading()) {
-          <p class="text-2xl font-bold text-gray-400">&mdash;</p>
-        } @else {
-          <p class="text-2xl font-bold text-gray-900">{{ activeVotesCount() }}</p>
-        }
-        <p class="text-sm text-gray-500">Active Votes</p>
-      </div>
-    </lfx-card>
-
-    <!-- Open Surveys -->
-    <lfx-card styleClass="h-full [&_.p-card-body]:h-full [&_.p-card-content]:h-full">
-      <div class="flex flex-col items-center justify-center gap-1 h-full">
-        @if (surveysLoading()) {
-          <p class="text-2xl font-bold text-gray-400">&mdash;</p>
-        } @else {
-          <p class="text-2xl font-bold text-gray-900">{{ openSurveysCount() }}</p>
-        }
-        <p class="text-sm text-gray-500">Open Surveys</p>
-      </div>
-    </lfx-card>
-
-    <!-- Chairs Card (inline in stats row) -->
-    <lfx-card [style]="{ height: '100%' }" data-testid="committee-overview-chairs">
-      <div class="relative flex flex-col justify-center gap-1.5 h-full">
-        @if (canEdit() && !membersLoading()) {
-          <lfx-button
-            class="absolute top-0 right-0"
-            icon="fa-light fa-pen-to-square"
-            [text]="true"
-            [rounded]="true"
-            size="small"
-            severity="secondary"
-            tooltip="Edit chairs"
-            data-testid="committee-overview-edit-chairs-btn"
-            (onClick)="startEditChairs()"></lfx-button>
-        }
-        <p class="text-[11px] text-gray-500 uppercase tracking-wide font-semibold">Chairs</p>
-        @if (membersLoading()) {
-          <div class="flex flex-col gap-1.5">
-            <p-skeleton width="100%" height="1.75rem" />
-            <p-skeleton width="100%" height="1.75rem" />
+      <!-- LEFT: Stats list + Chairs -->
+      <lfx-card styleClass="[&_.p-card-body]:!p-0">
+        <!-- Stats rows -->
+        <div class="flex flex-col divide-y divide-gray-100">
+          <!-- Members -->
+          <div class="flex items-center gap-3 px-4 py-3">
+            <i class="fa-light fa-users text-gray-400 w-4 text-center flex-shrink-0"></i>
+            <span class="text-sm text-gray-700 flex-1">Members</span>
+            @if (membersLoading()) {
+              <p-skeleton width="24px" height="1rem" />
+            } @else {
+              <span class="text-sm font-semibold text-gray-900">{{ members().length }}</span>
+            }
           </div>
-        } @else if (chairs().length > 0) {
-          <div class="flex flex-col gap-1.5">
-            @for (chair of chairs(); track chair.uid) {
-              <div class="flex items-center gap-2">
-                <div
-                  class="w-7 h-7 rounded-full flex items-center justify-center text-white text-[10px] font-semibold flex-shrink-0"
-                  [style.background-color]="chair.role?.name === 'Chair' ? '#6366f1' : '#f59e0b'">
-                  {{ (chair.first_name[0] || '') + (chair.last_name[0] || '') }}
+          <!-- Organizations -->
+          <div class="flex items-center gap-3 px-4 py-3">
+            <i class="fa-light fa-building text-gray-400 w-4 text-center flex-shrink-0"></i>
+            <span class="text-sm text-gray-700 flex-1">Organizations</span>
+            @if (membersLoading()) {
+              <p-skeleton width="24px" height="1rem" />
+            } @else {
+              <span class="text-sm font-semibold text-gray-900">{{ orgCount() }}</span>
+            }
+          </div>
+          <!-- Meetings YTD -->
+          <div class="flex items-center gap-3 px-4 py-3">
+            <i class="fa-light fa-calendar text-gray-400 w-4 text-center flex-shrink-0"></i>
+            <span class="text-sm text-gray-700 flex-1">Meetings</span>
+            @if (meetingsLoading()) {
+              <p-skeleton width="24px" height="1rem" />
+            } @else {
+              <span class="text-sm font-semibold text-gray-900">{{ meetingsCount() }}</span>
+            }
+          </div>
+          <!-- Active Votes -->
+          <div class="flex items-center gap-3 px-4 py-3">
+            <i class="fa-light fa-check-to-slot text-gray-400 w-4 text-center flex-shrink-0"></i>
+            <span class="text-sm text-gray-700 flex-1">Active Votes</span>
+            @if (votesLoading()) {
+              <p-skeleton width="24px" height="1rem" />
+            } @else {
+              <span class="text-sm font-semibold text-gray-900">{{ activeVotesCount() }}</span>
+            }
+          </div>
+          <!-- Open Surveys -->
+          <div class="flex items-center gap-3 px-4 py-3">
+            <i class="fa-light fa-clipboard-list text-gray-400 w-4 text-center flex-shrink-0"></i>
+            <span class="text-sm text-gray-700 flex-1">Open Surveys</span>
+            @if (surveysLoading()) {
+              <p-skeleton width="24px" height="1rem" />
+            } @else {
+              <span class="text-sm font-semibold text-gray-900">{{ openSurveysCount() }}</span>
+            }
+          </div>
+        </div>
+
+        <!-- Chairs -->
+        <div class="border-t border-gray-100 px-4 py-3" data-testid="committee-overview-chairs">
+          <div class="flex items-center justify-between mb-2">
+            <p class="text-[11px] text-gray-500 uppercase tracking-wide font-semibold">Chairs</p>
+            @if (canEdit() && !membersLoading()) {
+              <lfx-button
+                icon="fa-light fa-pen-to-square"
+                [text]="true"
+                [rounded]="true"
+                size="small"
+                severity="secondary"
+                tooltip="Edit chairs"
+                data-testid="committee-overview-edit-chairs-btn"
+                (onClick)="startEditChairs()"></lfx-button>
+            }
+          </div>
+          @if (membersLoading()) {
+            <div class="flex flex-col gap-1.5">
+              <p-skeleton width="100%" height="1.75rem" />
+              <p-skeleton width="100%" height="1.75rem" />
+            </div>
+          } @else if (chairs().length > 0) {
+            <div class="flex flex-col gap-1.5">
+              @for (chair of chairs(); track chair.uid) {
+                <div class="flex items-center gap-2">
+                  <div
+                    class="w-7 h-7 rounded-full flex items-center justify-center text-white text-[10px] font-semibold flex-shrink-0"
+                    [style.background-color]="chair.role?.name === 'Chair' ? '#6366f1' : '#f59e0b'">
+                    {{ (chair.first_name[0] || '') + (chair.last_name[0] || '') }}
+                  </div>
+                  <div class="min-w-0">
+                    <p class="text-[13px] font-medium text-gray-900 truncate">{{ chair.first_name }} {{ chair.last_name }}</p>
+                    <p class="text-[10.5px] text-gray-500">{{ chair.role?.name ?? 'Member' }}</p>
+                  </div>
                 </div>
-                <div class="min-w-0">
-                  <p class="text-[13px] font-medium text-gray-900 truncate">{{ chair.first_name }} {{ chair.last_name }}</p>
-                  <p class="text-[10.5px] text-gray-500">{{ chair.role?.name ?? 'Member' }}</p>
+              }
+            </div>
+          } @else {
+            <div class="flex items-center gap-2 py-1">
+              <i class="fa-light fa-user-crown text-gray-300"></i>
+              <p class="text-xs text-gray-400">No chairs assigned</p>
+            </div>
+          }
+        </div>
+      </lfx-card>
+
+      <!-- RIGHT: Meetings + Pending Actions stacked -->
+      <div class="flex flex-col gap-5">
+        @if (!isVisitor()) {
+          <!-- Next Meeting -->
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center justify-between">
+              <h2 class="text-sm font-medium text-gray-700 flex items-center gap-2">
+                <i class="fa-light fa-calendar text-gray-400"></i>
+                Next Meeting
+              </h2>
+              <lfx-button label="View All" [text]="true" size="small" severity="info" styleClass="!text-xs" (onClick)="navigateToTab('meetings:upcoming')"></lfx-button>
+            </div>
+            @if (upcomingMeetingsLoading()) {
+              <lfx-card>
+                <div class="flex flex-col gap-3">
+                  <p-skeleton width="60%" height="1rem" />
+                  <p-skeleton width="40%" height="0.75rem" />
+                </div>
+              </lfx-card>
+            } @else if (nextMeeting(); as meeting) {
+              <lfx-dashboard-meeting-card [meeting]="meeting" />
+            } @else {
+              <lfx-card>
+                <div class="flex flex-col items-center py-6">
+                  <i class="fa-light fa-calendar-check text-2xl text-gray-300 mb-2"></i>
+                  <p class="text-sm font-medium text-gray-500">No upcoming meetings</p>
+                  <p class="text-xs text-gray-400 mt-1">Scheduled meetings for this group will appear here.</p>
+                </div>
+              </lfx-card>
+            }
+          </div>
+
+          <!-- Last Meeting -->
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center justify-between">
+              <h2 class="text-sm font-medium text-gray-700 flex items-center gap-2">
+                <i class="fa-light fa-clock-rotate-left text-gray-400"></i>
+                Past Meeting
+              </h2>
+              <lfx-button label="View All" [text]="true" size="small" severity="info" styleClass="!text-xs" (onClick)="navigateToTab('meetings:past')"></lfx-button>
+            </div>
+            @if (pastMeetingsLoading()) {
+              <lfx-card>
+                <div class="flex flex-col gap-3">
+                  <p-skeleton width="60%" height="1rem" />
+                  <p-skeleton width="40%" height="0.75rem" />
+                </div>
+              </lfx-card>
+            } @else if (lastMeeting(); as meeting) {
+              <lfx-dashboard-meeting-card [meeting]="meeting" [detailUrl]="'/meetings/' + meeting.id" />
+            } @else {
+              <lfx-card>
+                <div class="flex flex-col items-center py-6">
+                  <i class="fa-light fa-clock-rotate-left text-2xl text-gray-300 mb-2"></i>
+                  <p class="text-sm font-medium text-gray-500">No past meetings</p>
+                  <p class="text-xs text-gray-400 mt-1">Past meetings for this group will appear here.</p>
+                </div>
+              </lfx-card>
+            }
+          </div>
+
+          <!-- My Pending Actions -->
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center justify-between">
+              <h2 class="text-sm font-medium text-gray-700 flex items-center gap-2">
+                <i class="fa-light fa-list-check text-gray-400"></i>
+                My Pending Actions
+              </h2>
+              @if (pendingActionItems().length > 0) {
+                <lfx-button
+                  label="View All"
+                  [text]="true"
+                  size="small"
+                  severity="info"
+                  styleClass="!text-xs"
+                  (onClick)="navigateToTab(pendingActionsViewAllTab())"></lfx-button>
+              }
+            </div>
+            @if (votesLoading() || surveysLoading()) {
+              <div class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200">
+                @for (i of [1, 2]; track i) {
+                  <div class="flex items-center gap-4 px-4 py-3">
+                    <p-skeleton width="15%" height="1.5rem" borderRadius="1rem" />
+                    <p-skeleton width="55%" height="1rem" />
+                    <p-skeleton width="20%" height="1.75rem" borderRadius="0.375rem" styleClass="ml-auto" />
+                  </div>
+                }
+              </div>
+            } @else if (pendingActionItems().length > 0) {
+              <div
+                class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200"
+                data-testid="committee-overview-pending-actions-list">
+                @for (item of pendingActionItems(); track item.type + item.text) {
+                  <div
+                    class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0 px-4 py-3 bg-gradient-to-r from-white to-[rgba(255,251,235,0.8)]"
+                    [attr.data-testid]="'committee-overview-pending-action-' + item.type">
+                    <div class="shrink-0 sm:w-1/5">
+                      <lfx-tag [value]="item.type" [severity]="item.severity" [icon]="item.icon" styleClass="whitespace-nowrap" />
+                    </div>
+                    <p class="text-sm font-medium text-gray-900 sm:w-3/5 sm:min-w-0 sm:truncate sm:px-4" [attr.title]="item.text">
+                      {{ item.text }}
+                    </p>
+                    <div class="self-start sm:self-auto sm:w-1/5 sm:flex sm:justify-end">
+                      <lfx-button size="small" severity="secondary" [outlined]="true" (onClick)="handlePendingActionClick(item)" [label]="item.buttonText" />
+                    </div>
+                  </div>
+                }
+              </div>
+            } @else {
+              <div class="bg-gray-50 rounded-2xl border border-gray-200 flex items-center justify-center gap-4 px-5 py-8">
+                <i class="fa-light fa-box-check text-3xl text-gray-400 shrink-0"></i>
+                <div>
+                  <p class="text-sm font-medium text-gray-700">Your desk is clear</p>
+                  <p class="text-xs text-gray-400 mt-0.5">No pending actions assigned to you</p>
                 </div>
               </div>
             }
           </div>
-        } @else {
-          <div class="flex items-center gap-2 py-1">
-            <i class="fa-light fa-user-crown text-gray-300"></i>
-            <p class="text-xs text-gray-400">No chairs assigned</p>
+        } @else if (canJoin()) {
+          <!-- Visitor CTA -->
+          <div class="rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-100 p-6 text-center" data-testid="committee-overview-visitor-cta">
+            <div class="flex flex-col gap-3 items-center">
+              <i [class]="joinCtaIcon() + ' text-2xl text-blue-500'"></i>
+              <h3 class="text-base font-semibold text-gray-900">{{ joinCtaTitle() }}</h3>
+              <p class="text-sm text-gray-600 max-w-md">{{ joinCtaDescription() }}</p>
+              <lfx-button [label]="joinButtonLabel()" severity="info" size="small" [icon]="joinButtonIcon()" (onClick)="onJoinClick()"></lfx-button>
+            </div>
           </div>
         }
       </div>
-    </lfx-card>
-  </div>
-
-  <!-- Conditional Layout: Member/Chair Dashboard vs Visitor View -->
-
-  @if (!myRoleLoading() && !isVisitor()) {
-    <!-- Meetings Row: Last Meeting + Next Meeting -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
-      <!-- Left Column: Last Meeting -->
-      <div class="flex flex-col gap-2">
-        <div class="flex items-center justify-between">
-          <h2 class="text-base font-normal text-gray-900 flex items-center gap-2">
-            <i class="fa-light fa-clock-rotate-left text-gray-400"></i>
-            Last Meeting
-          </h2>
-          <lfx-button label="View All" [text]="true" size="small" severity="info" styleClass="!text-xs" (onClick)="navigateToTab('meetings:past')"></lfx-button>
-        </div>
-        @if (pastMeetingsLoading()) {
-          <lfx-card>
-            <div class="flex flex-col gap-3">
-              <p-skeleton width="60%" height="1rem" />
-              <p-skeleton width="40%" height="0.75rem" />
-            </div>
-          </lfx-card>
-        } @else if (lastMeeting(); as meeting) {
-          <lfx-dashboard-meeting-card [meeting]="meeting" [detailUrl]="'/meetings/' + meeting.id" />
-        } @else {
-          <lfx-card>
-            <div class="flex flex-col items-center py-6">
-              <i class="fa-light fa-clock-rotate-left text-2xl text-gray-300 mb-2"></i>
-              <p class="text-sm font-medium text-gray-500">No past meetings</p>
-              <p class="text-xs text-gray-400 mt-1">Past meetings for this group will appear here.</p>
-            </div>
-          </lfx-card>
-        }
-      </div>
-
-      <!-- Right Column: Next Meeting -->
-      <div class="flex flex-col gap-2">
-        <div class="flex items-center justify-between">
-          <h2 class="text-base font-normal text-gray-900 flex items-center gap-2">
-            <i class="fa-light fa-calendar text-gray-400"></i>
-            Next Meeting
-          </h2>
-          <lfx-button
-            label="View All"
-            [text]="true"
-            size="small"
-            severity="info"
-            styleClass="!text-xs"
-            (onClick)="navigateToTab('meetings:upcoming')"></lfx-button>
-        </div>
-        @if (upcomingMeetingsLoading()) {
-          <lfx-card>
-            <div class="flex flex-col gap-3">
-              <p-skeleton width="60%" height="1rem" />
-              <p-skeleton width="40%" height="0.75rem" />
-            </div>
-          </lfx-card>
-        } @else if (nextMeeting(); as meeting) {
-          <lfx-dashboard-meeting-card [meeting]="meeting" />
-        } @else {
-          <lfx-card>
-            <div class="flex flex-col items-center py-6">
-              <i class="fa-light fa-calendar-check text-2xl text-gray-300 mb-2"></i>
-              <p class="text-sm font-medium text-gray-500">No upcoming meetings</p>
-              <p class="text-xs text-gray-400 mt-1">Scheduled meetings for this group will appear here.</p>
-            </div>
-          </lfx-card>
-        }
-      </div>
     </div>
-
-    <!-- My Pending Actions -->
-    <div class="flex flex-col gap-2">
-      <div class="flex items-center justify-between">
-        <h2 class="text-base font-normal text-gray-900 flex items-center gap-2">
-          <i class="fa-light fa-list-check text-gray-400"></i>
-          My Pending Actions
-        </h2>
-        @if (pendingActionItems().length > 2) {
-          <lfx-button
-            label="View All"
-            [text]="true"
-            size="small"
-            severity="info"
-            styleClass="!text-xs"
-            (onClick)="navigateToTab(pendingActionsViewAllTab())"></lfx-button>
-        }
-      </div>
-      @if (votesLoading() || surveysLoading()) {
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
-          <lfx-card>
-            <div class="flex flex-col gap-3">
-              <p-skeleton width="30%" height="1.25rem" borderRadius="1rem" />
-              <p-skeleton width="70%" height="1rem" />
-              <p-skeleton width="100%" height="2rem" borderRadius="0.5rem" />
-            </div>
-          </lfx-card>
-          <lfx-card>
-            <div class="flex flex-col gap-3">
-              <p-skeleton width="30%" height="1.25rem" borderRadius="1rem" />
-              <p-skeleton width="70%" height="1rem" />
-              <p-skeleton width="100%" height="2rem" borderRadius="0.5rem" />
-            </div>
-          </lfx-card>
-        </div>
-      } @else if (pendingActionItems().length > 0) {
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
-          @for (item of pendingActionItems().slice(0, 2); track item.type + item.text) {
-            <div
-              class="p-4 flex flex-col gap-3 border rounded-xl shadow-md transition-all cursor-pointer"
-              [ngClass]="{
-                'bg-amber-50 hover:border-amber-300': item.severity === 'warn',
-                'bg-blue-200 hover:border-blue-300': item.severity === 'info',
-                'bg-emerald-200 hover:border-emerald-300': item.severity === 'success',
-                'bg-violet-200 hover:border-violet-300': item.severity === 'secondary',
-              }"
-              (click)="handlePendingActionClick(item)">
-              <div class="flex items-center gap-2 flex-wrap">
-                <lfx-tag [value]="item.type" [severity]="item.severity" [icon]="item.icon" />
-              </div>
-              <div class="flex items-start justify-between gap-2">
-                <div class="flex flex-col gap-1 truncate max-w-full">
-                  <h4 class="line-clamp-2 text-sm leading-tight font-medium text-gray-900 truncate">{{ item.text }}</h4>
-                  @if (item.date) {
-                    <span class="text-xs text-gray-600 whitespace-nowrap">{{ item.date }}</span>
-                  }
-                </div>
-              </div>
-              <div class="flex gap-2">
-                <lfx-button size="small" class="w-full text-sm" styleClass="w-full text-sm h-8" severity="secondary" [label]="item.buttonText"> </lfx-button>
-              </div>
-            </div>
-          }
-          @if (pendingActionItems().length < 2) {
-            <lfx-card>
-              <div class="flex flex-col items-center py-6">
-                <i class="fa-light fa-circle-check text-2xl text-gray-300 mb-2"></i>
-                <p class="text-sm font-medium text-gray-500">No more pending actions</p>
-                <p class="text-xs text-gray-400 mt-1">You're all caught up!</p>
-              </div>
-            </lfx-card>
-          }
-        </div>
-      } @else {
-        <lfx-card>
-          <div class="flex flex-col items-center py-6">
-            <i class="fa-light fa-circle-check text-2xl text-gray-300 mb-2"></i>
-            <p class="text-sm font-medium text-gray-500">You're all caught up!</p>
-            <p class="text-xs text-gray-400 mt-1">Active votes and open surveys will appear here.</p>
-          </div>
-        </lfx-card>
-      }
-    </div>
-  } @else if (!myRoleLoading()) {
-    <!-- Visitor View: Key Info + CTA -->
-
-    <!-- Visitor CTA -->
-    @if (canJoin()) {
-      <div class="rounded-xl bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-100 p-6 text-center" data-testid="committee-overview-visitor-cta">
-        <div class="flex flex-col gap-3 items-center">
-          <i [class]="joinCtaIcon() + ' text-2xl text-blue-500'"></i>
-          <h3 class="text-base font-semibold text-gray-900">{{ joinCtaTitle() }}</h3>
-          <p class="text-sm text-gray-600 max-w-md">{{ joinCtaDescription() }}</p>
-          <lfx-button [label]="joinButtonLabel()" severity="info" size="small" [icon]="joinButtonIcon()" (onClick)="onJoinClick()"></lfx-button>
-        </div>
-      </div>
-    }
   }
 </div>
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -3,8 +3,7 @@
 
 <div class="flex flex-col gap-6 pt-2">
   <!-- Two-column layout: Stats+Chairs | Meetings+Actions -->
-  @if (!myRoleLoading()) {
-    <div class="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-6 items-start" data-testid="committee-overview-stats">
+  <div class="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-6 items-start" data-testid="committee-overview-stats">
       <!-- LEFT: Stats list + Chairs -->
       <lfx-card styleClass="[&_.p-card-body]:!p-0">
         <!-- Stats rows -->
@@ -252,7 +251,6 @@
         }
       </div>
     </div>
-  }
 </div>
 
 <!-- Vote Results Drawer -->

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -148,13 +148,7 @@ export class CommitteeOverviewComponent {
     return `${name} is closed to new members. Contact a group admin for access.`;
   });
 
-  public joinCtaTitle: Signal<string> = computed(() => {
-    const mode = this.committee().join_mode;
-    const name = this.committee().name;
-    if (mode === 'application') return `Apply to join ${name}`;
-    if (mode === 'invite_only') return `Request access to ${name}`;
-    return `Join ${name}`;
-  });
+  public joinCtaTitle: Signal<string> = computed(() => `Interested in ${this.committee().name}?`);
 
   public joinCtaDescription: Signal<string> = computed(() => {
     const mode = this.committee().join_mode;

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -378,8 +378,7 @@ export class CommitteeOverviewComponent {
 
   private initPendingActionsViewAllTab(): Signal<'votes' | 'surveys'> {
     return computed(() => {
-      const overflow = this.pendingActionItems().slice(2);
-      const hasVotes = overflow.some((item) => item.type === 'Vote');
+      const hasVotes = this.pendingActionItems().some((item) => item.type === 'Vote');
       return hasVotes ? 'votes' : 'surveys';
     });
   }

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -648,7 +648,7 @@ export type CommitteeTab = 'overview' | 'members' | 'votes' | 'meetings' | 'surv
 /** Configuration entry for a committee view tab. Visibility and badge are closures so each consumer can wire its own signals/state. */
 export interface TabConfigEntry {
   key: CommitteeTab;
-  label: string;
+  label: string | (() => string);
   icon: string;
   visible: () => boolean;
   badge?: () => number | null;


### PR DESCRIPTION
## What
Redesigns the group detail page header and Overview tab to match a cleaner card-based layout.

## How
- Wraps the entire header (title, description, tags, channels, tabs) in a single card
- Replaces breadcrumbs with a contextual back link ("My Groups" or "Groups"), derived from router navigation state passed by the groups list
- Tabs restyled as pill buttons inside the card (matching the Documents filter-pills style), with icons and inline member count on the Members tab
- Overview tab reworked into a two-column layout: stats + chairs on the left, Next Meeting / Past Meeting / My Pending Actions stacked on the right
- Pending actions now use the same row-based card style as the Dashboard (tag | description | outlined button)
- Stats always shown regardless of membership role
- Role banners removed from the Overview tab

## Checklist
- [x] License headers on modified files
- [x] No mock data included in commit

🤖 Generated with [Claude Code](https://claude.ai/code)