### PR TITLE
fix(profile): skip CDP create for linkedin identities

### DIFF
--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -1812,7 +1812,11 @@ export class ProfileController {
       // Google uses email as its value — skip CDP create if the same email is already a verified email identity
       const isEmailAlreadyVerified = enriched.some((id) => id.platform === 'email' && id.value === value && id.verified && id.verifiedBy === lfid);
 
-      if (!isEmailAlreadyVerified) {
+      // Skip CDP create for LinkedIn — Auth0 returns the user's email as the identity value,
+      // but CDP expects a vanity username, so a synthetic POST would write bad data.
+      const skipCdpCreate = cdpPlatform === 'linkedin';
+
+      if (!isEmailAlreadyVerified && !skipCdpCreate) {
         // Fire-and-forget: persist auth-service identity to CDP
         const isEmailType = cdpPlatform === 'email' || cdpPlatform === 'google';
         const cdpPostPlatform = isEmailType ? 'custom' : cdpPlatform;


### PR DESCRIPTION
 LinkedIn identities returned by Auth0 carry the user's email as the identity value, but CDP expects a vanity username (e.g. `john-doe`). The fire-and-forget `POST /identities` in `reconcileIdentities` was pushing email-as-username into CDP whenever an Auth0 LinkedIn identity had no CDP counterpart, writing bad data into the platform.                                                                                                                                       
  
Skip the CDP create call when the platform is `linkedin`. The synthetic display entry is still pushed, so the LinkedIn identity continues to render in the Identities tab as verified — only the outbound CDP write is dropped.            
                                                        
Fixes [LFXV2-1592](https://linuxfoundation.atlassian.net/browse/LFXV2-1592)                                                                                                                                                                
                                                        
## Test plan                                                                                                                                                                                                                               
                                                        
- [ ] Open the Identities tab as a user whose Auth0 LinkedIn identity is not yet in CDP — LinkedIn still appears as verified                                                                                                               
- [ ] Confirm no `POST /identities` to CDP fires for LinkedIn (server logs — no `reconcile_identities` create with `platform: 'linkedin'`)
 - [ ] GitHub / Google / Email synthetic creates still fire as before  

[LFXV2-1592]: https://linuxfoundation.atlassian.net/browse/LFXV2-1592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