### PR TITLE
fix(meetings): default recurrence end_date_time to 100 years when unset

### DIFF
--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -14,6 +14,7 @@ import {
   Meeting,
   MeetingAttachment,
   MeetingJoinURL,
+  MeetingRecurrence,
   MeetingRegistrant,
   MeetingRsvp,
   PaginatedResponse,
@@ -262,6 +263,7 @@ export class MeetingService {
     const createPayload = {
       ...meetingData,
       ...(username && { organizers: [username] }),
+      ...(meetingData.recurrence && { recurrence: this.normalizeRecurrence(meetingData.recurrence) }),
     };
 
     const sanitizedPayload = logger.sanitize({ createPayload });
@@ -325,6 +327,7 @@ export class MeetingService {
     const updatePayload = {
       ...meetingData,
       organizers: Array.from(organizersSet),
+      ...(meetingData.recurrence && { recurrence: this.normalizeRecurrence(meetingData.recurrence) }),
     };
 
     const sanitizedPayload = logger.sanitize({ updatePayload, editType });
@@ -1279,5 +1282,19 @@ export class MeetingService {
     }
 
     return nameMap;
+  }
+
+  /**
+   * Ensures a recurrence object always has an end condition.
+   * The upstream meeting service requires either end_date_time or end_times.
+   * Defaults to 100 years from now when neither is specified.
+   */
+  private normalizeRecurrence(recurrence: MeetingRecurrence): MeetingRecurrence {
+    if (recurrence.end_date_time || recurrence.end_times) {
+      return recurrence;
+    }
+    const hundredYearsFromNow = new Date();
+    hundredYearsFromNow.setFullYear(hundredYearsFromNow.getFullYear() + 100);
+    return { ...recurrence, end_date_time: hundredYearsFromNow.toISOString() };
   }
 }


### PR DESCRIPTION
## Summary

- Creating or updating a recurring meeting without specifying an end condition fails because the upstream meeting service requires either `end_date_time` or `end_times` on the recurrence object
- Added a private `normalizeRecurrence` helper in `meeting.service.ts` that defaults `end_date_time` to 100 years from now when neither field is set
- Applied in both `createMeeting` and `updateMeeting` before forwarding to the upstream service

## Changes

- **`meeting.service.ts`**: added `normalizeRecurrence` helper + call it in `createMeeting` and `updateMeeting`

## Test plan

- [ ] Create a recurring meeting without specifying an end date — meeting creates successfully
- [ ] Create a recurring meeting with an explicit `end_date_time` — value is passed through unchanged
- [ ] Create a recurring meeting with `end_times` — value is passed through unchanged
- [ ] Update a recurring meeting without an end condition — updates successfully
- [ ] Non-recurring meetings unaffected (no recurrence object sent)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)