### PR TITLE
fix(analytics): suppress Segment tracking during impersonation

### DIFF
--- a/apps/lfx-one/src/app/app.component.ts
+++ b/apps/lfx-one/src/app/app.component.ts
@@ -67,10 +67,12 @@ export class AppComponent {
         this.userService.canImpersonate.set(true);
       }
 
-      if (this.auth?.impersonating) {
+      const isImpersonating = Boolean(this.auth?.impersonating);
+      this.segmentService.setImpersonating(isImpersonating);
+
+      if (isImpersonating) {
         this.userService.impersonating.set(true);
         this.userService.impersonator.set(this.auth.impersonator ?? null);
-        this.segmentService.setImpersonating(true);
       }
 
       this.segmentService.identifyUser(this.auth.user);

--- a/apps/lfx-one/src/app/app.component.ts
+++ b/apps/lfx-one/src/app/app.component.ts
@@ -62,18 +62,12 @@ export class AppComponent {
         this.accountContextService.initializeUserOrganizations(this.auth.organizations);
       }
 
-      // Hydrate canImpersonate permission from server context
-      if (this.auth?.canImpersonate) {
-        this.userService.canImpersonate.set(true);
-      }
+      this.userService.canImpersonate.set(Boolean(this.auth?.canImpersonate));
 
       const isImpersonating = Boolean(this.auth?.impersonating);
       this.segmentService.setImpersonating(isImpersonating);
-
-      if (isImpersonating) {
-        this.userService.impersonating.set(true);
-        this.userService.impersonator.set(this.auth.impersonator ?? null);
-      }
+      this.userService.impersonating.set(isImpersonating);
+      this.userService.impersonator.set(isImpersonating ? (this.auth.impersonator ?? null) : null);
 
       this.segmentService.identifyUser(this.auth.user);
 

--- a/apps/lfx-one/src/app/app.component.ts
+++ b/apps/lfx-one/src/app/app.component.ts
@@ -67,15 +67,12 @@ export class AppComponent {
         this.userService.canImpersonate.set(true);
       }
 
-      // Hydrate impersonation state from server context — must run before any
-      // Segment calls so the suppression flag is set before identifyUser fires.
       if (this.auth?.impersonating) {
         this.userService.impersonating.set(true);
         this.userService.impersonator.set(this.auth.impersonator ?? null);
         this.segmentService.setImpersonating(true);
       }
 
-      // Identify user with Segment tracking (suppressed during impersonation)
       this.segmentService.identifyUser(this.auth.user);
 
       // Initialize feature flags with user context

--- a/apps/lfx-one/src/app/app.component.ts
+++ b/apps/lfx-one/src/app/app.component.ts
@@ -62,7 +62,20 @@ export class AppComponent {
         this.accountContextService.initializeUserOrganizations(this.auth.organizations);
       }
 
-      // Identify user with Segment tracking (pass entire Auth0 user object)
+      // Hydrate canImpersonate permission from server context
+      if (this.auth?.canImpersonate) {
+        this.userService.canImpersonate.set(true);
+      }
+
+      // Hydrate impersonation state from server context — must run before any
+      // Segment calls so the suppression flag is set before identifyUser fires.
+      if (this.auth?.impersonating) {
+        this.userService.impersonating.set(true);
+        this.userService.impersonator.set(this.auth.impersonator ?? null);
+        this.segmentService.setImpersonating(true);
+      }
+
+      // Identify user with Segment tracking (suppressed during impersonation)
       this.segmentService.identifyUser(this.auth.user);
 
       // Initialize feature flags with user context
@@ -72,17 +85,6 @@ export class AppComponent {
 
       // Set DataDog RUM user context for session tracking
       this.dataDogRumService.setUser(this.auth.user);
-
-      // Hydrate canImpersonate permission from server context
-      if (this.auth?.canImpersonate) {
-        this.userService.canImpersonate.set(true);
-      }
-
-      // Hydrate impersonation state from server context
-      if (this.auth?.impersonating) {
-        this.userService.impersonating.set(true);
-        this.userService.impersonator.set(this.auth.impersonator ?? null);
-      }
     }
   }
 }

