### PR TITLE
feat(dashboards): handle rsvp pending actions inline

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -24,13 +24,58 @@
           <div class="shrink-0 sm:w-1/5">
             <lfx-tag [value]="item.type" [severity]="item.severity" [icon]="item.icon" styleClass="whitespace-nowrap" />
           </div>
-          <!-- Description — 60% on sm+ -->
-          <p class="text-sm font-medium text-gray-900 sm:w-3/5 sm:min-w-0 sm:truncate sm:px-4" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
-            {{ item.text }}
-          </p>
+          <!-- Description — 60% on sm+. For RSVP rows the title doubles as a "view meeting"
+               affordance: clicking it opens the meeting detail page in a new tab without
+               dismissing the row, so the user can drill in for context and still come back to
+               RSVP inline. Non-RSVP rows render a plain <p> — their action button already opens
+               the link. -->
+          @if (isRsvpInline(item) && item.buttonLink) {
+            <a
+              [href]="item.buttonLink"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-sm font-medium text-gray-900 sm:w-3/5 sm:min-w-0 sm:px-4 hover:text-blue-600 hover:underline inline-flex items-center gap-1.5"
+              [attr.title]="item.text"
+              [attr.aria-label]="'Open meeting in new tab: ' + item.text"
+              data-testid="dashboard-pending-actions-title">
+              <span class="sm:truncate">{{ item.text }}</span>
+              <i class="fa-light fa-arrow-up-right-from-square text-[11px] text-gray-400 shrink-0" aria-hidden="true"></i>
+            </a>
+          } @else {
+            <p
+              class="text-sm font-medium text-gray-900 sm:w-3/5 sm:min-w-0 sm:truncate sm:px-4"
+              [attr.title]="item.text"
+              data-testid="dashboard-pending-actions-title">
+              {{ item.text }}
+            </p>
+          }
           <!-- Action button — 20% on sm+, right-aligned -->
           <div class="self-start sm:self-auto sm:w-1/5 sm:flex sm:justify-end">
