### PR TITLE
feat(me-lens): show up to 3 role tags with icons in sidebar

### DIFF
--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -36,9 +36,9 @@
             <p class="font-semibold text-base text-gray-900 leading-5 tracking-tight line-clamp-2">{{ user()?.name }}</p>
             @if (showPersonaBadge()) {
               <div class="flex flex-wrap gap-1">
-                @for (tag of personaLabels(); track tag.label) {
+                @for (tag of personaLabels(); track $index) {
                   <span class="inline-flex items-center gap-1 text-xs text-gray-700 bg-white border border-gray-200 rounded-full px-2 py-0.5 leading-4">
-                    <i [ngClass]="tag.icon" class="text-[10px]"></i>{{ tag.label }}
+                    <i [ngClass]="tag.icon" class="text-[10px]" aria-hidden="true"></i>{{ tag.label }}
                   </span>
                 }
               </div>

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -30,13 +30,17 @@
 
       <!-- [class.hidden] avoids SSR hydration mismatch -->
       <div class="px-4 mb-6 w-full" [class.hidden]="!showMeSelector()">
-        <div data-testid="me-selector" class="box-border flex gap-3 items-center p-3 w-full rounded-lg">
+        <div data-testid="me-selector" class="box-border flex gap-3 items-start p-3 w-full rounded-lg">
           <lfx-avatar [image]="user()?.picture ?? ''" [label]="user()?.name ?? ''" shape="circle" size="large" styleClass="shrink-0 size-10"></lfx-avatar>
           <div class="flex flex-col gap-1 grow min-w-0">
             <p class="font-semibold text-base text-gray-900 leading-5 tracking-tight line-clamp-2">{{ user()?.name }}</p>
             @if (showPersonaBadge()) {
               <div class="flex flex-wrap gap-1">
-                <span class="inline-block text-xs text-gray-700 bg-white border border-gray-200 rounded-full px-2 py-0.5 leading-4">{{ personaLabel() }}</span>
+                @for (tag of personaLabels(); track tag.label) {
+                  <span class="inline-flex items-center gap-1 text-xs text-gray-700 bg-white border border-gray-200 rounded-full px-2 py-0.5 leading-4">
+                    <i [ngClass]="tag.icon" class="text-[10px]"></i>{{ tag.label }}
+                  </span>
+                }
               </div>
             }
           </div>

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -8,7 +8,7 @@ import { AvatarComponent } from '@components/avatar/avatar.component';
 import { BadgeComponent } from '@components/badge/badge.component';
 import { ProjectSelectorComponent } from '@components/project-selector/project-selector.component';
 import { environment } from '@environments/environment';
-import { PERSONA_OPTIONS } from '@lfx-one/shared/constants';
+import { PERSONA_OPTIONS, PERSONA_PRIORITY } from '@lfx-one/shared/constants';
 import { LensItem, NavLens, ProjectContext, SidebarMenuItem } from '@lfx-one/shared/interfaces';
 import { lensItemToProjectContext, toTitleCase } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
@@ -17,6 +17,13 @@ import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { UserService } from '@services/user.service';
 import { SkeletonModule } from 'primeng/skeleton';
+
+const PERSONA_ICONS: Record<string, string> = {
+  'executive-director': 'fa-light fa-briefcase',
+  'board-member': 'fa-light fa-building-columns',
+  'maintainer': 'fa-light fa-code',
+  'contributor': 'fa-light fa-code',
+};
 
 @Component({
   selector: 'lfx-sidebar',
@@ -48,7 +55,7 @@ export class SidebarComponent {
 
   protected readonly user = this.userService.user;
   protected readonly userInitials = this.userService.userInitials;
-  protected readonly personaLabel: Signal<string> = this.initPersonaLabel();
+  protected readonly personaLabels: Signal<{ label: string; icon: string }[]> = this.initPersonaLabels();
   // Hide the persona badge when the user is a root-writer — executive-director is spoofed, not naturally detected.
   protected readonly showPersonaBadge: Signal<boolean> = computed(() => !this.personaService.isRootWriter());
 
@@ -100,11 +107,21 @@ export class SidebarComponent {
     });
   }
 
-  private initPersonaLabel(): Signal<string> {
+  private initPersonaLabels(): Signal<{ label: string; icon: string }[]> {
     return computed(() => {
-      const persona = this.personaService.currentPersona();
-      const option = PERSONA_OPTIONS.find((o) => o.value === persona);
-      return option?.label ?? toTitleCase(persona);
+      const toTag = (p: string) => {
+        const option = PERSONA_OPTIONS.find((o) => o.value === p);
+        return { label: option?.label ?? toTitleCase(p), icon: PERSONA_ICONS[p] ?? 'fa-light fa-user' };
+      };
+
+      if (this.activeLens() === 'me') {
+        const sorted = [...this.personaService.allPersonas()].sort(
+          (a, b) => PERSONA_PRIORITY.indexOf(a) - PERSONA_PRIORITY.indexOf(b),
+        );
+        return sorted.slice(0, 3).map(toTag);
+      }
+
+      return [toTag(this.personaService.currentPersona())];
     });
   }
 

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -9,7 +9,7 @@ import { BadgeComponent } from '@components/badge/badge.component';
 import { ProjectSelectorComponent } from '@components/project-selector/project-selector.component';
 import { environment } from '@environments/environment';
 import { PERSONA_OPTIONS, PERSONA_PRIORITY } from '@lfx-one/shared/constants';
-import { LensItem, NavLens, ProjectContext, SidebarMenuItem } from '@lfx-one/shared/interfaces';
+import { LensItem, NavLens, PersonaType, ProjectContext, SidebarMenuItem } from '@lfx-one/shared/interfaces';
 import { lensItemToProjectContext, toTitleCase } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
 import { NavigationService } from '@services/navigation.service';
@@ -18,7 +18,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { UserService } from '@services/user.service';
 import { SkeletonModule } from 'primeng/skeleton';
 
-const PERSONA_ICONS: Record<string, string> = {
+const PERSONA_ICONS: Partial<Record<PersonaType, string>> = {
   'executive-director': 'fa-light fa-briefcase',
   'board-member': 'fa-light fa-building-columns',
   'maintainer': 'fa-light fa-code',
@@ -109,14 +109,15 @@ export class SidebarComponent {
 
   private initPersonaLabels(): Signal<{ label: string; icon: string }[]> {
     return computed(() => {
-      const toTag = (p: string) => {
+      const toTag = (p: PersonaType) => {
         const option = PERSONA_OPTIONS.find((o) => o.value === p);
         return { label: option?.label ?? toTitleCase(p), icon: PERSONA_ICONS[p] ?? 'fa-light fa-user' };
       };
 
       if (this.activeLens() === 'me') {
+        const priorityMap = new Map(PERSONA_PRIORITY.map((p, i) => [p, i]));
         const sorted = [...this.personaService.allPersonas()].sort(
-          (a, b) => PERSONA_PRIORITY.indexOf(a) - PERSONA_PRIORITY.indexOf(b),
+          (a, b) => (priorityMap.get(a) ?? Number.MAX_SAFE_INTEGER) - (priorityMap.get(b) ?? Number.MAX_SAFE_INTEGER),
         );
         return sorted.slice(0, 3).map(toTag);
       }


### PR DESCRIPTION
## What
Users with multiple roles (e.g. Executive Director for Foundation A and Maintainer for Project B) now see up to 3 role tags in the Me lens sidebar, sorted by priority and each with a contextual icon. Foundation and Project lenses are unchanged — they continue showing a single tag for the active persona.

## How
- `personaLabels` signal replaces the previous `personaLabel` (singular) — returns `{ label, icon }[]`
- On the Me lens, reads `allPersonas()`, sorts by `PERSONA_PRIORITY`, slices to 3, maps to label + icon
- On other lenses, falls back to a single-element array from `currentPersona()` — no behaviour change
- Avatar alignment changed to `items-start` so it pins to the top when tags wrap to a second line
- Icons: briefcase (Executive Director), building-columns (Board Member), code (Maintainer + Contributor)

## Checklist
- [x] Me lens: up to 3 tags shown, sorted by priority
- [x] Foundation/Project lens: single tag unchanged
- [x] Single-role users: one tag (no regression)
- [x] Root-writer: badge hidden (unchanged)
- [x] Avatar top-aligned when tags wrap
- [x] License headers present
- [x] No mock data included

🤖 Generated with [Claude Code](https://claude.ai/claude-code)