### PR TITLE
fix(mailing-lists): show dash when mailing list name is empty

### DIFF
--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
@@ -123,14 +123,14 @@
           <td>
             @if (isBoardMember()) {
               <span class="text-sm font-medium" [attr.data-testid]="'mailing-list-title-' + mailingList.uid">
-                {{ mailingList.title }}
+                {{ mailingList.title || '-' }}
               </span>
             } @else {
               <a
                 [routerLink]="['/mailing-lists', mailingList.uid]"
                 class="lfx-table-name-link text-sm"
                 [attr.data-testid]="'mailing-list-title-' + mailingList.uid">
-                {{ mailingList.title }}
+                {{ mailingList.title || '-' }}
               </a>
             }
           </td>
@@ -202,11 +202,11 @@
             <div class="flex flex-col gap-1">
               @if (isBoardMember()) {
                 <span class="text-sm font-medium">
-                  {{ mailingList.title }}
+                  {{ mailingList.title || '-' }}
                 </span>
               } @else {
                 <a [routerLink]="['/mailing-lists', mailingList.uid]" class="lfx-table-name-link text-sm">
-                  {{ mailingList.title }}
+                  {{ mailingList.title || '-' }}
                 </a>
               }
               <span class="text-xs text-gray-500">{{ mailingList | groupEmail }}</span>

--- a/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
+++ b/apps/lfx-one/src/app/modules/mailing-lists/components/mailing-list-table/mailing-list-table.component.html
@@ -123,14 +123,14 @@
           <td>
             @if (isBoardMember()) {
               <span class="text-sm font-medium" [attr.data-testid]="'mailing-list-title-' + mailingList.uid">
-                {{ mailingList.title || '-' }}
+                {{ mailingList.title || mailingList.group_name || '-' }}
               </span>
             } @else {
               <a
                 [routerLink]="['/mailing-lists', mailingList.uid]"
                 class="lfx-table-name-link text-sm"
                 [attr.data-testid]="'mailing-list-title-' + mailingList.uid">
-                {{ mailingList.title || '-' }}
+                {{ mailingList.title || mailingList.group_name || '-' }}
               </a>
             }
           </td>
@@ -202,11 +202,11 @@
             <div class="flex flex-col gap-1">
               @if (isBoardMember()) {
                 <span class="text-sm font-medium">
-                  {{ mailingList.title || '-' }}
+                  {{ mailingList.title || mailingList.group_name || '-' }}
                 </span>
               } @else {
                 <a [routerLink]="['/mailing-lists', mailingList.uid]" class="lfx-table-name-link text-sm">
-                  {{ mailingList.title || '-' }}
+                  {{ mailingList.title || mailingList.group_name || '-' }}
                 </a>
               }
               <span class="text-xs text-gray-500">{{ mailingList | groupEmail }}</span>


### PR DESCRIPTION
## Summary

- When `mailingList.title` is empty, the Name column was blank instead of showing a placeholder
- Updated both the maintainer view and PMO view Name columns to display `-` when the title is empty, consistent with the Description and Public column fallback pattern

## Changes

- **`mailing-list-table.component.html`**: add `|| '-'` fallback to `mailingList.title` in all four Name column render paths (maintainer board-member span, maintainer link, PMO board-member span, PMO link)

## Test plan

- [ ] Mailing list with a title renders the title as expected
- [ ] Mailing list with an empty/missing title shows `-` in the Name column
- [ ] Both maintainer view and PMO view affected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)