### PR TITLE
fix(meetings): use deterministic sentinel for never-ending recurrences

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -16,7 +16,6 @@ import {
   MAX_EARLY_JOIN_TIME,
   MEETING_STEP_TITLES,
   MIN_EARLY_JOIN_TIME,
-  RECURRENCE_NO_END_SENTINEL_DATE,
   STEPPER_SCROLL_OFFSET,
   TOTAL_STEPS,
 } from '@lfx-one/shared/constants';
@@ -41,6 +40,7 @@ import {
   generateRecurrenceObject,
   getDefaultStartDateTime,
   getUserTimezone,
+  isRecurrenceNeverEndSentinel,
   mapRecurrenceToFormValue,
 } from '@lfx-one/shared/utils';
 import { editModeDateTimeValidator, futureDateTimeValidator } from '@lfx-one/shared/validators';
@@ -781,12 +781,7 @@ export class MeetingManageComponent {
 
       let endTypeUI = 'never';
       const recurrenceEndDateTime = meeting.recurrence.end_date_time;
-      const parsedRecurrenceEndDateTime = recurrenceEndDateTime ? new Date(recurrenceEndDateTime) : null;
-      const parsedSentinelEndDateTime = new Date(RECURRENCE_NO_END_SENTINEL_DATE);
-      const hasValidRecurrenceEndDateTime = parsedRecurrenceEndDateTime !== null && !Number.isNaN(parsedRecurrenceEndDateTime.getTime());
-      const hasValidSentinelEndDateTime = !Number.isNaN(parsedSentinelEndDateTime.getTime());
-      const isSentinel =
-        hasValidRecurrenceEndDateTime && hasValidSentinelEndDateTime && parsedRecurrenceEndDateTime!.getTime() === parsedSentinelEndDateTime.getTime();
+      const isSentinel = isRecurrenceNeverEndSentinel(recurrenceEndDateTime);
       if (recurrenceEndDateTime && !isSentinel) endTypeUI = 'date';
       else if (meeting.recurrence.end_times) endTypeUI = 'occurrences';
 
@@ -1265,10 +1260,7 @@ export class MeetingManageComponent {
     if (recurrence.weekly_days && recurrence.weekly_days.split(',').length > 1) return true;
 
     // End conditions (end date or occurrence count) — exclude the sentinel, which means "never ends"
-    const endDateMs = recurrence.end_date_time ? new Date(recurrence.end_date_time).getTime() : NaN;
-    const sentinelMs = new Date(RECURRENCE_NO_END_SENTINEL_DATE).getTime();
-    const hasRealEndDateTime = Number.isFinite(endDateMs) && Number.isFinite(sentinelMs) && endDateMs !== sentinelMs;
-    if (hasRealEndDateTime) return true;
+    if (recurrence.end_date_time && !isRecurrenceNeverEndSentinel(recurrence.end_date_time)) return true;
     if ((recurrence.end_times ?? 0) > 0) return true;
 
     return false;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -783,13 +783,10 @@ export class MeetingManageComponent {
       const recurrenceEndDateTime = meeting.recurrence.end_date_time;
       const parsedRecurrenceEndDateTime = recurrenceEndDateTime ? new Date(recurrenceEndDateTime) : null;
       const parsedSentinelEndDateTime = new Date(RECURRENCE_NO_END_SENTINEL_DATE);
-      const hasValidRecurrenceEndDateTime =
-        parsedRecurrenceEndDateTime !== null && !Number.isNaN(parsedRecurrenceEndDateTime.getTime());
+      const hasValidRecurrenceEndDateTime = parsedRecurrenceEndDateTime !== null && !Number.isNaN(parsedRecurrenceEndDateTime.getTime());
       const hasValidSentinelEndDateTime = !Number.isNaN(parsedSentinelEndDateTime.getTime());
       const isSentinel =
-        hasValidRecurrenceEndDateTime &&
-        hasValidSentinelEndDateTime &&
-        parsedRecurrenceEndDateTime!.getTime() === parsedSentinelEndDateTime.getTime();
+        hasValidRecurrenceEndDateTime && hasValidSentinelEndDateTime && parsedRecurrenceEndDateTime!.getTime() === parsedSentinelEndDateTime.getTime();
       if (recurrenceEndDateTime && !isSentinel) endTypeUI = 'date';
       else if (meeting.recurrence.end_times) endTypeUI = 'occurrences';
 
@@ -1268,8 +1265,11 @@ export class MeetingManageComponent {
     if (recurrence.weekly_days && recurrence.weekly_days.split(',').length > 1) return true;
 
     // End conditions (end date or occurrence count) — exclude the sentinel, which means "never ends"
-    if (recurrence.end_date_time && recurrence.end_date_time !== RECURRENCE_NO_END_SENTINEL_DATE) return true;
-    if (recurrence.end_times) return true;
+    const endDateMs = recurrence.end_date_time ? new Date(recurrence.end_date_time).getTime() : NaN;
+    const sentinelMs = new Date(RECURRENCE_NO_END_SENTINEL_DATE).getTime();
+    const hasRealEndDateTime = Number.isFinite(endDateMs) && Number.isFinite(sentinelMs) && endDateMs !== sentinelMs;
+    if (hasRealEndDateTime) return true;
+    if ((recurrence.end_times ?? 0) > 0) return true;
 
     return false;
   }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -780,8 +780,17 @@ export class MeetingManageComponent {
       else if (meeting.recurrence.monthly_week && meeting.recurrence.monthly_week_day) monthlyTypeUI = 'dayOfWeek';
 
       let endTypeUI = 'never';
-      const isSentinel = meeting.recurrence.end_date_time === RECURRENCE_NO_END_SENTINEL_DATE;
-      if (meeting.recurrence.end_date_time && !isSentinel) endTypeUI = 'date';
+      const recurrenceEndDateTime = meeting.recurrence.end_date_time;
+      const parsedRecurrenceEndDateTime = recurrenceEndDateTime ? new Date(recurrenceEndDateTime) : null;
+      const parsedSentinelEndDateTime = new Date(RECURRENCE_NO_END_SENTINEL_DATE);
+      const hasValidRecurrenceEndDateTime =
+        parsedRecurrenceEndDateTime !== null && !Number.isNaN(parsedRecurrenceEndDateTime.getTime());
+      const hasValidSentinelEndDateTime = !Number.isNaN(parsedSentinelEndDateTime.getTime());
+      const isSentinel =
+        hasValidRecurrenceEndDateTime &&
+        hasValidSentinelEndDateTime &&
+        parsedRecurrenceEndDateTime!.getTime() === parsedSentinelEndDateTime.getTime();
+      if (recurrenceEndDateTime && !isSentinel) endTypeUI = 'date';
       else if (meeting.recurrence.end_times) endTypeUI = 'occurrences';
 
       // Set the pattern type UI control if this is custom recurrence
@@ -1258,8 +1267,9 @@ export class MeetingManageComponent {
     // Multiple days selected for weekly
     if (recurrence.weekly_days && recurrence.weekly_days.split(',').length > 1) return true;
 
-    // End conditions (end date or occurrence count)
-    if (recurrence.end_date_time || recurrence.end_times) return true;
+    // End conditions (end date or occurrence count) — exclude the sentinel, which means "never ends"
+    if (recurrence.end_date_time && recurrence.end_date_time !== RECURRENCE_NO_END_SENTINEL_DATE) return true;
+    if (recurrence.end_times) return true;
 
     return false;
   }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -16,6 +16,7 @@ import {
   MAX_EARLY_JOIN_TIME,
   MEETING_STEP_TITLES,
   MIN_EARLY_JOIN_TIME,
+  RECURRENCE_NO_END_SENTINEL_DATE,
   STEPPER_SCROLL_OFFSET,
   TOTAL_STEPS,
 } from '@lfx-one/shared/constants';
@@ -779,7 +780,8 @@ export class MeetingManageComponent {
       else if (meeting.recurrence.monthly_week && meeting.recurrence.monthly_week_day) monthlyTypeUI = 'dayOfWeek';
 
       let endTypeUI = 'never';
-      if (meeting.recurrence.end_date_time) endTypeUI = 'date';
+      const isSentinel = meeting.recurrence.end_date_time === RECURRENCE_NO_END_SENTINEL_DATE;
+      if (meeting.recurrence.end_date_time && !isSentinel) endTypeUI = 'date';
       else if (meeting.recurrence.end_times) endTypeUI = 'occurrences';
 
       // Set the pattern type UI control if this is custom recurrence
@@ -796,7 +798,7 @@ export class MeetingManageComponent {
           monthly_day: meeting.recurrence.monthly_day || null,
           monthly_week: meeting.recurrence.monthly_week || null,
           monthly_week_day: meeting.recurrence.monthly_week_day || null,
-          end_date_time: meeting.recurrence.end_date_time ? new Date(meeting.recurrence.end_date_time) : null,
+          end_date_time: meeting.recurrence.end_date_time && !isSentinel ? new Date(meeting.recurrence.end_date_time) : null,
           end_times: meeting.recurrence.end_times || null,
           // UI helper controls
           monthlyTypeUI: monthlyTypeUI,

--- a/apps/lfx-one/src/app/shared/pipes/recurrence-summary.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/recurrence-summary.pipe.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Pipe, PipeTransform } from '@angular/core';
-import { buildRecurrenceSummary, CustomRecurrencePattern, MeetingRecurrence, RECURRENCE_NO_END_SENTINEL_DATE } from '@lfx-one/shared';
+import { buildRecurrenceSummary, CustomRecurrencePattern, isRecurrenceNeverEndSentinel, MeetingRecurrence } from '@lfx-one/shared';
 
 @Pipe({
   name: 'recurrenceSummary',
@@ -52,10 +52,7 @@ export class RecurrenceSummaryPipe implements PipeTransform {
 
     // Determine end type — sentinel means "never ends", not a real user-chosen date
     let endType: 'never' | 'date' | 'occurrences' = 'never';
-    const endDateMs = recurrence.end_date_time ? new Date(recurrence.end_date_time).getTime() : NaN;
-    const sentinelMs = new Date(RECURRENCE_NO_END_SENTINEL_DATE).getTime();
-    const hasRealEndDate = Number.isFinite(endDateMs) && Number.isFinite(sentinelMs) && endDateMs !== sentinelMs;
-    if (hasRealEndDate) endType = 'date';
+    if (recurrence.end_date_time && !isRecurrenceNeverEndSentinel(recurrence.end_date_time)) endType = 'date';
     else if ((endTimes ?? 0) > 0) endType = 'occurrences';
 
     // Convert weekly_days to array if present

--- a/apps/lfx-one/src/app/shared/pipes/recurrence-summary.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/recurrence-summary.pipe.ts
@@ -52,9 +52,11 @@ export class RecurrenceSummaryPipe implements PipeTransform {
 
     // Determine end type — sentinel means "never ends", not a real user-chosen date
     let endType: 'never' | 'date' | 'occurrences' = 'never';
-    const hasRealEndDate = recurrence.end_date_time && recurrence.end_date_time !== RECURRENCE_NO_END_SENTINEL_DATE;
+    const endDateMs = recurrence.end_date_time ? new Date(recurrence.end_date_time).getTime() : NaN;
+    const sentinelMs = new Date(RECURRENCE_NO_END_SENTINEL_DATE).getTime();
+    const hasRealEndDate = Number.isFinite(endDateMs) && Number.isFinite(sentinelMs) && endDateMs !== sentinelMs;
     if (hasRealEndDate) endType = 'date';
-    else if (endTimes) endType = 'occurrences';
+    else if ((endTimes ?? 0) > 0) endType = 'occurrences';
 
     // Convert weekly_days to array if present
     let weeklyDaysArray: number[] = [];

--- a/apps/lfx-one/src/app/shared/pipes/recurrence-summary.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/recurrence-summary.pipe.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Pipe, PipeTransform } from '@angular/core';
-import { buildRecurrenceSummary, CustomRecurrencePattern, MeetingRecurrence } from '@lfx-one/shared';
+import { buildRecurrenceSummary, CustomRecurrencePattern, MeetingRecurrence, RECURRENCE_NO_END_SENTINEL_DATE } from '@lfx-one/shared';
 
 @Pipe({
   name: 'recurrenceSummary',
@@ -50,9 +50,10 @@ export class RecurrenceSummaryPipe implements PipeTransform {
       monthlyType = 'dayOfWeek';
     }
 
-    // Determine end type
+    // Determine end type — sentinel means "never ends", not a real user-chosen date
     let endType: 'never' | 'date' | 'occurrences' = 'never';
-    if (recurrence.end_date_time) endType = 'date';
+    const hasRealEndDate = recurrence.end_date_time && recurrence.end_date_time !== RECURRENCE_NO_END_SENTINEL_DATE;
+    if (hasRealEndDate) endType = 'date';
     else if (endTimes) endType = 'occurrences';
 
     // Convert weekly_days to array if present

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1294,8 +1294,7 @@ export class MeetingService {
    * the meeting as "never ends" rather than showing a specific end date.
    */
   private normalizeRecurrence(req: Request, recurrence: MeetingRecurrence): MeetingRecurrence {
-    const hasValidEndDateTime =
-      typeof recurrence.end_date_time === 'string' && recurrence.end_date_time.trim().length > 0;
+    const hasValidEndDateTime = typeof recurrence.end_date_time === 'string' && recurrence.end_date_time.trim().length > 0;
     const hasValidEndTimes = typeof recurrence.end_times === 'number' && recurrence.end_times > 0;
 
     if (hasValidEndDateTime || hasValidEndTimes) {
@@ -1303,6 +1302,7 @@ export class MeetingService {
     }
     logger.debug(req, 'normalize_recurrence', 'Stamping never-end sentinel — recurrence has no end condition', {
       end_date_time: RECURRENCE_NO_END_SENTINEL_DATE,
+      recurrence_type: recurrence.type,
     });
     return { ...recurrence, end_date_time: RECURRENCE_NO_END_SENTINEL_DATE };
   }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1294,7 +1294,11 @@ export class MeetingService {
    * the meeting as "never ends" rather than showing a specific end date.
    */
   private normalizeRecurrence(req: Request, recurrence: MeetingRecurrence): MeetingRecurrence {
-    if (recurrence.end_date_time != null || recurrence.end_times != null) {
+    const hasValidEndDateTime =
+      typeof recurrence.end_date_time === 'string' && recurrence.end_date_time.trim().length > 0;
+    const hasValidEndTimes = typeof recurrence.end_times === 'number' && recurrence.end_times > 0;
+
+    if (hasValidEndDateTime || hasValidEndTimes) {
       return recurrence;
     }
     logger.debug(req, 'normalize_recurrence', 'Stamping never-end sentinel — recurrence has no end condition', {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { RECURRENCE_NO_END_SENTINEL_DATE } from '@lfx-one/shared/constants';
 import { QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import {
   ApiResponse,
@@ -263,7 +264,7 @@ export class MeetingService {
     const createPayload = {
       ...meetingData,
       ...(username && { organizers: [username] }),
-      ...(meetingData.recurrence && { recurrence: this.normalizeRecurrence(meetingData.recurrence) }),
+      ...(meetingData.recurrence?.type && { recurrence: this.normalizeRecurrence(req, meetingData.recurrence) }),
     };
 
     const sanitizedPayload = logger.sanitize({ createPayload });
@@ -327,7 +328,7 @@ export class MeetingService {
     const updatePayload = {
       ...meetingData,
       organizers: Array.from(organizersSet),
-      ...(meetingData.recurrence && { recurrence: this.normalizeRecurrence(meetingData.recurrence) }),
+      ...(meetingData.recurrence?.type && { recurrence: this.normalizeRecurrence(req, meetingData.recurrence) }),
     };
 
     const sanitizedPayload = logger.sanitize({ updatePayload, editType });
@@ -1286,15 +1287,19 @@ export class MeetingService {
 
   /**
    * Ensures a recurrence object always has an end condition.
-   * The upstream meeting service requires either end_date_time or end_times.
-   * Defaults to 100 years from now when neither is specified.
+   * Zoom's recurrence API (via the itx adapter) requires either end_date_time or
+   * end_times; the Goa schema marks both optional but Zoom rejects payloads where
+   * neither is set. When neither is present, we stamp RECURRENCE_NO_END_SENTINEL_DATE
+   * so the upstream call succeeds. The client recognises this sentinel and renders
+   * the meeting as "never ends" rather than showing a specific end date.
    */
-  private normalizeRecurrence(recurrence: MeetingRecurrence): MeetingRecurrence {
-    if (recurrence.end_date_time || recurrence.end_times) {
+  private normalizeRecurrence(req: Request, recurrence: MeetingRecurrence): MeetingRecurrence {
+    if (recurrence.end_date_time != null || recurrence.end_times != null) {
       return recurrence;
     }
-    const hundredYearsFromNow = new Date();
-    hundredYearsFromNow.setFullYear(hundredYearsFromNow.getFullYear() + 100);
-    return { ...recurrence, end_date_time: hundredYearsFromNow.toISOString() };
+    logger.debug(req, 'normalize_recurrence', 'Stamping never-end sentinel — recurrence has no end condition', {
+      end_date_time: RECURRENCE_NO_END_SENTINEL_DATE,
+    });
+    return { ...recurrence, end_date_time: RECURRENCE_NO_END_SENTINEL_DATE };
   }
 }

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -360,6 +360,16 @@ export const MEETING_FORM_STEPS = {
 };
 
 /**
+ * Sentinel date used when a recurrence has no explicit end condition.
+ * Zoom's recurrence API requires either end_date_time or end_times; this value
+ * satisfies that requirement without representing a real user-chosen end date.
+ * Both the server write path (normalizeRecurrence) and the client read path
+ * (meeting-manage form population) must agree on this constant so the UI can
+ * distinguish "never ends" from a user-selected date.
+ */
+export const RECURRENCE_NO_END_SENTINEL_DATE = '2999-12-31T23:59:59Z';
+
+/**
  * Recurrence type string mappings
  * @description Maps recurrence types to their string identifiers used in forms and API
  * @readonly

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -367,7 +367,7 @@ export const MEETING_FORM_STEPS = {
  * (meeting-manage form population) must agree on this constant so the UI can
  * distinguish "never ends" from a user-selected date.
  */
-export const RECURRENCE_NO_END_SENTINEL_DATE = '2999-12-31T23:59:59Z';
+export const RECURRENCE_NO_END_SENTINEL_DATE = '2999-12-31T23:59:59.000Z';
 
 /**
  * Recurrence type string mappings

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -3,7 +3,7 @@
 
 import { HttpParams } from '@angular/common/http';
 
-import { RECURRENCE_DAYS_OF_WEEK, RECURRENCE_WEEKLY_ORDINALS } from '../constants';
+import { RECURRENCE_DAYS_OF_WEEK, RECURRENCE_NO_END_SENTINEL_DATE, RECURRENCE_WEEKLY_ORDINALS } from '../constants';
 import {
   CustomRecurrencePattern,
   Meeting,
@@ -15,6 +15,18 @@ import {
   V1PastMeetingSummary,
   V1SummaryDetail,
 } from '../interfaces';
+
+/**
+ * Whether the recurrence end_date_time matches the "never ends" sentinel.
+ * Compares via Date.getTime() so equivalent ISO variants (e.g. '...59Z' vs '...59.000Z')
+ * are treated as equal.
+ */
+export function isRecurrenceNeverEndSentinel(endDateTime: string | null | undefined): boolean {
+  if (!endDateTime) return false;
+  const end = new Date(endDateTime).getTime();
+  const sentinel = new Date(RECURRENCE_NO_END_SENTINEL_DATE).getTime();
+  return Number.isFinite(end) && Number.isFinite(sentinel) && end === sentinel;
+}
 
 /**
  * Build a human-readable recurrence summary from custom recurrence pattern
@@ -295,7 +307,7 @@ export function buildJoinUrlWithParams(joinUrl: string, user?: User | null, opti
  * allowing callers to distinguish "no counts provided" from "counts are truly 0".
  */
 export function resolveMeetingBaseCount(
-  meeting: Pick<Meeting, 'individual_registrants_count' | 'committee_members_count' | 'registrant_count'>,
+  meeting: Pick<Meeting, 'individual_registrants_count' | 'committee_members_count' | 'registrant_count'>
 ): number | undefined {
   const hasSplitCounts = meeting.individual_registrants_count != null || meeting.committee_members_count != null;
 


### PR DESCRIPTION
## Summary

Follow-up to #593, addressing @asithade's review feedback after merge.

- Add `RECURRENCE_NO_END_SENTINEL_DATE = '2999-12-31T23:59:59Z'` to `@lfx-one/shared/constants` — a deterministic value both server and client agree on
- Replace `new Date() + 100 years` with the sentinel so the stored value is stable across saves (prevents audit log drift and unnecessary ETag invalidation)
- Tighten `normalizeRecurrence` call-site guard from `recurrence &&` to `recurrence?.type &&` to avoid stamping the sentinel onto an otherwise-empty object
- Add `req` param and `logger.debug()` to `normalizeRecurrence` so CloudWatch has a trace when normalization fires
- Update JSDoc to cite Zoom's recurrence API as the source of the end-condition requirement (the Goa schema marks both fields optional; Zoom rejects payloads where neither is set)
- Fix the UI round-trip regression: `meeting-manage.component.ts` now recognises the sentinel on the read path — meetings saved as "never ends" reopen with the "Never" selector instead of "End by date: year 2999"

## Root cause of the UI regression

`meeting-manage.component.ts:781-783` derived `endTypeUI` purely from field presence:
```ts
if (meeting.recurrence.end_date_time) endTypeUI = 'date';
```
After #593, every "never ends" meeting had `end_date_time` set, so all of them reopened in "End by date" mode. This PR adds a sentinel check before deriving `endTypeUI` and clears `end_date_time` from the form patch when the sentinel is detected.

## Test plan

- [ ] Create a recurring meeting with "Never ends" — save succeeds (no upstream rejection)
- [ ] Reopen the meeting form — "Never ends" is selected, end date field is empty
- [ ] Create a recurring meeting with an explicit end date — reopen shows the correct date
- [ ] Create a recurring meeting with N occurrences — reopen shows the correct count
- [ ] Edit an existing "never ends" meeting and save — no sentinel drift in the stored value

Addresses review: https://github.com/linuxfoundation/lfx-v2-ui/pull/593#pullrequestreview-4172798985