### PR TITLE
feat(mailing-lists): wrap detail page header in card with back link

### DIFF
--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-dashboard/mailing-list-dashboard.component.ts
@@ -127,7 +127,9 @@ export class MailingListDashboardComponent {
    * Handle mailing list row click - navigate to detail page
    */
   public onMailingListClick(mailingList: GroupsIOMailingList): void {
-    this.router.navigate(['/mailing-lists', mailingList.uid]);
+    this.router.navigate(['/mailing-lists', mailingList.uid], {
+      state: { backLabel: this.isMeLens() ? `My ${this.mailingListLabelPlural}` : this.mailingListLabelPlural },
+    });
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.html
@@ -29,14 +29,34 @@
     @let ml = mailingList()!;
     <div class="flex flex-col gap-6">
       <!-- Header Section -->
-      <div class="flex justify-between items-start">
-        <div class="flex flex-col gap-4" data-testid="mailing-list-view-header">
-          <lfx-breadcrumb [model]="breadcrumbItems()" data-testid="mailing-list-view-breadcrumb"></lfx-breadcrumb>
-          <div class="flex flex-col gap-1">
-            <h1 data-testid="mailing-list-view-title">{{ ml.title }}</h1>
-            @if (ml.description) {
-              <p class="text-gray-500" data-testid="mailing-list-view-description">{{ ml.description | stripHtml }}</p>
-            }
+      <lfx-card styleClass="[&_.p-card-body]:!p-0" data-testid="mailing-list-view-header">
+        <div class="px-6 pt-5 pb-4 flex flex-col gap-4">
+          <button
+            type="button"
+            class="flex items-center gap-1.5 text-sm text-blue-600 hover:text-blue-800 transition-colors w-fit"
+            (click)="goBack()"
+            data-testid="mailing-list-view-back-link">
+            <i class="fa-light fa-angle-left text-xs"></i>
+            {{ backLabel() }}
+          </button>
+
+          <!-- Title row + Edit button -->
+          <div class="flex items-start gap-3">
+            <div class="flex flex-col gap-1 flex-1">
+              <h1 class="font-display font-light text-[20px]" data-testid="mailing-list-view-title">{{ ml.title }}</h1>
+              @if (ml.description) {
+                <p class="text-gray-500 text-sm" data-testid="mailing-list-view-description">{{ ml.description | stripHtml }}</p>
+              }
+            </div>
+            <div class="flex items-center gap-3 flex-shrink-0">
+              <lfx-button
+                icon="fa-light fa-edit"
+                label="Edit {{ mailingListLabel.singular }}"
+                size="small"
+                [routerLink]="editRoute()"
+                data-testid="mailing-list-view-edit-button">
+              </lfx-button>
+            </div>
           </div>
 
           <!-- Metadata Row -->
@@ -75,18 +95,7 @@
             }
           </div>
         </div>
-
-        <!-- Action Button -->
-        <div class="flex items-center gap-3">
-          <lfx-button
-            icon="fa-light fa-edit"
-            label="Edit {{ mailingListLabel.singular }}"
-            size="small"
-            [routerLink]="editRoute()"
-            data-testid="mailing-list-view-edit-button">
-          </lfx-button>
-        </div>
-      </div>
+      </lfx-card>
 
       <!-- Two Column Grid -->
       <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 items-stretch">

--- a/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
+++ b/apps/lfx-one/src/app/modules/mailing-lists/mailing-list-view/mailing-list-view.component.ts
@@ -5,7 +5,6 @@ import { LowerCasePipe } from '@angular/common';
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { BreadcrumbComponent } from '@components/breadcrumb/breadcrumb.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -22,7 +21,7 @@ import { CommitteeReference, GroupsIOMailingList } from '@lfx-one/shared/interfa
 import { MailingListVisibilitySeverityPipe } from '@pipes/mailing-list-visibility-severity.pipe';
 import { StripHtmlPipe } from '@pipes/strip-html.pipe';
 import { MailingListService } from '@services/mailing-list.service';
-import { MenuItem, MessageService } from 'primeng/api';
+import { MessageService } from 'primeng/api';
 import { TooltipModule } from 'primeng/tooltip';
 import { BehaviorSubject, catchError, combineLatest, of, switchMap } from 'rxjs';
 
@@ -31,7 +30,6 @@ import { MailingListMembersComponent } from '../components/mailing-list-members/
 @Component({
   selector: 'lfx-mailing-list-view',
   imports: [
-    BreadcrumbComponent,
     CardComponent,
     ButtonComponent,
     TagComponent,
@@ -52,6 +50,9 @@ export class MailingListViewComponent {
   private readonly mailingListService = inject(MailingListService);
   private readonly messageService = inject(MessageService);
 
+  // Back-navigation label injected from router state at navigation time
+  private readonly navBackLabel: string | null = this.router.getCurrentNavigation()?.extras?.state?.['backLabel'] ?? null;
+
   // Protected constants
   protected readonly mailingListLabel = MAILING_LIST_LABEL;
   protected readonly memberLabel = MAILING_LIST_MEMBER_LABEL;
@@ -67,7 +68,7 @@ export class MailingListViewComponent {
 
   // Complex computed/toSignal signals
   public readonly mailingList: Signal<GroupsIOMailingList | null> = this.initMailingList();
-  public readonly breadcrumbItems: Signal<MenuItem[]> = this.initBreadcrumbItems();
+  public readonly backLabel: Signal<string> = computed(() => this.navBackLabel ?? this.mailingListLabel.plural);
   public readonly emailAddress: Signal<string> = this.initEmailAddress();
   public readonly memberCount: Signal<number> = this.initMemberCount();
   public readonly linkedCommittees: Signal<CommitteeReference[]> = this.initLinkedCommittees();
@@ -79,6 +80,10 @@ export class MailingListViewComponent {
 
   public refreshData(): void {
     this.refresh.next();
+  }
+
+  public goBack(): void {
+    this.router.navigate(['/', 'mailing-lists']);
   }
 
   // Private initializer functions
@@ -114,10 +119,6 @@ export class MailingListViewComponent {
     );
   }
 
-  private initBreadcrumbItems(): Signal<MenuItem[]> {
-    return computed(() => [{ label: this.mailingListLabel.plural, routerLink: ['/mailing-lists'] }, { label: this.mailingList()?.title || '' }]);
-  }
-
   private initEmailAddress(): Signal<string> {
     return computed(() => {
       const ml = this.mailingList();
@@ -128,10 +129,7 @@ export class MailingListViewComponent {
   }
 
   private initMemberCount(): Signal<number> {
-    return computed(() => {
-      // Placeholder - will be populated from API when available
-      return 0;
-    });
+    return computed(() => this.mailingList()?.subscriber_count ?? 0);
   }
 
   private initLinkedCommittees(): Signal<CommitteeReference[]> {


### PR DESCRIPTION
## What
Redesigns the mailing list detail page header to match the group detail page pattern introduced in #587.

## How
- Wraps the header section in `lfx-card` with `[&_.p-card-body]:!p-0` (same as committee view)
- Moves the edit button inline with the title row inside the card
- Replaces the breadcrumb with a simple `‹ Mailing Lists` / `‹ My Mailing Lists` back link (reads `backLabel` from router navigation state, falls back to the label constant)
- Fixes `memberCount` signal to read from `subscriber_count` on the mailing list object (was hardcoded to `0`)

## Related
- Follows the pattern from #587 (group detail page redesign)

## Checklist
- [x] Matches group detail card pattern exactly
- [x] Back link label is dynamic via router state
- [x] No new components or imports added — `CardComponent` was already imported
- [x] `data-testid` attributes preserved on all elements
- [x] License headers present

🤖 Generated with [Claude Code](https://claude.ai/code)