### PR TITLE
refactor(server): drop redundant v=1 from proxy callers

### DIFF
--- a/apps/lfx-one/src/app/modules/surveys/components/survey-timing-reminders/survey-timing-reminders.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/components/survey-timing-reminders/survey-timing-reminders.component.ts
@@ -6,7 +6,12 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CalendarComponent } from '@components/calendar/calendar.component';
 import { SelectComponent } from '@components/select/select.component';
-import { SURVEY_AUTO_REMINDER_FREQUENCY_OPTIONS, SURVEY_DISTRIBUTION_OPTIONS, SURVEY_IMMEDIATE_SEND_OFFSET_MS, SURVEY_REMINDER_TYPE_OPTIONS } from '@lfx-one/shared/constants';
+import {
+  SURVEY_AUTO_REMINDER_FREQUENCY_OPTIONS,
+  SURVEY_DISTRIBUTION_OPTIONS,
+  SURVEY_IMMEDIATE_SEND_OFFSET_MS,
+  SURVEY_REMINDER_TYPE_OPTIONS,
+} from '@lfx-one/shared/constants';
 import { SurveyDistributionMethod, SurveyReminderType } from '@lfx-one/shared/interfaces';
 import { map, startWith, switchMap, of } from 'rxjs';
 

--- a/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/surveys/survey-manage/survey-manage.component.ts
@@ -30,7 +30,6 @@ import { SurveyEmailDraftComponent } from '../components/survey-email-draft/surv
 import { SurveyReviewComponent } from '../components/survey-review/survey-review.component';
 import { SurveyTimingRemindersComponent } from '../components/survey-timing-reminders/survey-timing-reminders.component';
 
