### PR TITLE
feat(dashboards): show groups/channels on foundation projects

### DIFF
--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -169,7 +169,10 @@ export class MainLayoutComponent {
           return of(false);
         }
         return this.analyticsService.getFoundationProjectsDetail(slug).pipe(
-          map((response) => response.projects.length > 0),
+          // Use totalCount (response-level aggregate) rather than projects.length
+          // so the sidebar decision is decoupled from how many rows happen to be
+          // included in the `projects` array.
+          map((response) => response.totalCount > 0),
           startWith(false)
         );
       })

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
@@ -55,7 +55,7 @@
           <th scope="col" class="text-right">Stars</th>
           <th scope="col" class="text-right">Contributors</th>
           <th scope="col" class="text-right">Commits (90d)</th>
-          <th scope="col"></th>
+          <th scope="col" class="text-right"><span class="sr-only">Actions</span></th>
         </tr>
       </ng-template>
 
@@ -63,11 +63,12 @@
         @let counts = getCountFor(project);
         <tr [attr.data-testid]="'foundation-projects-row-' + project.projectSlug">
           <td>
+            @let lensReady = canOpenProjectLens(project);
             <button
               type="button"
               class="flex flex-col items-start border-none bg-transparent p-0 text-left disabled:cursor-not-allowed disabled:opacity-60"
-              [disabled]="!project.projectId"
-              [attr.title]="!project.projectId ? 'Project lens unavailable for this row' : null"
+              [disabled]="!lensReady"
+              [attr.title]="!lensReady ? 'Project lens unavailable for this row' : null"
               (click)="openProjectLens(project)"
               [attr.data-testid]="'foundation-projects-name-' + project.projectSlug">
               <span class="lfx-table-name-link text-sm">{{ project.projectName }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
@@ -21,6 +21,11 @@
     <lfx-stat-card-grid [cards]="summaryCards()" [loading]="loading()" />
 
     <div class="flex flex-col gap-3" data-testid="foundation-projects-filters">
+      <lfx-filter-pills
+        [options]="pillOptions()"
+        [selectedFilter]="activePill()"
+        (filterChange)="onPillChange($event)"
+        data-testid="foundation-projects-pills" />
       <lfx-input-text
         control="query"
         [form]="searchForm"
@@ -44,6 +49,8 @@
       <ng-template #header>
         <tr>
           <th scope="col">Project Name</th>
+          <th scope="col" class="text-center">Groups</th>
+          <th scope="col" class="text-center">Channels</th>
           <th scope="col" class="text-right">Maintainers</th>
           <th scope="col" class="text-right">Stars</th>
           <th scope="col" class="text-right">Contributors</th>
@@ -53,6 +60,7 @@
       </ng-template>
 
       <ng-template #body let-project>
+        @let counts = getCountFor(project);
         <tr [attr.data-testid]="'foundation-projects-row-' + project.projectSlug">
           <td>
             <button
@@ -67,6 +75,36 @@
                 <span class="text-xs text-slate-500">Updated {{ project.lastUpdated }}</span>
               }
             </button>
+          </td>
+          <td class="text-center">
+            <i
+              class="fa-light fa-users-rectangle"
+              [class.text-blue-600]="counts.committees > 0"
+              [class.text-gray-300]="counts.committees === 0"
+              aria-hidden="true"
+              [title]="counts.committees + ' groups'"
+              [attr.data-testid]="'foundation-projects-groups-' + project.projectSlug"></i>
+            <span class="sr-only">{{ counts.committees }} groups</span>
+          </td>
+          <td class="text-center">
+            <span class="inline-flex items-center justify-center gap-2">
+              <i
+                class="fa-light fa-envelope"
+                [class.text-blue-600]="counts.mailingLists > 0"
+                [class.text-gray-300]="counts.mailingLists === 0"
+                aria-hidden="true"
+                [title]="counts.mailingLists + ' mailing lists'"
+                [attr.data-testid]="'foundation-projects-mailing-lists-' + project.projectSlug"></i>
+              <span class="sr-only">{{ counts.mailingLists }} mailing lists</span>
+              <i
+                class="fa-light fa-message"
+                [class.text-blue-600]="counts.hasChat"
+                [class.text-gray-300]="!counts.hasChat"
+                aria-hidden="true"
+                [title]="counts.hasChat ? 'Chat configured' : 'No chat configured'"
+                [attr.data-testid]="'foundation-projects-chat-' + project.projectSlug"></i>
+              <span class="sr-only">{{ counts.hasChat ? 'Chat configured' : 'No chat configured' }}</span>
+            </span>
           </td>
           <td class="text-right text-sm text-gray-700">{{ project.maintainers | number }}</td>
           <td class="text-right text-sm text-gray-700">{{ project.stars | number }}</td>
@@ -87,7 +125,7 @@
 
       <ng-template #emptymessage>
         <tr>
