### PR TITLE
fix(navigation): keep contributor with board-member role

### DIFF
--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -101,8 +101,7 @@ export class NavigationService {
     // other lenses (e.g., Me → Open) doesn't get overridden by the default picker.
     if (selectedUid && !pageToken) {
       const alreadyIncluded = accumulated.some((item) => item.uid === selectedUid);
-      const allowedByPersona = !eligibleUids || eligibleUids.has(selectedUid);
-      if (!alreadyIncluded && allowedByPersona) {
+      if (!alreadyIncluded) {
         const selectedItem = await this.fetchSelectedItem(req, lens, selectedUid);
         if (selectedItem) {
           accumulated.unshift(selectedItem);

--- a/apps/lfx-one/src/server/services/persona-detection.service.ts
+++ b/apps/lfx-one/src/server/services/persona-detection.service.ts
@@ -372,8 +372,10 @@ export class PersonaDetectionService {
       personas.add('contributor');
     }
 
-    // Drop contributor when a more specific role is present.
-    if (personas.size > 1 && personas.has('contributor')) {
+    // Drop contributor only when maintainer is present — the true upgrade
+    // of the same domain. Board-member / executive-director are orthogonal
+    // foundation roles and must not cause contributor to be dropped.
+    if (personas.has('contributor') && personas.has('maintainer')) {
       personas.delete('contributor');
     }
 


### PR DESCRIPTION
Two interacting bugs caused a project to disappear from the project dropdown for users with both committee_member and board_member (from parent foundation) detections.

Bug 1: mapDetectionsToPersonas dropped contributor whenever any other persona was present. board-member is an orthogonal foundation role — not an upgrade of contributor. Only maintainer is a true domain upgrade, so restrict the drop logic to that pair.

Bug 2: selectedUid injection in buildLensItems was blocked by allowedByPersona when Bug 1 excluded the project from eligibleUids. Remove the guard; fetchSelectedItem already validates project stage and lens type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)