-
 @Component({
   selector: 'lfx-survey-manage',
   imports: [
@@ -412,9 +411,7 @@ Thank you,
 
         const scheduledDateValid = distributionMethod === 'scheduled' ? !!scheduledDate : true;
 
-        const effectiveSendDate = distributionMethod === 'immediate'
-          ? new Date(Date.now() + SURVEY_IMMEDIATE_SEND_OFFSET_MS)
-          : scheduledDate;
+        const effectiveSendDate = distributionMethod === 'immediate' ? new Date(Date.now() + SURVEY_IMMEDIATE_SEND_OFFSET_MS) : scheduledDate;
         const cutoffDateValid = !!cutoffDate && (!effectiveSendDate || cutoffDate > effectiveSendDate);
 
         const reminderTypeValid = !!form.get('reminderType')?.valid;

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -485,7 +485,6 @@ export class CommitteeService {
 
   public async getCommitteeMembersByCategory(req: Request, username: string, userEmail: string, category: string): Promise<CommitteeMember[]> {
     const params = {
-      v: '1',
       type: 'committee_member',
       tags_all: [`username:${username}`, `committee_category:${category}`],
     };
@@ -528,7 +527,6 @@ export class CommitteeService {
 
     const memberships = await fetchAllQueryResources<CommitteeMember>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        v: '1',
         type: 'committee_member',
         tags_all: tagsAll,
         ...(pageToken && { page_token: pageToken }),
@@ -553,7 +551,6 @@ export class CommitteeService {
 
     const memberships = await fetchAllQueryResources<CommitteeMember>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        v: '1',
         type: 'committee_member',
         tags_all: tagsAll,
         ...(pageToken && { page_token: pageToken }),
@@ -937,7 +934,6 @@ export class CommitteeService {
             req,
             (pageToken) =>
               this.microserviceProxy.proxyRequest<QueryServiceResponse<Committee>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-                v: '1',
                 type: 'committee',
                 filters_or: batch.map((uid) => `uid:${uid}`),
                 ...(pageToken && { page_token: pageToken }),

--- a/apps/lfx-one/src/server/services/document.service.ts
+++ b/apps/lfx-one/src/server/services/document.service.ts
@@ -170,10 +170,8 @@ export class DocumentService {
     const filtersOr = myCommittees.map((c) => `committee_uid:${c.uid}`);
 
     // Fetch committee link documents (links and folders) via filters_or
-    // We use v=1 for the new filters_or param (requires query service PR #41)
     const linkAttachments = await fetchAllQueryResources<CommitteeLinkQueryResult>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<CommitteeLinkQueryResult>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        v: '1',
         type: 'committee_link',
         filters_or: filtersOr,
         ...(pageToken && { page_token: pageToken }),
@@ -365,7 +363,6 @@ export class DocumentService {
 
     return fetchAllQueryResources<MeetingAttachment>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingAttachment>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        v: '1',
         type: 'v1_meeting_attachment',
         filters_or: filtersOr,
         ...(projectUid && { tags: `project_uid:${projectUid}` }),
@@ -437,7 +434,6 @@ export class DocumentService {
 
     return fetchAllQueryResources<PastMeetingAttachment>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingAttachment>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        v: '1',
         type: 'v1_past_meeting_attachment',
         filters_or: filtersOr,
         ...(projectUid && { tags: `project_uid:${projectUid}` }),
@@ -488,7 +484,6 @@ export class DocumentService {
 
     return fetchAllQueryResources<PastMeetingRecordingQueryResult>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingRecordingQueryResult>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        v: '1',
         type: 'v1_past_meeting_recording',
         filters_or: filtersOr,
         ...(projectUid && { tags: `project_uid:${projectUid}` }),
@@ -541,7 +536,6 @@ export class DocumentService {
 
     return fetchAllQueryResources<PastMeetingTranscriptQueryResult>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingTranscriptQueryResult>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        v: '1',
         type: 'v1_past_meeting_transcript',
         filters_or: filtersOr,
         ...(projectUid && { tags: `project_uid:${projectUid}` }),
@@ -593,7 +587,6 @@ export class DocumentService {
 
     return fetchAllQueryResources<PastMeetingSummaryQueryResult>(req, (pageToken) =>
       this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingSummaryQueryResult>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        v: '1',
         type: 'v1_past_meeting_summary',
         filters_or: filtersOr,
         ...(projectUid && { tags: `project_uid:${projectUid}` }),

--- a/apps/lfx-one/src/server/services/mailing-list.service.ts
+++ b/apps/lfx-one/src/server/services/mailing-list.service.ts
@@ -372,7 +372,6 @@ export class MailingListService {
       memberQueries.push(
         fetchAllQueryResources<MailingListMember>(req, (pageToken) =>
           this.microserviceProxy.proxyRequest<QueryServiceResponse<MailingListMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-            v: '1',
             type: 'groupsio_member',
             tags_all: [`email:${email}`],
             ...(pageToken && { page_token: pageToken }),
@@ -385,7 +384,6 @@ export class MailingListService {
       memberQueries.push(
         fetchAllQueryResources<MailingListMember>(req, (pageToken) =>
           this.microserviceProxy.proxyRequest<QueryServiceResponse<MailingListMember>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-            v: '1',
             type: 'groupsio_member',
             tags_all: [`username:${username}`],
             ...(pageToken && { page_token: pageToken }),
@@ -765,7 +763,6 @@ export class MailingListService {
           req,
           (pageToken) =>
             this.microserviceProxy.proxyRequest<QueryServiceResponse<{ uid: string; name: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-              v: '1',
               type: 'committee',
               filters_or: batch.map((uid) => `uid:${uid}`),
               page_size: 500,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -5088,7 +5088,6 @@ export class ProjectService {
         '/query/resources',
         'GET',
         {
-          v: '1',
           type: 'project',
           parent: `project:${foundationUid}`,
         }

--- a/apps/lfx-one/src/server/services/search.service.ts
+++ b/apps/lfx-one/src/server/services/search.service.ts
@@ -21,7 +21,6 @@ export class SearchService {
    */
   public async searchUsers(req: Request, params: UserSearchParams): Promise<UserSearchResponse> {
     const queryParams = {
-      v: '1',
       ...(params.name ? { name: params.name } : {}),
       ...(params.tags ? { tags: params.tags } : {}),
       type: params.type,

--- a/apps/lfx-one/src/server/services/survey.service.ts
+++ b/apps/lfx-one/src/server/services/survey.service.ts
@@ -17,7 +17,6 @@ import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { ProjectService } from './project.service';
 
-
 /**
  * Service for handling survey business logic with microservice proxy
  */

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -837,7 +837,6 @@ export class UserService {
     if (email) {
       const emailParticipants = await fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
         this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-          v: '1',
           type: 'v1_past_meeting_participant',
           tags: `email:${email}`,
           ...(pageToken && { page_token: pageToken }),
@@ -850,7 +849,6 @@ export class UserService {
       const plainUsername = stripAuthPrefix(username);
       const usernameParticipants = await fetchAllQueryResources<PastMeetingParticipant>(req, (pageToken) =>
         this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeetingParticipant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-          v: '1',
           type: 'v1_past_meeting_participant',
           tags: `username:${plainUsername}`,
           ...(pageToken && { page_token: pageToken }),


### PR DESCRIPTION
## Summary

- `MicroserviceProxyService` already merges `DEFAULT_QUERY_PARAMS = { v: '1' }` into every request, with the defaults spread *after* the caller's query — so any caller-supplied `v: '1'` is redundant and a caller-supplied `v: '2'` would be silently overridden.
- Removed the duplicated `v: '1'` assignment from 17 call sites across `committee.service.ts`, `document.service.ts`, `mailing-list.service.ts`, `project.service.ts`, `search.service.ts`, and `user.service.ts`. Also dropped a now-misleading inline comment in `document.service.ts` referencing `v=1`.
- `packages/shared/src/constants/api.constants.ts` remains the single source of truth.
- Includes a `style:` commit fixing pre-existing prettier issues in three unrelated survey files that the pre-commit hook flagged.