### PR TITLE
style: apply prettier to drift on existing dashboard files

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/board-member/board-member-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/board-member/board-member-dashboard.component.ts
@@ -18,7 +18,14 @@ import { PendingActionsComponent } from '../components/pending-actions/pending-a
 
 @Component({
   selector: 'lfx-board-member-dashboard',
-  imports: [OrganizationInvolvementComponent, PendingActionsComponent, MyMeetingsComponent, FoundationHealthComponent, SkeletonModule, DashboardQuicklinksComponent],
+  imports: [
+    OrganizationInvolvementComponent,
+    PendingActionsComponent,
+    MyMeetingsComponent,
+    FoundationHealthComponent,
+    SkeletonModule,
+    DashboardQuicklinksComponent,
+  ],
   templateUrl: './board-member-dashboard.component.html',
   styleUrl: './board-member-dashboard.component.scss',
 })
@@ -61,9 +68,7 @@ export class BoardMemberDashboardComponent {
               }
 
               // Fetch all pending actions from unified backend endpoint
-              return this.projectService.getPendingActions(project.slug, project.uid, 'board-member').pipe(
-                catchError(() => of([]))
-              );
+              return this.projectService.getPendingActions(project.slug, project.uid, 'board-member').pipe(catchError(() => of([])));
             })
           );
         })

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-quicklinks/dashboard-quicklinks.component.html
@@ -5,10 +5,7 @@
   <div class="flex items-center gap-2 text-sm" data-testid="dashboard-quicklinks">
     <span class="text-surface-400 font-medium">Quick links:</span>
     @for (link of links; track link.testId; let last = $last) {
-      <a
-        [routerLink]="link.route"
-        class="flex items-center gap-1.5 text-primary hover:underline"
-        [attr.data-testid]="'dashboard-quicklink-' + link.testId">
+      <a [routerLink]="link.route" class="flex items-center gap-1.5 text-primary hover:underline" [attr.data-testid]="'dashboard-quicklink-' + link.testId">
         <i [class]="link.icon" aria-hidden="true"></i>
         {{ link.label }}
       </a>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -84,7 +84,9 @@
 
     <!-- FIRST FOLD: Needs Your Attention -->
     @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="brand-health-drawer-attention">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+        data-testid="brand-health-drawer-attention">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-triangle-exclamation text-red-600"></i>
           <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -115,7 +117,9 @@
 
     <!-- SECOND FOLD: Performing Well -->
     @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="brand-health-drawer-performing">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+        data-testid="brand-health-drawer-performing">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-check text-green-600"></i>
           <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
@@ -64,7 +64,9 @@
 
     <!-- FIRST FOLD: Needs Your Attention -->
     @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="brand-reach-drawer-attention">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+        data-testid="brand-reach-drawer-attention">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-triangle-exclamation text-red-600"></i>
           <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -95,7 +97,9 @@
 
     <!-- SECOND FOLD: Performing Well -->
     @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="brand-reach-drawer-performing">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+        data-testid="brand-reach-drawer-performing">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-check text-green-600"></i>
           <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -41,7 +41,9 @@
     } @else {
       <!-- Cross-Channel Insights -->
       @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-        <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="email-ctr-drawer-attention">
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+          data-testid="email-ctr-drawer-attention">
           <div class="flex items-center gap-2 px-4 pt-4 pb-2">
             <i class="fa-light fa-triangle-exclamation text-red-600"></i>
             <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -71,7 +73,9 @@
       }
 
       @if (performingActions().length > 0 || performingInsights().length > 0) {
-        <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="email-ctr-drawer-performing">
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+          data-testid="email-ctr-drawer-performing">
           <div class="flex items-center gap-2 px-4 pt-4 pb-2">
             <i class="fa-light fa-check text-green-600"></i>
             <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -55,7 +55,9 @@
 
     <!-- FIRST FOLD: Needs Your Attention -->
     @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="engaged-community-drawer-attention">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+        data-testid="engaged-community-drawer-attention">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-triangle-exclamation text-red-600"></i>
           <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -86,7 +88,9 @@
 
     <!-- SECOND FOLD: Performing Well -->
     @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="engaged-community-drawer-performing">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+        data-testid="engaged-community-drawer-performing">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-check text-green-600"></i>
           <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -105,7 +105,9 @@
 
     <!-- FIRST FOLD: Needs Your Attention -->
     @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="event-growth-drawer-attention">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+        data-testid="event-growth-drawer-attention">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-triangle-exclamation text-red-600"></i>
           <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -136,7 +138,9 @@
 
     <!-- SECOND FOLD: Performing Well -->
     @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="event-growth-drawer-performing">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+        data-testid="event-growth-drawer-performing">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-check text-green-600"></i>
           <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -63,7 +63,9 @@
 
     <!-- FIRST FOLD: Needs Your Attention -->
     @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="flywheel-conversion-drawer-attention">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+        data-testid="flywheel-conversion-drawer-attention">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-triangle-exclamation text-red-600"></i>
           <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -94,7 +96,9 @@
 
     <!-- SECOND FOLD: Performing Well -->
     @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="flywheel-conversion-drawer-performing">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+        data-testid="flywheel-conversion-drawer-performing">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-check text-green-600"></i>
           <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -194,7 +194,6 @@
       data-testid="ed-evolution-shadow-left"
       aria-hidden="true"></div>
   </div>
-
 </section>
 
 <!-- Drill-Down Drawers -->

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -85,7 +85,9 @@
 
     <!-- FIRST FOLD: Needs Your Attention -->
     @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="member-acquisition-drawer-attention">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+        data-testid="member-acquisition-drawer-attention">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-triangle-exclamation text-red-600"></i>
           <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -116,7 +118,9 @@
 
     <!-- SECOND FOLD: Performing Well -->
     @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="member-acquisition-drawer-performing">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+        data-testid="member-acquisition-drawer-performing">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-check text-green-600"></i>
           <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -61,7 +61,9 @@
 
     <!-- FIRST FOLD: Needs Your Attention -->
     @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="member-retention-drawer-attention">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+        data-testid="member-retention-drawer-attention">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-triangle-exclamation text-red-600"></i>
           <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -92,7 +94,9 @@
 
     <!-- SECOND FOLD: Performing Well -->
     @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="member-retention-drawer-performing">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+        data-testid="member-retention-drawer-performing">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-check text-green-600"></i>
           <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/paid-social-reach-drawer/paid-social-reach-drawer.component.html
@@ -75,7 +75,9 @@
 
       <!-- FIRST FOLD: Needs Your Attention -->
       @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-        <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="paid-social-reach-drawer-attention">
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+          data-testid="paid-social-reach-drawer-attention">
           <div class="flex items-center gap-2 px-4 pt-4 pb-2">
             <i class="fa-light fa-triangle-exclamation text-red-600"></i>
             <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -106,7 +108,9 @@
 
       <!-- SECOND FOLD: Performing Well -->
       @if (performingActions().length > 0 || performingInsights().length > 0) {
-        <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="paid-social-reach-drawer-performing">
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+          data-testid="paid-social-reach-drawer-performing">
           <div class="flex items-center gap-2 px-4 pt-4 pb-2">
             <i class="fa-light fa-check text-green-600"></i>
             <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/revenue-impact-drawer/revenue-impact-drawer.component.html
@@ -30,7 +30,9 @@
   <div class="flex flex-col gap-6 pb-2" data-testid="revenue-impact-drawer-content">
     <!-- FIRST FOLD: Needs Your Attention -->
     @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="revenue-impact-drawer-attention">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+        data-testid="revenue-impact-drawer-attention">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-triangle-exclamation text-red-600"></i>
           <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -61,7 +63,9 @@
 
     <!-- SECOND FOLD: Performing Well -->
     @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="revenue-impact-drawer-performing">
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+        data-testid="revenue-impact-drawer-performing">
         <div class="flex items-center gap-2 px-4 pt-4 pb-2">
           <i class="fa-light fa-check text-green-600"></i>
           <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/social-media-drawer/social-media-drawer.component.html
@@ -72,7 +72,9 @@
 
       <!-- FIRST FOLD: Needs Your Attention -->
       @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-        <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="social-media-drawer-attention">
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+          data-testid="social-media-drawer-attention">
           <div class="flex items-center gap-2 px-4 pt-4 pb-2">
             <i class="fa-light fa-triangle-exclamation text-red-600"></i>
             <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -103,7 +105,9 @@
 
       <!-- SECOND FOLD: Performing Well -->
       @if (performingActions().length > 0 || performingInsights().length > 0) {
-        <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="social-media-drawer-performing">
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+          data-testid="social-media-drawer-performing">
           <div class="flex items-center gap-2 px-4 pt-4 pb-2">
             <i class="fa-light fa-check text-green-600"></i>
             <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -57,7 +57,9 @@
 
       <!-- FIRST FOLD: Needs Your Attention -->
       @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-        <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden" data-testid="website-visits-drawer-attention">
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+          data-testid="website-visits-drawer-attention">
           <div class="flex items-center gap-2 px-4 pt-4 pb-2">
             <i class="fa-light fa-triangle-exclamation text-red-600"></i>
             <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
@@ -88,7 +90,9 @@
 
       <!-- SECOND FOLD: Performing Well -->
       @if (performingActions().length > 0 || performingInsights().length > 0) {
-        <div class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden" data-testid="website-visits-drawer-performing">
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+          data-testid="website-visits-drawer-performing">
           <div class="flex items-center gap-2 px-4 pt-4 pb-2">
             <i class="fa-light fa-check text-green-600"></i>
             <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/executive-director-dashboard.component.ts
@@ -70,9 +70,7 @@ export class ExecutiveDirectorDashboardComponent {
             return of([]);
           }
 
-          return this.projectService.getPendingActions(project.slug, project.uid, 'executive-director').pipe(
-            catchError(() => of([]))
-          );
+          return this.projectService.getPendingActions(project.slug, project.uid, 'executive-director').pipe(catchError(() => of([])));
         })
       ),
       { initialValue: [] }

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.html
@@ -218,9 +218,7 @@
           </ng-template>
           <ng-template #emptymessage>
             <tr>
-              <td [attr.colspan]="3 + (showTypeColumn() ? 1 : 0)" class="py-8 text-center text-sm text-gray-400">
-                No foundations or projects found.
-              </td>
+              <td [attr.colspan]="3 + (showTypeColumn() ? 1 : 0)" class="py-8 text-center text-sm text-gray-400">No foundations or projects found.</td>
             </tr>
           </ng-template>
         </lfx-table>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -416,7 +416,12 @@
 
     <!-- Meeting Registrants Drawer -->
     @if (meeting().organizer) {
-      <p-drawer [(visible)]="showRegistrants" position="right" styleClass="lg:w-1/3 w-full" data-testid="meeting-registrants-drawer" (onHide)="drawerGuestCount.set(0)">
+      <p-drawer
+        [(visible)]="showRegistrants"
+        position="right"
+        styleClass="lg:w-1/3 w-full"
+        data-testid="meeting-registrants-drawer"
+        (onHide)="drawerGuestCount.set(0)">
         <ng-template #header>
           <div class="flex items-center gap-3">
             <div class="bg-blue-600 text-white rounded-full w-12 h-12 flex items-center justify-center">

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -285,9 +285,7 @@ export class MeetingRegistrantsDisplayComponent {
       }
       const fetchedEmails = new Set(list.map((r) => r.email?.trim().toLowerCase()));
       const pending = this.optimisticRegistrants().filter((r) => !fetchedEmails.has(r.email?.trim().toLowerCase()));
-      return pending.length
-        ? ([...pending, ...list].sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as MeetingRegistrant[])
-        : list;
+      return pending.length ? ([...pending, ...list].sort((a, b) => a.first_name?.localeCompare(b.first_name ?? '') ?? 0) as MeetingRegistrant[]) : list;
     });
   }
 

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -21,8 +21,8 @@ import { SkeletonModule } from 'primeng/skeleton';
 const PERSONA_ICONS: Partial<Record<PersonaType, string>> = {
   'executive-director': 'fa-light fa-briefcase',
   'board-member': 'fa-light fa-building-columns',
-  'maintainer': 'fa-light fa-code',
-  'contributor': 'fa-light fa-code',
+  maintainer: 'fa-light fa-code',
+  contributor: 'fa-light fa-code',
 };
 
 @Component({
@@ -117,7 +117,7 @@ export class SidebarComponent {
       if (this.activeLens() === 'me') {
         const priorityMap = new Map(PERSONA_PRIORITY.map((p, i) => [p, i]));
         const sorted = [...this.personaService.allPersonas()].sort(
-          (a, b) => (priorityMap.get(a) ?? Number.MAX_SAFE_INTEGER) - (priorityMap.get(b) ?? Number.MAX_SAFE_INTEGER),
+          (a, b) => (priorityMap.get(a) ?? Number.MAX_SAFE_INTEGER) - (priorityMap.get(b) ?? Number.MAX_SAFE_INTEGER)
         );
         return sorted.slice(0, 3).map(toTag);
       }

--- a/apps/lfx-one/src/server/services/vote.service.ts
+++ b/apps/lfx-one/src/server/services/vote.service.ts
@@ -1,7 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CreateVoteRequest, IndexedVote, QueryServiceCountResponse, QueryServiceResponse, UpdateVoteRequest, Vote, VoteResultsResponse } from '@lfx-one/shared/interfaces';
+import {
+  CreateVoteRequest,
+  IndexedVote,
+  QueryServiceCountResponse,
+  QueryServiceResponse,
+  UpdateVoteRequest,
+  Vote,
+  VoteResultsResponse,
+} from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
 import { ResourceNotFoundError } from '../errors';


### PR DESCRIPTION
## Summary

Pre-existing prettier drift on `main` — pure formatting (line wrapping, quote-style cleanup) across 21 files. Zero behavior change.

This was originally bundled into PR #602 (LFXV2-1584 inline RSVP) because `yarn format:check` failed during preflight. Splitting it out per reviewer feedback so #602 stays focused on the feature.

## Files affected

- 12 executive-director marketing drawer HTML templates
- `dashboard-quicklinks.component.html`, `multi-persona-dashboard.component.html`, `marketing-overview.component.html`
- `meeting-card.component.html`, `meeting-registrants-display.component.ts`
- `board-member-dashboard.component.ts`, `executive-director-dashboard.component.ts`
- `sidebar.component.ts`, `vote.service.ts`

## Test plan

- [ ] CI runs `yarn format:check` and passes on this branch
- [ ] No functional changes — diff is whitespace and line-wrapping only

🤖 Generated with [Claude Code](https://claude.com/claude-code)