-          <td colspan="6" class="p-10 text-center">
+          <td colspan="8" class="p-10 text-center">
             @if (searchQuery().trim()) {
               <div class="flex flex-col items-center gap-2" data-testid="foundation-projects-search-empty">
                 <i class="fa-light fa-magnifying-glass text-3xl text-gray-400"></i>

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
@@ -67,7 +67,8 @@
               type="button"
               class="flex flex-col items-start border-none bg-transparent p-0 text-left disabled:cursor-not-allowed disabled:opacity-60"
               [disabled]="!view.lensReady"
-              [attr.title]="!view.lensReady ? 'Project lens unavailable for this row' : null"
+              [pTooltip]="view.lensReady ? '' : 'Project lens unavailable for this row'"
+              tooltipPosition="top"
               (click)="openProjectLens(project)"
               [attr.data-testid]="'foundation-projects-name-' + project.projectSlug">
               <span class="lfx-table-name-link text-sm">{{ project.projectName }}</span>
@@ -83,7 +84,8 @@
               [class.text-gray-300]="view.groupsPresence === 'absent'"
               [class.text-gray-200]="view.groupsPresence === 'pending'"
               aria-hidden="true"
-              [title]="view.groupsText"
+              [pTooltip]="view.groupsText"
+              tooltipPosition="top"
               [attr.data-testid]="'foundation-projects-groups-' + project.projectSlug"></i>
             <span class="sr-only">{{ view.groupsText }}</span>
           </td>
@@ -95,7 +97,8 @@
                 [class.text-gray-300]="view.mailingListsPresence === 'absent'"
                 [class.text-gray-200]="view.mailingListsPresence === 'pending'"
                 aria-hidden="true"
-                [title]="view.mailingListsText"
+                [pTooltip]="view.mailingListsText"
+                tooltipPosition="top"
                 [attr.data-testid]="'foundation-projects-mailing-lists-' + project.projectSlug"></i>
               <span class="sr-only">{{ view.mailingListsText }}</span>
               <i
@@ -104,7 +107,8 @@
                 [class.text-gray-300]="view.chatPresence === 'absent'"
                 [class.text-gray-200]="view.chatPresence === 'pending'"
                 aria-hidden="true"
-                [title]="view.chatText"
+                [pTooltip]="view.chatText"
+                tooltipPosition="top"
                 [attr.data-testid]="'foundation-projects-chat-' + project.projectSlug"></i>
               <span class="sr-only">{{ view.chatText }}</span>
             </span>

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
@@ -83,9 +83,9 @@
               [class.text-blue-600]="counts.committees > 0"
               [class.text-gray-300]="counts.committees === 0"
               aria-hidden="true"
-              [title]="counts.committees + ' groups'"
+              [title]="counts.committees + ' ' + (counts.committees === 1 ? 'group' : 'groups')"
               [attr.data-testid]="'foundation-projects-groups-' + project.projectSlug"></i>
-            <span class="sr-only">{{ counts.committees }} groups</span>
+            <span class="sr-only">{{ counts.committees }} {{ counts.committees === 1 ? 'group' : 'groups' }}</span>
           </td>
           <td class="text-center">
             <span class="inline-flex items-center justify-center gap-2">
@@ -94,9 +94,9 @@
                 [class.text-blue-600]="counts.mailingLists > 0"
                 [class.text-gray-300]="counts.mailingLists === 0"
                 aria-hidden="true"
-                [title]="counts.mailingLists + ' mailing lists'"
+                [title]="counts.mailingLists + ' ' + (counts.mailingLists === 1 ? 'mailing list' : 'mailing lists')"
                 [attr.data-testid]="'foundation-projects-mailing-lists-' + project.projectSlug"></i>
-              <span class="sr-only">{{ counts.mailingLists }} mailing lists</span>
+              <span class="sr-only">{{ counts.mailingLists }} {{ counts.mailingLists === 1 ? 'mailing list' : 'mailing lists' }}</span>
               <i
                 class="fa-light fa-message"
                 [class.text-blue-600]="counts.hasChat"

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
@@ -60,15 +60,14 @@
       </ng-template>
 
       <ng-template #body let-project>
-        @let counts = getCountFor(project);
+        @let view = projectRowViews().get(project.projectSlug) ?? defaultRowView;
         <tr [attr.data-testid]="'foundation-projects-row-' + project.projectSlug">
           <td>
-            @let lensReady = canOpenProjectLens(project);
             <button
               type="button"
               class="flex flex-col items-start border-none bg-transparent p-0 text-left disabled:cursor-not-allowed disabled:opacity-60"
-              [disabled]="!lensReady"
-              [attr.title]="!lensReady ? 'Project lens unavailable for this row' : null"
+              [disabled]="!view.lensReady"
+              [attr.title]="!view.lensReady ? 'Project lens unavailable for this row' : null"
               (click)="openProjectLens(project)"
               [attr.data-testid]="'foundation-projects-name-' + project.projectSlug">
               <span class="lfx-table-name-link text-sm">{{ project.projectName }}</span>
@@ -80,34 +79,34 @@
           <td class="text-center">
             <i
               class="fa-light fa-users-rectangle"
-              [class.text-blue-600]="counts.committees > 0"
-              [class.text-gray-300]="counts.committees !== undefined && counts.committees === 0"
-              [class.text-gray-200]="counts.committees === undefined"
+              [class.text-blue-600]="view.groupsPresence === 'present'"
+              [class.text-gray-300]="view.groupsPresence === 'absent'"
+              [class.text-gray-200]="view.groupsPresence === 'pending'"
               aria-hidden="true"
-              [title]="counts.committees !== undefined ? (counts.committees + ' ' + (counts.committees === 1 ? 'group' : 'groups')) : 'Loading'"
+              [title]="view.groupsText"
               [attr.data-testid]="'foundation-projects-groups-' + project.projectSlug"></i>
-            <span class="sr-only">{{ counts.committees !== undefined ? (counts.committees + ' ' + (counts.committees === 1 ? 'group' : 'groups')) : 'Loading' }}</span>
+            <span class="sr-only">{{ view.groupsText }}</span>
           </td>
           <td class="text-center">
             <span class="inline-flex items-center justify-center gap-2">
               <i
                 class="fa-light fa-envelope"
-                [class.text-blue-600]="counts.mailingLists > 0"
-                [class.text-gray-300]="counts.mailingLists !== undefined && counts.mailingLists === 0"
-                [class.text-gray-200]="counts.mailingLists === undefined"
+                [class.text-blue-600]="view.mailingListsPresence === 'present'"
+                [class.text-gray-300]="view.mailingListsPresence === 'absent'"
+                [class.text-gray-200]="view.mailingListsPresence === 'pending'"
                 aria-hidden="true"
-                [title]="counts.mailingLists !== undefined ? (counts.mailingLists + ' ' + (counts.mailingLists === 1 ? 'mailing list' : 'mailing lists')) : 'Loading'"
+                [title]="view.mailingListsText"
                 [attr.data-testid]="'foundation-projects-mailing-lists-' + project.projectSlug"></i>
-              <span class="sr-only">{{ counts.mailingLists !== undefined ? (counts.mailingLists + ' ' + (counts.mailingLists === 1 ? 'mailing list' : 'mailing lists')) : 'Loading' }}</span>
+              <span class="sr-only">{{ view.mailingListsText }}</span>
               <i
                 class="fa-light fa-message"
-                [class.text-blue-600]="counts.hasChat === true"
-                [class.text-gray-300]="counts.hasChat === false"
-                [class.text-gray-200]="counts.hasChat === undefined"
+                [class.text-blue-600]="view.chatPresence === 'present'"
+                [class.text-gray-300]="view.chatPresence === 'absent'"
+                [class.text-gray-200]="view.chatPresence === 'pending'"
                 aria-hidden="true"
-                [title]="counts.hasChat !== undefined ? (counts.hasChat ? 'Chat configured' : 'No chat configured') : 'Loading'"
+                [title]="view.chatText"
                 [attr.data-testid]="'foundation-projects-chat-' + project.projectSlug"></i>
-              <span class="sr-only">{{ counts.hasChat !== undefined ? (counts.hasChat ? 'Chat configured' : 'No chat configured') : 'Loading' }}</span>
+              <span class="sr-only">{{ view.chatText }}</span>
             </span>
           </td>
           <td class="text-right text-sm text-gray-700">{{ project.maintainers | number }}</td>

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.html
@@ -81,30 +81,33 @@
             <i
               class="fa-light fa-users-rectangle"
               [class.text-blue-600]="counts.committees > 0"
-              [class.text-gray-300]="counts.committees === 0"
+              [class.text-gray-300]="counts.committees !== undefined && counts.committees === 0"
+              [class.text-gray-200]="counts.committees === undefined"
               aria-hidden="true"
-              [title]="counts.committees + ' ' + (counts.committees === 1 ? 'group' : 'groups')"
+              [title]="counts.committees !== undefined ? (counts.committees + ' ' + (counts.committees === 1 ? 'group' : 'groups')) : 'Loading'"
               [attr.data-testid]="'foundation-projects-groups-' + project.projectSlug"></i>
-            <span class="sr-only">{{ counts.committees }} {{ counts.committees === 1 ? 'group' : 'groups' }}</span>
+            <span class="sr-only">{{ counts.committees !== undefined ? (counts.committees + ' ' + (counts.committees === 1 ? 'group' : 'groups')) : 'Loading' }}</span>
           </td>
           <td class="text-center">
             <span class="inline-flex items-center justify-center gap-2">
               <i
                 class="fa-light fa-envelope"
                 [class.text-blue-600]="counts.mailingLists > 0"
-                [class.text-gray-300]="counts.mailingLists === 0"
+                [class.text-gray-300]="counts.mailingLists !== undefined && counts.mailingLists === 0"
+                [class.text-gray-200]="counts.mailingLists === undefined"
                 aria-hidden="true"
-                [title]="counts.mailingLists + ' ' + (counts.mailingLists === 1 ? 'mailing list' : 'mailing lists')"
+                [title]="counts.mailingLists !== undefined ? (counts.mailingLists + ' ' + (counts.mailingLists === 1 ? 'mailing list' : 'mailing lists')) : 'Loading'"
                 [attr.data-testid]="'foundation-projects-mailing-lists-' + project.projectSlug"></i>
-              <span class="sr-only">{{ counts.mailingLists }} {{ counts.mailingLists === 1 ? 'mailing list' : 'mailing lists' }}</span>
+              <span class="sr-only">{{ counts.mailingLists !== undefined ? (counts.mailingLists + ' ' + (counts.mailingLists === 1 ? 'mailing list' : 'mailing lists')) : 'Loading' }}</span>
               <i
                 class="fa-light fa-message"
-                [class.text-blue-600]="counts.hasChat"
-                [class.text-gray-300]="!counts.hasChat"
+                [class.text-blue-600]="counts.hasChat === true"
+                [class.text-gray-300]="counts.hasChat === false"
+                [class.text-gray-200]="counts.hasChat === undefined"
                 aria-hidden="true"
-                [title]="counts.hasChat ? 'Chat configured' : 'No chat configured'"
+                [title]="counts.hasChat !== undefined ? (counts.hasChat ? 'Chat configured' : 'No chat configured') : 'Loading'"
                 [attr.data-testid]="'foundation-projects-chat-' + project.projectSlug"></i>
-              <span class="sr-only">{{ counts.hasChat ? 'Chat configured' : 'No chat configured' }}</span>
+              <span class="sr-only">{{ counts.hasChat !== undefined ? (counts.hasChat ? 'Chat configured' : 'No chat configured') : 'Loading' }}</span>
             </span>
           </td>
           <td class="text-right text-sm text-gray-700">{{ project.maintainers | number }}</td>

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
@@ -11,7 +11,13 @@ import { FilterPillsComponent } from '@components/filter-pills/filter-pills.comp
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
 import { TableComponent } from '@components/table/table.component';
-import { DEFAULT_FOUNDATION_PROJECTS_DETAIL, FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY, PRESENCE_PILL_IDS, UUID_REGEX } from '@lfx-one/shared/constants';
+import {
+  DEFAULT_FOUNDATION_PROJECT_ROW_VIEW,
+  DEFAULT_FOUNDATION_PROJECTS_DETAIL,
+  FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY,
+  PRESENCE_PILL_IDS,
+  UUID_REGEX,
+} from '@lfx-one/shared/constants';
 import { buildLensAwareInsightsUrl, hasAnyChannel } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { CommitteeService } from '@services/committee.service';
@@ -19,12 +25,14 @@ import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
-import { catchError, combineLatest, finalize, from, map, mergeMap, Observable, of, scan, startWith, switchMap } from 'rxjs';
+import { bufferTime, catchError, combineLatest, filter, finalize, from, map, mergeMap, Observable, of, scan, startWith, switchMap } from 'rxjs';
 
 import type {
   FilterPillOption,
+  FoundationProjectRowView,
   FoundationProjectsDetailResponse,
   PresencePill,
+  PresenceState,
   ProjectCounts,
   ProjectTableRow,
   StatCardItem,
@@ -77,6 +85,13 @@ export class FoundationProjectsComponent {
   private readonly subProjectUidBySlug: Signal<Map<string, string>> = this.initSubProjectUidBySlug();
   protected readonly projectCounts: Signal<Map<string, ProjectCounts>> = this.initProjectCounts();
   protected readonly pillOptions: Signal<FilterPillOption[]> = this.initPillOptions();
+  // Per-row display data — lens-ready flag + pre-formatted tooltip / sr-only
+  // labels — keyed by project slug. Computed once per (projects ⊕ counts ⊕
+  // slug→uid) update so the template consumes bare property reads instead of
+  // component methods during change detection.
+  protected readonly projectRowViews: Signal<Map<string, FoundationProjectRowView>> = this.initProjectRowViews();
+  // Exposed so the template can `?? defaultRowView` without calling a getter.
+  protected readonly defaultRowView: FoundationProjectRowView = DEFAULT_FOUNDATION_PROJECT_ROW_VIEW;
 
   // === Protected Methods ===
   protected getInsightsUrl(slug: string): string {
@@ -85,18 +100,6 @@ export class FoundationProjectsComponent {
 
   protected openProjectLens(project: ProjectTableRow): void {
     this.navigateToProject(project, '/project/overview');
-  }
-
-  // True when lens navigation has a trustworthy canonical project-service UID
-  // to hand to ProjectContextService. Prefers the slug→uid map; falls back to
-  // Snowflake's PROJECT_ID only when it looks like a UUID (not a Salesforce ID).
-  protected canOpenProjectLens(project: ProjectTableRow): boolean {
-    if (this.subProjectUidBySlug().has(project.projectSlug)) return true;
-    return !!project.projectId && UUID_REGEX.test(project.projectId);
-  }
-
-  protected getCountFor(project: ProjectTableRow): ProjectCounts {
-    return this.projectCounts().get(project.projectSlug) ?? { committees: undefined, mailingLists: undefined, hasChat: undefined };
   }
 
   protected onPillChange(pillId: string): void {
@@ -300,16 +303,26 @@ export class FoundationProjectsComponent {
             this.countsLoading.set(false);
             return of(initialCounts);
           }
+          // Coalesce mergeMap results into ~50ms batches before folding them into
+          // the signal-backed Map. Without this, each of the 2N upstream responses
+          // emits a fresh Map and triggers downstream computeds (filter + pill
+          // options) to re-run — ~800 recomputes for a 400-project foundation.
+          // Buffering keeps the row-by-row "light up" feel visually intact while
+          // collapsing bursts into at most ~20 signal updates per second.
           return from(requests).pipe(
             mergeMap((req$) => req$, FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY),
-            scan((acc, result) => {
-              const existing = acc.get(result.slug) ?? { committees: undefined, mailingLists: undefined, hasChat: undefined };
+            bufferTime(50),
+            filter((batch) => batch.length > 0),
+            scan((acc, batch) => {
               const next = new Map(acc);
-              next.set(result.slug, {
-                committees: result.committees ?? existing.committees,
-                mailingLists: result.mailingLists ?? existing.mailingLists,
-                hasChat: result.hasChat ?? existing.hasChat,
-              });
+              for (const result of batch) {
+                const existing = next.get(result.slug) ?? { committees: undefined, mailingLists: undefined, hasChat: undefined };
+                next.set(result.slug, {
+                  committees: result.committees ?? existing.committees,
+                  mailingLists: result.mailingLists ?? existing.mailingLists,
+                  hasChat: result.hasChat ?? existing.hasChat,
+                });
+              }
               return next;
             }, initialCounts),
             startWith(initialCounts),
@@ -350,7 +363,61 @@ export class FoundationProjectsComponent {
     });
   }
 
+  private initProjectRowViews(): Signal<Map<string, FoundationProjectRowView>> {
+    return computed(() => {
+      const projects = this.allProjects();
+      const counts = this.projectCounts();
+      const slugToUid = this.subProjectUidBySlug();
+      const views = new Map<string, FoundationProjectRowView>();
+      for (const project of projects) {
+        const row = counts.get(project.projectSlug);
+        const committees = row?.committees;
+        const mailingLists = row?.mailingLists;
+        const hasChat = row?.hasChat;
+        views.set(project.projectSlug, {
+          lensReady: this.resolveLensReady(project, slugToUid),
+          groupsPresence: this.countPresence(committees),
+          mailingListsPresence: this.countPresence(mailingLists),
+          chatPresence: this.booleanPresence(hasChat),
+          groupsText: this.formatCountLabel(committees, 'group', 'groups'),
+          mailingListsText: this.formatCountLabel(mailingLists, 'mailing list', 'mailing lists'),
+          chatText: this.formatChatLabel(hasChat),
+        });
+      }
+      return views;
+    });
+  }
+
   // === Private Helper Methods ===
+  private resolveLensReady(project: ProjectTableRow, slugToUid: Map<string, string>): boolean {
+    if (slugToUid.has(project.projectSlug)) return true;
+    return !!project.projectId && UUID_REGEX.test(project.projectId);
+  }
+
+  private countPresence(count: number | undefined): PresenceState {
+    if (count === undefined) return 'pending';
+    if (count > 0) return 'present';
+    return 'absent';
+  }
+
+  private booleanPresence(value: boolean | undefined): PresenceState {
+    if (value === undefined) return 'pending';
+    if (value) return 'present';
+    return 'absent';
+  }
+
+  private formatCountLabel(count: number | undefined, singular: string, plural: string): string {
+    if (count === undefined) return 'Loading';
+    if (count === 1) return `1 ${singular}`;
+    return `${count} ${plural}`;
+  }
+
+  private formatChatLabel(hasChat: boolean | undefined): string {
+    if (hasChat === undefined) return 'Loading';
+    if (hasChat) return 'Chat configured';
+    return 'No chat configured';
+  }
+
   private navigateToProject(project: ProjectTableRow, destination: string): void {
     // Resolve the canonical project-service UID from the foundation's sub-project
     // listing — this is the same identifier that committee/mailing-list tagging

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
@@ -1,28 +1,50 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { HttpParams } from '@angular/common/http';
 import { DecimalPipe } from '@angular/common';
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
 import { TableComponent } from '@components/table/table.component';
 import { DEFAULT_FOUNDATION_PROJECTS_DETAIL } from '@lfx-one/shared/constants';
 import { buildLensAwareInsightsUrl } from '@lfx-one/shared/utils';
+import { HttpParams } from '@angular/common/http';
 import { AnalyticsService } from '@services/analytics.service';
+import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
+import { MailingListService } from '@services/mailing-list.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
-import { catchError, finalize, map, of, startWith, switchMap } from 'rxjs';
+import { catchError, combineLatest, finalize, from, map, mergeMap, Observable, of, scan, startWith, switchMap } from 'rxjs';
 
-import type { FoundationProjectsDetailResponse, ProjectTableRow, StatCardItem } from '@lfx-one/shared/interfaces';
+import type { FilterPillOption, FoundationProjectsDetailResponse, ProjectTableRow, StatCardItem } from '@lfx-one/shared/interfaces';
+
+interface ProjectCounts {
+  committees: number;
+  mailingLists: number;
+  hasChat: boolean;
+}
+
+type PresencePill = 'all' | 'with-groups' | 'without-groups' | 'with-channels' | 'without-channels';
+
+// Limit concurrent per-project count fetches so a large foundation doesn't burst
+// N × 2 HTTP requests at once. Results are accumulated progressively so pill
+// counts and channel indicators update row-by-row as each project resolves.
+const COUNT_FETCH_CONCURRENCY = 8;
+
+/** A project "has channels" when it has at least one mailing list OR a chat_channel. */
+function hasAnyChannel(counts: ProjectCounts | undefined): boolean {
+  if (!counts) return false;
+  return counts.mailingLists > 0 || counts.hasChat;
+}
 
 @Component({
   selector: 'lfx-foundation-projects',
-  imports: [DecimalPipe, ReactiveFormsModule, InputTextComponent, StatCardGridComponent, TableComponent],
+  imports: [DecimalPipe, ReactiveFormsModule, FilterPillsComponent, InputTextComponent, StatCardGridComponent, TableComponent],
   templateUrl: './foundation-projects.component.html',
   styleUrl: './foundation-projects.component.scss',
 })
@@ -30,6 +52,8 @@ export class FoundationProjectsComponent {
   // === Services ===
   private readonly projectContextService = inject(ProjectContextService);
   private readonly analyticsService = inject(AnalyticsService);
+  private readonly committeeService = inject(CommitteeService);
+  private readonly mailingListService = inject(MailingListService);
   private readonly projectService = inject(ProjectService);
   private readonly lensService = inject(LensService);
   private readonly router = inject(Router);
@@ -42,6 +66,7 @@ export class FoundationProjectsComponent {
 
   // === Simple WritableSignals ===
   protected readonly loading = signal(false);
+  protected readonly activePill = signal<PresencePill>('all');
 
   // === Computed/toSignal Signals ===
   protected readonly foundationSlug: Signal<string> = computed(() => this.projectContextService.selectedFoundation()?.slug ?? '');
@@ -53,11 +78,28 @@ export class FoundationProjectsComponent {
   protected readonly summaryCards: Signal<StatCardItem[]> = this.initSummaryCards();
   protected readonly filteredProjects: Signal<ProjectTableRow[]> = this.initFilteredProjects();
   // Canonical project-service UIDs keyed by slug, resolved once per foundation change.
-  // Used by openProjectLens so lens switching uses the proper upstream UID instead of
-  // Snowflake's PROJECT_ID, which may be a Salesforce ID for some foundations per
-  // ProjectTableRow JSDoc. `startWith(new Map())` inside the inner switchMap clears
-  // any stale map from the previous foundation while the new request is in flight.
+  // Shared between initProjectCounts (upstream count filter) and navigateToProject
+  // (lens context uid) so we never fall back to the ambiguous Snowflake PROJECT_ID
+  // when the correct project-service UID is already on hand.
   private readonly subProjectUidBySlug: Signal<Map<string, string>> = this.initSubProjectUidBySlug();
+  protected readonly projectCounts: Signal<Record<string, ProjectCounts>> = this.initProjectCounts();
+  protected readonly pillOptions: Signal<FilterPillOption[]> = computed(() => {
+    const projects = this.allProjects();
+    const counts = this.projectCounts();
+    const withGroups = projects.filter((p) => (counts[p.projectSlug]?.committees ?? 0) > 0).length;
+    const withoutGroups = projects.length - withGroups;
+    // Channels = mailing lists OR chat channel. A project with just a chat
+    // channel should still count as "with channels" to match the Channels column.
+    const withChannels = projects.filter((p) => hasAnyChannel(counts[p.projectSlug])).length;
+    const withoutChannels = projects.length - withChannels;
+    return [
+      { id: 'all', label: `All (${projects.length})` },
+      { id: 'with-groups', label: `With Groups (${withGroups})` },
+      { id: 'without-groups', label: `Without Groups (${withoutGroups})` },
+      { id: 'with-channels', label: `With Channels (${withChannels})` },
+      { id: 'without-channels', label: `Without Channels (${withoutChannels})` },
+    ];
+  });
 
   // === Protected Methods ===
   protected getInsightsUrl(slug: string): string {
@@ -65,23 +107,15 @@ export class FoundationProjectsComponent {
   }
 
   protected openProjectLens(project: ProjectTableRow): void {
-    // Prefer the canonical project-service UID resolved from the foundation's
-    // sub-project listing; fall back to Snowflake's PROJECT_ID only if the
-    // sub-projects response hasn't landed or the slug isn't in the map. The
-    // resolved UID is the identifier committee/mailing-list tagging uses, so
-    // lens switching consistently lands on the right project instead of
-    // tripping on Salesforce-vs-UUID ambiguity.
-    const resolvedUid = this.subProjectUidBySlug().get(project.projectSlug) ?? project.projectId;
-    if (!resolvedUid) {
-      return;
-    }
-    this.projectContextService.setProject({
-      uid: resolvedUid,
-      name: project.projectName,
-      slug: project.projectSlug,
-    });
-    this.lensService.setLens('project');
-    this.router.navigate(['/project/overview']);
+    this.navigateToProject(project, '/project/overview');
+  }
+
+  protected getCountFor(project: ProjectTableRow): ProjectCounts {
+    return this.projectCounts()[project.projectSlug] ?? { committees: 0, mailingLists: 0, hasChat: false };
+  }
+
+  protected onPillChange(pillId: string): void {
+    this.activePill.set(pillId as PresencePill);
   }
 
   // === Private Initializers ===
@@ -144,13 +178,41 @@ export class FoundationProjectsComponent {
     });
   }
 
+  private navigateToProject(project: ProjectTableRow, destination: string): void {
+    // Prefer the canonical project-service UID resolved from the foundation's
+    // sub-project listing; fall back to Snowflake's PROJECT_ID only if the
+    // sub-projects response hasn't landed or the slug isn't in the map. The
+    // resolved UID is the same identifier that committee/mailing-list tagging
+    // uses, so lens switching consistently lands on the right project.
+    const resolvedUid = this.subProjectUidBySlug().get(project.projectSlug) ?? project.projectId;
+    if (!resolvedUid) {
+      return;
+    }
+    this.projectContextService.setProject({
+      uid: resolvedUid,
+      name: project.projectName,
+      slug: project.projectSlug,
+    });
+    this.lensService.setLens('project');
+    this.router.navigate([destination]);
+  }
+
   private initFilteredProjects(): Signal<ProjectTableRow[]> {
     return computed(() => {
       const query = this.searchQuery().toLowerCase().trim();
-      if (!query) {
-        return this.allProjects();
-      }
-      return this.allProjects().filter((project) => project.projectName.toLowerCase().includes(query));
+      const pill = this.activePill();
+      const counts = this.projectCounts();
+      return this.allProjects().filter((project) => {
+        if (query && !project.projectName.toLowerCase().includes(query)) return false;
+        const row = counts[project.projectSlug];
+        const committees = row?.committees ?? 0;
+        const channels = hasAnyChannel(row);
+        if (pill === 'with-groups' && committees === 0) return false;
+        if (pill === 'without-groups' && committees > 0) return false;
+        if (pill === 'with-channels' && !channels) return false;
+        if (pill === 'without-channels' && channels) return false;
+        return true;
+      });
     });
   }
 
@@ -158,9 +220,11 @@ export class FoundationProjectsComponent {
   // Snowflake's PROJECT_ID is foundation-specific and may be a Salesforce ID rather
   // than the canonical project-service UUID used by committee/mailing-list tagging,
   // so we fetch the sub-projects once per foundation change and build an authoritative
-  // slug→uid map. `startWith(new Map())` inside the inner switchMap clears the map
-  // when a new slug arrives so a stale mapping from the previous foundation can't
-  // leak through if slugs happen to overlap.
+  // slug→uid map. Used by both initProjectCounts (filter the count queries) and
+  // navigateToProject (set the correct lens context UID).
+  // `startWith(new Map())` inside the inner switchMap clears the map immediately when
+  // a new slug arrives so a stale mapping from the previous foundation can't leak
+  // through if slugs overlap across foundations.
   private initSubProjectUidBySlug(): Signal<Map<string, string>> {
     return toSignal(
       toObservable(this.foundationSlug).pipe(
@@ -187,6 +251,71 @@ export class FoundationProjectsComponent {
         })
       ),
       { initialValue: new Map<string, string>() }
+    );
+  }
+
+  // Fire per-project committee + mailing-list count fetches with bounded concurrency.
+  // Counts accumulate progressively (row-by-row) via `scan` so the table updates as
+  // each project resolves, instead of waiting for every request to finish before any
+  // indicator lights up. Reuses `subProjectUidBySlug` rather than refetching.
+  //
+  // Known fan-out cost: for N projects this issues 2N upstream calls, and the
+  // committees endpoint is itself enriched per-committee (mailing-list association,
+  // access checks) in the BFF. Accepted here because:
+  //   1. Loads only when a user visits /foundation/projects (page-scoped, not site-wide).
+  //   2. Chat-channel presence requires the committee list (no lightweight endpoint
+  //      exposes `chat_channel` membership today).
+  //   3. Concurrency is capped via COUNT_FETCH_CONCURRENCY to avoid flooding the BFF.
+  // Long-term fix: add a Snowflake-aggregated column or a lightweight
+  // /api/committees/chat-exists?tags=project_uid:X endpoint.
+  private initProjectCounts(): Signal<Record<string, ProjectCounts>> {
+    return toSignal(
+      combineLatest([toObservable(this.allProjects), toObservable(this.subProjectUidBySlug)]).pipe(
+        switchMap(([projects, slugToUid]) => {
+          if (projects.length === 0 || slugToUid.size === 0) {
+            return of({} as Record<string, ProjectCounts>);
+          }
+          const initialCounts: Record<string, ProjectCounts> = {};
+          for (const project of projects) {
+            initialCounts[project.projectSlug] = { committees: 0, mailingLists: 0, hasChat: false };
+          }
+          const requests: Observable<{ slug: string; committees?: number; hasChat?: boolean; mailingLists?: number }>[] = [];
+          for (const project of projects) {
+            const uid = slugToUid.get(project.projectSlug);
+            if (!uid) continue;
+            requests.push(
+              // Fetch committees (not just count) so we can detect chat_channel presence in one call.
+              this.committeeService.getCommitteesByProject(uid).pipe(
+                map((list) => ({
+                  slug: project.projectSlug,
+                  committees: list.length,
+                  hasChat: list.some((c) => !!c.chat_channel),
+                })),
+                catchError(() => of({ slug: project.projectSlug, committees: 0, hasChat: false }))
+              ),
+              this.mailingListService.getMailingListsCount({ tags: `project_uid:${uid}` }).pipe(
+                map((count) => ({ slug: project.projectSlug, mailingLists: count })),
+                catchError(() => of({ slug: project.projectSlug, mailingLists: 0 }))
+              )
+            );
+          }
+          if (requests.length === 0) {
+            return of(initialCounts);
+          }
+          return from(requests).pipe(
+            mergeMap((req$) => req$, COUNT_FETCH_CONCURRENCY),
+            scan((acc, result) => {
+              const next = { ...acc, [result.slug]: { ...acc[result.slug] } };
+              if (result.committees !== undefined) next[result.slug].committees = result.committees;
+              if (result.hasChat !== undefined) next[result.slug].hasChat = result.hasChat;
+              if (result.mailingLists !== undefined) next[result.slug].mailingLists = result.mailingLists;
+              return next;
+            }, initialCounts),
+            startWith(initialCounts)
+          );
+        })
+      ),
+      { initialValue: {} as Record<string, ProjectCounts> }
     );
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
@@ -21,15 +21,14 @@ import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { catchError, combineLatest, finalize, from, map, mergeMap, Observable, of, scan, startWith, switchMap } from 'rxjs';
 
-import type { FilterPillOption, FoundationProjectsDetailResponse, ProjectTableRow, StatCardItem } from '@lfx-one/shared/interfaces';
-
-interface ProjectCounts {
-  committees: number;
-  mailingLists: number;
-  hasChat: boolean;
-}
-
-type PresencePill = 'all' | 'with-groups' | 'without-groups' | 'with-channels' | 'without-channels';
+import type {
+  FilterPillOption,
+  FoundationProjectsDetailResponse,
+  PresencePill,
+  ProjectCounts,
+  ProjectTableRow,
+  StatCardItem,
+} from '@lfx-one/shared/interfaces';
 
 // UUID v4 pattern — used to decide whether Snowflake's PROJECT_ID is safe to
 // use as a fallback project-service UID. Some foundations store a Salesforce

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
@@ -31,6 +31,11 @@ interface ProjectCounts {
 
 type PresencePill = 'all' | 'with-groups' | 'without-groups' | 'with-channels' | 'without-channels';
 
+// UUID v4 pattern — used to decide whether Snowflake's PROJECT_ID is safe to
+// use as a fallback project-service UID. Some foundations store a Salesforce
+// ID there instead; those must NEVER be passed to lens navigation.
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // Limit concurrent per-project count fetches so a large foundation doesn't burst
 // N × 2 HTTP requests at once. Results are accumulated progressively so pill
 // counts and channel indicators update row-by-row as each project resolves.
@@ -110,6 +115,14 @@ export class FoundationProjectsComponent {
     this.navigateToProject(project, '/project/overview');
   }
 
+  // True when lens navigation has a trustworthy canonical project-service UID
+  // to hand to ProjectContextService. Prefers the slug→uid map; falls back to
+  // Snowflake's PROJECT_ID only when it looks like a UUID (not a Salesforce ID).
+  protected canOpenProjectLens(project: ProjectTableRow): boolean {
+    if (this.subProjectUidBySlug().has(project.projectSlug)) return true;
+    return !!project.projectId && UUID_V4_REGEX.test(project.projectId);
+  }
+
   protected getCountFor(project: ProjectTableRow): ProjectCounts {
     return this.projectCounts()[project.projectSlug] ?? { committees: 0, mailingLists: 0, hasChat: false };
   }
@@ -139,7 +152,15 @@ export class FoundationProjectsComponent {
           // Error handling lives in AnalyticsService.getFoundationProjectsDetail,
           // which returns `{ projects: [], totalCount: 0 }` on failure and evicts
           // the failed slug from its cache. No component-level catchError needed.
-          return this.analyticsService.getFoundationProjectsDetail(slug).pipe(finalize(() => this.loading.set(false)));
+          // `startWith(DEFAULT)` clears rawData immediately on slug change,
+          // symmetric with `subProjectUidBySlug`'s own startWith. Without it,
+          // `initProjectCounts`'s combineLatest could briefly pair the NEW
+          // slug→uid map with the OLD projects list and fire count fetches
+          // against the wrong data.
+          return this.analyticsService.getFoundationProjectsDetail(slug).pipe(
+            startWith(DEFAULT_FOUNDATION_PROJECTS_DETAIL),
+            finalize(() => this.loading.set(false))
+          );
         })
       ),
       { initialValue: DEFAULT_FOUNDATION_PROJECTS_DETAIL }
@@ -179,12 +200,14 @@ export class FoundationProjectsComponent {
   }
 
   private navigateToProject(project: ProjectTableRow, destination: string): void {
-    // Prefer the canonical project-service UID resolved from the foundation's
-    // sub-project listing; fall back to Snowflake's PROJECT_ID only if the
-    // sub-projects response hasn't landed or the slug isn't in the map. The
-    // resolved UID is the same identifier that committee/mailing-list tagging
-    // uses, so lens switching consistently lands on the right project.
-    const resolvedUid = this.subProjectUidBySlug().get(project.projectSlug) ?? project.projectId;
+    // Resolve the canonical project-service UID from the foundation's sub-project
+    // listing — this is the same identifier that committee/mailing-list tagging
+    // uses. Only fall back to Snowflake's PROJECT_ID when it's already a UUID;
+    // some foundations' PROJECT_ID is a Salesforce ID, which would lens-switch
+    // to the wrong (or invalid) project. If neither is available, no-op — the
+    // template's [disabled] binding should have blocked this click anyway.
+    const mappedUid = this.subProjectUidBySlug().get(project.projectSlug);
+    const resolvedUid = mappedUid ?? (project.projectId && UUID_V4_REGEX.test(project.projectId) ? project.projectId : undefined);
     if (!resolvedUid) {
       return;
     }

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
@@ -166,32 +166,6 @@ export class FoundationProjectsComponent {
     });
   }
 
-  private navigateToProject(project: ProjectTableRow, destination: string): void {
-    // Resolve the canonical project-service UID from the foundation's sub-project
-    // listing — this is the same identifier that committee/mailing-list tagging
-    // uses. Only fall back to Snowflake's PROJECT_ID when it's already a UUID;
-    // some foundations' PROJECT_ID is a Salesforce ID, which would lens-switch
-    // to the wrong (or invalid) project. If neither is available, no-op — the
-    // template's [disabled] binding should have blocked this click anyway.
-    const mappedUid = this.subProjectUidBySlug().get(project.projectSlug);
-    let resolvedUid: string | undefined;
-    if (mappedUid) {
-      resolvedUid = mappedUid;
-    } else if (project.projectId && UUID_REGEX.test(project.projectId)) {
-      resolvedUid = project.projectId;
-    }
-    if (!resolvedUid) {
-      return;
-    }
-    this.projectContextService.setProject({
-      uid: resolvedUid,
-      name: project.projectName,
-      slug: project.projectSlug,
-    });
-    this.lensService.setLens('project');
-    this.router.navigate([destination]);
-  }
-
   private initFilteredProjects(): Signal<ProjectTableRow[]> {
     return computed(() => {
       const query = this.searchQuery().toLowerCase().trim();
@@ -336,5 +310,32 @@ export class FoundationProjectsComponent {
         { id: 'without-channels', label: `Without Channels (${withoutChannels})` },
       ];
     });
+  }
+
+  // === Private Helper Methods ===
+  private navigateToProject(project: ProjectTableRow, destination: string): void {
+    // Resolve the canonical project-service UID from the foundation's sub-project
+    // listing — this is the same identifier that committee/mailing-list tagging
+    // uses. Only fall back to Snowflake's PROJECT_ID when it's already a UUID;
+    // some foundations' PROJECT_ID is a Salesforce ID, which would lens-switch
+    // to the wrong (or invalid) project. If neither is available, no-op — the
+    // template's [disabled] binding should have blocked this click anyway.
+    const mappedUid = this.subProjectUidBySlug().get(project.projectSlug);
+    let resolvedUid: string | undefined;
+    if (mappedUid) {
+      resolvedUid = mappedUid;
+    } else if (project.projectId && UUID_REGEX.test(project.projectId)) {
+      resolvedUid = project.projectId;
+    }
+    if (!resolvedUid) {
+      return;
+    }
+    this.projectContextService.setProject({
+      uid: resolvedUid,
+      name: project.projectName,
+      slug: project.projectSlug,
+    });
+    this.lensService.setLens('project');
+    this.router.navigate([destination]);
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
@@ -260,8 +260,12 @@ export class FoundationProjectsComponent {
     return toSignal(
       combineLatest([toObservable(this.allProjects), toObservable(this.subProjectUidBySlug)]).pipe(
         switchMap(([projects, slugToUid]) => {
-          if (projects.length === 0 || slugToUid.size === 0) {
+          if (projects.length === 0) {
             this.countsLoading.set(false);
+            return of(new Map<string, ProjectCounts>());
+          }
+          if (slugToUid.size === 0) {
+            this.countsLoading.set(true);
             return of(new Map<string, ProjectCounts>());
           }
           this.countsLoading.set(true);

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
@@ -96,7 +96,7 @@ export class FoundationProjectsComponent {
   }
 
   protected getCountFor(project: ProjectTableRow): ProjectCounts {
-    return this.projectCounts().get(project.projectSlug) ?? { committees: 0, mailingLists: 0, hasChat: false };
+    return this.projectCounts().get(project.projectSlug) ?? { committees: undefined, mailingLists: undefined, hasChat: undefined };
   }
 
   protected onPillChange(pillId: string): void {
@@ -189,12 +189,15 @@ export class FoundationProjectsComponent {
       return this.allProjects().filter((project) => {
         if (query && !project.projectName.toLowerCase().includes(query)) return false;
         const row = counts.get(project.projectSlug);
-        const committees = row?.committees ?? 0;
-        const channels = hasAnyChannel(row);
-        if (pill === 'with-groups' && committees === 0) return false;
-        if (pill === 'without-groups' && committees > 0) return false;
-        if (pill === 'with-channels' && !channels) return false;
-        if (pill === 'without-channels' && channels) return false;
+        const committees = row?.committees;
+        // hasAnyChannel returns undefined while channel fields are still in-flight.
+        // Pending rows are excluded from both "with" and "without" filters so they
+        // never inflate the "Without Channels/Groups" count while loading.
+        const channelStatus = hasAnyChannel(row);
+        if (pill === 'with-groups' && (committees === undefined || committees === 0)) return false;
+        if (pill === 'without-groups' && (committees === undefined || committees > 0)) return false;
+        if (pill === 'with-channels' && channelStatus !== true) return false;
+        if (pill === 'without-channels' && channelStatus !== false) return false;
         return true;
       });
     });
@@ -264,7 +267,10 @@ export class FoundationProjectsComponent {
           this.countsLoading.set(true);
           const initialCounts = new Map<string, ProjectCounts>();
           for (const project of projects) {
-            initialCounts.set(project.projectSlug, { committees: 0, mailingLists: 0, hasChat: false });
+            // undefined fields signal "pending" — distinct from confirmed zero.
+            // Pending rows are excluded from "With/Without" filter pills so they
+            // never inflate the "Without" count while requests are still in flight.
+            initialCounts.set(project.projectSlug, { committees: undefined, mailingLists: undefined, hasChat: undefined });
           }
           const requests: Observable<{ slug: string; committees?: number; hasChat?: boolean; mailingLists?: number }>[] = [];
           for (const project of projects) {
@@ -293,7 +299,7 @@ export class FoundationProjectsComponent {
           return from(requests).pipe(
             mergeMap((req$) => req$, FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY),
             scan((acc, result) => {
-              const existing = acc.get(result.slug) ?? { committees: 0, mailingLists: 0, hasChat: false };
+              const existing = acc.get(result.slug) ?? { committees: undefined, mailingLists: undefined, hasChat: undefined };
               const next = new Map(acc);
               next.set(result.slug, {
                 committees: result.committees ?? existing.committees,
@@ -324,7 +330,10 @@ export class FoundationProjectsComponent {
       const withoutGroups = projects.length - withGroups;
       // Channels = mailing lists OR chat channel. A project with just a chat
       // channel should still count as "with channels" to match the Channels column.
-      const withChannels = projects.filter((p) => hasAnyChannel(counts.get(p.projectSlug))).length;
+      // hasAnyChannel returns `true | false | undefined`; treat undefined (pending)
+      // the same as false for the running pill count while `countsStreaming` hides
+      // the suffix anyway.
+      const withChannels = projects.filter((p) => hasAnyChannel(counts.get(p.projectSlug)) === true).length;
       const withoutChannels = projects.length - withChannels;
       const suffix = (n: number): string => (countsStreaming ? '' : ` (${n})`);
       return [

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
@@ -25,6 +25,7 @@ import { LensService } from '@services/lens.service';
 import { MailingListService } from '@services/mailing-list.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
+import { TooltipModule } from 'primeng/tooltip';
 import { bufferTime, catchError, combineLatest, filter, finalize, from, map, mergeMap, Observable, of, scan, startWith, switchMap } from 'rxjs';
 
 import type {
@@ -40,7 +41,7 @@ import type {
 
 @Component({
   selector: 'lfx-foundation-projects',
-  imports: [DecimalPipe, ReactiveFormsModule, FilterPillsComponent, InputTextComponent, StatCardGridComponent, TableComponent],
+  imports: [DecimalPipe, ReactiveFormsModule, FilterPillsComponent, InputTextComponent, StatCardGridComponent, TableComponent, TooltipModule],
   templateUrl: './foundation-projects.component.html',
   styleUrl: './foundation-projects.component.scss',
 })
@@ -343,15 +344,17 @@ export class FoundationProjectsComponent {
       // "With Groups (0)" → "(1)" → "(2)" per resolved row. The "All (N)" count
       // is sourced from rawData and is stable from first paint, so it stays.
       const countsStreaming = this.countsLoading();
+      // Count explicit resolved states so pending rows (committees / hasAnyChannel
+      // === undefined) are excluded from BOTH "with" and "without" buckets — matching
+      // initFilteredProjects, which also excludes undefined from both views. Without
+      // this, rows without a slug→uid mapping stay pending permanently and would
+      // inflate the "without" suffix counts vs. the actually-rendered row count.
       const withGroups = projects.filter((p) => (counts.get(p.projectSlug)?.committees ?? 0) > 0).length;
-      const withoutGroups = projects.length - withGroups;
+      const withoutGroups = projects.filter((p) => counts.get(p.projectSlug)?.committees === 0).length;
       // Channels = mailing lists OR chat channel. A project with just a chat
       // channel should still count as "with channels" to match the Channels column.
-      // hasAnyChannel returns `true | false | undefined`; treat undefined (pending)
-      // the same as false for the running pill count while `countsStreaming` hides
-      // the suffix anyway.
       const withChannels = projects.filter((p) => hasAnyChannel(counts.get(p.projectSlug)) === true).length;
-      const withoutChannels = projects.length - withChannels;
+      const withoutChannels = projects.filter((p) => hasAnyChannel(counts.get(p.projectSlug)) === false).length;
       const suffix = (n: number): string => (countsStreaming ? '' : ` (${n})`);
       return [
         { id: 'all', label: `All (${projects.length})` },

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
@@ -11,7 +11,7 @@ import { FilterPillsComponent } from '@components/filter-pills/filter-pills.comp
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
 import { TableComponent } from '@components/table/table.component';
-import { DEFAULT_FOUNDATION_PROJECTS_DETAIL, FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY, UUID_REGEX } from '@lfx-one/shared/constants';
+import { DEFAULT_FOUNDATION_PROJECTS_DETAIL, FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY, PRESENCE_PILL_IDS, UUID_REGEX } from '@lfx-one/shared/constants';
 import { buildLensAwareInsightsUrl, hasAnyChannel } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { CommitteeService } from '@services/committee.service';
@@ -55,6 +55,11 @@ export class FoundationProjectsComponent {
   // === Simple WritableSignals ===
   protected readonly loading = signal(false);
   protected readonly activePill = signal<PresencePill>('all');
+  // True while any of the per-project committee / mailing-list count fetches
+  // are still in flight. Flips to false once the mergeMap stream completes.
+  // Used by `initPillOptions` to hide the count suffix during progressive
+  // loading so "With Groups" doesn't flicker 0 → 1 → 2 → 3 per resolution.
+  protected readonly countsLoading = signal(false);
 
   // === Computed/toSignal Signals ===
   protected readonly foundationSlug: Signal<string> = computed(() => this.projectContextService.selectedFoundation()?.slug ?? '');
@@ -95,6 +100,11 @@ export class FoundationProjectsComponent {
   }
 
   protected onPillChange(pillId: string): void {
+    // Runtime-validate against PRESENCE_PILL_IDS (the same tuple PresencePill
+    // is derived from). An unknown id is a contract bug — silently no-op
+    // rather than cast-through, which would short-circuit all filter branches
+    // and look like "All" while not being semantically "all".
+    if (!(PRESENCE_PILL_IDS as readonly string[]).includes(pillId)) return;
     this.activePill.set(pillId as PresencePill);
   }
 
@@ -103,6 +113,11 @@ export class FoundationProjectsComponent {
     return toSignal(
       toObservable(this.foundationSlug).pipe(
         switchMap((slug) => {
+          // Reset the presence filter back to "All" on every foundation change
+          // so a selection from the previous foundation (e.g. "With Groups")
+          // doesn't silently narrow the new foundation's table while the pill
+          // still appears active.
+          this.activePill.set('all');
           // Handle the empty-slug case inside switchMap (not via an upstream `filter`)
           // so that clearing the foundation also cancels any in-flight request for the
           // previous slug — otherwise the old fetch could complete and overwrite
@@ -243,8 +258,10 @@ export class FoundationProjectsComponent {
       combineLatest([toObservable(this.allProjects), toObservable(this.subProjectUidBySlug)]).pipe(
         switchMap(([projects, slugToUid]) => {
           if (projects.length === 0 || slugToUid.size === 0) {
+            this.countsLoading.set(false);
             return of(new Map<string, ProjectCounts>());
           }
+          this.countsLoading.set(true);
           const initialCounts = new Map<string, ProjectCounts>();
           for (const project of projects) {
             initialCounts.set(project.projectSlug, { committees: 0, mailingLists: 0, hasChat: false });
@@ -270,6 +287,7 @@ export class FoundationProjectsComponent {
             );
           }
           if (requests.length === 0) {
+            this.countsLoading.set(false);
             return of(initialCounts);
           }
           return from(requests).pipe(
@@ -284,7 +302,8 @@ export class FoundationProjectsComponent {
               });
               return next;
             }, initialCounts),
-            startWith(initialCounts)
+            startWith(initialCounts),
+            finalize(() => this.countsLoading.set(false))
           );
         })
       ),
@@ -296,18 +315,24 @@ export class FoundationProjectsComponent {
     return computed(() => {
       const projects = this.allProjects();
       const counts = this.projectCounts();
+      // Hide the presence-pill count suffixes while per-project committee /
+      // mailing-list fetches are still streaming in — otherwise labels flicker
+      // "With Groups (0)" → "(1)" → "(2)" per resolved row. The "All (N)" count
+      // is sourced from rawData and is stable from first paint, so it stays.
+      const countsStreaming = this.countsLoading();
       const withGroups = projects.filter((p) => (counts.get(p.projectSlug)?.committees ?? 0) > 0).length;
       const withoutGroups = projects.length - withGroups;
       // Channels = mailing lists OR chat channel. A project with just a chat
       // channel should still count as "with channels" to match the Channels column.
       const withChannels = projects.filter((p) => hasAnyChannel(counts.get(p.projectSlug))).length;
       const withoutChannels = projects.length - withChannels;
+      const suffix = (n: number): string => (countsStreaming ? '' : ` (${n})`);
       return [
         { id: 'all', label: `All (${projects.length})` },
-        { id: 'with-groups', label: `With Groups (${withGroups})` },
-        { id: 'without-groups', label: `Without Groups (${withoutGroups})` },
-        { id: 'with-channels', label: `With Channels (${withChannels})` },
-        { id: 'without-channels', label: `Without Channels (${withoutChannels})` },
+        { id: 'with-groups', label: `With Groups${suffix(withGroups)}` },
+        { id: 'without-groups', label: `Without Groups${suffix(withoutGroups)}` },
+        { id: 'with-channels', label: `With Channels${suffix(withChannels)}` },
+        { id: 'without-channels', label: `Without Channels${suffix(withoutChannels)}` },
       ];
     });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/foundation-projects/foundation-projects.component.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { DecimalPipe } from '@angular/common';
+import { HttpParams } from '@angular/common/http';
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -10,9 +11,8 @@ import { FilterPillsComponent } from '@components/filter-pills/filter-pills.comp
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
 import { TableComponent } from '@components/table/table.component';
-import { DEFAULT_FOUNDATION_PROJECTS_DETAIL } from '@lfx-one/shared/constants';
-import { buildLensAwareInsightsUrl } from '@lfx-one/shared/utils';
-import { HttpParams } from '@angular/common/http';
+import { DEFAULT_FOUNDATION_PROJECTS_DETAIL, FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY, UUID_REGEX } from '@lfx-one/shared/constants';
+import { buildLensAwareInsightsUrl, hasAnyChannel } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
@@ -29,22 +29,6 @@ import type {
   ProjectTableRow,
   StatCardItem,
 } from '@lfx-one/shared/interfaces';
-
-// UUID v4 pattern — used to decide whether Snowflake's PROJECT_ID is safe to
-// use as a fallback project-service UID. Some foundations store a Salesforce
-// ID there instead; those must NEVER be passed to lens navigation.
-const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-// Limit concurrent per-project count fetches so a large foundation doesn't burst
-// N × 2 HTTP requests at once. Results are accumulated progressively so pill
-// counts and channel indicators update row-by-row as each project resolves.
-const COUNT_FETCH_CONCURRENCY = 8;
-
-/** A project "has channels" when it has at least one mailing list OR a chat_channel. */
-function hasAnyChannel(counts: ProjectCounts | undefined): boolean {
-  if (!counts) return false;
-  return counts.mailingLists > 0 || counts.hasChat;
-}
 
 @Component({
   selector: 'lfx-foundation-projects',
@@ -86,24 +70,8 @@ export class FoundationProjectsComponent {
   // (lens context uid) so we never fall back to the ambiguous Snowflake PROJECT_ID
   // when the correct project-service UID is already on hand.
   private readonly subProjectUidBySlug: Signal<Map<string, string>> = this.initSubProjectUidBySlug();
-  protected readonly projectCounts: Signal<Record<string, ProjectCounts>> = this.initProjectCounts();
-  protected readonly pillOptions: Signal<FilterPillOption[]> = computed(() => {
-    const projects = this.allProjects();
-    const counts = this.projectCounts();
-    const withGroups = projects.filter((p) => (counts[p.projectSlug]?.committees ?? 0) > 0).length;
-    const withoutGroups = projects.length - withGroups;
-    // Channels = mailing lists OR chat channel. A project with just a chat
-    // channel should still count as "with channels" to match the Channels column.
-    const withChannels = projects.filter((p) => hasAnyChannel(counts[p.projectSlug])).length;
-    const withoutChannels = projects.length - withChannels;
-    return [
-      { id: 'all', label: `All (${projects.length})` },
-      { id: 'with-groups', label: `With Groups (${withGroups})` },
-      { id: 'without-groups', label: `Without Groups (${withoutGroups})` },
-      { id: 'with-channels', label: `With Channels (${withChannels})` },
-      { id: 'without-channels', label: `Without Channels (${withoutChannels})` },
-    ];
-  });
+  protected readonly projectCounts: Signal<Map<string, ProjectCounts>> = this.initProjectCounts();
+  protected readonly pillOptions: Signal<FilterPillOption[]> = this.initPillOptions();
 
   // === Protected Methods ===
   protected getInsightsUrl(slug: string): string {
@@ -119,11 +87,11 @@ export class FoundationProjectsComponent {
   // Snowflake's PROJECT_ID only when it looks like a UUID (not a Salesforce ID).
   protected canOpenProjectLens(project: ProjectTableRow): boolean {
     if (this.subProjectUidBySlug().has(project.projectSlug)) return true;
-    return !!project.projectId && UUID_V4_REGEX.test(project.projectId);
+    return !!project.projectId && UUID_REGEX.test(project.projectId);
   }
 
   protected getCountFor(project: ProjectTableRow): ProjectCounts {
-    return this.projectCounts()[project.projectSlug] ?? { committees: 0, mailingLists: 0, hasChat: false };
+    return this.projectCounts().get(project.projectSlug) ?? { committees: 0, mailingLists: 0, hasChat: false };
   }
 
   protected onPillChange(pillId: string): void {
@@ -206,7 +174,12 @@ export class FoundationProjectsComponent {
     // to the wrong (or invalid) project. If neither is available, no-op — the
     // template's [disabled] binding should have blocked this click anyway.
     const mappedUid = this.subProjectUidBySlug().get(project.projectSlug);
-    const resolvedUid = mappedUid ?? (project.projectId && UUID_V4_REGEX.test(project.projectId) ? project.projectId : undefined);
+    let resolvedUid: string | undefined;
+    if (mappedUid) {
+      resolvedUid = mappedUid;
+    } else if (project.projectId && UUID_REGEX.test(project.projectId)) {
+      resolvedUid = project.projectId;
+    }
     if (!resolvedUid) {
       return;
     }
@@ -226,7 +199,7 @@ export class FoundationProjectsComponent {
       const counts = this.projectCounts();
       return this.allProjects().filter((project) => {
         if (query && !project.projectName.toLowerCase().includes(query)) return false;
-        const row = counts[project.projectSlug];
+        const row = counts.get(project.projectSlug);
         const committees = row?.committees ?? 0;
         const channels = hasAnyChannel(row);
         if (pill === 'with-groups' && committees === 0) return false;
@@ -287,19 +260,20 @@ export class FoundationProjectsComponent {
   //   1. Loads only when a user visits /foundation/projects (page-scoped, not site-wide).
   //   2. Chat-channel presence requires the committee list (no lightweight endpoint
   //      exposes `chat_channel` membership today).
-  //   3. Concurrency is capped via COUNT_FETCH_CONCURRENCY to avoid flooding the BFF.
+  //   3. Concurrency is capped via FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY to
+  //      avoid flooding the BFF.
   // Long-term fix: add a Snowflake-aggregated column or a lightweight
   // /api/committees/chat-exists?tags=project_uid:X endpoint.
-  private initProjectCounts(): Signal<Record<string, ProjectCounts>> {
+  private initProjectCounts(): Signal<Map<string, ProjectCounts>> {
     return toSignal(
       combineLatest([toObservable(this.allProjects), toObservable(this.subProjectUidBySlug)]).pipe(
         switchMap(([projects, slugToUid]) => {
           if (projects.length === 0 || slugToUid.size === 0) {
-            return of({} as Record<string, ProjectCounts>);
+            return of(new Map<string, ProjectCounts>());
           }
-          const initialCounts: Record<string, ProjectCounts> = {};
+          const initialCounts = new Map<string, ProjectCounts>();
           for (const project of projects) {
-            initialCounts[project.projectSlug] = { committees: 0, mailingLists: 0, hasChat: false };
+            initialCounts.set(project.projectSlug, { committees: 0, mailingLists: 0, hasChat: false });
           }
           const requests: Observable<{ slug: string; committees?: number; hasChat?: boolean; mailingLists?: number }>[] = [];
           for (const project of projects) {
@@ -325,19 +299,42 @@ export class FoundationProjectsComponent {
             return of(initialCounts);
           }
           return from(requests).pipe(
-            mergeMap((req$) => req$, COUNT_FETCH_CONCURRENCY),
+            mergeMap((req$) => req$, FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY),
             scan((acc, result) => {
-              const next = { ...acc, [result.slug]: { ...acc[result.slug] } };
-              if (result.committees !== undefined) next[result.slug].committees = result.committees;
-              if (result.hasChat !== undefined) next[result.slug].hasChat = result.hasChat;
-              if (result.mailingLists !== undefined) next[result.slug].mailingLists = result.mailingLists;
+              const existing = acc.get(result.slug) ?? { committees: 0, mailingLists: 0, hasChat: false };
+              const next = new Map(acc);
+              next.set(result.slug, {
+                committees: result.committees ?? existing.committees,
+                mailingLists: result.mailingLists ?? existing.mailingLists,
+                hasChat: result.hasChat ?? existing.hasChat,
+              });
               return next;
             }, initialCounts),
             startWith(initialCounts)
           );
         })
       ),
-      { initialValue: {} as Record<string, ProjectCounts> }
+      { initialValue: new Map<string, ProjectCounts>() }
     );
+  }
+
+  private initPillOptions(): Signal<FilterPillOption[]> {
+    return computed(() => {
+      const projects = this.allProjects();
+      const counts = this.projectCounts();
+      const withGroups = projects.filter((p) => (counts.get(p.projectSlug)?.committees ?? 0) > 0).length;
+      const withoutGroups = projects.length - withGroups;
+      // Channels = mailing lists OR chat channel. A project with just a chat
+      // channel should still count as "with channels" to match the Channels column.
+      const withChannels = projects.filter((p) => hasAnyChannel(counts.get(p.projectSlug))).length;
+      const withoutChannels = projects.length - withChannels;
+      return [
+        { id: 'all', label: `All (${projects.length})` },
+        { id: 'with-groups', label: `With Groups (${withGroups})` },
+        { id: 'without-groups', label: `Without Groups (${withoutGroups})` },
+        { id: 'with-channels', label: `With Channels (${withChannels})` },
+        { id: 'without-channels', label: `Without Channels (${withoutChannels})` },
+      ];
+    });
   }
 }

--- a/packages/shared/src/constants/foundation-projects.constants.ts
+++ b/packages/shared/src/constants/foundation-projects.constants.ts
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Maximum concurrent per-project count fetches fired by the foundation
- * projects page. Caps the burst for large foundations (hundreds of projects)
- * so the BFF is not flooded by N × 2 in-flight requests on initial load.
- * Results accumulate progressively — channel/group indicators light up
- * row-by-row as each project resolves.
+ * Maximum number of concurrent HTTP request subscriptions fired by the
+ * foundation projects page. Each project issues 2 requests (committees +
+ * mailing-lists), so this value caps concurrent request subscriptions, not
+ * projects — a value of 8 keeps approximately 4 projects in flight at once.
+ * Prevents large foundations (hundreds of projects) from flooding the BFF
+ * with N × 2 simultaneous requests on initial load. Results accumulate
+ * progressively — channel/group indicators light up row-by-row as each
+ * project resolves.
  */
 export const FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY = 8;
 

--- a/packages/shared/src/constants/foundation-projects.constants.ts
+++ b/packages/shared/src/constants/foundation-projects.constants.ts
@@ -9,3 +9,12 @@
  * row-by-row as each project resolves.
  */
 export const FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY = 8;
+
+/**
+ * All valid presence-filter pill IDs on the foundation projects page, in
+ * display order. Source of truth for the {@link PresencePill} type, which
+ * is derived from this tuple — so adding or removing an ID here updates the
+ * type automatically and keeps the runtime validator (`onPillChange`) in
+ * sync with the TypeScript union.
+ */
+export const PRESENCE_PILL_IDS = ['all', 'with-groups', 'without-groups', 'with-channels', 'without-channels'] as const;

--- a/packages/shared/src/constants/foundation-projects.constants.ts
+++ b/packages/shared/src/constants/foundation-projects.constants.ts
@@ -1,0 +1,11 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Maximum concurrent per-project count fetches fired by the foundation
+ * projects page. Caps the burst for large foundations (hundreds of projects)
+ * so the BFF is not flooded by N × 2 in-flight requests on initial load.
+ * Results accumulate progressively — channel/group indicators light up
+ * row-by-row as each project resolves.
+ */
+export const FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY = 8;

--- a/packages/shared/src/constants/foundation-projects.constants.ts
+++ b/packages/shared/src/constants/foundation-projects.constants.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { FoundationProjectRowView } from '../interfaces/dashboard-metric.interface';
+
 /**
  * Maximum number of concurrent HTTP request subscriptions fired by the
  * foundation projects page. Each project issues 2 requests (committees +
@@ -21,3 +23,19 @@ export const FOUNDATION_PROJECT_COUNT_FETCH_CONCURRENCY = 8;
  * sync with the TypeScript union.
  */
 export const PRESENCE_PILL_IDS = ['all', 'with-groups', 'without-groups', 'with-channels', 'without-channels'] as const;
+
+/**
+ * Fallback row view used when the precomputed `projectRowViews` map has no
+ * entry for a given project slug (transient — e.g. a new project arriving
+ * before the view-computed has rebuilt). Mirrors a fully-pending row with
+ * all display labels set to `"Loading"`.
+ */
+export const DEFAULT_FOUNDATION_PROJECT_ROW_VIEW: FoundationProjectRowView = {
+  lensReady: false,
+  groupsPresence: 'pending',
+  mailingListsPresence: 'pending',
+  chatPresence: 'pending',
+  groupsText: 'Loading',
+  mailingListsText: 'Loading',
+  chatText: 'Loading',
+};

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -46,3 +46,5 @@ export * from './training.constants';
 export * from './documents.constants';
 export * from './transaction.constants';
 export * from './rewards.constants';
+export * from './regex.constants';
+export * from './foundation-projects.constants';

--- a/packages/shared/src/constants/regex.constants.ts
+++ b/packages/shared/src/constants/regex.constants.ts
@@ -1,0 +1,11 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Matches any UUID-shaped string (8-4-4-4-12 hex groups). Does NOT enforce
+ * the v4 version/variant bits — it is intentionally permissive so callers
+ * can recognize any canonical UUID produced by project-service / other LFX
+ * microservices, not only v4. Use this to distinguish a project-service UUID
+ * from a Salesforce-style ID before handing the value to downstream lookups.
+ */
+export const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -306,6 +306,38 @@ export interface ProjectCounts {
  */
 export type PresencePill = (typeof PRESENCE_PILL_IDS)[number];
 
+/**
+ * Three-state presence marker for an individual indicator (groups, mailing
+ * lists, chat) on the foundation projects row. `'pending'` = upstream request
+ * still in flight; `'present'` = confirmed non-zero count / truthy flag;
+ * `'absent'` = confirmed zero / falsy resolution.
+ */
+export type PresenceState = 'present' | 'absent' | 'pending';
+
+/**
+ * Pre-computed per-row display data for the foundation projects table.
+ * Derived once per row by a computed signal so the template can consume bare
+ * property reads (no component-method calls during change detection). Tooltip
+ * strings and presence-state enums are computed once per counts-update and
+ * reused across every CD cycle.
+ */
+export interface FoundationProjectRowView {
+  /** True when lens navigation has a trustworthy project-service UID to hand to `ProjectContextService`. */
+  lensReady: boolean;
+  /** Three-state marker for the groups icon — drives icon class bindings. */
+  groupsPresence: PresenceState;
+  /** Three-state marker for the mailing-lists icon. */
+  mailingListsPresence: PresenceState;
+  /** Three-state marker for the chat icon. */
+  chatPresence: PresenceState;
+  /** Tooltip / sr-only label for the groups icon, e.g. `"3 groups"`, `"1 group"`, or `"Loading"`. */
+  groupsText: string;
+  /** Tooltip / sr-only label for the mailing-lists icon. */
+  mailingListsText: string;
+  /** Tooltip / sr-only label for the chat icon — `"Chat configured"`, `"No chat configured"`, or `"Loading"`. */
+  chatText: string;
+}
+
 // ============================================
 // Health Metrics Page (Summary Cards)
 // ============================================

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -275,6 +275,27 @@ export interface ProjectTableRow {
   lastUpdated: string | null;
 }
 
+/**
+ * Per-project group/channel indicator counts for the foundation projects page.
+ * Populated row-by-row from upstream committee + mailing-list queries; drives
+ * the Groups and Channels column icons and the presence filter pills.
+ */
+export interface ProjectCounts {
+  /** Number of committees (groups) scoped to this project via `project_uid` tag. */
+  committees: number;
+  /** Number of mailing lists scoped to this project via `project_uid` tag. */
+  mailingLists: number;
+  /** True when any committee on this project has a `chat_channel` configured. */
+  hasChat: boolean;
+}
+
+/**
+ * Filter pill identifiers for the foundation projects page presence filter.
+ * `channels` = mailing lists OR chat, so a project with just a chat channel
+ * still lands in the "with-channels" bucket.
+ */
+export type PresencePill = 'all' | 'with-groups' | 'without-groups' | 'with-channels' | 'without-channels';
+
 // ============================================
 // Health Metrics Page (Summary Cards)
 // ============================================

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -281,14 +281,20 @@ export interface ProjectTableRow {
  * Per-project group/channel indicator counts for the foundation projects page.
  * Populated row-by-row from upstream committee + mailing-list queries; drives
  * the Groups and Channels column icons and the presence filter pills.
+ *
+ * Fields are `undefined` while the corresponding upstream request is still in
+ * flight (pending state). Once the request resolves — or fails — they become a
+ * concrete number / boolean. This allows the UI to distinguish "not yet loaded"
+ * from "confirmed zero / false" and avoid showing unresolved rows as confirmed
+ * absent in the filter pills.
  */
 export interface ProjectCounts {
-  /** Number of committees (groups) scoped to this project via `project_uid` tag. */
-  committees: number;
-  /** Number of mailing lists scoped to this project via `project_uid` tag. */
-  mailingLists: number;
-  /** True when any committee on this project has a `chat_channel` configured. */
-  hasChat: boolean;
+  /** Number of committees (groups) scoped to this project via `project_uid` tag. `undefined` while the request is in-flight. */
+  committees: number | undefined;
+  /** Number of mailing lists scoped to this project via `project_uid` tag. `undefined` while the request is in-flight. */
+  mailingLists: number | undefined;
+  /** True when any committee on this project has a `chat_channel` configured. `undefined` while the request is in-flight. */
+  hasChat: boolean | undefined;
 }
 
 /**

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -3,7 +3,7 @@
 
 import type { ChartData, ChartOptions, ChartType } from 'chart.js';
 
-import type { PRESENCE_PILL_IDS } from '../constants/foundation-projects.constants';
+import { PRESENCE_PILL_IDS } from '../constants/foundation-projects.constants';
 
 /**
  * Health score type for foundations

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -3,6 +3,8 @@
 
 import type { ChartData, ChartOptions, ChartType } from 'chart.js';
 
+import type { PRESENCE_PILL_IDS } from '../constants/foundation-projects.constants';
+
 /**
  * Health score type for foundations
  * @description Indicates the overall health status of a foundation
@@ -292,9 +294,11 @@ export interface ProjectCounts {
 /**
  * Filter pill identifiers for the foundation projects page presence filter.
  * `channels` = mailing lists OR chat, so a project with just a chat channel
- * still lands in the "with-channels" bucket.
+ * still lands in the "with-channels" bucket. Derived from the
+ * {@link PRESENCE_PILL_IDS} tuple so the runtime validator and the static
+ * union can never drift apart.
  */
-export type PresencePill = 'all' | 'with-groups' | 'without-groups' | 'with-channels' | 'without-channels';
+export type PresencePill = (typeof PRESENCE_PILL_IDS)[number];
 
 // ============================================
 // Health Metrics Page (Summary Cards)

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -23,3 +23,4 @@ export * from './flywheel.utils';
 export * from './rewards.utils';
 export * from './insights.utils';
 export * from './pagination.utils';
+export * from './project-counts.utils';

--- a/packages/shared/src/utils/project-counts.utils.ts
+++ b/packages/shared/src/utils/project-counts.utils.ts
@@ -10,17 +10,21 @@ import type { ProjectCounts } from '../interfaces';
  * project with only a chat channel (no mailing lists) still counts as
  * "with channels".
  *
- * Returns `undefined` when neither the `mailingLists` nor the `hasChat` field
- * has resolved yet (i.e., both are still `undefined` / in-flight). This lets
- * callers distinguish "pending" from "confirmed no channels" and avoid
- * counting unresolved rows as absent in the "Without Channels" filter.
+ * Resolution rules:
+ * - `true` as soon as either field confirms presence (short-circuits even
+ *   while the other source is still in-flight).
+ * - `undefined` when either field is still pending and no presence has been
+ *   confirmed yet — so callers can distinguish "loading" from
+ *   "confirmed no channels" and avoid counting unresolved rows as absent.
+ * - `false` only once both sources have resolved to `0` / `false`.
  */
 export function hasAnyChannel(counts: ProjectCounts | undefined): boolean | undefined {
   if (!counts) return undefined;
-  // If at least one channel field is confirmed present, short-circuit immediately.
-  if ((counts.mailingLists ?? 0) > 0 || counts.hasChat === true) return true;
-  // If both channel fields are still pending, the channel status is unknown.
-  if (counts.mailingLists === undefined && counts.hasChat === undefined) return undefined;
-  // Both fields have resolved (to 0 / false) — confirmed no channels.
+  // Confirmed presence short-circuits — don't wait on the other source.
+  if (counts.mailingLists !== undefined && counts.mailingLists > 0) return true;
+  if (counts.hasChat === true) return true;
+  // Either field still pending → channel status is unknown.
+  if (counts.mailingLists === undefined || counts.hasChat === undefined) return undefined;
+  // Both fields resolved to 0 / false — confirmed no channels.
   return false;
 }

--- a/packages/shared/src/utils/project-counts.utils.ts
+++ b/packages/shared/src/utils/project-counts.utils.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { ProjectCounts } from '../interfaces';
+
+/**
+ * A project "has channels" when it has at least one mailing list OR a chat
+ * channel configured on any committee. Used by the foundation projects page
+ * to drive the Channels column icons and the presence filter pills — a
+ * project with only a chat channel (no mailing lists) still counts as
+ * "with channels".
+ */
+export function hasAnyChannel(counts: ProjectCounts | undefined): boolean {
+  return !!counts && (counts.mailingLists > 0 || counts.hasChat);
+}

--- a/packages/shared/src/utils/project-counts.utils.ts
+++ b/packages/shared/src/utils/project-counts.utils.ts
@@ -9,7 +9,18 @@ import type { ProjectCounts } from '../interfaces';
  * to drive the Channels column icons and the presence filter pills — a
  * project with only a chat channel (no mailing lists) still counts as
  * "with channels".
+ *
+ * Returns `undefined` when neither the `mailingLists` nor the `hasChat` field
+ * has resolved yet (i.e., both are still `undefined` / in-flight). This lets
+ * callers distinguish "pending" from "confirmed no channels" and avoid
+ * counting unresolved rows as absent in the "Without Channels" filter.
  */
-export function hasAnyChannel(counts: ProjectCounts | undefined): boolean {
-  return !!counts && (counts.mailingLists > 0 || counts.hasChat);
+export function hasAnyChannel(counts: ProjectCounts | undefined): boolean | undefined {
+  if (!counts) return undefined;
+  // If at least one channel field is confirmed present, short-circuit immediately.
+  if ((counts.mailingLists ?? 0) > 0 || counts.hasChat === true) return true;
+  // If both channel fields are still pending, the channel status is unknown.
+  if (counts.mailingLists === undefined && counts.hasChat === undefined) return undefined;
+  // Both fields have resolved (to 0 / false) — confirmed no channels.
+  return false;
 }


### PR DESCRIPTION
> Stacked on #588 — review after #588 lands, or review in `feat/foundation-projects-counts...feat/foundation-projects-page` range.

## Summary

- Adds **Groups** and **Channels** columns to the Foundation-lens Projects page. Both are visual indicators only (blue = present, gray = absent, tooltip shows the count).
- Channels column shows two icons per row: envelope (mailing lists) + chat bubble (committee chat channels).
- Adds filter pills above the table: `All` / `With Groups` / `Without Groups` / `With Channels` / `Without Channels`. Counts update live as data arrives.

## Data wiring

One round-trip per foundation load resolves slug → UID (`projectService.getProjects({ parent: 'project:<foundation_uid>' })`), then 2 parallel fetches per project:

1. `CommitteeService.getCommitteesByProject(uid)` — returns the list so we can derive both `committees` count and `hasChat = list.some(c => !!c.chat_channel)`
2. `MailingListService.getMailingListsCount({ tags: 'project_uid:<uid>' })` — returns the count

**Why not use Snowflake's `PROJECT_ID` directly?** It's foundation-specific (Salesforce ID on some foundations, project-service UUID on others) and doesn't reliably match the `project_uid` tag used at committee/mailing-list ingest. The slug→uid resolve gives us the canonical project-service UUID used everywhere else.

## Cost

- **1 extra call** per foundation load (slug→uid resolver)
- **2N parallel calls** per foundation (N = projects); small foundations like AAIF = 6 calls, TLF ≈ 400
- Documented in the commit message; long-term fix is a Snowflake-aggregated `COMMITTEE_COUNT`/`MAILING_LIST_COUNT` column on the platinum table
