### PR TITLE
feat(observability): add plausible analytics for production

### DIFF
--- a/apps/lfx-one/src/app/app.component.ts
+++ b/apps/lfx-one/src/app/app.component.ts
@@ -9,6 +9,7 @@ import { ToastModule } from 'primeng/toast';
 import { AccountContextService } from './shared/services/account-context.service';
 import { DataDogRumService } from './shared/services/datadog-rum.service';
 import { FeatureFlagService } from './shared/services/feature-flag.service';
+import { PlausibleService } from './shared/services/plausible.service';
 import { SegmentService } from './shared/services/segment.service';
 import { UserService } from './shared/services/user.service';
 
@@ -21,6 +22,7 @@ import { UserService } from './shared/services/user.service';
 export class AppComponent {
   private readonly userService = inject(UserService);
   private readonly segmentService = inject(SegmentService);
+  private readonly plausibleService = inject(PlausibleService);
   private readonly featureFlagService = inject(FeatureFlagService);
   private readonly dataDogRumService = inject(DataDogRumService);
   private readonly accountContextService = inject(AccountContextService);
@@ -32,6 +34,9 @@ export class AppComponent {
   public constructor() {
     // Initialize Segment tracking
     this.segmentService.initialize();
+
+    // Initialize Plausible analytics
+    this.plausibleService.initialize();
 
     const reqContext = inject(REQUEST_CONTEXT, { optional: true }) as {
       auth: AuthContext;
@@ -66,6 +71,7 @@ export class AppComponent {
 
       const isImpersonating = Boolean(this.auth?.impersonating);
       this.segmentService.setImpersonating(isImpersonating);
+      this.plausibleService.setImpersonating(isImpersonating);
       this.userService.impersonating.set(isImpersonating);
       this.userService.impersonator.set(isImpersonating ? (this.auth.impersonator ?? null) : null);
 

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -100,7 +100,11 @@ export class PlausibleService {
         ((options?: Record<string, unknown>) => {
           window.plausible!.o = options || {};
         });
-      window.plausible.init();
+      // Disable the SDK's automatic initial pageview so impersonated sessions
+      // (where setImpersonating(true) lands after initialize()) cannot leak a
+      // hit. We fire the first pageview manually from onload, gated on
+      // `impersonating`, and subsequent navigations go through trackPage().
+      window.plausible.init({ autoCapturePageviews: false });
 
       const script = document.createElement('script');
       script.src = PLAUSIBLE_SRC;
@@ -112,9 +116,12 @@ export class PlausibleService {
       // only after the bundle has executed and replaced the queue stub.
       script.onload = () => {
         this.analyticsReady = true;
+        this.trackPage();
       };
 
       script.onerror = (error) => {
+        // Reset so a future initialize() can retry after a transient failure.
+        this.scriptLoaded = false;
         console.error('Failed to load Plausible analytics script:', error);
       };
 
@@ -164,17 +171,18 @@ export class PlausibleService {
 
   /**
    * Strip query params and hash from a router-emitted URL so we never
-   * forward sensitive segments through the `path` prop. Falls back to the
-   * raw input if URL parsing fails or if called outside the browser (SSR).
+   * forward sensitive segments through the `path` prop. Both the SSR
+   * fallback and the URL-parse-failure fallback also strip `?` and `#` so
+   * sanitization is guaranteed regardless of which path runs.
    */
   private getSanitizedPath(rawPath: string): string {
     if (typeof window === 'undefined') {
-      return rawPath;
+      return rawPath.split('#')[0].split('?')[0];
     }
     try {
       return new URL(rawPath, window.location.origin).pathname;
     } catch {
-      return rawPath;
+      return rawPath.split('#')[0].split('?')[0];
     }
   }
 }

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -138,6 +138,9 @@ export class PlausibleService {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((event: NavigationEnd) => {
+        if (typeof document === 'undefined') {
+          return;
+        }
         this.trackPage({
           path: this.getSanitizedPath(event.urlAfterRedirects),
           url: this.getSanitizedUrl(),
@@ -150,17 +153,24 @@ export class PlausibleService {
    * Build a privacy-safe URL string for Plausible.
    * Strips query params and hash to avoid leaking auth tokens, OTPs, or
    * password-reset codes that callbacks sometimes carry in the URL.
+   * Returns an empty string when called outside the browser (SSR).
    */
   private getSanitizedUrl(): string {
+    if (typeof window === 'undefined') {
+      return '';
+    }
     return `${window.location.origin}${window.location.pathname}`;
   }
 
   /**
    * Strip query params and hash from a router-emitted URL so we never
    * forward sensitive segments through the `path` prop. Falls back to the
-   * raw input if URL parsing fails.
+   * raw input if URL parsing fails or if called outside the browser (SSR).
    */
   private getSanitizedPath(rawPath: string): string {
+    if (typeof window === 'undefined') {
+      return rawPath;
+    }
     try {
       return new URL(rawPath, window.location.origin).pathname;
     } catch {

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -5,6 +5,7 @@ import { afterNextRender, DestroyRef, inject, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { environment } from '@environments/environment';
+import { PLAUSIBLE_DOMAIN, PLAUSIBLE_SRC } from '@lfx-one/shared/constants';
 import { filter } from 'rxjs';
 
 /**
@@ -50,7 +51,7 @@ export class PlausibleService {
    * @param properties Optional page properties
    */
   public trackPage(properties?: Record<string, unknown>): void {
-    if (this.impersonating || !this.analyticsReady || !window.plausible) {
+    if (typeof window === 'undefined' || this.impersonating || !this.analyticsReady || !window.plausible) {
       return;
     }
 
@@ -67,7 +68,7 @@ export class PlausibleService {
    * @param properties Event properties
    */
   public trackEvent(eventName: string, properties?: Record<string, unknown>): void {
-    if (this.impersonating || !this.analyticsReady || !window.plausible) {
+    if (typeof window === 'undefined' || this.impersonating || !this.analyticsReady || !window.plausible) {
       return;
     }
 
@@ -102,10 +103,8 @@ export class PlausibleService {
       window.plausible.init();
 
       const script = document.createElement('script');
-      script.src = environment.plausible.src;
-      if (environment.plausible.domain) {
-        script.setAttribute('data-domain', environment.plausible.domain);
-      }
+      script.src = PLAUSIBLE_SRC;
+      script.setAttribute('data-domain', PLAUSIBLE_DOMAIN);
       script.async = true;
       script.defer = true;
 

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -1,0 +1,165 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { afterNextRender, DestroyRef, inject, Injectable } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { NavigationEnd, Router } from '@angular/router';
+import { environment } from '@environments/environment';
+import { filter } from 'rxjs';
+
+declare global {
+  interface Window {
+    plausible?: ((eventName: string, options?: { u?: string; props?: Record<string, unknown> }) => void) & {
+      q?: unknown[];
+      init?: (options?: Record<string, unknown>) => void;
+      o?: Record<string, unknown>;
+    };
+  }
+}
+
+/**
+ * Plausible analytics service for privacy-friendly page and event tracking.
+ * Uses Angular's afterNextRender for SSR-safe script loading.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class PlausibleService {
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private scriptLoaded = false;
+  private analyticsReady = false;
+  private impersonating = false;
+
+  public setImpersonating(isImpersonating: boolean): void {
+    this.impersonating = isImpersonating;
+  }
+
+  /**
+   * Initialize the analytics service - should be called from app component
+   */
+  public initialize(): void {
+    afterNextRender(() => {
+      this.loadPlausibleScript();
+      this.setupRouteTracking();
+    });
+  }
+
+  /**
+   * Track a page view
+   * @param properties Optional page properties
+   */
+  public trackPage(properties?: Record<string, unknown>): void {
+    if (this.impersonating || !this.analyticsReady || !window.plausible) {
+      return;
+    }
+
+    try {
+      window.plausible('pageview', { u: window.location.href, props: properties });
+    } catch (error) {
+      console.error('Error tracking page with Plausible:', error);
+    }
+  }
+
+  /**
+   * Track a custom event
+   * @param eventName Event name
+   * @param properties Event properties
+   */
+  public trackEvent(eventName: string, properties?: Record<string, unknown>): void {
+    if (this.impersonating || !this.analyticsReady || !window.plausible) {
+      return;
+    }
+
+    try {
+      window.plausible(eventName, { props: properties });
+    } catch (error) {
+      console.error('Error tracking event with Plausible:', error);
+    }
+  }
+
+  /**
+   * Load Plausible script from CDN
+   */
+  private loadPlausibleScript(): void {
+    if (!environment.plausible?.enabled || this.scriptLoaded) {
+      return;
+    }
+
+    try {
+      // Stub queues events fired before the real script finishes loading
+      window.plausible =
+        window.plausible ||
+        ((...args: unknown[]) => {
+          (window.plausible!.q = window.plausible!.q || []).push(args);
+        });
+      window.plausible.init =
+        window.plausible.init ||
+        ((options?: Record<string, unknown>) => {
+          window.plausible!.o = options || {};
+        });
+
+      const script = document.createElement('script');
+      script.src = environment.plausible.src;
+      script.async = true;
+      script.defer = true;
+
+      script.onload = () => {
+        this.scriptLoaded = true;
+        this.waitForPlausible();
+      };
+
+      script.onerror = (error) => {
+        console.error('Failed to load Plausible analytics script:', error);
+      };
+
+      document.head.appendChild(script);
+    } catch (error) {
+      console.error('Error initializing Plausible:', error);
+    }
+  }
+
+  /**
+   * Wait for Plausible to be available and initialize it
+   */
+  private async waitForPlausible(): Promise<void> {
+    const maxAttempts = 100; // 10 seconds max wait
+    let attempts = 0;
+
+    while (attempts < maxAttempts) {
+      if (typeof window?.plausible === 'function') {
+        try {
+          window.plausible.init?.();
+          this.analyticsReady = true;
+        } catch (error) {
+          console.error('Error initializing Plausible:', error);
+        }
+        return;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      attempts++;
+    }
+
+    console.error('Plausible not available after timeout');
+  }
+
+  /**
+   * Set up automatic page tracking on route navigation
+   */
+  private setupRouteTracking(): void {
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((event: NavigationEnd) => {
+        this.trackPage({
+          path: event.urlAfterRedirects,
+          url: window.location.href,
+          title: document.title,
+        });
+      });
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -22,6 +22,12 @@ export class PlausibleService {
   private analyticsReady = false;
   private impersonating = false;
 
+  /**
+   * Enable or disable analytics suppression for the current session.
+   * Pass `true` while the user is impersonating another account so their
+   * activity does not pollute the impersonated user's analytics.
+   * @param isImpersonating Whether the current session is impersonated
+   */
   public setImpersonating(isImpersonating: boolean): void {
     this.impersonating = isImpersonating;
   }

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -7,16 +7,6 @@ import { NavigationEnd, Router } from '@angular/router';
 import { environment } from '@environments/environment';
 import { filter } from 'rxjs';
 
-declare global {
-  interface Window {
-    plausible?: ((eventName: string, options?: { u?: string; props?: Record<string, unknown> }) => void) & {
-      q?: unknown[];
-      init?: (options?: Record<string, unknown>) => void;
-      o?: Record<string, unknown>;
-    };
-  }
-}
-
 /**
  * Plausible analytics service for privacy-friendly page and event tracking.
  * Uses Angular's afterNextRender for SSR-safe script loading.

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -46,7 +46,7 @@ export class PlausibleService {
     }
 
     try {
-      window.plausible('pageview', { u: window.location.href, props: properties });
+      window.plausible('pageview', { u: this.getSanitizedUrl(), props: properties });
     } catch (error) {
       console.error('Error tracking page with Plausible:', error);
     }
@@ -78,7 +78,8 @@ export class PlausibleService {
     }
 
     try {
-      // Stub queues events fired before the real script finishes loading
+      // Stub queues events fired before the real script finishes loading;
+      // the real Plausible script drains q and o on first run.
       window.plausible =
         window.plausible ||
         ((...args: unknown[]) => {
@@ -89,15 +90,21 @@ export class PlausibleService {
         ((options?: Record<string, unknown>) => {
           window.plausible!.o = options || {};
         });
+      window.plausible.init();
 
       const script = document.createElement('script');
       script.src = environment.plausible.src;
+      if (environment.plausible.domain) {
+        script.setAttribute('data-domain', environment.plausible.domain);
+      }
       script.async = true;
       script.defer = true;
 
+      // analyticsReady is gated on the real script loading — onload fires
+      // only after the bundle has executed and replaced the queue stub.
       script.onload = () => {
         this.scriptLoaded = true;
-        this.waitForPlausible();
+        this.analyticsReady = true;
       };
 
       script.onerror = (error) => {
@@ -108,31 +115,6 @@ export class PlausibleService {
     } catch (error) {
       console.error('Error initializing Plausible:', error);
     }
-  }
-
-  /**
-   * Wait for Plausible to be available and initialize it
-   */
-  private async waitForPlausible(): Promise<void> {
-    const maxAttempts = 100; // 10 seconds max wait
-    let attempts = 0;
-
-    while (attempts < maxAttempts) {
-      if (typeof window?.plausible === 'function') {
-        try {
-          window.plausible.init?.();
-          this.analyticsReady = true;
-        } catch (error) {
-          console.error('Error initializing Plausible:', error);
-        }
-        return;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      attempts++;
-    }
-
-    console.error('Plausible not available after timeout');
   }
 
   /**
@@ -147,9 +129,18 @@ export class PlausibleService {
       .subscribe((event: NavigationEnd) => {
         this.trackPage({
           path: event.urlAfterRedirects,
-          url: window.location.href,
+          url: this.getSanitizedUrl(),
           title: document.title,
         });
       });
+  }
+
+  /**
+   * Build a privacy-safe URL string for Plausible.
+   * Strips query params and hash to avoid leaking auth tokens, OTPs, or
+   * password-reset codes that callbacks sometimes carry in the URL.
+   */
+  private getSanitizedUrl(): string {
+    return `${window.location.origin}${window.location.pathname}`;
   }
 }

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -6,6 +6,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { environment } from '@environments/environment';
 import { PLAUSIBLE_DOMAIN, PLAUSIBLE_SRC } from '@lfx-one/shared/constants';
+import { PlausibleCall } from '@lfx-one/shared/interfaces';
 import { filter } from 'rxjs';
 
 /**
@@ -92,7 +93,7 @@ export class PlausibleService {
       // the real Plausible script drains q and o on first run.
       window.plausible =
         window.plausible ||
-        ((...args: unknown[]) => {
+        ((...args: PlausibleCall) => {
           (window.plausible!.q = window.plausible!.q || []).push(args);
         });
       window.plausible.init =

--- a/apps/lfx-one/src/app/shared/services/plausible.service.ts
+++ b/apps/lfx-one/src/app/shared/services/plausible.service.ts
@@ -36,6 +36,9 @@ export class PlausibleService {
    * Initialize the analytics service - should be called from app component
    */
   public initialize(): void {
+    if (!environment.plausible?.enabled) {
+      return;
+    }
     afterNextRender(() => {
       this.loadPlausibleScript();
       this.setupRouteTracking();
@@ -109,7 +112,6 @@ export class PlausibleService {
       // analyticsReady is gated on the real script loading — onload fires
       // only after the bundle has executed and replaced the queue stub.
       script.onload = () => {
-        this.scriptLoaded = true;
         this.analyticsReady = true;
       };
 
@@ -117,6 +119,10 @@ export class PlausibleService {
         console.error('Failed to load Plausible analytics script:', error);
       };
 
+      // Mark scriptLoaded BEFORE appending so any re-entry into
+      // loadPlausibleScript() short-circuits and we never inject a duplicate
+      // <script> tag.
+      this.scriptLoaded = true;
       document.head.appendChild(script);
     } catch (error) {
       console.error('Error initializing Plausible:', error);
@@ -134,7 +140,7 @@ export class PlausibleService {
       )
       .subscribe((event: NavigationEnd) => {
         this.trackPage({
-          path: event.urlAfterRedirects,
+          path: this.getSanitizedPath(event.urlAfterRedirects),
           url: this.getSanitizedUrl(),
           title: document.title,
         });
@@ -148,5 +154,18 @@ export class PlausibleService {
    */
   private getSanitizedUrl(): string {
     return `${window.location.origin}${window.location.pathname}`;
+  }
+
+  /**
+   * Strip query params and hash from a router-emitted URL so we never
+   * forward sensitive segments through the `path` prop. Falls back to the
+   * raw input if URL parsing fails.
+   */
+  private getSanitizedPath(rawPath: string): string {
+    try {
+      return new URL(rawPath, window.location.origin).pathname;
+    } catch {
+      return rawPath;
+    }
   }
 }

--- a/apps/lfx-one/src/app/shared/services/segment.service.ts
+++ b/apps/lfx-one/src/app/shared/services/segment.service.ts
@@ -5,16 +5,8 @@ import { afterNextRender, DestroyRef, inject, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
 import { environment } from '@environments/environment';
-import { LfxSegmentAnalytics, LfxSegmentAnalyticsClass } from '@lfx-one/shared/interfaces';
+import { LfxSegmentAnalytics } from '@lfx-one/shared/interfaces';
 import { filter } from 'rxjs';
-
-declare global {
-  interface Window {
-    LfxAnalytics?: {
-      LfxSegmentsAnalytics: LfxSegmentAnalyticsClass;
-    };
-  }
-}
 
 /**
  * Segment tracking service for Segment integration

--- a/apps/lfx-one/src/app/shared/services/segment.service.ts
+++ b/apps/lfx-one/src/app/shared/services/segment.service.ts
@@ -45,7 +45,7 @@ export class SegmentService {
    * @param properties Optional page properties
    */
   public trackPage(pageName: string, properties?: Record<string, unknown>): void {
-    if (this.impersonating || !this.analyticsReady || !this.analytics) {
+    if (typeof window === 'undefined' || this.impersonating || !this.analyticsReady || !this.analytics) {
       return;
     }
 
@@ -62,7 +62,7 @@ export class SegmentService {
    * @param properties Event properties
    */
   public trackEvent(eventName: string, properties?: Record<string, unknown>): void {
-    if (this.impersonating || !this.analyticsReady || !this.analytics) {
+    if (typeof window === 'undefined' || this.impersonating || !this.analyticsReady || !this.analytics) {
       return;
     }
 
@@ -78,7 +78,7 @@ export class SegmentService {
    * @param auth0User Auth0 user object
    */
   public identifyUser(auth0User: unknown): void {
-    if (!auth0User || this.impersonating) {
+    if (typeof window === 'undefined' || !auth0User || this.impersonating) {
       return;
     }
 
@@ -177,6 +177,9 @@ export class SegmentService {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((event: NavigationEnd) => {
+        if (typeof window === 'undefined' || typeof document === 'undefined') {
+          return;
+        }
         const pageName = event.urlAfterRedirects.split('/').pop() || 'Home';
         this.trackPage(pageName, {
           path: event.urlAfterRedirects,

--- a/apps/lfx-one/src/environments/environment.dev.ts
+++ b/apps/lfx-one/src/environments/environment.dev.ts
@@ -16,8 +16,6 @@ export const environment = {
     enabled: true,
   },
   plausible: {
-    src: 'https://plausible.io/js/pa-5WzbGW1iBhdv7vxTOxXEQ.js',
-    domain: 'app.lfx.dev',
     enabled: false,
   },
   datadog: {

--- a/apps/lfx-one/src/environments/environment.dev.ts
+++ b/apps/lfx-one/src/environments/environment.dev.ts
@@ -15,6 +15,11 @@ export const environment = {
     cdnUrl: 'https://lfx-segment.dev.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',
     enabled: true,
   },
+  plausible: {
+    src: 'https://plausible.io/js/pa-5WzbGW1iBhdv7vxTOxXEQ.js',
+    domain: 'app.lfx.dev',
+    enabled: false,
+  },
   datadog: {
     site: 'datadoghq.com',
     service: 'lfx-one',

--- a/apps/lfx-one/src/environments/environment.prod.ts
+++ b/apps/lfx-one/src/environments/environment.prod.ts
@@ -15,6 +15,11 @@ export const environment = {
     cdnUrl: 'https://lfx-segment.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',
     enabled: true,
   },
+  plausible: {
+    src: 'https://plausible.io/js/pa-5WzbGW1iBhdv7vxTOxXEQ.js',
+    domain: 'app.lfx.dev',
+    enabled: true,
+  },
   datadog: {
     site: 'datadoghq.com',
     service: 'lfx-one',

--- a/apps/lfx-one/src/environments/environment.prod.ts
+++ b/apps/lfx-one/src/environments/environment.prod.ts
@@ -16,8 +16,6 @@ export const environment = {
     enabled: true,
   },
   plausible: {
-    src: 'https://plausible.io/js/pa-5WzbGW1iBhdv7vxTOxXEQ.js',
-    domain: 'app.lfx.dev',
     enabled: true,
   },
   datadog: {

--- a/apps/lfx-one/src/environments/environment.staging.ts
+++ b/apps/lfx-one/src/environments/environment.staging.ts
@@ -16,8 +16,6 @@ export const environment = {
     enabled: true,
   },
   plausible: {
-    src: 'https://plausible.io/js/pa-5WzbGW1iBhdv7vxTOxXEQ.js',
-    domain: 'app.lfx.dev',
     enabled: false,
   },
   datadog: {

--- a/apps/lfx-one/src/environments/environment.staging.ts
+++ b/apps/lfx-one/src/environments/environment.staging.ts
@@ -15,6 +15,11 @@ export const environment = {
     cdnUrl: 'https://lfx-segment.dev.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',
     enabled: true,
   },
+  plausible: {
+    src: 'https://plausible.io/js/pa-5WzbGW1iBhdv7vxTOxXEQ.js',
+    domain: 'app.lfx.dev',
+    enabled: false,
+  },
   datadog: {
     site: 'datadoghq.com',
     service: 'lfx-one',

--- a/apps/lfx-one/src/environments/environment.ts
+++ b/apps/lfx-one/src/environments/environment.ts
@@ -16,8 +16,6 @@ export const environment = {
     enabled: true,
   },
   plausible: {
-    src: 'https://plausible.io/js/pa-5WzbGW1iBhdv7vxTOxXEQ.js',
-    domain: 'app.lfx.dev',
     enabled: false,
   },
   datadog: {

--- a/apps/lfx-one/src/environments/environment.ts
+++ b/apps/lfx-one/src/environments/environment.ts
@@ -15,6 +15,11 @@ export const environment = {
     cdnUrl: 'https://lfx-segment.dev.platform.linuxfoundation.org/latest/lfx-segment-analytics.min.js?ver=1.0.1',
     enabled: true,
   },
+  plausible: {
+    src: 'https://plausible.io/js/pa-5WzbGW1iBhdv7vxTOxXEQ.js',
+    domain: 'app.lfx.dev',
+    enabled: false,
+  },
   datadog: {
     site: 'datadoghq.com',
     service: 'lfx-one',

--- a/apps/lfx-one/src/types/window.d.ts
+++ b/apps/lfx-one/src/types/window.d.ts
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Centralized augmentation of the browser `Window` type for third-party
+// scripts that attach themselves to `window.*`. Add one entry per integration —
+// individual services should import the underlying interface from
+// `@lfx-one/shared/interfaces` and use it directly without redeclaring the
+// global. `tsconfig.app.json` registers `src/types/` as a typeRoot, so this
+// file is picked up automatically.
+
+import type { LfxSegmentAnalyticsClass, PlausibleFunction } from '@lfx-one/shared/interfaces';
+
+declare global {
+  interface Window {
+    LfxAnalytics?: { LfxSegmentsAnalytics: LfxSegmentAnalyticsClass };
+    plausible?: PlausibleFunction;
+  }
+}
+
+export {};

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -23,6 +23,7 @@ export * from './dashboard-metrics.constants';
 export * from './snowflake.constant';
 export * from './accounts.constants';
 export * from './analytics.constants';
+export * from './plausible.constants';
 export * from './chart.constants';
 export * from './chart-options.constants';
 export * from './cookie.constants';

--- a/packages/shared/src/constants/plausible.constants.ts
+++ b/packages/shared/src/constants/plausible.constants.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Plausible analytics script URL.
+ *
+ * The site identity is baked into the script ID itself (`pa-…`), so this
+ * value is invariant across all environments — only `environment.plausible.enabled`
+ * gates whether the script is actually injected.
+ */
+export const PLAUSIBLE_SRC = 'https://plausible.io/js/pa-5WzbGW1iBhdv7vxTOxXEQ.js';
+
+/**
+ * Domain registered in the Plausible site that owns the script ID above.
+ * Forwarded as the `data-domain` attribute on the injected `<script>` tag.
+ */
+export const PLAUSIBLE_DOMAIN = 'app.lfx.dev';

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -54,6 +54,7 @@ export * from './user-statistics.interface';
 
 // Analytics interfaces
 export * from './segment.interface';
+export * from './plausible.interface';
 export * from './analytics-data.interface';
 
 // Persona interfaces

--- a/packages/shared/src/interfaces/plausible.interface.ts
+++ b/packages/shared/src/interfaces/plausible.interface.ts
@@ -1,0 +1,29 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Plausible configuration from environment
+ */
+export interface PlausibleConfig {
+  /** Plausible script URL (CDN or proxied) */
+  src: string;
+  /** Domain registered in Plausible (kept for clarity / future portability) */
+  domain: string;
+  /** Whether analytics is enabled for this environment */
+  enabled: boolean;
+}
+
+/**
+ * Plausible browser API
+ *
+ * The runtime function is created either by the official upstream snippet (a
+ * queue stub that buffers calls until the real script loads) or by the loaded
+ * `pa-*.js` script itself once it replaces the stub. Both shapes share this
+ * type — the queue/init/options properties are populated by the stub and read
+ * by the real script during initialization.
+ */
+export type PlausibleFunction = ((eventName: string, options?: { u?: string; props?: Record<string, unknown> }) => void) & {
+  q?: unknown[];
+  init?: (options?: Record<string, unknown>) => void;
+  o?: Record<string, unknown>;
+};

--- a/packages/shared/src/interfaces/plausible.interface.ts
+++ b/packages/shared/src/interfaces/plausible.interface.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Plausible configuration from environment
+ * Plausible configuration from environment.
+ *
+ * Only `enabled` varies per environment — the script URL and registered
+ * domain are environment-invariant constants in `@lfx-one/shared/constants`
+ * (`PLAUSIBLE_SRC`, `PLAUSIBLE_DOMAIN`).
  */
 export interface PlausibleConfig {
-  /** Plausible script URL (CDN or proxied) */
-  src: string;
-  /** Domain registered in Plausible (kept for clarity / future portability) */
-  domain: string;
   /** Whether analytics is enabled for this environment */
   enabled: boolean;
 }

--- a/packages/shared/src/interfaces/plausible.interface.ts
+++ b/packages/shared/src/interfaces/plausible.interface.ts
@@ -14,16 +14,24 @@ export interface PlausibleConfig {
 }
 
 /**
+ * One queued Plausible call captured by the upstream snippet's queue stub
+ * before the real script loads. Each entry is the full argument tuple the
+ * caller invoked `window.plausible(...)` with.
+ */
+export type PlausibleCall = [eventName: string, options?: { u?: string; props?: Record<string, unknown> }];
+
+/**
  * Plausible browser API
  *
  * The runtime function is created either by the official upstream snippet (a
  * queue stub that buffers calls until the real script loads) or by the loaded
  * `pa-*.js` script itself once it replaces the stub. Both shapes share this
  * type — the queue/init/options properties are populated by the stub and read
- * by the real script during initialization.
+ * by the real script during initialization. `q` is an array of argument
+ * tuples (one per buffered call), not a flat array of arguments.
  */
-export type PlausibleFunction = ((eventName: string, options?: { u?: string; props?: Record<string, unknown> }) => void) & {
-  q?: unknown[];
+export type PlausibleFunction = ((...args: PlausibleCall) => void) & {
+  q?: PlausibleCall[];
   init?: (options?: Record<string, unknown>) => void;
   o?: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary

- Adds a `PlausibleService` (`apps/lfx-one/src/app/shared/services/plausible.service.ts`) that loads the Plausible script and tracks page views + route changes via the existing SSR-safe pattern used by `SegmentService` (`afterNextRender`, `Router.events` `NavigationEnd`, `takeUntilDestroyed`)
- Plausible is **enabled only in `environment.prod.ts`** (`app.lfx.dev`); base/local, dev, and staging keep `enabled: false` until separate sites exist
- Impersonated sessions are suppressed (`setImpersonating(true)` is wired alongside the existing Segment hook), so staff impersonating customers won't pollute production analytics
- Outgoing URLs and paths are sanitized (query string and hash stripped) so auth callbacks, OTPs, or password-reset tokens cannot reach Plausible
- Plausible's automatic initial pageview is disabled (`autoCapturePageviews: false`); the first pageview is fired manually from the script's `onload` so an impersonated session that flips `setImpersonating(true)` between `initialize()` and script load can never leak a hit
- Centralizes browser `Window` type augmentation into a new `apps/lfx-one/src/types/window.d.ts` (registered as a typeRoot via `tsconfig.app.json`) — `SegmentService` no longer redeclares the global, and future integrations add a single line in this file
- Hardens `SegmentService` and `PlausibleService` against SSR by guarding all `window` / `document` access with `typeof` checks (route subscriber, `trackPage`, `trackEvent`, `identifyUser`)
- Constants (`PLAUSIBLE_SRC`, `PLAUSIBLE_DOMAIN`) and interfaces (`PlausibleConfig`, `PlausibleFunction`) live in `@lfx-one/shared`
- No `index.html`, server, Helm, runtime-config, or CSP changes — frontend-only, single hard-coded site

JIRA: [LFXV2-1615](https://linuxfoundation.atlassian.net/browse/LFXV2-1615)
Snippet source: provided by Jonathan Reimer (`pa-5WzbGW1iBhdv7vxTOxXEQ.js`, domain `app.lfx.dev`)

## Open question for the reviewer

The Plausible site for `app.lfx.dev` is currently in a **personal Plausible workspace** (mine), not an LF-org-managed one. We should either confirm this is intentional for the initial rollout, or move ownership to an LF org workspace before this lands in production. The code change is identical either way — only the script ID/domain would swap.

## Notes

- `trackPage()` and `trackEvent()` are public on `PlausibleService` but not wired to any callsite yet — kept as forward-compatible API for future custom event tracking. Happy to drop them if reviewers prefer YAGNI.
- `PlausibleService` deliberately has no `identifyUser` method — Plausible is privacy-first by design and does not have a user-identity API.
- The two `!` non-null assertions inside the queue-stub block in `loadPlausibleScript()` mirror the upstream Plausible snippet; both run inside a closure where `window.plausible` was just set synchronously two lines above.

[LFXV2-1615]: https://linuxfoundation.atlassian.net/browse/LFXV2-1615