### PR TITLE
fix(committees): keep search bar visible when filter returns no results

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -122,8 +122,9 @@
               subtitle="This project has no groups set up yet."
               data-testid="committees-project-empty-state">
             </lfx-empty-state>
-          } @else {
+          } @else if (project()?.uid) {
             <lfx-committee-table
+              data-testid="committees-project-table"
               [committees]="filteredCommittees()"
               [hasItems]="committees().length > 0"
               [canManageCommittee]="canWrite()"
@@ -134,6 +135,13 @@
               (refresh)="refreshCommittees()"
               (rowClick)="onCommitteeClick($event)">
             </lfx-committee-table>
+          } @else {
+            <lfx-empty-state
+              icon="fa-light fa-folder-open"
+              title="Select a project"
+              [subtitle]="'Choose a project to view its ' + committeeLabel.plural.toLowerCase() + '.'"
+              data-testid="committees-no-project-empty-state">
+            </lfx-empty-state>
           }
         </div>
       }

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -122,16 +122,10 @@
               subtitle="This project has no groups set up yet."
               data-testid="committees-project-empty-state">
             </lfx-empty-state>
-          } @else if (filteredCommittees().length === 0) {
-            <lfx-empty-state
-              icon="fa-light fa-users-rectangle"
-              [title]="'No ' + committeeLabel.plural.toLowerCase() + ' found'"
-              subtitle="Try adjusting your search or filter criteria."
-              data-testid="committees-filtered-empty-state">
-            </lfx-empty-state>
           } @else {
             <lfx-committee-table
               [committees]="filteredCommittees()"
+              [hasItems]="committees().length > 0"
               [canManageCommittee]="canWrite()"
               [myCommitteeUids]="myCommitteeUids()"
               [searchForm]="searchForm"


### PR DESCRIPTION
## Summary

- Fixes a bug where searching for a non-matching term on the **Projects → Groups** page caused the entire table component (including the search bar) to disappear
- The search bar lives inside `<lfx-committee-table>` — when the dashboard's `@else if (filteredCommittees().length === 0)` branch fired, it replaced the whole component with an empty state div instead of letting the table handle it internally
- Fix: remove the dashboard-level filtered-empty-state branch and always render `<lfx-committee-table>` when there are committees, passing `[hasItems]="committees().length > 0"` so the search bar remains visible. The table already has its own "No results found" empty state with a "Reset filters" CTA.

## Root cause

The Me-lens table always rendered (with `[hasItems]="myCommittees().length > 0"` based on the unfiltered count), so the bug only affected the **Project lens** (Projects → Groups).

## Test plan

- [ ] Go to Projects → Groups
- [ ] Type a search term that matches no committees
- [ ] Verify the search bar remains visible and a "No results found" empty state appears inside the card
- [ ] Verify the "Reset filters" CTA clears the search and restores the list
- [ ] Verify the Me lens (My Groups) is unaffected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)