### PR TITLE
fix(badges): use effective identity helpers for impersonation

### DIFF
--- a/apps/lfx-one/src/server/controllers/badges.controller.ts
+++ b/apps/lfx-one/src/server/controllers/badges.controller.ts
@@ -9,6 +9,7 @@ import { AuthenticationError } from '../errors';
 import { CredlyService } from '../services/credly.service';
 import { EmailVerificationService } from '../services/email-verification.service';
 import { logger } from '../services/logger.service';
+import { getEffectiveEmail, getEffectiveSub } from '../utils/auth-helper';
 
 export class BadgesController {
   private readonly credlyService = new CredlyService();
@@ -18,7 +19,8 @@ export class BadgesController {
    * GET /api/badges
    * Get badges for the authenticated user from Credly.
    * Resolves all verified emails from auth-service so badges earned under secondary
-   * addresses are included. Falls back to the single OIDC email on failure.
+   * addresses are included. Falls back to the single effective session email
+   * (impersonated target during impersonation, otherwise the OIDC user) on failure.
    */
   public async getBadges(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_badges');
@@ -47,22 +49,23 @@ export class BadgesController {
    * Resolve email addresses for the authenticated user used to look up Credly badges.
    * Queries auth-service via NATS and returns the primary email plus any alternate
    * emails flagged verified by auth-service (the primary has no separate verified flag,
-   * so it is always included). Falls back to the single OIDC session email if the
+   * so it is always included). Falls back to the single effective session email
+   * (impersonated target during impersonation, otherwise the OIDC user) if the
    * auth-service lookup fails or returns no usable addresses.
    */
   private async resolveUserEmails(req: Request): Promise<string[]> {
-    const oidcEmail = (req.oidc?.user?.['email'] as string | undefined)?.toLowerCase();
-    const userSub = req.oidc?.user?.['sub'] as string | undefined;
+    const effectiveEmail = getEffectiveEmail(req);
+    const userSub = getEffectiveSub(req);
 
     if (!userSub) {
-      logger.debug(req, 'resolve_user_emails', 'No sub from OIDC, using session email only', {});
-      return oidcEmail ? [oidcEmail] : [];
+      logger.debug(req, 'resolve_user_emails', 'No effective sub for user, using session email only', {});
+      return effectiveEmail ? [effectiveEmail] : [];
     }
 
     const emailData = await this.emailVerificationService.getUserEmails(req, userSub);
 
     if (!emailData) {
-      return oidcEmail ? [oidcEmail] : [];
+      return effectiveEmail ? [effectiveEmail] : [];
     }
 
     const seen = new Set<string>();
@@ -90,6 +93,6 @@ export class BadgesController {
     });
 
     if (verifiedEmails.length > 0) return verifiedEmails;
-    return oidcEmail ? [oidcEmail] : [];
+    return effectiveEmail ? [effectiveEmail] : [];
   }
 }

--- a/docs/architecture/backend/impersonation.md
+++ b/docs/architecture/backend/impersonation.md
@@ -164,7 +164,7 @@ Many controllers and services read the user's email/username from `req.oidc.user
 | `getEffectiveUsername(req)` | Impersonated username or OIDC nickname        |
 | `getEffectiveSub(req)`      | Impersonated sub or OIDC sub                  |
 
-These check `req.appSession['impersonationUser']` first, falling back to `req.oidc.user`. All controllers/services that filter by user identity use these helpers (meetings, events, committees, votes, surveys, mailing lists, documents, analytics, persona detection).
+These check `req.appSession['impersonationUser']` first, falling back to `req.oidc.user`. All controllers/services that filter by user identity use these helpers (meetings, events, committees, votes, surveys, mailing lists, documents, analytics, badges, persona detection).
 
 **Exception:** The profile controller always uses `req.oidc.user` directly because profile operations (change password, update metadata, link identities) must act on the real user's account.
 


### PR DESCRIPTION
# Summary

This pull request updates the badges controller to consistently use "effective" user identity helpers, ensuring correct behavior during user impersonation. The changes replace direct access to OIDC user fields with the `getEffectiveEmail` and `getEffectiveSub` helpers, improving how user emails and subs are resolved for badge lookups. Documentation is also updated to reflect these changes.

**Improvements to user identity resolution in the badges controller:**

* Replaced direct access to `req.oidc.user` for email and sub with `getEffectiveEmail(req)` and `getEffectiveSub(req)` in the `BadgesController`, ensuring correct handling during impersonation. [[1]](diffhunk://#diff-1fb64ced55b6fd8d3150f3ea2877ca47973f0bd7f5a78bf22c01d4bf13afb24fR12) [[2]](diffhunk://#diff-1fb64ced55b6fd8d3150f3ea2877ca47973f0bd7f5a78bf22c01d4bf13afb24fL50-R68) [[3]](diffhunk://#diff-1fb64ced55b6fd8d3150f3ea2877ca47973f0bd7f5a78bf22c01d4bf13afb24fL93-R96)
* Updated fallback logic and comments in `BadgesController` to clarify that the system now uses the effective session email (impersonated or OIDC) when necessary. [[1]](diffhunk://#diff-1fb64ced55b6fd8d3150f3ea2877ca47973f0bd7f5a78bf22c01d4bf13afb24fL21-R23) [[2]](diffhunk://#diff-1fb64ced55b6fd8d3150f3ea2877ca47973f0bd7f5a78bf22c01d4bf13afb24fL50-R68)

**Documentation update:**

* Updated the impersonation architecture documentation to note that the badges controller now uses the effective identity helpers for user filtering.