### PR TITLE
fix(navigation): show formation-stage projects in lens dropdown

### DIFF
--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -168,7 +168,12 @@ export class NavigationService {
       const project = response?.resources?.[0]?.data;
       if (!project) return null;
       // Mirror the main-pipeline contract so an archived selection doesn't get re-injected.
-      if (project.stage !== 'Active' && project.stage !== 'Formation - Engaged') return null;
+      // Formation - Engaged is only valid for the project lens; foundation lens stays strict.
+      if (lens === 'foundation') {
+        if (project.stage !== 'Active') return null;
+      } else {
+        if (project.stage !== 'Active' && project.stage !== 'Formation - Engaged') return null;
+      }
       if (lens === 'foundation' && !computeIsFoundation(project)) return null;
       return this.toLensItem(project);
     } catch (error) {

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { LENS_PERSONA_MAP, NAV_MAX_UPSTREAM_ITERATIONS, NAV_MIN_ITEMS_PER_RESPONSE } from '@lfx-one/shared/constants';
-import { ProjectFunding } from '@lfx-one/shared/enums';
+import { ProjectFunding, ProjectStage } from '@lfx-one/shared/enums';
 import {
   EnrichedPersonaProject,
   GetLensItemsParams,
@@ -15,7 +15,7 @@ import {
   Project,
   QueryServiceResponse,
 } from '@lfx-one/shared/interfaces';
-import { computeIsFoundation } from '@lfx-one/shared/utils';
+import { computeIsFoundation, computeIsFoundationEligible } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { personaDetectionService } from '../utils/persona-helper';
@@ -168,13 +168,11 @@ export class NavigationService {
       const project = response?.resources?.[0]?.data;
       if (!project) return null;
       // Mirror the main-pipeline contract so an archived selection doesn't get re-injected.
-      // Formation - Engaged is only valid for the project lens; foundation lens stays strict.
       if (lens === 'foundation') {
-        if (project.stage !== 'Active') return null;
+        if (!computeIsFoundationEligible(project)) return null;
       } else {
-        if (project.stage !== 'Active' && project.stage !== 'Formation - Engaged') return null;
+        if (project.stage !== ProjectStage.Active && project.stage !== ProjectStage.FormationEngaged) return null;
       }
-      if (lens === 'foundation' && !computeIsFoundation(project)) return null;
       return this.toLensItem(project);
     } catch (error) {
       logger.warning(req, 'fetch_selected_item', 'Failed to fetch selected lens item', { err: error, uid, lens });
@@ -186,7 +184,7 @@ export class NavigationService {
     let projects = resources.map((r) => r.data);
     // legal_entity_type negation isn't supported by the filter grammar — re-check locally.
     if (lens === 'foundation') {
-      projects = projects.filter((p) => computeIsFoundation(p));
+      projects = projects.filter((p) => computeIsFoundationEligible(p));
     }
     if (eligibleUids) {
       projects = projects.filter((p) => eligibleUids.has(p.uid));
@@ -198,11 +196,14 @@ export class NavigationService {
     // legal_entity_type negation is post-filtered (filter grammar has no exclusions).
     const base: LensItemsQuery = { type: 'project', filters: [], sort: 'name_asc' };
     if (lens === 'foundation') {
-      base.filters = ['stage:Active', `funding:${ProjectFunding.Funded}`, 'funding_model:Membership'];
+      // Funding + membership required (AND); Active or Formation - Engaged accepted (OR).
+      // This ensures pre-launch foundations appear in the dropdown before they go Active.
+      base.filters = [`funding:${ProjectFunding.Funded}`, 'funding_model:Membership'];
+      base.filters_or = [`stage:${ProjectStage.Active}`, `stage:${ProjectStage.FormationEngaged}`];
     } else {
       // Include Formation - Engaged projects so persona-eligible pre-launch
       // projects appear in the project dropdown.
-      base.filters_or = ['stage:Active', 'stage:Formation - Engaged'];
+      base.filters_or = [`stage:${ProjectStage.Active}`, `stage:${ProjectStage.FormationEngaged}`];
     }
 
     if (pageToken) base.page_token = pageToken;

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -15,7 +15,7 @@ import {
   Project,
   QueryServiceResponse,
 } from '@lfx-one/shared/interfaces';
-import { computeIsFoundation, computeIsFoundationEligible } from '@lfx-one/shared/utils';
+import { computeIsFoundation } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { personaDetectionService } from '../utils/persona-helper';
@@ -169,7 +169,7 @@ export class NavigationService {
       if (!project) return null;
       // Mirror the main-pipeline contract so an archived selection doesn't get re-injected.
       if (lens === 'foundation') {
-        if (!computeIsFoundationEligible(project)) return null;
+        if (!computeIsFoundation(project)) return null;
       } else {
         if (project.stage !== ProjectStage.Active && project.stage !== ProjectStage.FormationEngaged) return null;
       }
@@ -184,7 +184,7 @@ export class NavigationService {
     let projects = resources.map((r) => r.data);
     // legal_entity_type negation isn't supported by the filter grammar — re-check locally.
     if (lens === 'foundation') {
-      projects = projects.filter((p) => computeIsFoundationEligible(p));
+      projects = projects.filter((p) => computeIsFoundation(p));
     }
     if (eligibleUids) {
       projects = projects.filter((p) => eligibleUids.has(p.uid));

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -171,7 +171,7 @@ export class NavigationService {
       if (lens === 'foundation') {
         if (!computeIsFoundation(project)) return null;
       } else {
-        if (project.stage !== ProjectStage.Active && project.stage !== ProjectStage.FormationEngaged) return null;
+        if (project.stage !== ProjectStage.Active && project.stage !== ProjectStage.FormationEngaged && project.stage !== ProjectStage.FormationExploratory) return null;
       }
       return this.toLensItem(project);
     } catch (error) {
@@ -201,9 +201,9 @@ export class NavigationService {
       base.filters = [`funding:${ProjectFunding.Funded}`, 'funding_model:Membership'];
       base.filters_or = [`stage:${ProjectStage.Active}`, `stage:${ProjectStage.FormationEngaged}`];
     } else {
-      // Include Formation - Engaged projects so persona-eligible pre-launch
+      // Include all formation-stage projects so persona-eligible pre-launch
       // projects appear in the project dropdown.
-      base.filters_or = [`stage:${ProjectStage.Active}`, `stage:${ProjectStage.FormationEngaged}`];
+      base.filters_or = [`stage:${ProjectStage.Active}`, `stage:${ProjectStage.FormationEngaged}`, `stage:${ProjectStage.FormationExploratory}`];
     }
 
     if (pageToken) base.page_token = pageToken;

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -22,6 +22,9 @@ import { personaDetectionService } from '../utils/persona-helper';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 
+/** Stages eligible for the project lens — Active plus supported pre-launch formation stages. */
+const PROJECT_LENS_ALLOWED_STAGES = new Set<string>([ProjectStage.Active, ProjectStage.FormationEngaged, ProjectStage.FormationExploratory]);
+
 /** Powers the foundation/project lens dropdown. Root writers bypass the persona filter. */
 export class NavigationService {
   private readonly microserviceProxy: MicroserviceProxyService;
@@ -171,7 +174,7 @@ export class NavigationService {
       if (lens === 'foundation') {
         if (!computeIsFoundation(project)) return null;
       } else {
-        if (project.stage !== ProjectStage.Active && project.stage !== ProjectStage.FormationEngaged && project.stage !== ProjectStage.FormationExploratory) return null;
+        if (!PROJECT_LENS_ALLOWED_STAGES.has(project.stage)) return null;
       }
       return this.toLensItem(project);
     } catch (error) {
@@ -201,9 +204,9 @@ export class NavigationService {
       base.filters = [`funding:${ProjectFunding.Funded}`, 'funding_model:Membership'];
       base.filters_or = [`stage:${ProjectStage.Active}`, `stage:${ProjectStage.FormationEngaged}`];
     } else {
-      // Include all formation-stage projects so persona-eligible pre-launch
-      // projects appear in the project dropdown.
-      base.filters_or = [`stage:${ProjectStage.Active}`, `stage:${ProjectStage.FormationEngaged}`, `stage:${ProjectStage.FormationExploratory}`];
+      // Include active projects plus supported pre-launch formation stages so
+      // persona-eligible pre-launch projects appear in the project dropdown.
+      base.filters_or = [...PROJECT_LENS_ALLOWED_STAGES].map((stage) => `stage:${stage}`);
     }
 
     if (pageToken) base.page_token = pageToken;

--- a/apps/lfx-one/src/server/services/navigation.service.ts
+++ b/apps/lfx-one/src/server/services/navigation.service.ts
@@ -168,7 +168,7 @@ export class NavigationService {
       const project = response?.resources?.[0]?.data;
       if (!project) return null;
       // Mirror the main-pipeline contract so an archived selection doesn't get re-injected.
-      if (project.stage !== 'Active') return null;
+      if (project.stage !== 'Active' && project.stage !== 'Formation - Engaged') return null;
       if (lens === 'foundation' && !computeIsFoundation(project)) return null;
       return this.toLensItem(project);
     } catch (error) {
@@ -191,8 +191,14 @@ export class NavigationService {
 
   private buildQuery(lens: NavLens, pageToken: string | undefined, name: string | undefined): LensItemsQuery {
     // legal_entity_type negation is post-filtered (filter grammar has no exclusions).
-    const filters = lens === 'foundation' ? ['stage:Active', `funding:${ProjectFunding.Funded}`, 'funding_model:Membership'] : ['stage:Active'];
-    const base: LensItemsQuery = { type: 'project', filters, sort: 'name_asc' };
+    const base: LensItemsQuery = { type: 'project', filters: [], sort: 'name_asc' };
+    if (lens === 'foundation') {
+      base.filters = ['stage:Active', `funding:${ProjectFunding.Funded}`, 'funding_model:Membership'];
+    } else {
+      // Include Formation - Engaged projects so persona-eligible pre-launch
+      // projects appear in the project dropdown.
+      base.filters_or = ['stage:Active', 'stage:Formation - Engaged'];
+    }
 
     if (pageToken) base.page_token = pageToken;
     if (name) base.name = name;

--- a/packages/shared/src/constants/lens.constants.ts
+++ b/packages/shared/src/constants/lens.constants.ts
@@ -63,7 +63,7 @@ export const NAV_LENSES: readonly NavLens[] = ['foundation', 'project'] as const
 
 export const LENS_PERSONA_MAP: Readonly<Record<NavLens, readonly PersonaType[]>> = {
   foundation: ['board-member', 'executive-director'],
-  project: ['contributor', 'maintainer'],
+  project: ['contributor', 'maintainer', 'executive-director'],
 } as const;
 
 export const NAV_MIN_ITEMS_PER_RESPONSE = 15;

--- a/packages/shared/src/enums/index.ts
+++ b/packages/shared/src/enums/index.ts
@@ -12,3 +12,4 @@ export * from './poll.enum';
 export * from './survey.enum';
 export * from './event.enum';
 export * from './project-funding.enum';
+export * from './project-stage.enum';

--- a/packages/shared/src/enums/project-stage.enum.ts
+++ b/packages/shared/src/enums/project-stage.enum.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Project lifecycle stage, synced from SFDC via lfx-v1-sync-helper.
+ * Project lifecycle stage.
  * Values mirror the upstream Goa enum declared in `lfx-v2-project-service` at
  * `api/project/v1/design/types.go` (`ProjectStageAttribute`).
  */

--- a/packages/shared/src/enums/project-stage.enum.ts
+++ b/packages/shared/src/enums/project-stage.enum.ts
@@ -1,0 +1,18 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Project lifecycle stage, synced from SFDC via lfx-v1-sync-helper.
+ * Values mirror the upstream Goa enum declared in `lfx-v2-project-service` at
+ * `api/project/v1/design/types.go` (`ProjectStageAttribute`).
+ */
+export enum ProjectStage {
+  FormationExploratory = 'Formation - Exploratory',
+  FormationEngaged = 'Formation - Engaged',
+  FormationOnHold = 'Formation - On Hold',
+  FormationDisengaged = 'Formation - Disengaged',
+  FormationConfidential = 'Formation - Confidential',
+  Active = 'Active',
+  Archived = 'Archived',
+  Prospect = 'Prospect',
+}

--- a/packages/shared/src/interfaces/navigation.interface.ts
+++ b/packages/shared/src/interfaces/navigation.interface.ts
@@ -53,6 +53,7 @@ export interface GetLensItemsParams {
 export interface LensItemsQuery {
   type: 'project';
   filters: string[];
+  filters_or?: string[];
   sort: 'name_asc';
   page_token?: string;
   name?: string;

--- a/packages/shared/src/interfaces/navigation.interface.ts
+++ b/packages/shared/src/interfaces/navigation.interface.ts
@@ -52,7 +52,9 @@ export interface GetLensItemsParams {
 /** Upstream query-service params for lens-item lookups. */
 export interface LensItemsQuery {
   type: 'project';
+  /** AND — all terms must match (e.g. `['funding:Funded', 'funding_model:Membership']`). */
   filters: string[];
+  /** OR — at least one term must match (e.g. `['stage:Active', 'stage:Formation - Engaged']`). Combined with `filters` via AND. */
   filters_or?: string[];
   sort: 'name_asc';
   page_token?: string;

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ProjectFunding } from '../enums/project-funding.enum';
+import { ProjectStage } from '../enums/project-stage.enum';
 
 export interface Project {
   uid: string;
@@ -12,7 +13,8 @@ export interface Project {
   writer?: boolean;
   public: boolean;
   parent_uid: string;
-  stage: string;
+  /** Upstream Goa enum — optional to tolerate records indexed before the attribute was rolled out. */
+  stage: ProjectStage | string;
   category: string;
   /** Upstream Goa enum — optional to tolerate records indexed before the attribute was rolled out. */
   funding?: ProjectFunding;

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -13,7 +13,6 @@ export interface Project {
   writer?: boolean;
   public: boolean;
   parent_uid: string;
-  /** Upstream Goa enum — optional to tolerate records indexed before the attribute was rolled out. */
   stage: ProjectStage | string;
   category: string;
   /** Upstream Goa enum — optional to tolerate records indexed before the attribute was rolled out. */

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ProjectFunding } from '../enums/project-funding.enum';
+import { ProjectStage } from '../enums/project-stage.enum';
 import type { EnrichedPersonaProject, LensItem, Project, ProjectContext } from '../interfaces';
 
 export function toProjectContext(project: EnrichedPersonaProject): ProjectContext {
@@ -46,7 +47,24 @@ export function computeIsFoundation(project: Project | null): boolean {
   }
 
   return (
-    project.stage === 'Active' &&
+    project.stage === ProjectStage.Active &&
+    project.legal_entity_type !== 'Internal Allocation' &&
+    project.funding === ProjectFunding.Funded &&
+    Array.isArray(project.funding_model) &&
+    project.funding_model.includes('Membership')
+  );
+}
+
+/**
+ * Foundation-eligible for the navigation lens dropdown: includes both live
+ * (Active) and pre-launch (Formation - Engaged) membership-funded projects.
+ * Use this for the foundation lens; use `computeIsFoundation` everywhere else.
+ */
+export function computeIsFoundationEligible(project: Project | null): boolean {
+  if (!project) return false;
+  if (FOUNDATION_NAME_OVERRIDES.has(project.name)) return true;
+  return (
+    (project.stage === ProjectStage.Active || project.stage === ProjectStage.FormationEngaged) &&
     project.legal_entity_type !== 'Internal Allocation' &&
     project.funding === ProjectFunding.Funded &&
     Array.isArray(project.funding_model) &&

--- a/packages/shared/src/utils/project.utils.ts
+++ b/packages/shared/src/utils/project.utils.ts
@@ -36,7 +36,11 @@ export function isFoundationProject(project: EnrichedPersonaProject): boolean {
 // PCC test-project override (lfx-pcc helper.ts) — kept in sync with hasHealthMetricDashboard.
 const FOUNDATION_NAME_OVERRIDES = new Set(['Test Project Group IT', 'Test Project IT']);
 
-/** Active, membership-funded foundation (Funding === 'Funded'), not an Internal Allocation. PCC test projects also qualify. */
+/**
+ * Membership-funded foundation (Funding === 'Funded'), not an Internal Allocation.
+ * Includes both live (Active) and pre-launch (Formation - Engaged) foundations.
+ * PCC test projects also qualify.
+ */
 export function computeIsFoundation(project: Project | null): boolean {
   if (!project) {
     return false;
@@ -46,23 +50,6 @@ export function computeIsFoundation(project: Project | null): boolean {
     return true;
   }
 
-  return (
-    project.stage === ProjectStage.Active &&
-    project.legal_entity_type !== 'Internal Allocation' &&
-    project.funding === ProjectFunding.Funded &&
-    Array.isArray(project.funding_model) &&
-    project.funding_model.includes('Membership')
-  );
-}
-
-/**
- * Foundation-eligible for the navigation lens dropdown: includes both live
- * (Active) and pre-launch (Formation - Engaged) membership-funded projects.
- * Use this for the foundation lens; use `computeIsFoundation` everywhere else.
- */
-export function computeIsFoundationEligible(project: Project | null): boolean {
-  if (!project) return false;
-  if (FOUNDATION_NAME_OVERRIDES.has(project.name)) return true;
   return (
     (project.stage === ProjectStage.Active || project.stage === ProjectStage.FormationEngaged) &&
     project.legal_entity_type !== 'Internal Allocation' &&


### PR DESCRIPTION
## Summary

Fixes three independent blockers that prevented `Formation - Engaged` and `Formation - Exploratory` projects from appearing in the correct lens dropdowns, even for their executive directors.

### Root causes

| # | Location | Blocker |
|---|----------|---------| 
| 1 | `LENS_PERSONA_MAP` | `project` only listed `contributor` and `maintainer` — `executive-director` was excluded, so EDs of non-foundation projects never entered `eligibleUids` |
| 2 | `buildQuery` | `filters: ['stage:Active']` excluded Formation-stage projects from the upstream query entirely |
| 3 | `fetchSelectedItem` | `project.stage !== 'Active'` guard rejected the project even when fetched by UID |

### Changes

- **`packages/shared/src/constants/lens.constants.ts`** — add `executive-director` to `LENS_PERSONA_MAP.project`
- **`packages/shared/src/interfaces/navigation.interface.ts`** — add `filters_or?: string[]` to `LensItemsQuery`
- **`packages/shared/src/enums/project-stage.enum.ts`** — add `ProjectStage` enum with `Active`, `Formation - Engaged`, `Formation - Exploratory`
- **`packages/shared/src/interfaces/project.interface.ts`** — remove misleading JSDoc from required `stage` field
- **`packages/shared/src/utils/project.utils.ts`** — `computeIsFoundation` broadened to accept `Active` OR any Formation stage (membership + funding gates remain)
- **`apps/lfx-one/src/server/services/navigation.service.ts`** — project lens uses `filters_or` for stage matching; `fetchSelectedItem` allows Formation stages for project lens; foundation lens uses `computeIsFoundation` (Active or Formation + Membership + Funding)

### Foundation lens scope

The foundation lens **now includes** Formation-stage projects that already have Membership + Funding enabled (i.e., they are operationally foundations). This was added after review feedback identified a gap: a project transitioning from Formation to Active would briefly disappear from the foundation lens.

`computeIsFoundation` was intentionally broadened to cover these cases. All membership/funding gates remain in place.

## Test plan

- [ ] Executive director of a `Formation - Engaged` project sees it in the project lens dropdown
- [ ] Executive director of a `Formation - Exploratory` project sees it in the project lens dropdown
- [ ] Foundation lens: Formation-stage project with Membership + Funding appears in foundation lens
- [ ] Foundation lens: Formation-stage project without Membership/Funding does NOT appear in foundation lens
- [ ] Root writer: project lens shows Active + Formation - Engaged + Formation - Exploratory projects
- [x] `yarn check-types` passes

## JIRA

[LFXV2-1613](https://linuxfoundation.atlassian.net/browse/LFXV2-1613) — Formation-stage projects not displayed in Self Service UI lens dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-1613]: https://linuxfoundation.atlassian.net/browse/LFXV2-1613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