-            @if (item.buttonLink) {
+            @if (isRsvpInline(item)) {
+              @if (isExpanded(item)) {
+                @let meeting = getMeetingForItem(item);
+                @if (rsvpMeetingLoading() || !meeting) {
+                  <lfx-button
+                    size="small"
+                    severity="secondary"
+                    [outlined]="true"
+                    [disabled]="true"
+                    [label]="item.buttonText"
+                    icon="fa-light fa-spinner-third fa-spin"
+                    data-testid="dashboard-pending-actions-rsvp-loading" />
+                } @else {
+                  <div data-testid="dashboard-pending-actions-rsvp-buttons">
+                    <lfx-rsvp-button-group
+                      [meeting]="meeting"
+                      [showHeader]="false"
+                      [occurrenceId]="item.occurrenceId"
+                      (rsvpChanged)="handleRsvpChanged(item)" />
+                  </div>
+                }
+              } @else {
+                <lfx-button size="small" severity="secondary" [outlined]="true" (onClick)="handleActionClick(item)" [label]="item.buttonText" />
+              }
+            } @else if (item.buttonLink) {
               <lfx-button
                 size="small"
                 severity="secondary"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -16,7 +16,7 @@
     <div
       class="bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden divide-y divide-gray-200 max-h-[30rem] overflow-y-auto"
       data-testid="dashboard-pending-actions-list">
-      @for (item of visibleActions(); track item.buttonLink ?? item.type + '-' + item.text) {
+      @for (item of visibleActions(); track getRowKey(item)) {
         <div
           class="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-0 px-4 py-3 bg-gradient-to-r from-white to-[rgba(255,251,235,0.8)]"
           [attr.data-testid]="'dashboard-pending-actions-item-' + item.type">
@@ -54,7 +54,7 @@
             @if (isRsvpInline(item)) {
               @if (isExpanded(item)) {
                 @let meeting = getMeetingForItem(item);
-                @if (rsvpMeetingLoading() || !meeting) {
+                @if (isLoadingForItem(item) || !meeting) {
                   <lfx-button
                     size="small"
                     severity="secondary"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -144,33 +144,36 @@ export class PendingActionsComponent {
     if (this.rsvpMeetingCache()[meetingUid]) return;
 
     this.loadingMeetingUid.set(meetingUid);
-    this.meetingService.getMeeting(meetingUid).subscribe({
-      next: (meeting) => {
-        this.rsvpMeetingCache.update((cache) => ({ ...cache, [meetingUid]: meeting }));
-        // Only clear the loading flag when this response is the one we're still waiting on. If the
-        // user moved to a different row before this completed, leave the new row's loading state
-        // alone — its own request owns it now.
-        if (this.loadingMeetingUid() === meetingUid) {
-          this.loadingMeetingUid.set(null);
-        }
-      },
-      error: () => {
-        // Surface the failure so the user knows the click did register and why the inline RSVP
-        // didn't come up. Same staleness guard as the success path: a late-arriving failure for
-        // row A must not collapse row B if the user has already moved on.
-        if (this.loadingMeetingUid() === meetingUid) {
-          this.loadingMeetingUid.set(null);
-        }
-        if (this.expandedRsvpKey() === this.getRowKey(item)) {
-          this.expandedRsvpKey.set(null);
-        }
-        this.messageService.add({
-          severity: 'error',
-          summary: 'Could not load meeting',
-          detail: 'Open the meeting page from the title link and try again.',
-          life: 4000,
-        });
-      },
-    });
+    this.meetingService
+      .getMeeting(meetingUid)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (meeting) => {
+          this.rsvpMeetingCache.update((cache) => ({ ...cache, [meetingUid]: meeting }));
+          // Only clear the loading flag when this response is the one we're still waiting on. If the
+          // user moved to a different row before this completed, leave the new row's loading state
+          // alone — its own request owns it now.
+          if (this.loadingMeetingUid() === meetingUid) {
+            this.loadingMeetingUid.set(null);
+          }
+        },
+        error: () => {
+          // Surface the failure so the user knows the click did register and why the inline RSVP
+          // didn't come up. Same staleness guard as the success path: a late-arriving failure for
+          // row A must not collapse row B if the user has already moved on.
+          if (this.loadingMeetingUid() === meetingUid) {
+            this.loadingMeetingUid.set(null);
+          }
+          if (this.expandedRsvpKey() === this.getRowKey(item)) {
+            this.expandedRsvpKey.set(null);
+          }
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Could not load meeting',
+            detail: 'Open the meeting page from the title link and try again.',
+            life: 4000,
+          });
+        },
+      });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -1,13 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, input, output, signal, Signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, output, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RsvpButtonGroupComponent } from '@app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { MeetingService } from '@services/meeting.service';
 import { HiddenActionsService } from '@shared/services/hidden-actions.service';
 import { MessageService } from 'primeng/api';
+import { timer } from 'rxjs';
 
 import type { Meeting, PendingActionItem } from '@lfx-one/shared/interfaces';
 @Component({
@@ -20,6 +22,7 @@ export class PendingActionsComponent {
   private readonly hiddenActionsService = inject(HiddenActionsService);
   private readonly meetingService = inject(MeetingService);
   private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
 
   public readonly pendingActions = input.required<PendingActionItem[]>();
   public readonly displayLimit = input<number>(5);
@@ -33,13 +36,14 @@ export class PendingActionsComponent {
   private readonly hiddenActionsVersion = signal(0);
 
   // Tracks which row, if any, has been clicked into "RSVP mode" so the right-hand cell can swap
-  // from the Set RSVP CTA to the inline Yes/No/Maybe button group. Keyed by the same row key the
-  // template uses for @for tracking so a re-rendered list can preserve the expanded state.
+  // from the Set RSVP CTA to the inline Yes/No/Maybe button group. Keyed by getRowKey(item) — the
+  // same expression the template's @for trackBy uses, so reordering the list preserves expansion.
   protected readonly expandedRsvpKey = signal<string | null>(null);
 
-  // True while the Meeting payload for an expanded RSVP row is being fetched. Drives the inline
-  // spinner state on the CTA so the user gets immediate feedback after clicking Set RSVP.
-  protected readonly rsvpMeetingLoading = signal(false);
+  // The meetingUid currently being fetched (if any). Per-meeting tracking instead of a global flag
+  // so a stale response from row A's request can't clobber row B's loading state when the user
+  // quickly toggles between rows.
+  private readonly loadingMeetingUid = signal<string | null>(null);
 
   // Per-meetingUid cache so the user can collapse and re-expand the same row (or expand a sibling
   // RSVP row that points at the same meeting) without triggering a refetch each time.
@@ -83,12 +87,16 @@ export class PendingActionsComponent {
     //  - The cookie-based dismiss is a sufficient client-side reconciliation; the next page
     //    load reconciles authoritatively against the server.
     // Short delay before dismissing so the user can see their choice register inside the row
-    // and read the toast — abrupt removal feels like the click did nothing.
-    setTimeout(() => {
-      this.expandedRsvpKey.set(null);
-      this.hiddenActionsService.hideAction(item);
-      this.hiddenActionsVersion.update((v) => v + 1);
-    }, 1500);
+    // and read the toast — abrupt removal feels like the click did nothing. timer + takeUntilDestroyed
+    // (instead of raw setTimeout) ensures the deferred work is cancelled if the component unmounts
+    // mid-delay, so we never write to signals on a destroyed instance.
+    timer(1500)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.expandedRsvpKey.set(null);
+        this.hiddenActionsService.hideAction(item);
+        this.hiddenActionsVersion.update((v) => v + 1);
+      });
   }
 
   protected isRsvpInline(item: PendingActionItem): boolean {
@@ -99,11 +107,22 @@ export class PendingActionsComponent {
     return this.expandedRsvpKey() === this.getRowKey(item);
   }
 
+  protected isLoadingForItem(item: PendingActionItem): boolean {
+    return !!item.meetingUid && this.loadingMeetingUid() === item.meetingUid;
+  }
+
   protected getMeetingForItem(item: PendingActionItem): Meeting | null {
     return item.meetingUid ? (this.rsvpMeetingCache()[item.meetingUid] ?? null) : null;
   }
 
+  // Stable identifier for a row. Prefers intrinsic IDs (meetingUid + occurrenceId) when present —
+  // those don't drift if copy is edited or query strings shift. Falls back to a type+text+buttonLink
+  // composite for action types that don't carry IDs yet (Vote/Survey/Agenda). The template's @for
+  // trackBy uses this same expression so the row identity is consistent everywhere.
   protected getRowKey(item: PendingActionItem): string {
+    if (item.meetingUid) {
+      return `${item.type}-${item.meetingUid}-${item.occurrenceId ?? ''}`;
+    }
     return `${item.type}-${item.text}-${item.buttonLink ?? ''}`;
   }
 
@@ -115,18 +134,27 @@ export class PendingActionsComponent {
 
     if (this.rsvpMeetingCache()[meetingUid]) return;
 
-    this.rsvpMeetingLoading.set(true);
+    this.loadingMeetingUid.set(meetingUid);
     this.meetingService.getMeeting(meetingUid).subscribe({
       next: (meeting) => {
         this.rsvpMeetingCache.update((cache) => ({ ...cache, [meetingUid]: meeting }));
-        this.rsvpMeetingLoading.set(false);
+        // Only clear the loading flag when this response is the one we're still waiting on. If the
+        // user moved to a different row before this completed, leave the new row's loading state
+        // alone — its own request owns it now.
+        if (this.loadingMeetingUid() === meetingUid) {
+          this.loadingMeetingUid.set(null);
+        }
       },
       error: () => {
-        // Surface the failure so the user knows the click did register and why the inline
-        // RSVP didn't come up. Without this, the spinner just vanishes back to the Set RSVP
-        // CTA and looks like nothing happened.
-        this.rsvpMeetingLoading.set(false);
-        this.expandedRsvpKey.set(null);
+        // Surface the failure so the user knows the click did register and why the inline RSVP
+        // didn't come up. Same staleness guard as the success path: a late-arriving failure for
+        // row A must not collapse row B if the user has already moved on.
+        if (this.loadingMeetingUid() === meetingUid) {
+          this.loadingMeetingUid.set(null);
+        }
+        if (this.expandedRsvpKey() === this.getRowKey(item)) {
+          this.expandedRsvpKey.set(null);
+        }
         this.messageService.add({
           severity: 'error',
           summary: 'Could not load meeting',

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -2,19 +2,24 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, inject, input, output, signal, Signal } from '@angular/core';
+import { RsvpButtonGroupComponent } from '@app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component';
 import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
+import { MeetingService } from '@services/meeting.service';
 import { HiddenActionsService } from '@shared/services/hidden-actions.service';
+import { MessageService } from 'primeng/api';
 
-import type { PendingActionItem } from '@lfx-one/shared/interfaces';
+import type { Meeting, PendingActionItem } from '@lfx-one/shared/interfaces';
 @Component({
   selector: 'lfx-pending-actions',
-  imports: [ButtonComponent, TagComponent],
+  imports: [ButtonComponent, TagComponent, RsvpButtonGroupComponent],
   templateUrl: './pending-actions.component.html',
   styleUrl: './pending-actions.component.scss',
 })
 export class PendingActionsComponent {
   private readonly hiddenActionsService = inject(HiddenActionsService);
+  private readonly meetingService = inject(MeetingService);
+  private readonly messageService = inject(MessageService);
 
   public readonly pendingActions = input.required<PendingActionItem[]>();
   public readonly displayLimit = input<number>(5);
@@ -26,6 +31,19 @@ export class PendingActionsComponent {
   // re-trigger the computed on dismiss. Bumping this signal forces a recompute so the dismissed
   // row disappears and the next waiting item slides into the slot immediately.
   private readonly hiddenActionsVersion = signal(0);
+
+  // Tracks which row, if any, has been clicked into "RSVP mode" so the right-hand cell can swap
+  // from the Set RSVP CTA to the inline Yes/No/Maybe button group. Keyed by the same row key the
+  // template uses for @for tracking so a re-rendered list can preserve the expanded state.
+  protected readonly expandedRsvpKey = signal<string | null>(null);
+
+  // True while the Meeting payload for an expanded RSVP row is being fetched. Drives the inline
+  // spinner state on the CTA so the user gets immediate feedback after clicking Set RSVP.
+  protected readonly rsvpMeetingLoading = signal(false);
+
+  // Per-meetingUid cache so the user can collapse and re-expand the same row (or expand a sibling
+  // RSVP row that points at the same meeting) without triggering a refetch each time.
+  private readonly rsvpMeetingCache = signal<Record<string, Meeting>>({});
 
   // Windowed view of the incoming list: drop anything the user has dismissed (HiddenActionsService
   // sets a 24h cookie on click) and cap to displayLimit so the user focuses on a handful at a time.
@@ -43,8 +61,79 @@ export class PendingActionsComponent {
   });
 
   protected handleActionClick(item: PendingActionItem): void {
+    // RSVP-inline path: expand the row and lazy-load the Meeting. Don't dismiss the row or emit
+    // actionClick yet — both happen once the user actually picks a response (handleRsvpChanged).
+    if (this.isRsvpInline(item)) {
+      this.loadMeetingForRsvp(item);
+      return;
+    }
+
     this.hiddenActionsService.hideAction(item);
     this.hiddenActionsVersion.update((v) => v + 1);
     this.actionClick.emit(item);
+  }
+
+  protected handleRsvpChanged(item: PendingActionItem): void {
+    // Local, post-confirmation row removal. We deliberately do NOT emit `actionClick` here:
+    //  - The button group already gives the user visual confirmation (the selected response
+    //    becomes the active button + the success toast).
+    //  - Emitting `actionClick` makes parent dashboards call `refresh$.next()`, which puts the
+    //    pending-actions card into a loading state and briefly collapses every OTHER row into
+    //    a skeleton flash / "Your desk is clear" empty state.
+    //  - The cookie-based dismiss is a sufficient client-side reconciliation; the next page
+    //    load reconciles authoritatively against the server.
+    // Short delay before dismissing so the user can see their choice register inside the row
+    // and read the toast — abrupt removal feels like the click did nothing.
+    setTimeout(() => {
+      this.expandedRsvpKey.set(null);
+      this.hiddenActionsService.hideAction(item);
+      this.hiddenActionsVersion.update((v) => v + 1);
+    }, 1500);
+  }
+
+  protected isRsvpInline(item: PendingActionItem): boolean {
+    return item.type === 'RSVP' && !!item.meetingUid;
+  }
+
+  protected isExpanded(item: PendingActionItem): boolean {
+    return this.expandedRsvpKey() === this.getRowKey(item);
+  }
+
+  protected getMeetingForItem(item: PendingActionItem): Meeting | null {
+    return item.meetingUid ? (this.rsvpMeetingCache()[item.meetingUid] ?? null) : null;
+  }
+
+  protected getRowKey(item: PendingActionItem): string {
+    return `${item.type}-${item.text}-${item.buttonLink ?? ''}`;
+  }
+
+  private loadMeetingForRsvp(item: PendingActionItem): void {
+    const meetingUid = item.meetingUid;
+    if (!meetingUid) return;
+
+    this.expandedRsvpKey.set(this.getRowKey(item));
+
+    if (this.rsvpMeetingCache()[meetingUid]) return;
+
+    this.rsvpMeetingLoading.set(true);
+    this.meetingService.getMeeting(meetingUid).subscribe({
+      next: (meeting) => {
+        this.rsvpMeetingCache.update((cache) => ({ ...cache, [meetingUid]: meeting }));
+        this.rsvpMeetingLoading.set(false);
+      },
+      error: () => {
+        // Surface the failure so the user knows the click did register and why the inline
+        // RSVP didn't come up. Without this, the spinner just vanishes back to the Set RSVP
+        // CTA and looks like nothing happened.
+        this.rsvpMeetingLoading.set(false);
+        this.expandedRsvpKey.set(null);
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Could not load meeting',
+          detail: 'Open the meeting page from the title link and try again.',
+          life: 4000,
+        });
+      },
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -90,10 +90,19 @@ export class PendingActionsComponent {
     // and read the toast — abrupt removal feels like the click did nothing. timer + takeUntilDestroyed
     // (instead of raw setTimeout) ensures the deferred work is cancelled if the component unmounts
     // mid-delay, so we never write to signals on a destroyed instance.
+    //
+    // Capture this row's key up front so the guarded clear below knows exactly which row scheduled
+    // this timer. If the user RSVPs row A and opens row B before A's 1.5s timer fires, the timer
+    // must not collapse B's expansion just because A's deferred dismiss is firing. hideAction and
+    // the version bump still run unconditionally — those dismiss row A from the visible list,
+    // which is what the user actually asked for.
+    const rowKey = this.getRowKey(item);
     timer(1500)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
-        this.expandedRsvpKey.set(null);
+        if (this.expandedRsvpKey() === rowKey) {
+          this.expandedRsvpKey.set(null);
+        }
         this.hiddenActionsService.hideAction(item);
         this.hiddenActionsVersion.update((v) => v + 1);
       });

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -566,9 +566,9 @@ export class UserService {
 
       if ((email || username) && meetings.length > 0) {
         try {
-          const [userRsvps, activeRegistrantIds] = await Promise.all([
+          const [userRsvps, activeRegistrants] = await Promise.all([
             this.fetchAllUserRsvps(req, email, username),
-            this.fetchUserActiveRegistrantIds(req, email, username),
+            this.fetchUserActiveRegistrantIdentities(req, email, username),
           ]);
 
           // Strongest-response-wins (accepted/declined beats maybe beats nothing) — same logic as
@@ -578,7 +578,7 @@ export class UserService {
           const rsvpByMeeting = new Map<string, MeetingRsvp>();
           for (const rsvp of userRsvps) {
             if (!rsvp.meeting_id) continue;
-            if (!rsvp.registrant_id || !activeRegistrantIds.has(rsvp.registrant_id)) continue;
+            if (!rsvp.registrant_id || !activeRegistrants.uids.has(rsvp.registrant_id)) continue;
             const existing = rsvpByMeeting.get(rsvp.meeting_id);
             if (!existing || (existing.response_type === 'maybe' && rsvp.response_type !== 'maybe')) {
               rsvpByMeeting.set(rsvp.meeting_id, rsvp);
@@ -1143,11 +1143,11 @@ export class UserService {
     let rsvpActions: PendingActionItem[] = [];
     if (inWindowMeetings.length > 0) {
       try {
-        const [userRsvps, activeRegistrantIds] = await Promise.all([
+        const [userRsvps, activeRegistrants] = await Promise.all([
           this.fetchAllUserRsvps(req, email, username),
-          this.fetchUserActiveRegistrantIds(req, email, username),
+          this.fetchUserActiveRegistrantIdentities(req, email, username),
         ]);
-        rsvpActions = this.transformMissingRsvpsToActions(inWindowMeetings, userRsvps, activeRegistrantIds);
+        rsvpActions = this.transformMissingRsvpsToActions(inWindowMeetings, userRsvps, activeRegistrants);
       } catch (error) {
         logger.warning(req, 'get_user_pending_actions', 'RSVP prerequisite lookup failed, suppressing Set RSVP actions', { err: error });
       }
@@ -1286,17 +1286,26 @@ export class UserService {
   }
 
   /**
-   * Fetch the UIDs of every currently-active registrant record for the current user. RSVP rows
-   * persist from removed registrations, so we use the same guard as
-   * `MeetingService.getMeetingRsvps`: keep only those RSVPs whose `registrant_id` matches an
-   * active registrant. Otherwise an old accepted/declined RSVP from a removed registration
-   * would incorrectly suppress a Set RSVP action for the user's current registration.
+   * Fetch the active registrant identities for the current user, returning two sets:
+   *  - `uids`: registrant UIDs (used to invalidate RSVP rows that point at a removed registration —
+   *    same guard as `MeetingService.getMeetingRsvps`, prevents an old declined RSVP from
+   *    suppressing a Set RSVP action for a still-active re-registration).
+   *  - `meetingIds`: every `meeting_id` the user is currently a registrant for. Used to gate
+   *    Set RSVP action emission to meetings the RSVP API will actually accept — a v1_meeting can
+   *    show up via direct FGA grants (host, organizer, committee inheritance) without the user
+   *    having a v1_meeting_registrant row, in which case `createMeetingRsvp` returns 404
+   *    ("Only invited users are allowed to RSVP"). Filtering here keeps the dashboard from
+   *    surfacing rows the user can't action.
    */
-  private async fetchUserActiveRegistrantIds(req: Request, email: string, username: string | null): Promise<Set<string>> {
+  private async fetchUserActiveRegistrantIdentities(
+    req: Request,
+    email: string,
+    username: string | null
+  ): Promise<{ uids: Set<string>; meetingIds: Set<string> }> {
     const orClauses: string[] = [];
     if (email) orClauses.push(`email:${email.toLowerCase()}`);
     if (username) orClauses.push(`username:${username}`);
-    if (orClauses.length === 0) return new Set();
+    if (orClauses.length === 0) return { uids: new Set(), meetingIds: new Set() };
 
     // failOnPartial: a missing registrant UID here means an RSVP-guard lookup would wrongly
     // reject a still-active registrant's RSVP, which then fires a duplicate Set RSVP nag.
@@ -1311,7 +1320,13 @@ export class UserService {
       { failOnPartial: true }
     );
 
-    return new Set(registrants.map((r) => r.uid).filter((uid): uid is string => !!uid));
+    const uids = new Set<string>();
+    const meetingIds = new Set<string>();
+    for (const r of registrants) {
+      if (r.uid) uids.add(r.uid);
+      if (r.meeting_id) meetingIds.add(r.meeting_id);
+    }
+    return { uids, meetingIds };
   }
 
   /**
@@ -1350,7 +1365,11 @@ export class UserService {
    * set so historical RSVPs from removed registrations can't suppress a needed Set RSVP action
    * for the user's current registration.
    */
-  private transformMissingRsvpsToActions(meetings: Meeting[], rsvps: MeetingRsvp[], activeRegistrantIds: Set<string>): PendingActionItem[] {
+  private transformMissingRsvpsToActions(
+    meetings: Meeting[],
+    rsvps: MeetingRsvp[],
+    activeRegistrants: { uids: Set<string>; meetingIds: Set<string> }
+  ): PendingActionItem[] {
     if (meetings.length === 0) return [];
 
     const inWindowMeetingIds = new Set(meetings.map((m) => m.id).filter((id): id is string => !!id));
@@ -1358,7 +1377,7 @@ export class UserService {
     const respondedMeetingIds = new Set<string>();
     for (const rsvp of rsvps) {
       if (!rsvp.meeting_id || !inWindowMeetingIds.has(rsvp.meeting_id)) continue;
-      if (!rsvp.registrant_id || !activeRegistrantIds.has(rsvp.registrant_id)) continue;
+      if (!rsvp.registrant_id || !activeRegistrants.uids.has(rsvp.registrant_id)) continue;
       respondedMeetingIds.add(rsvp.meeting_id);
     }
 
@@ -1366,6 +1385,12 @@ export class UserService {
     for (const meeting of meetings) {
       if (!meeting.id) continue;
       if (respondedMeetingIds.has(meeting.id)) continue;
+      // Suppress the action when the user is not a registrant for this specific meeting.
+      // The pending-actions list comes from `filter_grants: 'direct'` on `v1_meeting`, which
+      // includes hosts/organizers and committee-inherited grants — none of which carry a
+      // `v1_meeting_registrant` row. The RSVP API requires that row, so showing a "Set RSVP"
+      // CTA we know will 404 is a UX dead end.
+      if (!activeRegistrants.meetingIds.has(meeting.id)) continue;
       actions.push(this.createRsvpAction(meeting));
     }
     return actions;
@@ -1432,6 +1457,8 @@ export class UserService {
       buttonText: 'Set RSVP',
       buttonLink,
       date: formattedDate,
+      meetingUid: meeting.id,
+      ...(nextOccurrence?.occurrence_id ? { occurrenceId: nextOccurrence.occurrence_id } : {}),
     };
   }
 

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -488,9 +488,9 @@ export interface PendingActionItem {
   buttonLink?: string;
   /** Optional date string for display (e.g., "Jan 15, 2025 at 10:00 AM") */
   date?: string;
-  /** Meeting UID (set on RSVP/Agenda action types). Used by the dashboard to lazy-load the Meeting and render the RSVP button group inline without leaving the page. */
+  /** Meeting UID (set on RSVP action types today; Agenda may populate this in a follow-up). Used by the dashboard to lazy-load the Meeting and render the RSVP button group inline without leaving the page. */
   meetingUid?: string;
-  /** Occurrence ID for recurring meetings (set on RSVP/Agenda action types). Passed to RsvpButtonGroupComponent so the scope picker (single / this_and_following / all) can scope the response correctly. */
+  /** Occurrence ID for recurring meetings (set on RSVP action types today). Passed to RsvpButtonGroupComponent so the scope picker (single / this_and_following / all) can scope the response correctly. */
   occurrenceId?: string;
 }
 

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -488,6 +488,10 @@ export interface PendingActionItem {
   buttonLink?: string;
   /** Optional date string for display (e.g., "Jan 15, 2025 at 10:00 AM") */
   date?: string;
+  /** Meeting UID (set on RSVP/Agenda action types). Used by the dashboard to lazy-load the Meeting and render the RSVP button group inline without leaving the page. */
+  meetingUid?: string;
+  /** Occurrence ID for recurring meetings (set on RSVP/Agenda action types). Passed to RsvpButtonGroupComponent so the scope picker (single / this_and_following / all) can scope the response correctly. */
+  occurrenceId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Inline RSVP from the dashboard pending-actions card.** Clicking *Set RSVP* expands the row in place and renders the existing `RsvpButtonGroupComponent` (the same Yes / No / Maybe widget already used on `meeting-card` and `meeting-join`). Recurring meetings continue to surface the existing scope picker (single / this_and_following / all). After the user picks a response, the row stays visible for ~1.5 s so the choice and toast can register, then dismisses via the existing 24 h cookie. **No parent refresh — no skeleton flash, no false empty state for the other rows.**
- **Meeting title doubles as a "view meeting" affordance.** Clicking the title opens the meeting detail page in a new tab without dismissing the row, so users can drill in for context and still come back to RSVP inline. Includes an external-link icon and `aria-label` for accessibility.
- **Pre-existing bug fix on the server.** `transformMissingRsvpsToActions` now gates Set RSVP emission on per-meeting registrant existence. Previously, meetings the user had direct FGA grants on (host, organizer, committee inheritance) but **no `v1_meeting_registrant` row** would surface a Set RSVP CTA that the API immediately 404'd ("Only invited users are allowed to RSVP"). The dashboard now mirrors the API contract.
- **Out of scope** (separate stories): inline behavior for Vote, Survey, Agenda action types; new `POST /api/votes/responses` proxy; refactor of committee-overview's existing inline-Vote pattern.

JIRA: [LFXV2-1584](https://linuxfoundation.atlassian.net/browse/LFXV2-1584)

## Files

- `packages/shared/src/interfaces/components.interface.ts` — `PendingActionItem` gains optional `meetingUid?` and `occurrenceId?` (additive, no breaking change).
- `apps/lfx-one/src/server/services/user.service.ts`
  - `createRsvpAction` populates the new fields.
  - `fetchUserActiveRegistrantIds` → `fetchUserActiveRegistrantIdentities` returns `{ uids, meetingIds }`.
  - `transformMissingRsvpsToActions` skips meetings the user has no registrant row for.
- `apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.{ts,html}` — inline RSVP UI, lazy meeting fetch, error toast on fetch failure, title-link affordance.

## Note on scope

This PR is feature-only (4 files). An earlier iteration bundled 21 pre-existing prettier-drift files that surfaced during local preflight; those have been removed from this PR. The drift is pre-existing on `main` (confirmed by running `yarn format:check` on a fresh checkout) and the `quality-check.yml` workflow is currently disabled (`workflow_dispatch` only), so the drift isn't blocking CI on any PR today. Bulk-formatting the dashboard tree is left as a separate maintainer concern.

## Test plan

- [ ] Dashboard loads — `My Pending Actions` card shows RSVP rows only for meetings the user is registered for. Direct-FGA-only meetings no longer appear as Set RSVP rows.
- [ ] Click **Set RSVP** on a one-off meeting → row expands, Yes/No/Maybe buttons render, picking a response submits successfully (toast appears), row dismisses after ~1.5 s.
- [ ] Click **Set RSVP** on a recurring meeting → scope picker dialog (single / this_and_following / all) appears, scope selection RSVPs successfully.
- [ ] Click the **meeting title** → opens the meeting detail page in a new tab, row stays put.
- [ ] After RSVPing the last remaining row → "Your desk is clear" empty state renders.
- [ ] Vote, Survey, and Agenda rows still open in a new tab via their action button (unchanged behavior).
- [ ] If meeting fetch fails (simulate offline / 500), an error toast appears and the row collapses back to the Set RSVP CTA.
- [ ] Reload after RSVP → server response correctly omits the just-RSVPed meeting from the pending-actions list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1584]: https://linuxfoundation.atlassian.net/browse/LFXV2-1584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
