### PR TITLE
fix(dashboards): use stacked bar chart for software value in Foundation Health card

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -317,8 +317,9 @@ export class FoundationHealthComponent {
   private transformSoftwareValue(metric: DashboardMetricCard): DashboardMetricCard {
     const data = this.softwareValueData();
 
-    // Incremental bucket values: top1, top2-3, top4-5, all others
+    const bucketLabels = ['Top 1', 'Top 2-3', 'Top 4-5', 'All Others'];
     const bucketValues = [data.top1Value, data.top3Value - data.top1Value, data.top5Value - data.top3Value, data.allOtherValue];
+    const bucketColors = [lfxColors.emerald[600], lfxColors.emerald[400], lfxColors.emerald[300], lfxColors.emerald[200]];
 
     return {
       ...metric,
@@ -326,31 +327,34 @@ export class FoundationHealthComponent {
       value: `$${this.formatSoftwareValue(data.totalValue)}`,
       subtitle: "Estimated total value of all foundation's projects",
       chartData: {
-        labels: ['Top 1', 'Top 2-3', 'Top 4-5', 'All Others'],
-        datasets: [
-          {
-            data: bucketValues,
-            borderColor: lfxColors.emerald[500],
-            backgroundColor: hexToRgba(lfxColors.emerald[500], 0.1),
-            fill: true,
-            tension: 0.4,
-            borderWidth: 2,
-            pointRadius: 0,
-          },
-        ],
+        labels: [''],
+        datasets: bucketLabels.map((label, i) => ({
+          label,
+          data: [bucketValues[i]],
+          backgroundColor: bucketColors[i],
+        })),
       },
       chartOptions: {
-        ...this.sparklineOptions,
+        ...this.barChartOptions,
+        scales: {
+          x: { display: false, stacked: true },
+          y: { display: false, stacked: true, min: 0 },
+        },
+        datasets: {
+          bar: {
+            barPercentage: 0.9,
+            categoryPercentage: 0.95,
+            borderRadius: 0,
+            borderSkipped: false,
+          },
+        },
         plugins: {
-          ...this.sparklineOptions.plugins,
+          legend: { display: false },
           tooltip: {
-            ...(this.sparklineOptions.plugins?.tooltip ?? {}),
+            ...(this.barChartOptions.plugins?.tooltip ?? {}),
             callbacks: {
-              title: (context) => context[0]?.label ?? '',
-              label: (context) => {
-                const value = context.parsed.y ?? 0;
-                return `Value: $${this.formatSoftwareValue(value)}`;
-              },
+              title: (context) => context[0]?.dataset?.label ?? '',
+              label: (context) => `Value: $${this.formatSoftwareValue(context.parsed.y ?? 0)}`,
             },
           },
         },

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -344,8 +344,9 @@ export class FoundationHealthComponent {
       chartOptions: {
         ...this.barChartOptions,
         scales: {
-          x: { display: false, stacked: true },
-          y: { display: false, stacked: true, min: 0 },
+          ...this.barChartOptions.scales,
+          x: { ...this.barChartOptions.scales?.['x'], display: false, stacked: true },
+          y: { ...this.barChartOptions.scales?.['y'], display: false, stacked: true, min: 0 },
         },
         datasets: {
           bar: {

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -317,6 +317,8 @@ export class FoundationHealthComponent {
   private transformSoftwareValue(metric: DashboardMetricCard): DashboardMetricCard {
     const data = this.softwareValueData();
 
+    // Incremental bucket values: top1, top2-3, top4-5, all others.
+    // Clamp to 0 so a non-monotonic API response can't render a negative segment.
     const bucketLabels = ['Top 1', 'Top 2-3', 'Top 4-5', 'All Others'];
     const bucketValues = [
       Math.max(0, data.top1Value),
@@ -347,10 +349,8 @@ export class FoundationHealthComponent {
         },
         datasets: {
           bar: {
-            barPercentage: 0.9,
-            categoryPercentage: 0.95,
+            ...this.barChartOptions.datasets?.bar,
             borderRadius: 0,
-            borderSkipped: false,
           },
         },
         interaction: { mode: 'nearest' as const, intersect: true },

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -318,7 +318,12 @@ export class FoundationHealthComponent {
     const data = this.softwareValueData();
 
     const bucketLabels = ['Top 1', 'Top 2-3', 'Top 4-5', 'All Others'];
-    const bucketValues = [data.top1Value, data.top3Value - data.top1Value, data.top5Value - data.top3Value, data.allOtherValue];
+    const bucketValues = [
+      Math.max(0, data.top1Value),
+      Math.max(0, data.top3Value - data.top1Value),
+      Math.max(0, data.top5Value - data.top3Value),
+      Math.max(0, data.allOtherValue),
+    ];
     const bucketColors = [lfxColors.emerald[600], lfxColors.emerald[400], lfxColors.emerald[300], lfxColors.emerald[200]];
 
     return {
@@ -348,10 +353,15 @@ export class FoundationHealthComponent {
             borderSkipped: false,
           },
         },
+        interaction: { mode: 'nearest' as const, intersect: true },
+        hover: { mode: 'nearest' as const, intersect: true },
         plugins: {
+          ...this.barChartOptions.plugins,
           legend: { display: false },
           tooltip: {
             ...(this.barChartOptions.plugins?.tooltip ?? {}),
+            mode: 'nearest' as const,
+            intersect: true,
             callbacks: {
               title: (context) => context[0]?.dataset?.label ?? '',
               label: (context) => `Value: $${this.formatSoftwareValue(context.parsed.y ?? 0)}`,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -184,7 +184,7 @@ export const PRIMARY_FOUNDATION_HEALTH_METRICS: DashboardMetricCard[] = [
   {
     title: 'Total Value of Projects',
     icon: 'fa-light fa-chart-column',
-    chartType: 'line',
+    chartType: 'bar',
     category: 'projects',
     testId: 'foundation-health-card-total-value',
     drawerType: DashboardDrawerType.TotalValueOfProjects,


### PR DESCRIPTION
## Summary

- Replaces the line chart with a stacked bar chart for the **Total Value of Projects** metric on the Foundation Health card
- Four color-coded segments represent value concentration: Top 1 (emerald-600), Top 2-3 (emerald-400), Top 4-5 (emerald-300), All Others (emerald-200)
- Tooltip shows the segment label and dollar-formatted value on hover

## Why

The line chart made it look like value was declining across projects (left-to-right slope), which is misleading. A stacked bar accurately shows distribution/concentration at a glance — per Manish's feedback.

## Test plan

- [ ] Foundation Health card shows a stacked bar instead of a line for Total Value of Projects
- [ ] Hovering each segment shows the correct label and dollar value in the tooltip
- [ ] Opening the Total Value drawer still works correctly
- [ ] No regressions on other Foundation Health metric cards