### PR TITLE
fix(committees): truncate long meeting descriptions on group overview

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -107,7 +107,7 @@
     </lfx-card>
 
     <!-- RIGHT: Meetings + Pending Actions stacked -->
-    <div class="flex flex-col gap-5">
+    <div class="flex flex-col gap-5 min-w-0">
       @if (!isVisitor()) {
         <!-- Next Meeting -->
         <div class="flex flex-col gap-2">

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.html
@@ -148,7 +148,7 @@
 
       <!-- Description snippet -->
       @if (meetingDescription()) {
-        <p class="text-[10px] text-gray-500 truncate" data-testid="dashboard-meeting-card-description">
+        <p class="text-[10px] text-gray-500 truncate min-w-0" data-testid="dashboard-meeting-card-description">
           {{ meetingDescription() }}
         </p>
       }


### PR DESCRIPTION
## What
Long URLs in meeting descriptions (e.g. a Google Docs agenda link with no whitespace) were overflowing the dashboard meeting card on the group/committee overview page and forcing the entire page to scroll horizontally.

## Why
The description `<p>` already had Tailwind's `truncate` class (`overflow: hidden; text-overflow: ellipsis; white-space: nowrap`), but it wasn't taking effect. The default `min-width: auto` on flex/grid items up the parent chain was letting the long-URL content expand the layout, defeating `overflow: hidden` before it could ever clip.

## How
Two targeted `min-w-0` additions to break the chain:

- `dashboard-meeting-card.component.html` — `min-w-0` on the description `<p>` so its `overflow: hidden` actually constrains to the parent's width.
- `committee-overview.component.html` — `min-w-0` on the right-column grid item so the `1fr` column doesn't grow to fit the card's intrinsic content width.

## Test plan
- [ ] Open any group/committee overview page where a meeting has a long URL in its description (e.g. AAIF working groups with Google Docs agenda links).
- [ ] Confirm the "Next Meeting" and "Past Meeting" descriptions render on a single line with an ellipsis (`…`).
- [ ] Confirm the page does not scroll horizontally.
- [ ] Verify nothing visually regresses on group pages where the description is short or empty.