--- a/apps/lfx-one/src/app/shared/services/segment.service.ts
+++ b/apps/lfx-one/src/app/shared/services/segment.service.ts
@@ -33,14 +33,9 @@ export class SegmentService {
   private identifyQueue: { user: unknown }[] = [];
   private impersonating = false;
 
-  /**
-   * Suppress all Segment tracking during impersonation sessions to prevent
-   * mixed-identity payloads from corrupting real member profiles in Segment.
-   */
   public setImpersonating(isImpersonating: boolean): void {
     this.impersonating = isImpersonating;
     if (isImpersonating) {
-      // Discard any queued identify calls from before the impersonation flag was set.
       this.identifyQueue = [];
     }
   }

--- a/apps/lfx-one/src/app/shared/services/segment.service.ts
+++ b/apps/lfx-one/src/app/shared/services/segment.service.ts
@@ -31,6 +31,19 @@ export class SegmentService {
   private analyticsReady = false;
   private analytics?: LfxSegmentAnalytics;
   private identifyQueue: { user: unknown }[] = [];
+  private impersonating = false;
+
+  /**
+   * Suppress all Segment tracking during impersonation sessions to prevent
+   * mixed-identity payloads from corrupting real member profiles in Segment.
+   */
+  public setImpersonating(isImpersonating: boolean): void {
+    this.impersonating = isImpersonating;
+    if (isImpersonating) {
+      // Discard any queued identify calls from before the impersonation flag was set.
+      this.identifyQueue = [];
+    }
+  }
 
   /**
    * Initialize the analytics service - should be called from app component
@@ -49,7 +62,7 @@ export class SegmentService {
    * @param properties Optional page properties
    */
   public trackPage(pageName: string, properties?: Record<string, unknown>): void {
-    if (!this.analyticsReady || !this.analytics) {
+    if (this.impersonating || !this.analyticsReady || !this.analytics) {
       return;
     }
 
@@ -66,7 +79,7 @@ export class SegmentService {
    * @param properties Event properties
    */
   public trackEvent(eventName: string, properties?: Record<string, unknown>): void {
-    if (!this.analyticsReady || !this.analytics) {
+    if (this.impersonating || !this.analyticsReady || !this.analytics) {
       return;
     }
 
@@ -82,7 +95,7 @@ export class SegmentService {
    * @param auth0User Auth0 user object
    */
   public identifyUser(auth0User: unknown): void {
-    if (!auth0User) {
+    if (!auth0User || this.impersonating) {
       return;
     }
 

--- a/apps/lfx-one/src/app/shared/services/segment.service.ts
+++ b/apps/lfx-one/src/app/shared/services/segment.service.ts
@@ -35,16 +35,12 @@ export class SegmentService {
 
   public setImpersonating(isImpersonating: boolean): void {
     this.impersonating = isImpersonating;
-    if (isImpersonating) {
-      this.identifyQueue = [];
-    }
   }
 
   /**
    * Initialize the analytics service - should be called from app component
    */
   public initialize(): void {
-    // SSR-safe initialization using afterNextRender
     afterNextRender(() => {
       this.loadSegmentScript();
       this.setupRouteTracking();

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -9,7 +9,7 @@ import { logger } from '../services/logger.service';
 import { OrganizationService } from '../services/organization.service';
 import { ProjectService } from '../services/project.service';
 import { UserService } from '../services/user.service';
-import { getEffectiveEmail, getUsernameFromAuth } from '../utils/auth-helper';
+import { getEffectiveEmail } from '../utils/auth-helper';
 
 /** Allowed pattern for foundationSlug: lowercase alphanumeric and hyphens only */
 const SLUG_PATTERN = /^[a-z0-9-]+$/;

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -6,7 +6,6 @@ import {
   LATEST_PAST_MEETINGS_RETURN_LIMIT,
   NATS_CONFIG,
   QUERY_SERVICE_FILTERS_OR_BATCH_SIZE,
-  ROOT_PROJECT_SLUG,
   TSHIRT_SIZES,
 } from '@lfx-one/shared/constants';
 import { NatsSubjects, PollStatus } from '@lfx-one/shared/enums';


### PR DESCRIPTION
## Summary

- Adds `setImpersonating(true)` gate to `SegmentService` that silences all `identify()`, `track()`, and `page()` calls
- Moves impersonation-state hydration in `app.component.ts` to run before `identifyUser()` so the suppression flag is armed before any Segment call fires
- Fixes data corruption where impersonator name traits were overwriting real member profiles in Segment (e.g. Greg Kroah-Hartman appearing as Jordan Evans)

Fixes [LFXV2-1594](https://linuxfoundation.atlassian.net/browse/LFXV2-1594)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[LFXV2-1594]: https://linuxfoundation.atlassian.net/browse/LFXV2-1594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