### PR TITLE
fix(meetings): guard committees access on join page drawer

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -740,7 +740,7 @@
                 <h1>Meeting Participants</h1>
                 <span class="text-base text-gray-500">{{ attendedCount() }} attended / {{ invitedCount() }} invited</span>
               </div>
-            } @else if (meeting().committees.length) {
+            } @else if (meeting().committees && meeting().committees.length) {
               <div class="flex flex-col">
                 <h1>Meeting Members</h1>
                 <span class="text-base text-gray-500">{{ totalInvitees() }} members</span>


### PR DESCRIPTION
## Summary

- Public/past meeting responses can omit the `committees` field, so `meeting().committees.length` threw `Cannot read properties of undefined (reading 'length')` when opening the Show Members drawer on the meeting join page.
- Added a truthy guard before reading `.length`, matching the same safe pattern already used at line 109 of the template.