### PR TITLE
feat(me-lens): add Crowdfunding link and convert Mentorships to external

### DIFF
--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -19,7 +19,7 @@ import { UserService } from '@services/user.service';
 import { DrawerModule } from 'primeng/drawer';
 import { filter, map, of, startWith, switchMap, take } from 'rxjs';
 
-import { environment } from '../../../environments/environment';
+import { environment } from '@environments/environment';
 
 import { ButtonComponent } from '@components/button/button.component';
 

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -19,6 +19,8 @@ import { UserService } from '@services/user.service';
 import { DrawerModule } from 'primeng/drawer';
 import { filter, map, of, startWith, switchMap, take } from 'rxjs';
 
+import { environment } from '../../../environments/environment';
+
 import { ButtonComponent } from '@components/button/button.component';
 
 @Component({
@@ -124,7 +126,12 @@ export class MainLayoutComponent {
         {
           label: 'Mentorships',
           icon: 'fa-light fa-chalkboard-teacher',
-          routerLink: '/me/mentorships',
+          url: environment.urls.mentorship,
+        },
+        {
+          label: 'Crowdfunding',
+          icon: 'fa-light fa-circle-dollar',
+          url: environment.urls.crowdfunding,
         },
         {
           label: 'Badges',

--- a/apps/lfx-one/src/environments/environment.dev.ts
+++ b/apps/lfx-one/src/environments/environment.dev.ts
@@ -8,6 +8,8 @@ export const environment = {
     support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
     pcc: 'https://pcc.dev.platform.linuxfoundation.org',
     changelog: 'https://changelog.lfx.dev/',
+    mentorship: 'https://people.dev.platform.linuxfoundation.org/#projects_all',
+    crowdfunding: 'https://funding.dev.platform.linuxfoundation.org/',
   },
   segment: {
     cdnUrl: 'https://lfx-segment.dev.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',

--- a/apps/lfx-one/src/environments/environment.prod.ts
+++ b/apps/lfx-one/src/environments/environment.prod.ts
@@ -8,6 +8,8 @@ export const environment = {
     support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
     pcc: 'https://projectadmin.lfx.linuxfoundation.org',
     changelog: 'https://changelog.lfx.dev/',
+    mentorship: 'https://mentorship.lfx.linuxfoundation.org/',
+    crowdfunding: 'https://crowdfunding.lfx.linuxfoundation.org/',
   },
   segment: {
     cdnUrl: 'https://lfx-segment.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',

--- a/apps/lfx-one/src/environments/environment.staging.ts
+++ b/apps/lfx-one/src/environments/environment.staging.ts
@@ -8,6 +8,8 @@ export const environment = {
     support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
     pcc: 'https://pcc.staging.platform.linuxfoundation.org',
     changelog: 'https://changelog.lfx.dev/',
+    mentorship: 'https://mentorship.lfx.linuxfoundation.org/',
+    crowdfunding: 'https://crowdfunding.lfx.linuxfoundation.org/',
   },
   segment: {
     cdnUrl: 'https://lfx-segment.dev.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',

--- a/apps/lfx-one/src/environments/environment.ts
+++ b/apps/lfx-one/src/environments/environment.ts
@@ -8,6 +8,8 @@ export const environment = {
     support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
     pcc: 'https://pcc.dev.platform.linuxfoundation.org',
     changelog: 'https://changelog.lfx.dev/',
+    mentorship: 'https://people.dev.platform.linuxfoundation.org/#projects_all',
+    crowdfunding: 'https://funding.dev.platform.linuxfoundation.org/',
   },
   segment: {
     cdnUrl: 'https://lfx-segment.dev.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',


### PR DESCRIPTION
## Summary

- Add **Crowdfunding** menu item to the Me Lens sidebar under **My Growth**, directly below Mentorships, linking to the standalone Crowdfunding app
- Convert existing **Mentorships** item from a dead internal `routerLink` to an external `url` pointing to the standalone Mentorship app
- Both items open in a new tab with `rel="noopener noreferrer"` and render an external-link arrow icon automatically via the existing sidebar template
- URLs are environment-aware: dev/local use dev platform URLs, staging and prod use the production links

## Changes

```
.../main-layout/main-layout.component.ts | 9 ++++++++-
apps/lfx-one/src/environments/environment.dev.ts     | 2 ++
apps/lfx-one/src/environments/environment.prod.ts    | 2 ++
apps/lfx-one/src/environments/environment.staging.ts | 2 ++
apps/lfx-one/src/environments/environment.ts         | 2 ++
5 files changed, 16 insertions(+), 1 deletion(-)
```

<img width="942" height="807" alt="image" src="https://github.com/user-attachments/assets/a15ab9e0-4963-4de3-a790-f0c0328088db" />


Jira: LFXV2-1579

Generated with [Claude Code](https://claude.ai/code)